### PR TITLE
Fix ARCH detection when default target of gcc doesn't match uname.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ Testing
 zconf.h
 zconf.h.cmakein
 zconf.h.included
+ztest*
 
 configure.log
 a.out

--- a/configure
+++ b/configure
@@ -199,6 +199,18 @@ show $cc -c $test.c
 if test "$gcc" -eq 1 && ($cc -c $test.c) >> configure.log 2>&1; then
   echo ... using gcc >> configure.log
   CC="$cc"
+# Re-check arch if gcc is a cross-compiler
+  GCC_ARCH=`$CC -dumpmachine | sed 's/-.*//g'`
+  case $GCC_ARCH in
+    i386 | i486 | i586 | i686)
+# Honor user choice if gcc is multilib and 64-bit is requested 
+      if test $build64 -eq 1; then
+        ARCH=x86_64
+      else
+        ARCH=$GCC_ARCH 
+      fi ;;
+    x86_64) ARCH=$GCC_ARCH ;;
+  esac
   CFLAGS="${CFLAGS--O3} ${ARCHS} -Wall"
   SFLAGS="${CFLAGS--O3} -fPIC"
   LDFLAGS="${LDFLAGS} ${ARCHS}"
@@ -271,6 +283,11 @@ if test "$gcc" -eq 1 && ($cc -c $test.c) >> configure.log 2>&1; then
         DEFFILE='win32/zlib.def'
         RC='windres'
         RCFLAGS='--define GCC_WINDRES'
+        if [ "$CC" == "mingw32-gcc" ]; then
+          case $ARCH in
+          i386 | i486 | i586 | i686) RCFLAGS="${RCFLAGS} -F pe-i386";;
+          esac;
+        fi
         RCOBJS='zlibrc.o'
         STRIP='strip'
         EXE='.exe' ;;


### PR DESCRIPTION
On MinGW32 and MinGW64 with original MSYS, "uname -m" always returns "i686" even if default target of gcc is x86_64.

This patch fixes two things:
1. ARCH is derived from "gcc -dumpmachine", which returns default target of gcc
2. windres under MinGW64 with original MSYS defaults to output x86_64 even if using 32-bit version of gcc (mingw32-gcc), if configure detects that current compiler is "mingw32-gcc", we force windres to output pe-i386 format, which is compatible with the 32-bit linker.
