### PR TITLE
Fix bug that accepted invalid zlib header when windowBits is zero.

### DIFF
--- a/inflate.c
+++ b/inflate.c
@@ -640,9 +640,9 @@ int ZEXPORT inflate(z_stream *strm, int flush) {
             }
             DROPBITS(4);
             len = BITS(4) + 8;
-            if (state->wbits == 0) {
+            if (state->wbits == 0)
                 state->wbits = len;
-            } else if (len > state->wbits) {
+            if (len > 15 || len > state->wbits) {
                 strm->msg = (char *)"invalid window size";
                 state->mode = BAD;
                 break;


### PR DESCRIPTION
When windowBits is zero, the size of the sliding window comes from
the zlib header.  The allowed values of the four-bit field are
0..7, but when windowBits is zero, values greater than 7 are
permitted and acted upon, resulting in large, mostly unused memory
allocations.  This fix rejects such invalid zlib headers.

Cherry-picked from madler/zlib@6cef1de7403b553ce8f7e790e38531da6529f34f
