### PR TITLE
Fix building out of source tree.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,8 +37,10 @@ CMakeCache.txt
 CMakeFiles
 Testing
 *.cmake
+zconf.h.included
 
 configure.log
+a.out
 
 /arch/arm/Makefile
 /arch/generic/Makefile

--- a/Makefile.in
+++ b/Makefile.in
@@ -40,7 +40,9 @@ TAR=tar
 SHELL=/bin/sh
 EXE=
 
-ARCHDIR=
+SRCDIR=.
+
+ARCHDIR=arch/generic
 ARCH_STATIC_OBJS=
 ARCH_SHARED_OBJS=
 
@@ -75,10 +77,10 @@ all64: example64$(EXE) minigzip64$(EXE)
 
 check: test
 
-$(ARCHDIR)/%.o: $(ARCHDIR)/%.c
+$(ARCHDIR)/%.o: $(SRCDIR)/$(ARCHDIR)/%.c
 	$(MAKE) -C $(ARCHDIR) $(notdir $@)
 
-$(ARCHDIR)/%.lo: $(ARCHDIR)/%.c
+$(ARCHDIR)/%.lo: $(SRCDIR)/$(ARCHDIR)/%.c
 	$(MAKE) -C $(ARCHDIR) $(notdir $@)
 
 %.o : $(ARCHDIR)/%.o
@@ -120,8 +122,8 @@ test64: all64
 	fi; \
 	rm -f $$TMP64
 
-infcover.o: test/infcover.c zlib.h zconf.h
-	$(CC) $(CFLAGS) -I. -c -o $@ test/infcover.c
+infcover.o: $(SRCDIR)/test/infcover.c $(SRCDIR)/zlib.h zconf.h
+	$(CC) $(CFLAGS) -I. -I$(SRCDIR) -c -o $@ $(SRCDIR)/test/infcover.c
 
 infcover: infcover.o libz.a
 	$(CC) $(CFLAGS) -o $@ infcover.o libz.a
@@ -135,21 +137,24 @@ libz.a: $(OBJS)
 	$(AR) $(ARFLAGS) $@ $(OBJS)
 	-@ ($(RANLIB) $@ || true) >/dev/null 2>&1
 
-example.o: test/example.c zlib.h zconf.h
-	$(CC) $(CFLAGS) -I. -c -o $@ test/example.c
+example.o: $(SRCDIR)/test/example.c $(SRCDIR)/zlib.h zconf.h
+	$(CC) $(CFLAGS) -I. -I$(SRCDIR) -c -o $@ $(SRCDIR)/test/example.c
 
-minigzip.o: test/minigzip.c zlib.h zconf.h
-	$(CC) $(CFLAGS) -I. -c -o $@ test/minigzip.c
+minigzip.o: $(SRCDIR)/test/minigzip.c $(SRCDIR)/zlib.h zconf.h
+	$(CC) $(CFLAGS) -I. -I$(SRCDIR) -c -o $@ $(SRCDIR)/test/minigzip.c
 
-example64.o: test/example.c zlib.h zconf.h
-	$(CC) $(CFLAGS) -I. -D_FILE_OFFSET_BITS=64 -c -o $@ test/example.c
+example64.o: $(SRCDIR)/test/example.c $(SRCDIR)/zlib.h zconf.h
+	$(CC) $(CFLAGS) -I. -I$(SRCDIR) -D_FILE_OFFSET_BITS=64 -c -o $@ $(SRCDIR)/test/example.c
 
-minigzip64.o: test/minigzip.c zlib.h zconf.h
-	$(CC) $(CFLAGS) -I. -D_FILE_OFFSET_BITS=64 -c -o $@ test/minigzip.c
+minigzip64.o: $(SRCDIR)/test/minigzip.c $(SRCDIR)/zlib.h zconf.h
+	$(CC) $(CFLAGS) -I. -I$(SRCDIR) -D_FILE_OFFSET_BITS=64 -c -o $@ $(SRCDIR)/test/minigzip.c
 
 .SUFFIXES: .lo
 
