### PR TITLE
Continuation of previous patch to add support for Visual Studio 2015.

### DIFF
--- a/test/minigzip.c
+++ b/test/minigzip.c
@@ -34,7 +34,7 @@
 #  define SET_BINARY_MODE(file)
 #endif
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && _MSC_VER < 1900
 #  define snprintf _snprintf
 #endif
 

--- a/zconf.h.in
+++ b/zconf.h.in
@@ -164,7 +164,7 @@ typedef void       *voidp;
 #if !defined(_WIN32) && defined(Z_LARGE64)
 #  define z_off64_t off64_t
 #else
-#  if defined(_WIN32) && !defined(__GNUC__)
+#  if (defined(_WIN32) || defined(WIN32)) && !defined(__GNUC__)
 #    define z_off64_t __int64
 #  else
 #    define z_off64_t z_off_t


### PR DESCRIPTION
- Fixes size of z_off64_t under Windows
- minigzip also uses snprintf() instead of _snprintf() when compiled with VS2015.
