### PR TITLE
Unbreak things: import the right zconf.h

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,8 @@ language: c
 compiler:
   - gcc
   - clang
-script: ./configure && make && make check
+env:
+  - BUILDDIR=. SRCDIR=.
+  - BUILDDIR=../build SRCDIR=../zlib-ng
+script: mkdir -p $BUILDDIR && cd $BUILDDIR &&
+        $SRCDIR/configure && make && make check

--- a/Makefile.in
+++ b/Makefile.in
@@ -152,11 +152,11 @@ minigzip64.o: $(SRCDIR)/test/minigzip.c $(SRCDIR)/zlib.h zconf.h
 .SUFFIXES: .lo
 
 %.o: $(SRCDIR)/%.c
-	$(CC) $(CFLAGS) -c -o $@ $<
+	$(CC) -I. -I$(SRCDIR) $(CFLAGS) -c -o $@ $<
 
 %.lo: $(SRCDIR)/%.c
 	-@mkdir objs 2>/dev/null || test -d objs
-	$(CC) $(SFLAGS) -DPIC -c -o objs/$*.o $<
+	$(CC) -I. -I$(SRCDIR) $(SFLAGS) -DPIC -c -o objs/$*.o $<
 	-@mv objs/$*.o $@
 
 placebo $(SHAREDLIBV): $(PIC_OBJS) libz.a


### PR DESCRIPTION
Previously I imported <zconf.h>. This worked on my box because I had a
system-wide zconf.h. It didn't work on Travis. This should fix that.
