### PR TITLE
Make parallel building work inside arch directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,9 @@ CMakeCache.txt
 CMakeFiles
 Testing
 *.cmake
+
+configure.log
+
+/arch/arm/Makefile
+/arch/generic/Makefile
+/arch/x86/Makefile

--- a/Makefile.in
+++ b/Makefile.in
@@ -65,24 +65,27 @@ OBJS = $(OBJC)
 
 PIC_OBJS = $(PIC_OBJC)
 
-all: $(ARCHDIR) static shared
+all: static shared
 
-static: subdirs example$(EXE) minigzip$(EXE)
+static: example$(EXE) minigzip$(EXE)
 
-shared: subdirs examplesh$(EXE) minigzipsh$(EXE)
+shared: examplesh$(EXE) minigzipsh$(EXE)
 
-all64: subdirs example64$(EXE) minigzip64$(EXE)
+all64: example64$(EXE) minigzip64$(EXE)
 
 check: test
 
-.PHONY: subdirs $(ARCHDIR)
+$(ARCHDIR)/%.o: $(ARCHDIR)/%.c
+	$(MAKE) -C $(ARCHDIR) $(notdir $@)
 
-subdirs: $(ARCHDIR)
+$(ARCHDIR)/%.lo: $(ARCHDIR)/%.c
+	$(MAKE) -C $(ARCHDIR) $(notdir $@)
 
-$(ARCHDIR):
-	$(MAKE) -C $@
-	-mv $@/*.o .
-	-mv $@/*.lo .
+%.o : $(ARCHDIR)/%.o
+	-cp $< $@
+
+%.lo : $(ARCHDIR)/%.lo
+	-cp $< $@
 
 test: all teststatic testshared
 


### PR DESCRIPTION
Fixes Dead2/zlib-ng#2 and makes parallel build able to select individual builds from both root and arch directories.
