### PR TITLE
Make 'make' make more magnificently.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -253,7 +253,7 @@ clean:
 	rm -f a.out
 
 maintainer-clean: distclean
-distclean: clean zconf zconf.h.cmakein docs
+distclean: clean zconf zconf.h.cmakein
 	@if [ -f $(ARCHDIR)/Makefile ]; then $(MAKE) -C $(ARCHDIR) distclean; fi
 	rm -f zlib.pc configure.log
 	-@rm -f .DS_Store

--- a/configure
+++ b/configure
@@ -421,9 +421,6 @@ else
   echo "Checking for strerror... No." | tee -a configure.log
 fi
 
-# We need to remove zconf.h from source directory if building outside of it
-if [ "$SRCDIR" != "$BUILDDIR" ]; then rm -f $SRCDIR/zconf.h; fi
-
 # copy clean zconf.h for subsequent edits
 cp -p $SRCDIR/zconf.h.in zconf.h
 
@@ -464,6 +461,10 @@ if test $zprefix -eq 1; then
   echo >> configure.log
   echo "Using z_ prefix on all symbols." | tee -a configure.log
 fi
+
+# take out the error path that makes sure an out of tree build doesn't touch the source tree's zconf.h
+sed < zconf.h 's/#error.*//' > zconf.temp.h
+mv zconf.temp.h zconf.h
 
 # if --solo compilation was requested, save that in zconf.h and remove gz stuff from object lists
 if test $solo -eq 1; then
@@ -742,7 +743,7 @@ sed < $SRCDIR/Makefile.in "
 mkdir -p $ARCHDIR
 
 ARCHINCLUDES="-I$SRCDIR/$ARCHDIR -I$SRCDIR"
-if [ "$SRCDIR" != "$BUILDDIR" ]; then ARCHINCLUDES="${ARCHINCLUDES} -I$BUILDDIR"; fi
+if [ "$SRCDIR" != "$BUILDDIR" ]; then ARCHINCLUDES="-I$BUILDDIR ${ARCHINCLUDES}"; fi
 
 sed < $SRCDIR/$ARCHDIR/Makefile.in "
 /^CC *=/s#=.*#=$CC#

--- a/zconf.h
+++ b/zconf.h
@@ -5,6 +5,8 @@
 
 /* @(#) $Id$ */
 
+#error "Error: unprepared zconf.h included. Build system broken."
+
 #ifndef ZCONF_H
 #define ZCONF_H
 

--- a/zconf.h.cmakein
+++ b/zconf.h.cmakein
@@ -5,6 +5,8 @@
 
 /* @(#) $Id$ */
 
+#error "Error: unprepared zconf.h included. Build system broken."
+
 #ifndef ZCONF_H
 #define ZCONF_H
 #cmakedefine Z_PREFIX

--- a/zconf.h.in
+++ b/zconf.h.in
@@ -5,6 +5,8 @@
 
 /* @(#) $Id$ */
 
+#error "Error: unprepared zconf.h included. Build system broken."
+
 #ifndef ZCONF_H
 #define ZCONF_H
 

--- a/zlib.h
+++ b/zlib.h
@@ -31,7 +31,7 @@
 #ifndef ZLIB_H
 #define ZLIB_H
 
-#include "zconf.h"
+#include <zconf.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
The make fixes for building out of tree were a bit quirky.
- Docs were built as part of distclean.
- Out of tree builds touched zconf.h in SRCDIR. Fix that. It's still a little quirky, but at least it means that building out of tree doesn't dirty the source tree.
