### PR TITLE
fix for preprocessor namespace pollution

### DIFF
--- a/zconf.h.in
+++ b/zconf.h.in
@@ -92,8 +92,8 @@
 #endif
 
 /* Fallback for something that includes us. */
-#define Byte unsigned char
-#define Bytef unsigned char
+typedef unsigned char Byte;
+typedef Byte Bytef;
 
 typedef unsigned int   uInt;  /* 16 bits or more */
 typedef unsigned long  uLong; /* 32 bits or more */


### PR DESCRIPTION
Do not pollute the namespace with a define for byte. This breaks various things. Instead use typedef which was also used in the original version of zlib.conf:

```
#if !defined(__MACTYPES__)
typedef unsigned char  Byte;  /* 8 bits */
#endif
typedef unsigned int   uInt;  /* 16 bits or more */
typedef unsigned long  uLong; /* 32 bits or more */

#ifdef SMALL_MEDIUM
   /* Borland C/C++ and some old MSC versions ignore FAR inside typedef */
#  define Bytef Byte FAR
#else
   typedef Byte  FAR Bytef;
#endif
```