-.c.lo:
+%.o: $(SRCDIR)/%.c
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+%.lo: $(SRCDIR)/%.c
 	-@mkdir objs 2>/dev/null || test -d objs
 	$(CC) $(SFLAGS) -DPIC -c -o objs/$*.o $<
 	-@mv objs/$*.o $@
@@ -198,7 +203,7 @@ install-libs: $(LIBS)
 	  ln -s $(SHAREDLIBV) $(DESTDIR)$(sharedlibdir)/$(SHAREDLIBM); \
 	  ($(LDCONFIG) || true)  >/dev/null 2>&1; \
 	fi
-	cp zlib.3 $(DESTDIR)$(man3dir)
+	cp $(SRCDIR)/zlib.3 $(DESTDIR)$(man3dir)
 	chmod 644 $(DESTDIR)$(man3dir)/zlib.3
 	cp zlib.pc $(DESTDIR)$(pkgconfigdir)
 	chmod 644 $(DESTDIR)$(pkgconfigdir)/zlib.pc
@@ -207,7 +212,7 @@ install-libs: $(LIBS)
 
 install: install-libs
 	-@if [ ! -d $(DESTDIR)$(includedir)   ]; then mkdir -p $(DESTDIR)$(includedir); fi
-	cp zlib.h zconf.h $(DESTDIR)$(includedir)
+	cp $(SRCDIR)/zlib.h zconf.h $(DESTDIR)$(includedir)
 	chmod 644 $(DESTDIR)$(includedir)/zlib.h $(DESTDIR)$(includedir)/zconf.h
 
 uninstall:
@@ -221,22 +226,22 @@ uninstall:
 
 docs: zlib.3.pdf
 
-zlib.3.pdf: zlib.3
-	groff -mandoc -f H -T ps zlib.3 | ps2pdf - zlib.3.pdf
+zlib.3.pdf: $(SRCDIR)/zlib.3
+	groff -mandoc -f H -T ps $(SRCDIR)/zlib.3 | ps2pdf - zlib.3.pdf
 
-zconf.h.cmakein: zconf.h.in
+zconf.h.cmakein: $(SRCDIR)/zconf.h.in
 	-@ TEMPFILE=zconfh_$$; \
 	echo "/#define ZCONF_H/ a\\\\\n#cmakedefine Z_PREFIX\\\\\n#cmakedefine Z_HAVE_UNISTD_H\n" >> $$TEMPFILE &&\
-	sed -f $$TEMPFILE zconf.h.in > zconf.h.cmakein &&\
-	touch -r zconf.h.in zconf.h.cmakein &&\
+	sed -f $$TEMPFILE $(SRCDIR)/zconf.h.in > zconf.h.cmakein &&\
+	touch -r $(SRCDIR)/zconf.h.in zconf.h.cmakein &&\
 	rm $$TEMPFILE
 
-zconf: zconf.h.in
-	cp -p zconf.h.in zconf.h
+zconf: $(SRCDIR)/zconf.h.in
+	cp -p $(SRCDIR)/zconf.h.in zconf.h
 
 mostlyclean: clean
 clean:
-	$(MAKE) -C $(ARCHDIR) clean
+	@if [ -f $(ARCHDIR)/Makefile ]; then $(MAKE) -C $(ARCHDIR) clean; fi
 	rm -f *.o *.lo *~ \
 	   example$(EXE) minigzip$(EXE) examplesh$(EXE) minigzipsh$(EXE) \
 	   example64$(EXE) minigzip64$(EXE) \
@@ -245,40 +250,50 @@ clean:
 	   _match.s maketree
 	rm -rf objs
 	rm -f *.gcda *.gcno *.gcov
+	rm -f a.out
 
 maintainer-clean: distclean
 distclean: clean zconf zconf.h.cmakein docs
-	$(MAKE) -C $(ARCHDIR) distclean
-	rm -f Makefile zlib.pc configure.log
+	@if [ -f $(ARCHDIR)/Makefile ]; then $(MAKE) -C $(ARCHDIR) distclean; fi
+	rm -f zlib.pc configure.log
 	-@rm -f .DS_Store
