### PR TITLE
Mingw

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -136,13 +136,13 @@ test64: all64
 infcover.o: $(SRCDIR)/test/infcover.c $(SRCDIR)/zlib.h zconf.h
 	$(CC) $(CFLAGS) $(INCLUDES) -c -o $@ $(SRCDIR)/test/infcover.c
 
-infcover: infcover.o $(STATICLIB)
+infcover$(EXE): infcover.o $(STATICLIB)
 	$(CC) $(CFLAGS) -o $@ infcover.o $(STATICLIB) $(BSDLIBS)
 ifneq ($(STRIP),)
 	$(STRIP) $@
 endif
 
-cover: infcover
+cover: infcover$(EXE)
 	rm -f *.gcda
 	./infcover
 	gcov inf*.c

--- a/arch/x86/crc_folding.c
+++ b/arch/x86/crc_folding.c
@@ -285,7 +285,7 @@ ZLIB_INTERNAL void crc_fold_copy(deflate_state *const s,
         goto partial;
     }
 
-    algn_diff = (0 - (unsigned long)src) & 0xF;
+    algn_diff = (0 - (uintptr_t)src) & 0xF;
     if (algn_diff) {
         xmm_crc_part = _mm_loadu_si128((__m128i *)src);
         _mm_storeu_si128((__m128i *)dst, xmm_crc_part);

--- a/arch/x86/deflate_quick.c
+++ b/arch/x86/deflate_quick.c
@@ -22,7 +22,7 @@ extern void flush_pending  (z_stream *strm);
 local inline long compare258(const unsigned char *const src0,
         const unsigned char *const src1)
 {
-    long ax, dx, cx;
+    uintptr_t ax, dx, cx;
     __m128i xmm_src0;
 
     ax = 16;
@@ -152,7 +152,7 @@ local inline Pos quick_insert_string(deflate_state *const s, const Pos str)
         "crc32l (%[window], %[str], 1), %0\n\t"
     : "+r" (h)
     : [window] "r" (s->window),
-      [str] "r" ((long)str)
+      [str] "r" ((uintptr_t)str)
     );
 
     ret = s->head[h & s->hash_mask];

--- a/configure
+++ b/configure
@@ -266,7 +266,7 @@ if test "$gcc" -eq 1 && ($cc -c $test.c) >> configure.log 2>&1; then
         SHAREDLIBV=''
         SHAREDTARGET=$SHAREDLIB
         IMPORTLIB='libz.dll.a'
-        LDSHARED=${LDSHARED-"$cc -shared -Wl,--out-implib,${IMPORTLIB},--version-script,${SRCDIR}/zlib.map"}
+        LDSHARED=${LDSHARED-"$cc -shared -Wl,--out-implib=${IMPORTLIB} -Wl,--version-script=${SRCDIR}/zlib.map"}
         LDSHAREDLIBC=""
         DEFFILE='win32/zlib.def'
         RC='windres'

--- a/test/infcover.c
+++ b/test/infcover.c
@@ -191,7 +191,7 @@ local void mem_used(z_stream *strm, char *prefix)
 {
     struct mem_zone *zone = strm->opaque;
 
-    fprintf(stderr, "%s: %lu allocated\n", prefix, zone->total);
+    fprintf(stderr, "%s: %zu allocated\n", prefix, zone->total);
 }
 
 /* show the high water allocation in bytes */
@@ -199,7 +199,7 @@ local void mem_high(z_stream *strm, char *prefix)
 {
     struct mem_zone *zone = strm->opaque;
 
-    fprintf(stderr, "%s: %lu high water mark\n", prefix, zone->highwater);
+    fprintf(stderr, "%s: %zu high water mark\n", prefix, zone->highwater);
 }
 
 /* release the memory allocation zone -- if there are any surprises, notify */
@@ -224,7 +224,7 @@ local void mem_done(z_stream *strm, char *prefix)
 
     /* issue alerts about anything unexpected */
     if (count || zone->total)
-        fprintf(stderr, "** %s: %lu bytes in %d blocks not freed\n",
+        fprintf(stderr, "** %s: %zu bytes in %d blocks not freed\n",
                 prefix, zone->total, count);
     if (zone->notlifo)
         fprintf(stderr, "** %s: %d frees not LIFO\n", prefix, zone->notlifo);
@@ -378,7 +378,7 @@ local void cover_support(void)
     mem_setup(&strm);
     strm.avail_in = 0;
     strm.next_in = Z_NULL;
-    ret = inflateInit_(&strm, ZLIB_VERSION - 1, (int)sizeof(z_stream));
+    ret = inflateInit_(&strm, ZLIB_VERSION + 1, (int)sizeof(z_stream));
                                                 assert(ret == Z_VERSION_ERROR);
     mem_done(&strm, "wrong version");
 
@@ -449,7 +449,7 @@ local void cover_wrap(void)
 }
 
 /* input and output functions for inflateBack() */
-local unsigned pull(void *desc, unsigned char **buf)
+local unsigned pull(void *desc, const unsigned char **buf)
 {
     static unsigned int next = 0;
     static unsigned char dat[] = {0x63, 0, 2, 0};


### PR DESCRIPTION
- MinGW's make doesn't automatically append .exe to executable targets
- When passing C variables to asm code, all pointer and register variables must be declared as uintptr_t
- test/infcover.c was reading past beginning of variable
- test/infcover.c had wrong signature for pull(), it was missing const qualifier
- test/infcover.c was using wrong printf format character for size_t variables.
