### PR TITLE
Fixes to make ./configure --cover work.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -57,7 +57,7 @@ OBJZ = adler32.o crc32.o deflate.o match.o infback.o inffast.o inflate.o inftree
 OBJG = compress.o uncompr.o gzclose.o gzlib.o gzread.o gzwrite.o
 OBJC = $(OBJZ) $(OBJG)
 
-PIC_OBJZ = adler32.lo crc32.lo deflate.lo match.o infback.lo inffast.lo inflate.lo inftrees.lo trees.lo zutil.lo $(ARCH_SHARED_OBJS)
+PIC_OBJZ = adler32.lo crc32.lo deflate.lo match.lo infback.lo inffast.lo inflate.lo inftrees.lo trees.lo zutil.lo $(ARCH_SHARED_OBJS)
 PIC_OBJG = compress.lo uncompr.lo gzclose.lo gzlib.lo gzread.lo gzwrite.lo
 PIC_OBJC = $(PIC_OBJZ) $(PIC_OBJG)
 

--- a/arch/x86/Makefile.in
+++ b/arch/x86/Makefile.in
@@ -12,7 +12,7 @@ x86.o:
 	$(CC) $(CFLAGS) -I. -I../../ -c -o $@ x86.c
 
 x86.lo:
-	$(CC) $(CFLAGS) -I. -I../../ -c -o $@ x86.c
+	$(CC) $(SFLAGS) -I. -I../../ -c -o $@ x86.c
 
 fill_window_sse.o:
 	$(CC) $(CFLAGS) -msse2 -I. -I../../ -c -o $@ fill_window_sse.c


### PR DESCRIPTION
This fixes building with ./configure --cover on x86_64 (and probably other architectures).