-	-@printf 'all:\n\t-@echo "Please use ./configure first.  Thank you."\n' > Makefile
-	-@printf '\ndistclean:\n\tmake -f Makefile.in distclean\n' >> Makefile
-	-@touch -r Makefile.in Makefile
+# Reset Makefile if building inside source tree
+	@if [ -f Makefile.in ]; then \
+	printf 'all:\n\t-@echo "Please use ./configure first.  Thank you."\n' > Makefile ; \
+	printf '\ndistclean:\n\tmake -f Makefile.in distclean\n' >> Makefile ; \
+	touch -r $(SRCDIR)/Makefile.in Makefile ; fi
+# Cleanup these files if building outside source tree
+	@if [ ! -f zlib.3 ]; then rm -f zlib.3.pdf Makefile zconf.h zconf.h.cmakein ; fi
+# Remove arch directory if building outside source tree
+	@if [ ! -f $(ARCHDIR)/Makefile.in ]; then rm -rf arch; fi
 
 tags:
-	etags *.[ch]
+	etags $(SRCDIR)/*.[ch]
 
 depend:
-	makedepend -- $(CFLAGS) -- *.[ch]
+	makedepend -- $(CFLAGS) -- $(SRCDIR)/*.[ch]
+	makedepend -a -o.lo -- $(SFLAGS) -- $(SRCDIR)/*.[ch]
+	@sed "s=^$(SRCDIR)/\([a-zA-Z0-9_]*\.\(lo\|o\):\)=\1=g" < Makefile > Makefile.tmp
+	@mv -f Makefile.tmp Makefile
 
 # DO NOT DELETE THIS LINE -- make depend depends on it.
 
-adler32.o zutil.o: zutil.h zlib.h zconf.h
-gzclose.o gzlib.o gzread.o gzwrite.o: zlib.h zconf.h gzguts.h
-compress.o example.o minigzip.o uncompr.o: zlib.h zconf.h
-crc32.o: zutil.h zlib.h zconf.h crc32.h
-deflate.o: deflate.h zutil.h zlib.h zconf.h
-infback.o inflate.o: zutil.h zlib.h zconf.h inftrees.h inflate.h inffast.h inffixed.h
-inffast.o: zutil.h zlib.h zconf.h inftrees.h inflate.h inffast.h
-inftrees.o: zutil.h zlib.h zconf.h inftrees.h
-trees.o: deflate.h zutil.h zlib.h zconf.h trees.h
+adler32.o zutil.o: $(SRCDIR)/zutil.h $(SRCDIR)/zlib.h zconf.h
+gzclose.o gzlib.o gzread.o gzwrite.o: $(SRCDIR)/zlib.h zconf.h $(SRCDIR)/gzguts.h
+compress.o example.o minigzip.o uncompr.o: $(SRCDIR)/zlib.h zconf.h
+crc32.o: $(SRCDIR)/zutil.h $(SRCDIR)/zlib.h zconf.h $(SRCDIR)/crc32.h
+deflate.o: $(SRCDIR)/deflate.h $(SRCDIR)/zutil.h $(SRCDIR)/zlib.h zconf.h
+infback.o inflate.o: $(SRCDIR)/zutil.h $(SRCDIR)/zlib.h zconf.h $(SRCDIR)/inftrees.h $(SRCDIR)/inflate.h $(SRCDIR)/inffast.h $(SRCDIR)/inffixed.h
+inffast.o: $(SRCDIR)/zutil.h $(SRCDIR)/zlib.h zconf.h $(SRCDIR)/inftrees.h $(SRCDIR)/inflate.h $(SRCDIR)/inffast.h
+inftrees.o: $(SRCDIR)/zutil.h $(SRCDIR)/zlib.h zconf.h $(SRCDIR)/inftrees.h
+trees.o: $(SRCDIR)/deflate.h $(SRCDIR)/zutil.h $(SRCDIR)/zlib.h zconf.h $(SRCDIR)/trees.h
 
-adler32.lo zutil.lo: zutil.h zlib.h zconf.h
-gzclose.lo gzlib.lo gzread.lo gzwrite.lo: zlib.h zconf.h gzguts.h
-compress.lo example.lo minigzip.lo uncompr.lo: zlib.h zconf.h
-crc32.lo: zutil.h zlib.h zconf.h crc32.h
-deflate.lo: deflate.h zutil.h zlib.h zconf.h
-infback.lo inflate.lo: zutil.h zlib.h zconf.h inftrees.h inflate.h inffast.h inffixed.h
-inffast.lo: zutil.h zlib.h zconf.h inftrees.h inflate.h inffast.h
-inftrees.lo: zutil.h zlib.h zconf.h inftrees.h
-trees.lo: deflate.h zutil.h zlib.h zconf.h trees.h
+adler32.lo zutil.lo: $(SRCDIR)/zutil.h $(SRCDIR)/zlib.h zconf.h
+gzclose.lo gzlib.lo gzread.lo gzwrite.lo: $(SRCDIR)/zlib.h zconf.h $(SRCDIR)/gzguts.h
+compress.lo example.lo minigzip.lo uncompr.lo: $(SRCDIR)/zlib.h zconf.h
+crc32.lo: $(SRCDIR)/zutil.h $(SRCDIR)/zlib.h zconf.h $(SRCDIR)/crc32.h
+deflate.lo: $(SRCDIR)/deflate.h $(SRCDIR)/zutil.h $(SRCDIR)/zlib.h zconf.h
+infback.lo inflate.lo: $(SRCDIR)/zutil.h $(SRCDIR)/zlib.h zconf.h $(SRCDIR)/inftrees.h $(SRCDIR)/inflate.h $(SRCDIR)/inffast.h $(SRCDIR)/inffixed.h
+inffast.lo: $(SRCDIR)/zutil.h $(SRCDIR)/zlib.h zconf.h $(SRCDIR)/inftrees.h $(SRCDIR)/inflate.h $(SRCDIR)/inffast.h
+inftrees.lo: $(SRCDIR)/zutil.h $(SRCDIR)/zlib.h zconf.h $(SRCDIR)/inftrees.h
+trees.lo: $(SRCDIR)/deflate.h $(SRCDIR)/zutil.h $(SRCDIR)/zlib.h zconf.h $(SRCDIR)/trees.h

--- a/arch/arm/Makefile.in
+++ b/arch/arm/Makefile.in
@@ -5,6 +5,10 @@
 CC=
 CFLAGS=
 SFLAGS=
+INCLUDES=
+
+SRCDIR=
+SRCTOP=
 
 all:
 

--- a/arch/generic/Makefile.in
+++ b/arch/generic/Makefile.in
@@ -5,6 +5,10 @@
 CC=
 CFLAGS=
 SFLAGS=
+INCLUDES=
+
+SRCDIR=
+SRCTOP=
 
 all:
 

--- a/arch/x86/Makefile.in
+++ b/arch/x86/Makefile.in
@@ -5,32 +5,36 @@
 CC=
 CFLAGS=
 SFLAGS=
+INCLUDES=
+
+SRCDIR=
+SRCTOP=
 
 all: x86.o x86.lo fill_window_sse.o fill_window_sse.lo deflate_quick.o deflate_quick.lo crc_folding.o crc_folding.lo
 
 x86.o:
-	$(CC) $(CFLAGS) -I. -I../../ -c -o $@ x86.c
+	$(CC) $(CFLAGS) $(INCLUDES) -c -o $@ $(SRCDIR)/x86.c
 
 x86.lo:
-	$(CC) $(SFLAGS) -I. -I../../ -c -o $@ x86.c
+	$(CC) $(SFLAGS) $(INCLUDES) -c -o $@ $(SRCDIR)/x86.c
 
 fill_window_sse.o:
-	$(CC) $(CFLAGS) -msse2 -I. -I../../ -c -o $@ fill_window_sse.c
+	$(CC) $(CFLAGS) -msse2 $(INCLUDES) -c -o $@ $(SRCDIR)/fill_window_sse.c
 
 fill_window_sse.lo:
-	$(CC) $(SFLAGS) -msse2 -DPIC -I. -I../../ -c -o $@ fill_window_sse.c
+	$(CC) $(SFLAGS) -msse2 -DPIC $(INCLUDES) -c -o $@ $(SRCDIR)/fill_window_sse.c
 
 deflate_quick.o:
-	$(CC) $(CFLAGS) -msse4 -I. -I../../ -c -o $@ deflate_quick.c
+	$(CC) $(CFLAGS) -msse4 $(INCLUDES) -c -o $@ $(SRCDIR)/deflate_quick.c
 
 deflate_quick.lo:
-	$(CC) $(SFLAGS) -msse4 -DPIC -I. -I../../ -c -o $@ deflate_quick.c
+	$(CC) $(SFLAGS) -msse4 -DPIC $(INCLUDES) -c -o $@ $(SRCDIR)/deflate_quick.c
 
 crc_folding.o:
-	$(CC) $(CFLAGS) -mpclmul -msse4 -I. -I../../ -c -o $@ crc_folding.c
+	$(CC) $(CFLAGS) -mpclmul -msse4 $(INCLUDES) -c -o $@ $(SRCDIR)/crc_folding.c
 
 crc_folding.lo:
-	$(CC) $(SFLAGS) -mpclmul -msse4 -DPIC -I. -I../../ -c -o $@ crc_folding.c
+	$(CC) $(SFLAGS) -mpclmul -msse4 -DPIC $(INCLUDES) -c -o $@ $(SRCDIR)/crc_folding.c
 
 
 mostlyclean: clean

--- a/configure
+++ b/configure
@@ -18,6 +18,9 @@ echo -------------------- >> configure.log
 echo $0 $* >> configure.log
 date >> configure.log
 
+SRCDIR=$(cd $(dirname $0); pwd)
+BUILDDIR=$(pwd)
+
 # set command prefix for cross-compilation
 if [ -n "${CHOST}" ]; then
     uname="`echo "${CHOST}" | sed -e 's/^[^-]*-\([^-]*\)$/\1/' -e 's/^[^-]*-[^-]*-\([^-]*\)$/\1/' -e 's/^[^-]*-[^-]*-\([^-]*\)-.*$/\1/'`"
@@ -48,10 +51,10 @@ esac
 STATICLIB=libz.a
 
 # extract zlib version numbers from zlib.h
-VER=`sed -n -e '/ZLIB_VERSION "/s/.*"\(.*\)".*/\1/p' < zlib.h`
-VER3=`sed -n -e '/ZLIB_VERSION "/s/.*"\([0-9]*\\.[0-9]*\\.[0-9]*\).*/\1/p' < zlib.h`
-VER2=`sed -n -e '/ZLIB_VERSION "/s/.*"\([0-9]*\\.[0-9]*\)\\..*/\1/p' < zlib.h`
-VER1=`sed -n -e '/ZLIB_VERSION "/s/.*"\([0-9]*\)\\..*/\1/p' < zlib.h`
+VER=`sed -n -e '/ZLIB_VERSION "/s/.*"\(.*\)".*/\1/p' < ${SRCDIR}/zlib.h`
+VER3=`sed -n -e '/ZLIB_VERSION "/s/.*"\([0-9]*\\.[0-9]*\\.[0-9]*\).*/\1/p' < ${SRCDIR}/zlib.h`
+VER2=`sed -n -e '/ZLIB_VERSION "/s/.*"\([0-9]*\\.[0-9]*\)\\..*/\1/p' < ${SRCDIR}/zlib.h`
+VER1=`sed -n -e '/ZLIB_VERSION "/s/.*"\([0-9]*\)\\..*/\1/p' < ${SRCDIR}/zlib.h`
 
 # establish commands for library building
 if "${CROSS_PREFIX}ar" --version >/dev/null 2>/dev/null || test $? -lt 126; then
