### PR TITLE
Compile with -Wall -Werror

### DIFF
--- a/arch/x86/crc_folding.c
+++ b/arch/x86/crc_folding.c
@@ -285,7 +285,7 @@ ZLIB_INTERNAL void crc_fold_copy(deflate_state *z_const s,
         goto partial;
     }
 
-    algn_diff = 0 - (unsigned long)src & 0xF;
+    algn_diff = (0 - (unsigned long)src) & 0xF;
     if (algn_diff) {
         xmm_crc_part = _mm_loadu_si128((__m128i *)src);
         _mm_storeu_si128((__m128i *)dst, xmm_crc_part);
@@ -418,7 +418,7 @@ unsigned ZLIB_INTERNAL crc_fold_512to32(deflate_state *z_const s)
     z_const __m128i xmm_mask2 = _mm_load_si128((__m128i *)crc_mask2);
 
     unsigned crc;
-    __m128i x_tmp0, x_tmp1, x_tmp2, x_tmp3, crc_fold;
+    __m128i x_tmp0, x_tmp1, x_tmp2, crc_fold;
 
     CRC_LOAD(s)
 

--- a/arch/x86/deflate_quick.c
+++ b/arch/x86/deflate_quick.c
@@ -27,6 +27,9 @@ local inline long compare258(z_const unsigned char *z_const src0,
 
     ax = 16;
     dx = 16;
+    /* set cx to something, otherwise gcc thinks it's used
+       uninitalised */
+    cx = 0;
 
     __asm__ __volatile__ (
     "1:"

--- a/configure
+++ b/configure
@@ -188,7 +188,7 @@ show $cc -c $test.c
 if test "$gcc" -eq 1 && ($cc -c $test.c) >> configure.log 2>&1; then
   echo ... using gcc >> configure.log
   CC="$cc"
-  CFLAGS="${CFLAGS--O3} ${ARCHS}"
+  CFLAGS="${CFLAGS--O3} ${ARCHS} -Wall -Werror"
   SFLAGS="${CFLAGS--O3} -fPIC"
   LDFLAGS="${LDFLAGS} ${ARCHS}"
   if test $build64 -eq 1; then
@@ -197,9 +197,9 @@ if test "$gcc" -eq 1 && ($cc -c $test.c) >> configure.log 2>&1; then
   fi
   if test "${ZLIBGCCWARN}" = "YES"; then
     if test "$zconst" -eq 1; then
-      CFLAGS="${CFLAGS} -Wall -Wextra -Wcast-qual -pedantic -DZLIB_CONST"
+      CFLAGS="${CFLAGS} -Wextra -Wcast-qual -pedantic -DZLIB_CONST"
     else
-      CFLAGS="${CFLAGS} -Wall -Wextra -pedantic"
+      CFLAGS="${CFLAGS} -Wextra -pedantic"
     fi
   fi
   if test -z "$uname"; then

--- a/configure
+++ b/configure
@@ -528,6 +528,7 @@ int main(void)
 {
     unsigned int zero = 0;
     long test = __builtin_ctzl(zero);
+    (void)test;
     return 0;
 }
 EOF
@@ -545,6 +546,7 @@ cat > $test.c << EOF
 int main(void)
 {
     __m128i zero = _mm_setzero_si128();
+    (void)zero;
     return 0;
 }
 EOF
@@ -565,6 +567,7 @@ int main(void)
     __m128i a = _mm_setzero_si128();
     __m128i b = _mm_setzero_si128();
     __m128i c = _mm_clmulepi64_si128(a, b, 0x10);
+    (void)c;
     return 0;
 }
 EOF

--- a/configure
+++ b/configure
@@ -630,7 +630,8 @@ case "${ARCH}" in
             fi
 
 	    # Enable deflate_quick at level 1?
-            if test $without_new_strategies -eq 0; then
+	    # requires SSE2: code uses fill_window_sse
+            if test ${HAVE_SSE2_INTRIN} -eq 1 && test $without_new_strategies -eq 0; then
                 CFLAGS="${CFLAGS} -DX86_QUICK_STRATEGY"
                 SFLAGS="${SFLAGS} -DX86_QUICK_STRATEGY"
 

--- a/deflate.c
+++ b/deflate.c
@@ -213,7 +213,7 @@ local inline Pos insert_string(deflate_state *z_const s, z_const Pos str)
 
 
 #ifndef NOT_TWEAK_COMPILER
-alwaysinline local void 
+local inline void
 bulk_insert_str(deflate_state *s, Pos startpos, uInt count) {
     uInt idx;
     for (idx = 0; idx < count; idx++) {

--- a/zutil.h
+++ b/zutil.h
@@ -98,12 +98,6 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
 #  define inline __inline
 #endif
 
-#if defined(_MSC_VER)
-#  define alwaysinline __forceinline
-#else
-#  define alwaysinline __attribute__ ((always_inline))
-#endif
-
         /* common defaults */
 
 #ifndef OS_CODE


### PR DESCRIPTION
-Wall -Werror should help us to keep code quality up.

This patch set makes it compile and then enforces it in ./configure.
