### PR TITLE
Use INCLUDES in root Makefile.in too

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -49,6 +49,7 @@ EXE=
 
 SRCDIR=.
 BSDLIBS=
+INCLUDES=-I$(SRCDIR)
 
 ARCHDIR=arch/generic
 ARCH_STATIC_OBJS=
@@ -132,7 +133,7 @@ test64: all64
 	rm -f $$TMP64
 
 infcover.o: $(SRCDIR)/test/infcover.c $(SRCDIR)/zlib.h zconf.h
-	$(CC) $(CFLAGS) -I. -I$(SRCDIR) -c -o $@ $(SRCDIR)/test/infcover.c
+	$(CC) $(CFLAGS) $(INCLUDES) -c -o $@ $(SRCDIR)/test/infcover.c
 
 infcover: infcover.o libz.a
 	$(CC) $(CFLAGS) -o $@ infcover.o libz.a $(BSDLIBS)
@@ -147,25 +148,25 @@ $(STATICLIB): $(OBJS)
 	-@ ($(RANLIB) $@ || true) >/dev/null 2>&1
 
 example.o: $(SRCDIR)/test/example.c $(SRCDIR)/zlib.h zconf.h
-	$(CC) $(CFLAGS) -I. -I$(SRCDIR) -c -o $@ $(SRCDIR)/test/example.c
+	$(CC) $(CFLAGS) $(INCLUDES) -c -o $@ $(SRCDIR)/test/example.c
 
 minigzip.o: $(SRCDIR)/test/minigzip.c $(SRCDIR)/zlib.h zconf.h
-	$(CC) $(CFLAGS) -I. -I$(SRCDIR) -c -o $@ $(SRCDIR)/test/minigzip.c
+	$(CC) $(CFLAGS) $(INCLUDES) -c -o $@ $(SRCDIR)/test/minigzip.c
 
 example64.o: $(SRCDIR)/test/example.c $(SRCDIR)/zlib.h zconf.h
-	$(CC) $(CFLAGS) -I. -I$(SRCDIR) -D_FILE_OFFSET_BITS=64 -c -o $@ $(SRCDIR)/test/example.c
+	$(CC) $(CFLAGS) $(INCLUDES) -D_FILE_OFFSET_BITS=64 -c -o $@ $(SRCDIR)/test/example.c
 
 minigzip64.o: $(SRCDIR)/test/minigzip.c $(SRCDIR)/zlib.h zconf.h
-	$(CC) $(CFLAGS) -I. -I$(SRCDIR) -D_FILE_OFFSET_BITS=64 -c -o $@ $(SRCDIR)/test/minigzip.c
+	$(CC) $(CFLAGS) $(INCLUDES) -D_FILE_OFFSET_BITS=64 -c -o $@ $(SRCDIR)/test/minigzip.c
 
 .SUFFIXES: .lo
 
 %.o: $(SRCDIR)/%.c
-	$(CC) -I. -I$(SRCDIR) $(CFLAGS) -c -o $@ $<
+	$(CC) $(INCLUDES) $(CFLAGS) -c -o $@ $<
 
 %.lo: $(SRCDIR)/%.c
 	-@mkdir objs 2>/dev/null || test -d objs
-	$(CC) -I. -I$(SRCDIR) $(SFLAGS) -DPIC -c -o objs/$*.o $<
+	$(CC) $(INCLUDES) $(SFLAGS) -DPIC -c -o objs/$*.o $<
 	-@mv objs/$*.o $@
 
 placebo $(SHAREDTARGET): $(PIC_OBJS) $(STATICLIB)

--- a/configure
+++ b/configure
@@ -762,6 +762,10 @@ echo ARCH_STATIC_OBJS = ${ARCH_STATIC_OBJS} >> configure.log
 echo ARCH_SHARED_OBJS = ${ARCH_SHARED_OBJS} >> configure.log
 
 # update Makefile with the configure results
+
+INCLUDES="-I$SRCDIR"
+if [ "$SRCDIR" != "$BUILDDIR" ]; then INCLUDES="-I$BUILDDIR ${INCLUDES}"; fi
+
 sed < $SRCDIR/Makefile.in "
 /^CC *=/s#=.*#=$CC#
 /^CFLAGS *=/s#=.*#=$CFLAGS#
@@ -788,6 +792,7 @@ sed < $SRCDIR/Makefile.in "
 /^mandir *=/s#=.*#=$mandir#
 /^SRCDIR *=/s#=.*#=$SRCDIR#
 /^BSDLIBS *=/s#=.*#=$BSDLIBS#
+/^INCLUDES *=/s#=.*#=$INCLUDES#
 /^OBJC *=/s#=.*#= $OBJC#
 /^PIC_OBJC *=/s#=.*#= $PIC_OBJC#
 /^all: */s#:.*#: $ALL#


### PR DESCRIPTION
This cleans up redundancy when compiling inside source tree.
