### PR TITLE
Replace (void *)0 with NULL.

### DIFF
--- a/compress.c
+++ b/compress.c
@@ -33,7 +33,7 @@ int ZEXPORT compress2 (unsigned char *dest, uLong *destLen, const unsigned char 
 
     stream.zalloc = (alloc_func)0;
     stream.zfree = (free_func)0;
-    stream.opaque = (void *)0;
+    stream.opaque = NULL;
 
     err = deflateInit(&stream, level);
     if (err != Z_OK) return err;

--- a/deflate.c
+++ b/deflate.c
@@ -267,7 +267,7 @@ int ZEXPORT deflateInit2_(z_stream *strm, int level, int method, int windowBits,
     strm->msg = Z_NULL;
     if (strm->zalloc == (alloc_func)0) {
         strm->zalloc = zcalloc;
-        strm->opaque = (void *)0;
+        strm->opaque = NULL;
     }
     if (strm->zfree == (free_func)0)
         strm->zfree = zcfree;

--- a/infback.c
+++ b/infback.c
@@ -39,7 +39,7 @@ int ZEXPORT inflateBackInit_(z_stream *strm, int windowBits, unsigned char *wind
     strm->msg = Z_NULL;                 /* in case we return an error */
     if (strm->zalloc == (alloc_func)0) {
         strm->zalloc = zcalloc;
-        strm->opaque = (void *)0;
+        strm->opaque = NULL;
     }
     if (strm->zfree == (free_func)0)
     strm->zfree = zcfree;

--- a/inflate.c
+++ b/inflate.c
@@ -184,7 +184,7 @@ int ZEXPORT inflateInit2_(z_stream *strm, int windowBits, const char *version,
     strm->msg = Z_NULL;                 /* in case we return an error */
     if (strm->zalloc == (alloc_func)0) {
         strm->zalloc = zcalloc;
-        strm->opaque = (void *)0;
+        strm->opaque = NULL;
     }
     if (strm->zfree == (free_func)0)
         strm->zfree = zcfree;


### PR DESCRIPTION
Makes no sense to use inconsistently both "(void *)0" and "NULL" when both are equal.
This is most likely relic from old compilers that didn't define NULL.