@@ -207,9 +210,9 @@ if test "$gcc" -eq 1 && ($cc -c $test.c) >> configure.log 2>&1; then
   fi
   case "$uname" in
   Linux* | linux* | GNU | GNU/* | solaris*)
-        LDSHARED=${LDSHARED-"$cc -shared -Wl,-soname,libz.so.1,--version-script,zlib.map"} ;;
+        LDSHARED=${LDSHARED-"$cc -shared -Wl,-soname,libz.so.1,--version-script,${SRCDIR}/zlib.map"} ;;
   *BSD | *bsd* | DragonFly)
-        LDSHARED=${LDSHARED-"$cc -shared -Wl,-soname,libz.so.1,--version-script,zlib.map"}
+        LDSHARED=${LDSHARED-"$cc -shared -Wl,-soname,libz.so.1,--version-script,${SRCDIR}/zlib.map"}
         LDCONFIG="ldconfig -m" ;;
   CYGWIN* | Cygwin* | cygwin* | OS/2*)
         EXE='.exe' ;;
@@ -418,8 +421,11 @@ else
   echo "Checking for strerror... No." | tee -a configure.log
 fi
 
+# We need to remove zconf.h from source directory if building outside of it
+if [ "$SRCDIR" != "$BUILDDIR" ]; then rm -f $SRCDIR/zconf.h; fi
+
 # copy clean zconf.h for subsequent edits
-cp -p zconf.h.in zconf.h
+cp -p $SRCDIR/zconf.h.in zconf.h
 
 echo >> configure.log
 
@@ -682,6 +688,8 @@ echo SFLAGS = $SFLAGS >> configure.log
 echo SHAREDLIB = $SHAREDLIB >> configure.log
 echo SHAREDLIBM = $SHAREDLIBM >> configure.log
 echo SHAREDLIBV = $SHAREDLIBV >> configure.log
+echo SRCDIR = $SRCDIR >> configure.log
+echo BUILDDIR = $BUILDDIR >> configure.log
 echo STATICLIB = $STATICLIB >> configure.log
 echo TEST = $TEST >> configure.log
 echo VER = $VER >> configure.log
@@ -698,7 +706,7 @@ echo ARCH_STATIC_OBJS = ${ARCH_STATIC_OBJS} >> configure.log
 echo ARCH_SHARED_OBJS = ${ARCH_SHARED_OBJS} >> configure.log
 
 # update Makefile with the configure results
-sed < Makefile.in "
+sed < $SRCDIR/Makefile.in "
 /^CC *=/s#=.*#=$CC#
 /^CFLAGS *=/s#=.*#=$CFLAGS#
 /^SFLAGS *=/s#=.*#=$SFLAGS#
@@ -720,6 +728,7 @@ sed < Makefile.in "
 /^sharedlibdir *=/s#=.*#=$sharedlibdir#
 /^includedir *=/s#=.*#=$includedir#
 /^mandir *=/s#=.*#=$mandir#
+/^SRCDIR *=/s#=.*#=$SRCDIR#
 /^OBJC *=/s#=.*#= $OBJC#
 /^PIC_OBJC *=/s#=.*#= $PIC_OBJC#
 /^all: */s#:.*#: $ALL#
