### PR TITLE
snprintf() was added to Visual Studio 2015.

### DIFF
--- a/gzguts.h
+++ b/gzguts.h
@@ -57,7 +57,7 @@
    Microsoft more than a decade later!), _snprintf does not guarantee null
    termination of the result -- however this is only used in gzlib.c where
    the result is assured to fit in the space provided */
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && _MSC_VER < 1900
 #  define snprintf _snprintf
 #endif
 


### PR DESCRIPTION
One of @daxtens commits depended on this commit... I promised to find out in what version of Visual Studio snprintf() is added. 
Tested with Visual Studio 2015 Release Candidate and Software Development Kit for Windows 10 Technology Preview.
