### PR TITLE
Enable gzopen_w for Cygwin

### DIFF
--- a/arch/x86/x86.h
+++ b/arch/x86/x86.h
@@ -6,7 +6,11 @@
 #ifndef CPU_H
 #define CPU_H
 
-#define ZLIB_INTERNAL __attribute__((visibility ("hidden")))
+#ifdef HAVE_HIDDEN
+# define ZLIB_INTERNAL __attribute__((visibility ("hidden")))
+#else
+# define ZLIB_INTERNAL
+#endif
 
 extern int x86_cpu_has_sse2;
 extern int x86_cpu_has_sse42;

--- a/gzlib.c
+++ b/gzlib.c
@@ -132,7 +132,7 @@ local gzFile gz_open(const void *path, int fd, const char *mode)
     }
 
     /* save the path name for error messages */
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
     if (fd == -2) {
         len = wcstombs(NULL, path, 0);
         if (len == (size_t)-1)
@@ -146,7 +146,7 @@ local gzFile gz_open(const void *path, int fd, const char *mode)
         free(state);
         return NULL;
     }
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
     if (fd == -2)
         if (len)
             wcstombs(state->path, path, len + 1);
@@ -181,6 +181,8 @@ local gzFile gz_open(const void *path, int fd, const char *mode)
     state->fd = fd > -1 ? fd : (
 #ifdef _WIN32
         fd == -2 ? _wopen(path, oflag, 0666) :
+#elif __CYGWIN__
+        fd == -2 ? open(state->path, oflag, 0666) :
 #endif
         open((const char *)path, oflag, 0666));
     if (state->fd == -1) {

--- a/zlib.h
+++ b/zlib.h
@@ -1735,7 +1735,7 @@ ZEXTERN const z_crc_t * ZEXPORT get_crc_table   (void);
 ZEXTERN int            ZEXPORT inflateUndermine (z_stream *, int);
 ZEXTERN int            ZEXPORT inflateResetKeep (z_stream *);
 ZEXTERN int            ZEXPORT deflateResetKeep (z_stream *);
-#if defined(_WIN32) && defined(WITH_GZFILEOP)
+#if (defined(_WIN32) || defined(__CYGWIN__)) && defined(WITH_GZFILEOP)
 ZEXTERN gzFile         ZEXPORT gzopen_w (const wchar_t *path, const char *mode);
 #endif
 #ifdef WITH_GZFILEOP


### PR DESCRIPTION
This is for ABI compatibility between Visual C++ and Cygwin builds under Windows.
All Windows builds actually convert wide char file names to multi-byte file names, because Cygwin and zlib internally don't use UTF-16 for file names.

Cygwin64 doesn't support **attribute**((visibility ("hidden"))).