@@ -730,14 +739,22 @@ sed < Makefile.in "
 " > Makefile
 
 # Generate Makefile in arch dir
-sed < $ARCHDIR/Makefile.in "
+mkdir -p $ARCHDIR
+
+ARCHINCLUDES="-I$SRCDIR/$ARCHDIR -I$SRCDIR"
+if [ "$SRCDIR" != "$BUILDDIR" ]; then ARCHINCLUDES="${ARCHINCLUDES} -I$BUILDDIR"; fi
+
+sed < $SRCDIR/$ARCHDIR/Makefile.in "
 /^CC *=/s#=.*#=$CC#
 /^CFLAGS *=/s#=.*#=$CFLAGS#
 /^SFLAGS *=/s#=.*#=$SFLAGS#
+/^INCLUDES *=/s#=.*#=$ARCHINCLUDES#
+/^SRCDIR *=/s#=.*#=$SRCDIR/$ARCHDIR#
+/^SRCTOP *=/s#=.*#=$SRCDIR#
 " > $ARCHDIR/Makefile
 
 # create zlib.pc with the configure results
-sed < zlib.pc.in "
+sed < $SRCDIR/zlib.pc.in "
 /^CC *=/s#=.*#=$CC#
 /^CFLAGS *=/s#=.*#=$CFLAGS#
 /^LDSHARED *=/s#=.*#=$LDSHARED#


### PR DESCRIPTION
Fixes Dead2/zlib-ng#1
- Adds **SRCDIR** variable to _configure_, and _Makefile.in_ files in root directory and subdirectories.
- _configure_ duplicates directory tree from source directory inside build directory
- _configure_ reads from source directory and writes to build directory preserving the relative path.
