### PR TITLE
Cleanup

### DIFF
--- a/adler32.c
+++ b/adler32.c
@@ -60,7 +60,7 @@ static uint32_t adler32_combine_(uint32_t adler1, uint32_t adler2, z_off64_t len
 #endif
 
 /* ========================================================================= */
-uint32_t ZEXPORT adler32(uint32_t adler, const unsigned char *buf, uInt len) {
+uint32_t ZEXPORT adler32(uint32_t adler, const unsigned char *buf, uint32_t len) {
     uint32_t sum2;
     unsigned n;
 

--- a/arch/x86/fill_window_sse.c
+++ b/arch/x86/fill_window_sse.c
@@ -21,12 +21,12 @@ ZLIB_INTERNAL void fill_window_sse(deflate_state *s) {
     register unsigned n;
     register Pos *p;
     unsigned more;    /* Amount of free space at the end of the window. */
-    uInt wsize = s->w_size;
+    unsigned int wsize = s->w_size;
 
     Assert(s->lookahead < MIN_LOOKAHEAD, "already enough lookahead");
 
     do {
-        more = (unsigned)(s->window_size -(ulg)s->lookahead -(ulg)s->strstart);
+        more = (unsigned)(s->window_size -(unsigned long)s->lookahead -(unsigned long)s->strstart);
 
         /* Deal with !@#$% 64K limit: */
         if (sizeof(int) <= 2) {
@@ -105,7 +105,7 @@ ZLIB_INTERNAL void fill_window_sse(deflate_state *s) {
 
         /* Initialize the hash value now that we have some input: */
         if (s->lookahead + s->insert >= MIN_MATCH) {
-            uInt str = s->strstart - s->insert;
+            unsigned int str = s->strstart - s->insert;
             s->ins_h = s->window[str];
             if (str >= 1)
                 UPDATE_HASH(s, s->ins_h, str + 1 - (MIN_MATCH-1));
@@ -135,8 +135,8 @@ ZLIB_INTERNAL void fill_window_sse(deflate_state *s) {
      * routines allow scanning to strstart + MAX_MATCH, ignoring lookahead.
      */
     if (s->high_water < s->window_size) {
-        ulg curr = s->strstart + (ulg)(s->lookahead);
-        ulg init;
+        unsigned long curr = s->strstart + (unsigned long)(s->lookahead);
+        unsigned long init;
 
         if (s->high_water < curr) {
             /* Previous high water mark below current data -- zero WIN_INIT
@@ -147,12 +147,12 @@ ZLIB_INTERNAL void fill_window_sse(deflate_state *s) {
                 init = WIN_INIT;
             memset(s->window + curr, 0, (unsigned)init);
             s->high_water = curr + init;
-        } else if (s->high_water < (ulg)curr + WIN_INIT) {
+        } else if (s->high_water < (unsigned long)curr + WIN_INIT) {
             /* High water mark at or above current data, but below current data
              * plus WIN_INIT -- zero out to current data plus WIN_INIT, or up
              * to end of window, whichever is less.
              */
-            init = (ulg)curr + WIN_INIT - s->high_water;
+            init = (unsigned long)curr + WIN_INIT - s->high_water;
             if (init > s->window_size - s->high_water)
                 init = s->window_size - s->high_water;
             memset(s->window + s->high_water, 0, (unsigned)init);
@@ -160,6 +160,6 @@ ZLIB_INTERNAL void fill_window_sse(deflate_state *s) {
         }
     }
 
-    Assert((ulg)s->strstart <= s->window_size - MIN_LOOKAHEAD, "not enough room for search");
+    Assert((unsigned long)s->strstart <= s->window_size - MIN_LOOKAHEAD, "not enough room for search");
 }
 #endif

--- a/compress.c
+++ b/compress.c
@@ -19,12 +19,12 @@
    memory, Z_BUF_ERROR if there was not enough room in the output buffer,
    Z_STREAM_ERROR if the level parameter is invalid.
 */
-int ZEXPORT compress2(unsigned char *dest, unsigned long *destLen, const unsigned char *source,
-                        unsigned long sourceLen, int level) {
+int ZEXPORT compress2(unsigned char *dest, size_t *destLen, const unsigned char *source,
+                        size_t sourceLen, int level) {
     z_stream stream;
     int err;
     const unsigned int max = (unsigned int)0 - 1;
-    unsigned long left;
+    size_t left;
 
     left = *destLen;
     *destLen = 0;
@@ -61,7 +61,7 @@ int ZEXPORT compress2(unsigned char *dest, unsigned long *destLen, const unsigne
 
 /* ===========================================================================
  */
-int ZEXPORT compress(unsigned char *dest, unsigned long *destLen, const unsigned char *source, unsigned long sourceLen) {
+int ZEXPORT compress(unsigned char *dest, size_t *destLen, const unsigned char *source, size_t sourceLen) {
     return compress2(dest, destLen, source, sourceLen, Z_DEFAULT_COMPRESSION);
 }
 
@@ -69,6 +69,6 @@ int ZEXPORT compress(unsigned char *dest, unsigned long *destLen, const unsigned
    If the default memLevel or windowBits for deflateInit() is changed, then
    this function needs to be updated.
  */
-unsigned long ZEXPORT compressBound(unsigned long sourceLen) {
+size_t ZEXPORT compressBound(size_t sourceLen) {
     return sourceLen + (sourceLen >> 12) + (sourceLen >> 14) + (sourceLen >> 25) + 13;
 }

--- a/compress.c
+++ b/compress.c
@@ -1,5 +1,5 @@
 /* compress.c -- compress a memory buffer
- * Copyright (C) 1995-2005, 2014 Jean-loup Gailly, Mark Adler
+ * Copyright (C) 1995-2005, 2014 Jean-loup Gailly, Mark Adler.
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
@@ -19,12 +19,12 @@
    memory, Z_BUF_ERROR if there was not enough room in the output buffer,
    Z_STREAM_ERROR if the level parameter is invalid.
 */
-int ZEXPORT compress2(unsigned char *dest, uLong *destLen, const unsigned char *source,
-                        uLong sourceLen, int level) {
+int ZEXPORT compress2(unsigned char *dest, unsigned long *destLen, const unsigned char *source,
+                        unsigned long sourceLen, int level) {
     z_stream stream;
     int err;
-    const uInt max = (uInt)0 - 1;
-    uLong left;
+    const unsigned int max = (unsigned int)0 - 1;
+    unsigned long left;
 
     left = *destLen;
     *destLen = 0;
@@ -44,11 +44,11 @@ int ZEXPORT compress2(unsigned char *dest, uLong *destLen, const unsigned char *
 
     do {
         if (stream.avail_out == 0) {
-            stream.avail_out = left > (uLong)max ? max : (uInt)left;
+            stream.avail_out = left > (unsigned long)max ? max : (unsigned int)left;
             left -= stream.avail_out;
         }
         if (stream.avail_in == 0) {
-            stream.avail_in = sourceLen > (uLong)max ? max : (uInt)sourceLen;
+            stream.avail_in = sourceLen > (unsigned long)max ? max : (unsigned int)sourceLen;
             sourceLen -= stream.avail_in;
         }
         err = deflate(&stream, sourceLen ? Z_NO_FLUSH : Z_FINISH);
@@ -61,15 +61,14 @@ int ZEXPORT compress2(unsigned char *dest, uLong *destLen, const unsigned char *
 
 /* ===========================================================================
  */
-int ZEXPORT compress(unsigned char *dest, uLong *destLen, const unsigned char *source, uLong sourceLen) {
+int ZEXPORT compress(unsigned char *dest, unsigned long *destLen, const unsigned char *source, unsigned long sourceLen) {
     return compress2(dest, destLen, source, sourceLen, Z_DEFAULT_COMPRESSION);
 }
 
 /* ===========================================================================
-     If the default memLevel or windowBits for deflateInit() is changed, then
+   If the default memLevel or windowBits for deflateInit() is changed, then
    this function needs to be updated.
  */
-uLong ZEXPORT compressBound(uLong sourceLen) {
-    return sourceLen + (sourceLen >> 12) + (sourceLen >> 14) +
-           (sourceLen >> 25) + 13;
+unsigned long ZEXPORT compressBound(unsigned long sourceLen) {
+    return sourceLen + (sourceLen >> 12) + (sourceLen >> 14) + (sourceLen >> 25) + 13;
 }

--- a/crc32.c
+++ b/crc32.c
@@ -13,7 +13,7 @@
 
 #ifdef __MINGW32__
 # include <sys/param.h>
-#elif _WIN32
+#elif defined(WIN32) || defined(_WIN32)
 # define LITTLE_ENDIAN 1234
 # define BIG_ENDIAN 4321
 # if defined(_M_IX86) || defined(_M_AMD64) || defined(_M_IA64)
@@ -49,9 +49,9 @@
 #include "deflate.h"
 
 #if BYTE_ORDER == LITTLE_ENDIAN
-static uint32_t crc32_little(uint32_t, const unsigned char *, unsigned);
+static uint32_t crc32_little(uint32_t, const unsigned char *, z_off64_t);
 #elif BYTE_ORDER == BIG_ENDIAN
-static uint32_t crc32_big(uint32_t, const unsigned char *, unsigned);
+static uint32_t crc32_big(uint32_t, const unsigned char *, z_off64_t);
 #endif
 
 /* Local functions for crc concatenation */
@@ -196,7 +196,7 @@ const uint32_t * ZEXPORT get_crc_table(void) {
 #define DO4 DO1; DO1; DO1; DO1
 
 /* ========================================================================= */
-uint32_t ZEXPORT crc32(uint32_t crc, const unsigned char *buf, uInt len) {
+uint32_t ZEXPORT crc32(uint32_t crc, const unsigned char *buf, z_off64_t len) {
     if (buf == Z_NULL) return 0;
 
 #ifdef DYNAMIC_CRC_TABLE
@@ -240,7 +240,7 @@ uint32_t ZEXPORT crc32(uint32_t crc, const unsigned char *buf, uInt len) {
 #define DOLIT32 DOLIT4; DOLIT4; DOLIT4; DOLIT4; DOLIT4; DOLIT4; DOLIT4; DOLIT4
 
 /* ========================================================================= */
-static uint32_t crc32_little(uint32_t crc, const unsigned char *buf, unsigned len) {
+static uint32_t crc32_little(uint32_t crc, const unsigned char *buf, z_off64_t len) {
     register uint32_t c;
     register const uint32_t *buf4;
 
@@ -282,7 +282,7 @@ static uint32_t crc32_little(uint32_t crc, const unsigned char *buf, unsigned le
 #define DOBIG32 DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4
 
 /* ========================================================================= */
-static uint32_t crc32_big(uint32_t crc, const unsigned char *buf, unsigned len) {
+static uint32_t crc32_big(uint32_t crc, const unsigned char *buf, z_off64_t len) {
     register uint32_t c;
     register const uint32_t *buf4;
 

--- a/deflate.h
+++ b/deflate.h
@@ -100,17 +100,17 @@ typedef unsigned IPos;
  */
 
 typedef struct internal_state {
-    z_stream *strm;      /* pointer back to this zlib stream */
-    int   status;        /* as the name implies */
-    unsigned char *pending_buf;  /* output still pending */
-    ulg   pending_buf_size; /* size of pending_buf */
-    unsigned char *pending_out;  /* next pending byte to output to the stream */
-    uInt   pending;      /* nb of bytes in the pending buffer */
-    int   wrap;          /* bit 0 true for zlib, bit 1 true for gzip */
-    gz_headerp  gzhead;  /* gzip header information to write */
-    uInt   gzindex;      /* where in extra, name, or comment */
-    unsigned char  method;        /* can only be DEFLATED */
-    int   last_flush;    /* value of flush param for previous deflate call */
+    z_stream      *strm;             /* pointer back to this zlib stream */
+    int           status;            /* as the name implies */
+    unsigned char *pending_buf;      /* output still pending */
+    unsigned long pending_buf_size;  /* size of pending_buf */
+    unsigned char *pending_out;      /* next pending byte to output to the stream */
+    unsigned int  pending;           /* nb of bytes in the pending buffer */
+    int           wrap;              /* bit 0 true for zlib, bit 1 true for gzip */
+    gz_headerp    gzhead;            /* gzip header information to write */
+    unsigned int  gzindex;           /* where in extra, name, or comment */
+    unsigned char method;            /* can only be DEFLATED */
+    int           last_flush;        /* value of flush param for previous deflate call */
 
 #ifdef X86_PCLMULQDQ_CRC
     unsigned ALIGNED_(16) crc0[4 * 5];
@@ -118,9 +118,9 @@ typedef struct internal_state {
 
                 /* used by deflate.c: */
 
-    uInt  w_size;        /* LZ77 window size (32K by default) */
-    uInt  w_bits;        /* log2(w_size)  (8..16) */
-    uInt  w_mask;        /* w_size - 1 */
+    unsigned int  w_size;            /* LZ77 window size (32K by default) */
+    unsigned int  w_bits;            /* log2(w_size)  (8..16) */
+    unsigned int  w_mask;            /* w_size - 1 */
 
     unsigned char *window;
     /* Sliding window. Input bytes are read into the second half of the window,
@@ -132,7 +132,7 @@ typedef struct internal_state {
      * To do: use the user input buffer as sliding window.
      */
 
-    ulg window_size;
+    unsigned long window_size;
     /* Actual size of window: 2*wSize, except when the user input buffer
      * is directly used as sliding window.
      */
@@ -145,12 +145,12 @@ typedef struct internal_state {
 
     Pos *head; /* Heads of the hash chains or NIL. */
 
-    uInt  ins_h;          /* hash index of string to be inserted */
-    uInt  hash_size;      /* number of elements in hash table */
-    uInt  hash_bits;      /* log2(hash_size) */
-    uInt  hash_mask;      /* hash_size-1 */
+    unsigned int  ins_h;             /* hash index of string to be inserted */
+    unsigned int  hash_size;         /* number of elements in hash table */
+    unsigned int  hash_bits;         /* log2(hash_size) */
+    unsigned int  hash_mask;         /* hash_size-1 */
 
-    uInt  hash_shift;
+    unsigned int  hash_shift;
     /* Number of bits by which ins_h must be shifted at each input
      * step. It must be such that after MIN_MATCH steps, the oldest
      * byte no longer takes part in the hash key, that is:
@@ -162,25 +162,25 @@ typedef struct internal_state {
      * negative when the window is moved backwards.
      */
 
-    uInt match_length;           /* length of best match */
-    IPos prev_match;             /* previous match */
-    int match_available;         /* set if previous match exists */
-    uInt strstart;               /* start of string to insert */
-    uInt match_start;            /* start of matching string */
-    uInt lookahead;              /* number of valid bytes ahead in window */
+    unsigned int match_length;       /* length of best match */
+    IPos         prev_match;         /* previous match */
+    int          match_available;    /* set if previous match exists */
+    unsigned int strstart;           /* start of string to insert */
+    unsigned int match_start;        /* start of matching string */
+    unsigned int lookahead;          /* number of valid bytes ahead in window */
 
-    uInt prev_length;
+    unsigned int prev_length;
     /* Length of the best match at previous step. Matches not greater than this
      * are discarded. This is used in the lazy match evaluation.
      */
 
-    uInt max_chain_length;
+    unsigned int max_chain_length;
     /* To speed up deflation, hash chains are never searched beyond this
      * length.  A higher limit improves compression ratio but degrades the
      * speed.
      */
 
-    uInt max_lazy_match;
+    unsigned int max_lazy_match;
     /* Attempt to find a better match only when the current match is strictly
      * smaller than this value. This mechanism is used only for compression
      * levels >= 4.
@@ -194,7 +194,7 @@ typedef struct internal_state {
     int level;    /* compression level (1..9) */
     int strategy; /* favor or force Huffman coding*/
 
-    uInt good_match;
+    unsigned int good_match;
     /* Use a faster search when the previous match is longer than this */
 
     int nice_match; /* Stop searching when current match exceeds this */
@@ -223,9 +223,9 @@ typedef struct internal_state {
     /* Depth of each subtree used as tie breaker for trees of equal frequency
      */
 
-    unsigned char *l_buf;          /* buffer for literals or lengths */
+    unsigned char *l_buf;       /* buffer for literals or lengths */
 
-    uInt  lit_bufsize;
+    unsigned int  lit_bufsize;
     /* Size of match buffer for literals/lengths.  There are 4 reasons for
      * limiting lit_bufsize to 64K:
      *   - frequencies can be kept in 16 bit counters
@@ -245,7 +245,7 @@ typedef struct internal_state {
      *   - I can't count above 4
      */
 
-    uInt last_lit;      /* running index in l_buf */
+    unsigned int last_lit;        /* running index in l_buf */
 
     uint16_t *d_buf;
     /* Buffer for distances. To simplify the code, d_buf and l_buf have
@@ -253,14 +253,14 @@ typedef struct internal_state {
      * array would be necessary.
      */
 
-    ulg opt_len;        /* bit length of current block with optimal trees */
-    ulg static_len;     /* bit length of current block with static trees */
-    uInt matches;       /* number of string matches in current block */
-    uInt insert;        /* bytes at end of window left to insert */
+    unsigned long opt_len;        /* bit length of current block with optimal trees */
+    unsigned long static_len;     /* bit length of current block with static trees */
+    unsigned int matches;         /* number of string matches in current block */
+    unsigned int insert;          /* bytes at end of window left to insert */
 
 #ifdef DEBUG
-    ulg compressed_len; /* total bit length of compressed file mod 2^32 */
-    ulg bits_sent;      /* bit length of compressed data sent mod 2^32 */
+    unsigned long compressed_len; /* total bit length of compressed file mod 2^32 */
+    unsigned long bits_sent;      /* bit length of compressed data sent mod 2^32 */
 #endif
 
     uint16_t bi_buf;
@@ -272,7 +272,7 @@ typedef struct internal_state {
      * are always zero.
      */
 
-    ulg high_water;
+    unsigned long high_water;
     /* High water mark offset in window for initialized bytes -- bytes above
      * this are set to zero in order to avoid memory check warnings when
      * longest match routines access bytes past the input.  This is then
@@ -334,10 +334,10 @@ typedef enum {
         /* in trees.c */
 void ZLIB_INTERNAL _tr_init(deflate_state *s);
 int ZLIB_INTERNAL _tr_tally(deflate_state *s, unsigned dist, unsigned lc);
-void ZLIB_INTERNAL _tr_flush_block(deflate_state *s, char *buf, ulg stored_len, int last);
+void ZLIB_INTERNAL _tr_flush_block(deflate_state *s, char *buf, unsigned long stored_len, int last);
 void ZLIB_INTERNAL _tr_flush_bits(deflate_state *s);
 void ZLIB_INTERNAL _tr_align(deflate_state *s);
-void ZLIB_INTERNAL _tr_stored_block(deflate_state *s, char *buf, ulg stored_len, int last);
+void ZLIB_INTERNAL _tr_stored_block(deflate_state *s, char *buf, unsigned long stored_len, int last);
 void ZLIB_INTERNAL bi_windup(deflate_state *s);
 
 #define d_code(dist) ((dist) < 256 ? _dist_code[dist] : _dist_code[256+((dist)>>7)])
@@ -424,7 +424,7 @@ void ZLIB_INTERNAL bi_windup(deflate_state *s);
 local void send_bits(deflate_state *s, int value, int length) {
     Tracevv((stderr, " l %2d v %4x ", length, value));
     Assert(length > 0 && length <= 15, "invalid length");
-    s->bits_sent += (ulg)length;
+    s->bits_sent += (unsigned long)length;
 
     /* If not enough room in bi_buf, use (valid) bits from bi_buf and
      * (16 - bi_valid) bits from value, leaving (width - (16-bi_valid))

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -12,10 +12,10 @@
 #include "match.h"
 
 struct match {
-    uInt match_start;
-    uInt match_length;
-    uInt strstart;
-    uInt orgstart;
+    unsigned int match_start;
+    unsigned int match_length;
+    unsigned int strstart;
+    unsigned int orgstart;
 };
 
 #define MAX_DIST2  ((1 << MAX_WBITS) - MIN_LOOKAHEAD)

--- a/gzguts.h
+++ b/gzguts.h
@@ -27,11 +27,11 @@
 #include <fcntl.h>
 #include "zlib.h"
 
-#ifdef _WIN32
+#ifdef WIN32
 #  include <stddef.h>
 #endif
 
-#if defined(_MSC_VER) || defined(_WIN32)
+#if defined(_MSC_VER) || defined(WIN32)
 #  include <io.h>
 #endif
 

--- a/gzlib.c
+++ b/gzlib.c
@@ -5,7 +5,7 @@
 
 #include "gzguts.h"
 
-#if defined(_WIN32) && !defined(__BORLANDC__)
+#if defined(WIN32) && !defined(__BORLANDC__)
 #  define LSEEK _lseeki64
 #else
 #if defined(_LARGEFILE64_SOURCE) && _LFS64_LARGEFILE-0
@@ -178,7 +178,7 @@ local gzFile gz_open(const void *path, int fd, const char *mode) {
 
     /* open the file with the appropriate flags (or just use fd) */
     state->fd = fd > -1 ? fd : (
-#if defined(_WIN32) || defined(__MINGW__)
+#if defined(WIN32) || defined(__MINGW__)
         fd == -2 ? _wopen(path, oflag, 0666) :
 #elif __CYGWIN__
         fd == -2 ? open(state->path, oflag, 0666) :

--- a/inffast.h
+++ b/inffast.h
@@ -10,6 +10,6 @@
    subject to change. Applications should only use zlib.h.
  */
 
-void ZLIB_INTERNAL inflate_fast(z_stream *strm, unsigned start);
+void ZLIB_INTERNAL inflate_fast(z_stream *strm, unsigned long start);
 
 #endif /* INFFAST_H_ */

--- a/inflate.c
+++ b/inflate.c
@@ -1337,7 +1337,7 @@ local unsigned syncsearch(uint32_t *have, const unsigned char *buf, uint32_t len
 
 int ZEXPORT inflateSync(z_stream *strm) {
     unsigned len;               /* number of bytes to look at or looked at */
-    unsigned long in, out;      /* temporary to save total_in and total_out */
+    size_t in, out;             /* temporary to save total_in and total_out */
     unsigned char buf[4];       /* to restore bit buffer to byte string */
     struct inflate_state *state;
 

--- a/inflate.c
+++ b/inflate.c
@@ -93,11 +93,11 @@
 
 /* function prototypes */
 local void fixedtables(struct inflate_state *state);
-local int updatewindow(z_stream *strm, const unsigned char *end, unsigned copy);
+local int updatewindow(z_stream *strm, const unsigned char *end, uint32_t copy);
 #ifdef BUILDFIXED
     void makefixed(void);
 #endif
-local unsigned syncsearch(unsigned *have, const unsigned char *buf, unsigned len);
+local uint32_t syncsearch(uint32_t *have, const unsigned char *buf, uint32_t len);
 
 int ZEXPORT inflateResetKeep(z_stream *strm) {
     struct inflate_state *state;
@@ -350,9 +350,9 @@ void makefixed(void) {
    output will fall in the output data, making match copies simpler and faster.
    The advantage may be dependent on the size of the processor's data caches.
  */
-local int updatewindow(z_stream *strm, const unsigned char *end, unsigned copy) {
+local int updatewindow(z_stream *strm, const unsigned char *end, uint32_t copy) {
     struct inflate_state *state;
-    unsigned dist;
+    uint32_t dist;
 
     state = (struct inflate_state *)strm->state;
 
@@ -460,7 +460,7 @@ local int updatewindow(z_stream *strm, const unsigned char *end, unsigned copy) 
     do { \
         if (have == 0) goto inf_leave; \
         have--; \
-        hold += (unsigned long)(*next++) << bits; \
+        hold += (*next++ << bits); \
         bits += 8; \
     } while (0)
 
@@ -474,7 +474,7 @@ local int updatewindow(z_stream *strm, const unsigned char *end, unsigned copy) 
 
 /* Return the low n bits of the bit accumulator (n < 16) */
 #define BITS(n) \
-    ((unsigned)hold & ((1U << (n)) - 1))
+    (hold & ((1U << (n)) - 1))
 
 /* Remove n bits from the bit accumulator */
 #define DROPBITS(n) \
@@ -574,14 +574,14 @@ local int updatewindow(z_stream *strm, const unsigned char *end, unsigned copy) 
 
 int ZEXPORT inflate(z_stream *strm, int flush) {
     struct inflate_state *state;
-    const unsigned char *next;    /* next input */
-    unsigned char *put;     /* next output */
+    const unsigned char *next;  /* next input */
+    unsigned char *put;         /* next output */
     unsigned have, left;        /* available input and output */
-    unsigned long hold;         /* bit buffer */
+    uint32_t hold;              /* bit buffer */
     unsigned bits;              /* bits in bit buffer */
-    unsigned in, out;           /* save starting available input and output */
+    uint32_t in, out;           /* save starting available input and output */
     unsigned copy;              /* number of stored or match bytes to copy */
-    unsigned char *from;    /* where to copy match bytes from */
+    unsigned char *from;        /* where to copy match bytes from */
     code here;                  /* current decoding table entry */
     code last;                  /* parent table entry */
     unsigned len;               /* length to copy for repeats, bits to drop */
@@ -694,9 +694,9 @@ int ZEXPORT inflate(z_stream *strm, int flush) {
         case EXLEN:
             if (state->flags & 0x0400) {
                 NEEDBITS(16);
-                state->length = (unsigned)(hold);
+                state->length = (uint16_t)hold;
                 if (state->head != Z_NULL)
-                    state->head->extra_len = (unsigned)hold;
+                    state->head->extra_len = (uint16_t)hold;
                 if (state->flags & 0x0200)
                     CRC2(state->check, hold);
                 INITBITS();
@@ -842,7 +842,7 @@ int ZEXPORT inflate(z_stream *strm, int flush) {
                 state->mode = BAD;
                 break;
             }
-            state->length = (unsigned)hold & 0xffff;
+            state->length = (uint16_t)hold;
             Tracev((stderr, "inflate:       stored length %u\n", state->length));
             INITBITS();
             state->mode = COPY_;
@@ -909,7 +909,7 @@ int ZEXPORT inflate(z_stream *strm, int flush) {
             while (state->have < state->nlen + state->ndist) {
                 for (;;) {
                     here = state->lencode[BITS(state->lenbits)];
-                    if ((unsigned)(here.bits) <= bits) break;
+                    if (here.bits <= bits) break;
                     PULLBYTE();
                 }
                 if (here.val < 16) {
@@ -1000,7 +1000,7 @@ int ZEXPORT inflate(z_stream *strm, int flush) {
             state->back = 0;
             for (;;) {
                 here = state->lencode[BITS(state->lenbits)];
-                if ((unsigned)(here.bits) <= bits)
+                if (here.bits <= bits)
                     break;
                 PULLBYTE();
             }
@@ -1008,7 +1008,7 @@ int ZEXPORT inflate(z_stream *strm, int flush) {
                 last = here;
                 for (;;) {
                     here = state->lencode[last.val + (BITS(last.bits + last.op) >> last.bits)];
-                    if ((unsigned)(last.bits + here.bits) <= bits)
+                    if ((unsigned)last.bits + (unsigned)here.bits <= bits)
                         break;
                     PULLBYTE();
                 }
@@ -1017,7 +1017,7 @@ int ZEXPORT inflate(z_stream *strm, int flush) {
             }
             DROPBITS(here.bits);
             state->back += here.bits;
-            state->length = (unsigned)here.val;
+            state->length = here.val;
             if ((int)(here.op) == 0) {
                 Tracevv((stderr, here.val >= 0x20 && here.val < 0x7f ?
                         "inflate:         literal '%c'\n" :
@@ -1036,7 +1036,7 @@ int ZEXPORT inflate(z_stream *strm, int flush) {
                 state->mode = BAD;
                 break;
             }
-            state->extra = (unsigned)(here.op) & 15;
+            state->extra = (here.op & 15);
             state->mode = LENEXT;
         case LENEXT:
             if (state->extra) {
@@ -1051,7 +1051,7 @@ int ZEXPORT inflate(z_stream *strm, int flush) {
         case DIST:
             for (;;) {
                 here = state->distcode[BITS(state->distbits)];
-                if ((unsigned)(here.bits) <= bits)
+                if (here.bits <= bits)
                     break;
                 PULLBYTE();
             }
@@ -1059,7 +1059,7 @@ int ZEXPORT inflate(z_stream *strm, int flush) {
                 last = here;
                 for (;;) {
                     here = state->distcode[last.val + (BITS(last.bits + last.op) >> last.bits)];
-                    if ((unsigned)(last.bits + here.bits) <= bits)
+                    if ((unsigned)last.bits + (unsigned)here.bits <= bits)
                         break;
                     PULLBYTE();
                 }
@@ -1073,8 +1073,8 @@ int ZEXPORT inflate(z_stream *strm, int flush) {
                 state->mode = BAD;
                 break;
             }
-            state->offset = (unsigned)here.val;
-            state->extra = (unsigned)(here.op) & 15;
+            state->offset = here.val;
+            state->extra = (here.op & 15);
             state->mode = DISTEXT;
         case DISTEXT:
             if (state->extra) {
@@ -1239,7 +1239,7 @@ int ZEXPORT inflateEnd(z_stream *strm) {
     return Z_OK;
 }
 
-int ZEXPORT inflateGetDictionary(z_stream *strm, unsigned char *dictionary, uInt *dictLength) {
+int ZEXPORT inflateGetDictionary(z_stream *strm, unsigned char *dictionary, unsigned int *dictLength) {
     struct inflate_state *state;
 
     /* check state */
@@ -1257,7 +1257,7 @@ int ZEXPORT inflateGetDictionary(z_stream *strm, unsigned char *dictionary, uInt
     return Z_OK;
 }
 
-int ZEXPORT inflateSetDictionary(z_stream *strm, const unsigned char *dictionary, uInt dictLength) {
+int ZEXPORT inflateSetDictionary(z_stream *strm, const unsigned char *dictionary, unsigned int dictLength) {
     struct inflate_state *state;
     unsigned long dictid;
     int ret;
@@ -1316,9 +1316,9 @@ int ZEXPORT inflateGetHeader(z_stream *strm, gz_headerp head) {
    called again with more data and the *have state.  *have is initialized to
    zero for the first call.
  */
-local unsigned syncsearch(unsigned *have, const unsigned char *buf, unsigned len) {
-    unsigned got;
-    unsigned next;
+local unsigned syncsearch(uint32_t *have, const unsigned char *buf, uint32_t len) {
+    uint32_t got;
+    uint32_t next;
 
     got = *have;
     next = 0;

--- a/inflate.h
+++ b/inflate.h
@@ -93,28 +93,28 @@ struct inflate_state {
     gz_headerp head;            /* where to save gzip header information */
         /* sliding window */
     unsigned wbits;             /* log base 2 of requested window size */
-    unsigned wsize;             /* window size or zero if not using window */
-    unsigned whave;             /* valid bytes in the window */
-    unsigned wnext;             /* window write index */
-    unsigned char *window;  /* allocated sliding window, if needed */
+    uint32_t wsize;             /* window size or zero if not using window */
+    uint32_t whave;             /* valid bytes in the window */
+    uint32_t wnext;             /* window write index */
+    unsigned char *window;      /* allocated sliding window, if needed */
         /* bit accumulator */
-    unsigned long hold;         /* input bit accumulator */
+    uint32_t hold;              /* input bit accumulator */
     unsigned bits;              /* number of bits in "in" */
         /* for string and stored block copying */
-    unsigned length;            /* literal or length of data to copy */
+    uint32_t length;            /* literal or length of data to copy */
     unsigned offset;            /* distance back to copy string from */
         /* for table and code decoding */
     unsigned extra;             /* extra bits needed */
         /* fixed and dynamic code tables */
-    code const *lencode;    /* starting table for length/literal codes */
-    code const *distcode;   /* starting table for distance codes */
+    code const *lencode;        /* starting table for length/literal codes */
+    code const *distcode;       /* starting table for distance codes */
     unsigned lenbits;           /* index bits for lencode */
     unsigned distbits;          /* index bits for distcode */
         /* dynamic table building */
     unsigned ncode;             /* number of code length code lengths */
     unsigned nlen;              /* number of length code lengths */
     unsigned ndist;             /* number of distance code lengths */
-    unsigned have;              /* number of code lengths in lens[] */
+    uint32_t have;              /* number of code lengths in lens[] */
     code *next;                 /* next available space in codes[] */
     uint16_t lens[320];         /* temporary storage for code lengths */
     uint16_t work[288];         /* work area for code table building */

--- a/match.c
+++ b/match.c
@@ -76,7 +76,7 @@ ZLIB_INTERNAL unsigned longest_match(deflate_state *const s, IPos cur_match) {
      * Do not looks for matches beyond the end of the input. This is
      * necessary to make deflate deterministic
      */
-    nice_match = (uInt)s->nice_match > s->lookahead ? s->lookahead : s->nice_match;
+    nice_match = (unsigned int)s->nice_match > s->lookahead ? s->lookahead : s->nice_match;
 
     /*
      * Stop when cur_match becomes <= limit. To simplify the code,
@@ -194,7 +194,7 @@ ZLIB_INTERNAL unsigned longest_match(deflate_state *const s, IPos cur_match) {
      * Do not looks for matches beyond the end of the input. This is
      * necessary to make deflate deterministic
      */
-    nice_match = (uInt)s->nice_match > s->lookahead ? s->lookahead : s->nice_match;
+    nice_match = (unsigned int)s->nice_match > s->lookahead ? s->lookahead : s->nice_match;
 
     /*
      * Stop when cur_match becomes <= limit. To simplify the code,
@@ -290,7 +290,7 @@ ZLIB_INTERNAL unsigned longest_match(deflate_state *const s, IPos cur_match) {
  * then-clause of the "#ifdef UNALIGNED_OK"-directive)
  *
  * ------------------------------------------------------------
- * uInt longest_match(...) {
+ * unsigned int longest_match(...) {
  *    ...
  *    do {
  *        match = s->window + cur_match;                //s0
@@ -359,7 +359,7 @@ ZLIB_INTERNAL unsigned longest_match(deflate_state *const s, IPos cur_match) {
      * we prevent matches with the string of window index 0.
      */
     Pos *prev = s->prev;
-    uInt wmask = s->w_mask;
+    unsigned int wmask = s->w_mask;
 
     register unsigned char *strend = s->window + s->strstart + MAX_MATCH;
     register uint16_t scan_start = *(uint16_t*)scan;
@@ -377,9 +377,9 @@ ZLIB_INTERNAL unsigned longest_match(deflate_state *const s, IPos cur_match) {
     /* Do not look for matches beyond the end of the input. This is necessary
      * to make deflate deterministic.
      */
-    if ((uInt)nice_match > s->lookahead) nice_match = s->lookahead;
+    if ((unsigned int)nice_match > s->lookahead) nice_match = s->lookahead;
 
-    Assert((ulg)s->strstart <= s->window_size-MIN_LOOKAHEAD, "need lookahead");
+    Assert((unsigned long)s->strstart <= s->window_size-MIN_LOOKAHEAD, "need lookahead");
 
     do {
         Assert(cur_match < s->strstart, "no future");
@@ -464,8 +464,8 @@ ZLIB_INTERNAL unsigned longest_match(deflate_state *const s, IPos cur_match) {
         }
     } while ((cur_match = prev[cur_match & wmask]) > limit && --chain_length != 0);
 
-    if ((uInt)best_len <= s->lookahead)
-        return (uInt)best_len;
+    if ((unsigned int)best_len <= s->lookahead)
+        return (unsigned int)best_len;
     return s->lookahead;
 }
 #endif

--- a/match.h
+++ b/match.h
@@ -1,6 +1,6 @@
 #ifndef MATCH_H_
 #define MATCH_H_
 
-uInt longest_match  (deflate_state *s, IPos cur_match);
+unsigned int longest_match  (deflate_state *s, IPos cur_match);
 
 #endif /* MATCH_H_ */

--- a/test/example.c
+++ b/test/example.c
@@ -10,6 +10,7 @@
 
 #include <string.h>
 #include <stdlib.h>
+#include <inttypes.h>
 
 #define TESTFILE "foo.gz"
 
@@ -26,32 +27,32 @@ const char hello[] = "hello, hello!";
  */
 
 const char dictionary[] = "hello";
-uLong dictId; /* Adler32 value of the dictionary */
+unsigned long dictId; /* Adler32 value of the dictionary */
 
-void test_deflate       (unsigned char *compr, uLong comprLen);
-void test_inflate       (unsigned char *compr, uLong comprLen, unsigned char *uncompr, uLong uncomprLen);
-void test_large_deflate (unsigned char *compr, uLong comprLen, unsigned char *uncompr, uLong uncomprLen);
-void test_large_inflate (unsigned char *compr, uLong comprLen, unsigned char *uncompr, uLong uncomprLen);
-void test_flush         (unsigned char *compr, uLong *comprLen);
-void test_sync          (unsigned char *compr, uLong comprLen, unsigned char *uncompr, uLong uncomprLen);
-void test_dict_deflate  (unsigned char *compr, uLong comprLen);
-void test_dict_inflate  (unsigned char *compr, uLong comprLen, unsigned char *uncompr, uLong uncomprLen);
+void test_deflate       (unsigned char *compr, unsigned long comprLen);
+void test_inflate       (unsigned char *compr, unsigned long comprLen, unsigned char *uncompr, unsigned long uncomprLen);
+void test_large_deflate (unsigned char *compr, unsigned long comprLen, unsigned char *uncompr, unsigned long uncomprLen);
+void test_large_inflate (unsigned char *compr, unsigned long comprLen, unsigned char *uncompr, unsigned long uncomprLen);
+void test_flush         (unsigned char *compr, unsigned long *comprLen);
+void test_sync          (unsigned char *compr, unsigned long comprLen, unsigned char *uncompr, unsigned long uncomprLen);
+void test_dict_deflate  (unsigned char *compr, unsigned long comprLen);
+void test_dict_inflate  (unsigned char *compr, unsigned long comprLen, unsigned char *uncompr, unsigned long uncomprLen);
 int  main               (int argc, char *argv[]);
 
 
 static alloc_func zalloc = (alloc_func)0;
 static free_func zfree = (free_func)0;
 
-void test_compress      (unsigned char *compr, uLong comprLen,
-                            unsigned char *uncompr, uLong uncomprLen);
+void test_compress      (unsigned char *compr, unsigned long comprLen,
+                            unsigned char *uncompr, unsigned long uncomprLen);
 
 /* ===========================================================================
  * Test compress() and uncompress()
  */
-void test_compress(unsigned char *compr, uLong comprLen, unsigned char *uncompr, uLong uncomprLen)
+void test_compress(unsigned char *compr, unsigned long comprLen, unsigned char *uncompr, unsigned long uncomprLen)
 {
     int err;
-    uLong len = (uLong)strlen(hello)+1;
+    unsigned long len = (unsigned long)strlen(hello)+1;
 
     err = compress(compr, &comprLen, (const unsigned char*)hello, len);
     CHECK_ERR(err, "compress");
@@ -71,12 +72,12 @@ void test_compress(unsigned char *compr, uLong comprLen, unsigned char *uncompr,
 
 #ifdef WITH_GZFILEOP
 void test_gzio          (const char *fname,
-                            unsigned char *uncompr, uLong uncomprLen);
+                            unsigned char *uncompr, unsigned long uncomprLen);
 
 /* ===========================================================================
  * Test read/write of .gz files
  */
-void test_gzio(const char *fname, unsigned char *uncompr, uLong uncomprLen)
+void test_gzio(const char *fname, unsigned char *uncompr, unsigned long uncomprLen)
 {
 #ifdef NO_GZCOMPRESS
     fprintf(stderr, "NO_GZCOMPRESS -- gz* functions cannot compress\n");
@@ -159,11 +160,11 @@ void test_gzio(const char *fname, unsigned char *uncompr, uLong uncomprLen)
 /* ===========================================================================
  * Test deflate() with small buffers
  */
-void test_deflate(unsigned char *compr, uLong comprLen)
+void test_deflate(unsigned char *compr, unsigned long comprLen)
 {
     z_stream c_stream; /* compression stream */
     int err;
-    uLong len = (uLong)strlen(hello)+1;
+    unsigned long len = (unsigned long)strlen(hello)+1;
 
     c_stream.zalloc = zalloc;
     c_stream.zfree = zfree;
@@ -195,7 +196,7 @@ void test_deflate(unsigned char *compr, uLong comprLen)
 /* ===========================================================================
  * Test inflate() with small buffers
  */
-void test_inflate(unsigned char *compr, uLong comprLen, unsigned char *uncompr, uLong uncomprLen)
+void test_inflate(unsigned char *compr, unsigned long comprLen, unsigned char *uncompr, unsigned long uncomprLen)
 {
     int err;
     z_stream d_stream; /* decompression stream */
@@ -234,7 +235,7 @@ void test_inflate(unsigned char *compr, uLong comprLen, unsigned char *uncompr, 
 /* ===========================================================================
  * Test deflate() with large buffers and dynamic change of compression level
  */
-void test_large_deflate(unsigned char *compr, uLong comprLen, unsigned char *uncompr, uLong uncomprLen)
+void test_large_deflate(unsigned char *compr, unsigned long comprLen, unsigned char *uncompr, unsigned long uncomprLen)
 {
     z_stream c_stream; /* compression stream */
     int err;
@@ -247,13 +248,13 @@ void test_large_deflate(unsigned char *compr, uLong comprLen, unsigned char *unc
     CHECK_ERR(err, "deflateInit");
 
     c_stream.next_out = compr;
-    c_stream.avail_out = (uInt)comprLen;
+    c_stream.avail_out = (unsigned int)comprLen;
 
     /* At this point, uncompr is still mostly zeroes, so it should compress
      * very well:
      */
     c_stream.next_in = uncompr;
-    c_stream.avail_in = (uInt)uncomprLen;
+    c_stream.avail_in = (unsigned int)uncomprLen;
     err = deflate(&c_stream, Z_NO_FLUSH);
     CHECK_ERR(err, "deflate");
     if (c_stream.avail_in != 0) {
@@ -264,14 +265,14 @@ void test_large_deflate(unsigned char *compr, uLong comprLen, unsigned char *unc
     /* Feed in already compressed data and switch to no compression: */
     deflateParams(&c_stream, Z_NO_COMPRESSION, Z_DEFAULT_STRATEGY);
     c_stream.next_in = compr;
-    c_stream.avail_in = (uInt)comprLen/2;
+    c_stream.avail_in = (unsigned int)comprLen/2;
     err = deflate(&c_stream, Z_NO_FLUSH);
     CHECK_ERR(err, "deflate");
 
     /* Switch back to compressing mode: */
     deflateParams(&c_stream, Z_BEST_COMPRESSION, Z_FILTERED);
     c_stream.next_in = uncompr;
-    c_stream.avail_in = (uInt)uncomprLen;
+    c_stream.avail_in = (unsigned int)uncomprLen;
     err = deflate(&c_stream, Z_NO_FLUSH);
     CHECK_ERR(err, "deflate");
 
@@ -287,7 +288,7 @@ void test_large_deflate(unsigned char *compr, uLong comprLen, unsigned char *unc
 /* ===========================================================================
  * Test inflate() with large buffers
  */
-void test_large_inflate(unsigned char *compr, uLong comprLen, unsigned char *uncompr, uLong uncomprLen)
+void test_large_inflate(unsigned char *compr, unsigned long comprLen, unsigned char *uncompr, unsigned long uncomprLen)
 {
     int err;
     z_stream d_stream; /* decompression stream */
@@ -299,14 +300,14 @@ void test_large_inflate(unsigned char *compr, uLong comprLen, unsigned char *unc
     d_stream.opaque = (void *)0;
 
     d_stream.next_in  = compr;
-    d_stream.avail_in = (uInt)comprLen;
+    d_stream.avail_in = (unsigned int)comprLen;
 
     err = inflateInit(&d_stream);
     CHECK_ERR(err, "inflateInit");
 
     for (;;) {
         d_stream.next_out = uncompr;            /* discard the output */
-        d_stream.avail_out = (uInt)uncomprLen;
+        d_stream.avail_out = (unsigned int)uncomprLen;
         err = inflate(&d_stream, Z_NO_FLUSH);
         if (err == Z_STREAM_END) break;
         CHECK_ERR(err, "large inflate");
@@ -316,7 +317,7 @@ void test_large_inflate(unsigned char *compr, uLong comprLen, unsigned char *unc
     CHECK_ERR(err, "inflateEnd");
 
     if (d_stream.total_out != 2*uncomprLen + comprLen/2) {
-        fprintf(stderr, "bad large inflate: %ld\n", d_stream.total_out);
+        fprintf(stderr, "bad large inflate: %" PRId32 "\n", d_stream.total_out);
         exit(1);
     } else {
         printf("large_inflate(): OK\n");
@@ -326,11 +327,11 @@ void test_large_inflate(unsigned char *compr, uLong comprLen, unsigned char *unc
 /* ===========================================================================
  * Test deflate() with full flush
  */
-void test_flush(unsigned char *compr, uLong *comprLen)
+void test_flush(unsigned char *compr, unsigned long *comprLen)
 {
     z_stream c_stream; /* compression stream */
     int err;
-    uInt len = (uInt)strlen(hello)+1;
+    unsigned int len = (unsigned int)strlen(hello)+1;
 
     c_stream.zalloc = zalloc;
     c_stream.zfree = zfree;
@@ -342,7 +343,7 @@ void test_flush(unsigned char *compr, uLong *comprLen)
     c_stream.next_in  = (const unsigned char *)hello;
     c_stream.next_out = compr;
     c_stream.avail_in = 3;
-    c_stream.avail_out = (uInt)*comprLen;
+    c_stream.avail_out = (unsigned int)*comprLen;
     err = deflate(&c_stream, Z_FULL_FLUSH);
     CHECK_ERR(err, "deflate");
 
@@ -362,7 +363,7 @@ void test_flush(unsigned char *compr, uLong *comprLen)
 /* ===========================================================================
  * Test inflateSync()
  */
-void test_sync(unsigned char *compr, uLong comprLen, unsigned char *uncompr, uLong uncomprLen)
+void test_sync(unsigned char *compr, unsigned long comprLen, unsigned char *uncompr, unsigned long uncomprLen)
 {
     int err;
     z_stream d_stream; /* decompression stream */
@@ -380,12 +381,12 @@ void test_sync(unsigned char *compr, uLong comprLen, unsigned char *uncompr, uLo
     CHECK_ERR(err, "inflateInit");
 
     d_stream.next_out = uncompr;
-    d_stream.avail_out = (uInt)uncomprLen;
+    d_stream.avail_out = (unsigned int)uncomprLen;
 
     err = inflate(&d_stream, Z_NO_FLUSH);
     CHECK_ERR(err, "inflate");
 
-    d_stream.avail_in = (uInt)comprLen-2;   /* read all compressed data */
+    d_stream.avail_in = (unsigned int)comprLen-2;   /* read all compressed data */
     err = inflateSync(&d_stream);           /* but skip the damaged part */
     CHECK_ERR(err, "inflateSync");
 
@@ -404,7 +405,7 @@ void test_sync(unsigned char *compr, uLong comprLen, unsigned char *uncompr, uLo
 /* ===========================================================================
  * Test deflate() with preset dictionary
  */
-void test_dict_deflate(unsigned char *compr, uLong comprLen)
+void test_dict_deflate(unsigned char *compr, unsigned long comprLen)
 {
     z_stream c_stream; /* compression stream */
     int err;
@@ -422,10 +423,10 @@ void test_dict_deflate(unsigned char *compr, uLong comprLen)
 
     dictId = c_stream.adler;
     c_stream.next_out = compr;
-    c_stream.avail_out = (uInt)comprLen;
+    c_stream.avail_out = (unsigned int)comprLen;
 
     c_stream.next_in = (const unsigned char *)hello;
-    c_stream.avail_in = (uInt)strlen(hello)+1;
+    c_stream.avail_in = (unsigned int)strlen(hello)+1;
 
     err = deflate(&c_stream, Z_FINISH);
     if (err != Z_STREAM_END) {
@@ -439,7 +440,7 @@ void test_dict_deflate(unsigned char *compr, uLong comprLen)
 /* ===========================================================================
  * Test inflate() with a preset dictionary
  */
-void test_dict_inflate(unsigned char *compr, uLong comprLen, unsigned char *uncompr, uLong uncomprLen)
+void test_dict_inflate(unsigned char *compr, unsigned long comprLen, unsigned char *uncompr, unsigned long uncomprLen)
 {
     int err;
     z_stream d_stream; /* decompression stream */
@@ -451,13 +452,13 @@ void test_dict_inflate(unsigned char *compr, uLong comprLen, unsigned char *unco
     d_stream.opaque = (void *)0;
 
     d_stream.next_in  = compr;
-    d_stream.avail_in = (uInt)comprLen;
+    d_stream.avail_in = (unsigned int)comprLen;
 
     err = inflateInit(&d_stream);
     CHECK_ERR(err, "inflateInit");
 
     d_stream.next_out = uncompr;
-    d_stream.avail_out = (uInt)uncomprLen;
+    d_stream.avail_out = (unsigned int)uncomprLen;
 
     for (;;) {
         err = inflate(&d_stream, Z_NO_FLUSH);
@@ -491,8 +492,8 @@ void test_dict_inflate(unsigned char *compr, uLong comprLen, unsigned char *unco
 int main(int argc, char *argv[])
 {
     unsigned char *compr, *uncompr;
-    uLong comprLen = 10000*sizeof(int); /* don't overflow on MSDOS */
-    uLong uncomprLen = comprLen;
+    unsigned long comprLen = 10000*sizeof(int); /* don't overflow on MSDOS */
+    unsigned long uncomprLen = comprLen;
     static const char* myVersion = ZLIB_VERSION;
 
     if (zlibVersion()[0] != myVersion[0]) {
@@ -506,8 +507,8 @@ int main(int argc, char *argv[])
     printf("zlib version %s = 0x%04x, compile flags = 0x%lx\n",
             ZLIB_VERSION, ZLIB_VERNUM, zlibCompileFlags());
 
-    compr    = (unsigned char*)calloc((uInt)comprLen, 1);
-    uncompr  = (unsigned char*)calloc((uInt)uncomprLen, 1);
+    compr    = (unsigned char*)calloc((unsigned int)comprLen, 1);
+    uncompr  = (unsigned char*)calloc((unsigned int)uncomprLen, 1);
     /* compr and uncompr are cleared to avoid reading uninitialized
      * data and to ensure that uncompr compresses well.
      */

--- a/test/example.c
+++ b/test/example.c
@@ -29,30 +29,30 @@ const char hello[] = "hello, hello!";
 const char dictionary[] = "hello";
 unsigned long dictId; /* Adler32 value of the dictionary */
 
-void test_deflate       (unsigned char *compr, unsigned long comprLen);
-void test_inflate       (unsigned char *compr, unsigned long comprLen, unsigned char *uncompr, unsigned long uncomprLen);
-void test_large_deflate (unsigned char *compr, unsigned long comprLen, unsigned char *uncompr, unsigned long uncomprLen);
-void test_large_inflate (unsigned char *compr, unsigned long comprLen, unsigned char *uncompr, unsigned long uncomprLen);
-void test_flush         (unsigned char *compr, unsigned long *comprLen);
-void test_sync          (unsigned char *compr, unsigned long comprLen, unsigned char *uncompr, unsigned long uncomprLen);
-void test_dict_deflate  (unsigned char *compr, unsigned long comprLen);
-void test_dict_inflate  (unsigned char *compr, unsigned long comprLen, unsigned char *uncompr, unsigned long uncomprLen);
+void test_deflate       (unsigned char *compr, size_t comprLen);
+void test_inflate       (unsigned char *compr, size_t comprLen, unsigned char *uncompr, size_t uncomprLen);
+void test_large_deflate (unsigned char *compr, size_t comprLen, unsigned char *uncompr, size_t uncomprLen);
+void test_large_inflate (unsigned char *compr, size_t comprLen, unsigned char *uncompr, size_t uncomprLen);
+void test_flush         (unsigned char *compr, size_t *comprLen);
+void test_sync          (unsigned char *compr, size_t comprLen, unsigned char *uncompr, size_t uncomprLen);
+void test_dict_deflate  (unsigned char *compr, size_t comprLen);
+void test_dict_inflate  (unsigned char *compr, size_t comprLen, unsigned char *uncompr, size_t uncomprLen);
 int  main               (int argc, char *argv[]);
 
 
 static alloc_func zalloc = (alloc_func)0;
 static free_func zfree = (free_func)0;
 
-void test_compress      (unsigned char *compr, unsigned long comprLen,
-                            unsigned char *uncompr, unsigned long uncomprLen);
+void test_compress      (unsigned char *compr, size_t comprLen,
+                            unsigned char *uncompr, size_t uncomprLen);
 
 /* ===========================================================================
  * Test compress() and uncompress()
  */
-void test_compress(unsigned char *compr, unsigned long comprLen, unsigned char *uncompr, unsigned long uncomprLen)
+void test_compress(unsigned char *compr, size_t comprLen, unsigned char *uncompr, size_t uncomprLen)
 {
     int err;
-    unsigned long len = (unsigned long)strlen(hello)+1;
+    size_t len = strlen(hello)+1;
 
     err = compress(compr, &comprLen, (const unsigned char*)hello, len);
     CHECK_ERR(err, "compress");
@@ -160,7 +160,7 @@ void test_gzio(const char *fname, unsigned char *uncompr, unsigned long uncomprL
 /* ===========================================================================
  * Test deflate() with small buffers
  */
-void test_deflate(unsigned char *compr, unsigned long comprLen)
+void test_deflate(unsigned char *compr, size_t comprLen)
 {
     z_stream c_stream; /* compression stream */
     int err;
@@ -196,7 +196,7 @@ void test_deflate(unsigned char *compr, unsigned long comprLen)
 /* ===========================================================================
  * Test inflate() with small buffers
  */
-void test_inflate(unsigned char *compr, unsigned long comprLen, unsigned char *uncompr, unsigned long uncomprLen)
+void test_inflate(unsigned char *compr, size_t comprLen, unsigned char *uncompr, size_t uncomprLen)
 {
     int err;
     z_stream d_stream; /* decompression stream */
@@ -235,7 +235,7 @@ void test_inflate(unsigned char *compr, unsigned long comprLen, unsigned char *u
 /* ===========================================================================
  * Test deflate() with large buffers and dynamic change of compression level
  */
-void test_large_deflate(unsigned char *compr, unsigned long comprLen, unsigned char *uncompr, unsigned long uncomprLen)
+void test_large_deflate(unsigned char *compr, size_t comprLen, unsigned char *uncompr, size_t uncomprLen)
 {
     z_stream c_stream; /* compression stream */
     int err;
@@ -288,7 +288,7 @@ void test_large_deflate(unsigned char *compr, unsigned long comprLen, unsigned c
 /* ===========================================================================
  * Test inflate() with large buffers
  */
-void test_large_inflate(unsigned char *compr, unsigned long comprLen, unsigned char *uncompr, unsigned long uncomprLen)
+void test_large_inflate(unsigned char *compr, size_t comprLen, unsigned char *uncompr, size_t uncomprLen)
 {
     int err;
     z_stream d_stream; /* decompression stream */
@@ -317,7 +317,7 @@ void test_large_inflate(unsigned char *compr, unsigned long comprLen, unsigned c
     CHECK_ERR(err, "inflateEnd");
 
     if (d_stream.total_out != 2*uncomprLen + comprLen/2) {
-        fprintf(stderr, "bad large inflate: %" PRId32 "\n", d_stream.total_out);
+        fprintf(stderr, "bad large inflate: %zu\n", d_stream.total_out);
         exit(1);
     } else {
         printf("large_inflate(): OK\n");
@@ -327,7 +327,7 @@ void test_large_inflate(unsigned char *compr, unsigned long comprLen, unsigned c
 /* ===========================================================================
  * Test deflate() with full flush
  */
-void test_flush(unsigned char *compr, unsigned long *comprLen)
+void test_flush(unsigned char *compr, size_t *comprLen)
 {
     z_stream c_stream; /* compression stream */
     int err;
@@ -363,7 +363,7 @@ void test_flush(unsigned char *compr, unsigned long *comprLen)
 /* ===========================================================================
  * Test inflateSync()
  */
-void test_sync(unsigned char *compr, unsigned long comprLen, unsigned char *uncompr, unsigned long uncomprLen)
+void test_sync(unsigned char *compr, size_t comprLen, unsigned char *uncompr, size_t uncomprLen)
 {
     int err;
     z_stream d_stream; /* decompression stream */
@@ -405,7 +405,7 @@ void test_sync(unsigned char *compr, unsigned long comprLen, unsigned char *unco
 /* ===========================================================================
  * Test deflate() with preset dictionary
  */
-void test_dict_deflate(unsigned char *compr, unsigned long comprLen)
+void test_dict_deflate(unsigned char *compr, size_t comprLen)
 {
     z_stream c_stream; /* compression stream */
     int err;
@@ -440,7 +440,7 @@ void test_dict_deflate(unsigned char *compr, unsigned long comprLen)
 /* ===========================================================================
  * Test inflate() with a preset dictionary
  */
-void test_dict_inflate(unsigned char *compr, unsigned long comprLen, unsigned char *uncompr, unsigned long uncomprLen)
+void test_dict_inflate(unsigned char *compr, size_t comprLen, unsigned char *uncompr, size_t uncomprLen)
 {
     int err;
     z_stream d_stream; /* decompression stream */
@@ -492,8 +492,8 @@ void test_dict_inflate(unsigned char *compr, unsigned long comprLen, unsigned ch
 int main(int argc, char *argv[])
 {
     unsigned char *compr, *uncompr;
-    unsigned long comprLen = 10000*sizeof(int); /* don't overflow on MSDOS */
-    unsigned long uncomprLen = comprLen;
+    size_t comprLen = 10000*sizeof(int); /* don't overflow on MSDOS */
+    size_t uncomprLen = comprLen;
     static const char* myVersion = ZLIB_VERSION;
 
     if (zlibVersion()[0] != myVersion[0]) {

--- a/test/minigzip.c
+++ b/test/minigzip.c
@@ -184,7 +184,7 @@ int gzread(gzFile gz, void *buf, unsigned len)
         if (strm->avail_in == 0)
         {
             strm->next_in = gz->buf;
-            strm->avail_in = (uInt)fread(gz->buf, 1, BUFLEN, gz->file);
+            strm->avail_in = (uint32_t)fread(gz->buf, 1, BUFLEN, gz->file);
         }
         if (strm->avail_in > 0)
         {

--- a/uncompr.c
+++ b/uncompr.c
@@ -1,5 +1,5 @@
 /* uncompr.c -- decompress a memory buffer
- * Copyright (C) 1995-2003, 2010, 2014 Jean-loup Gailly, Mark Adler
+ * Copyright (C) 1995-2003, 2010, 2014 Jean-loup Gailly, Mark Adler.
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
@@ -22,12 +22,12 @@
    buffer, or Z_DATA_ERROR if the input data was corrupted, including if the
    input data is an incomplete zlib stream.
 */
-int ZEXPORT uncompress(unsigned char *dest, uLong *destLen, const unsigned char *source, uLong sourceLen) {
+int ZEXPORT uncompress(unsigned char *dest, unsigned long *destLen, const unsigned char *source, unsigned long sourceLen) {
     z_stream stream;
     int err;
-    const uInt max = (uInt)0 - 1;
-    uLong left;
-    Byte buf[1];    /* for detection of incomplete stream when *destLen == 0 */
+    const unsigned int max = (unsigned int)0 - 1;
+    unsigned long left;
+    unsigned char buf[1];    /* for detection of incomplete stream when *destLen == 0 */
 
     if (*destLen) {
         left = *destLen;
@@ -42,7 +42,7 @@ int ZEXPORT uncompress(unsigned char *dest, uLong *destLen, const unsigned char 
     stream.avail_in = 0;
     stream.zalloc = (alloc_func)0;
     stream.zfree = (free_func)0;
-    stream.opaque = (void *)0;
+    stream.opaque = NULL;
 
     err = inflateInit(&stream);
     if (err != Z_OK) return err;

--- a/uncompr.c
+++ b/uncompr.c
@@ -22,11 +22,11 @@
    buffer, or Z_DATA_ERROR if the input data was corrupted, including if the
    input data is an incomplete zlib stream.
 */
-int ZEXPORT uncompress(unsigned char *dest, unsigned long *destLen, const unsigned char *source, unsigned long sourceLen) {
+int ZEXPORT uncompress(unsigned char *dest, size_t *destLen, const unsigned char *source, size_t sourceLen) {
     z_stream stream;
     int err;
     const unsigned int max = (unsigned int)0 - 1;
-    unsigned long left;
+    size_t left;
     unsigned char buf[1];    /* for detection of incomplete stream when *destLen == 0 */
 
     if (*destLen) {

--- a/zconf.h.in
+++ b/zconf.h.in
@@ -118,7 +118,7 @@ typedef void       *voidp;
 #include <sys/types.h>      /* for off_t */
 #include <stdarg.h>         /* for va_list */
 
-#ifdef _WIN32
+#ifdef WIN32
 #  include <stddef.h>         /* for wchar_t */
 #endif
 
@@ -161,10 +161,10 @@ typedef void       *voidp;
 #  define z_off_t long
 #endif
 
-#if !defined(_WIN32) && defined(Z_LARGE64)
+#if !defined(WIN32) && defined(Z_LARGE64)
 #  define z_off64_t off64_t
 #else
-#  if (defined(_WIN32) || defined(WIN32)) && !defined(__GNUC__)
+#  if defined(WIN32) && !defined(__GNUC__)
 #    define z_off64_t __int64
 #  else
 #    define z_off64_t z_off_t

--- a/zlib.h
+++ b/zlib.h
@@ -92,11 +92,11 @@ struct internal_state;
 typedef struct z_stream_s {
     const unsigned char   *next_in;   /* next input byte */
     uint32_t              avail_in;   /* number of bytes available at next_in */
-    uint32_t              total_in;   /* total number of input bytes read so far */
+    size_t                total_in;   /* total number of input bytes read so far */
 
     unsigned char         *next_out;  /* next output byte should be put there */
     uint32_t              avail_out;  /* remaining free space at next_out */
-    uint32_t              total_out;  /* total number of bytes output so far */
+    size_t                total_out;  /* total number of bytes output so far */
 
     const char            *msg;       /* last error message, NULL if no error */
     struct internal_state *state;     /* not visible by applications */
@@ -1148,7 +1148,7 @@ ZEXTERN unsigned long ZEXPORT zlibCompileFlags(void);
    you need special options.
 */
 
-ZEXTERN int ZEXPORT compress(unsigned char *dest, unsigned long *destLen, const unsigned char *source, unsigned long sourceLen);
+ZEXTERN int ZEXPORT compress(unsigned char *dest, size_t *destLen, const unsigned char *source, size_t sourceLen);
 /*
      Compresses the source buffer into the destination buffer.  sourceLen is
    the byte length of the source buffer.  Upon entry, destLen is the total size
@@ -1162,8 +1162,8 @@ ZEXTERN int ZEXPORT compress(unsigned char *dest, unsigned long *destLen, const 
    buffer.
 */
 
-ZEXTERN int ZEXPORT compress2(unsigned char *dest, unsigned long *destLen, const unsigned char *source,
-                              unsigned long sourceLen, int level);
+ZEXTERN int ZEXPORT compress2(unsigned char *dest, size_t *destLen, const unsigned char *source,
+                              size_t sourceLen, int level);
 /*
      Compresses the source buffer into the destination buffer.  The level
    parameter has the same meaning as in deflateInit.  sourceLen is the byte
@@ -1177,14 +1177,14 @@ ZEXTERN int ZEXPORT compress2(unsigned char *dest, unsigned long *destLen, const
    Z_STREAM_ERROR if the level parameter is invalid.
 */
 
-ZEXTERN unsigned long ZEXPORT compressBound(unsigned long sourceLen);
+ZEXTERN size_t ZEXPORT compressBound(size_t sourceLen);
 /*
      compressBound() returns an upper bound on the compressed size after
    compress() or compress2() on sourceLen bytes.  It would be used before a
    compress() or compress2() call to allocate the destination buffer.
 */
 
-ZEXTERN int ZEXPORT uncompress(unsigned char *dest, unsigned long *destLen, const unsigned char *source, unsigned long sourceLen);
+ZEXTERN int ZEXPORT uncompress(unsigned char *dest, size_t *destLen, const unsigned char *source, size_t sourceLen);
 /*
      Decompresses the source buffer into the destination buffer.  sourceLen is
    the byte length of the source buffer.  Upon entry, destLen is the total size

--- a/zlib.h
+++ b/zlib.h
@@ -84,30 +84,30 @@ extern "C" {
   even in case of corrupted input.
 */
 
-typedef void *(*alloc_func) (void *opaque, uInt items, uInt size);
+typedef void *(*alloc_func) (void *opaque, unsigned int items, unsigned int size);
 typedef void  (*free_func)  (void *opaque, void *address);
 
 struct internal_state;
 
 typedef struct z_stream_s {
-    const unsigned char *next_in;   /* next input byte */
-    uInt     avail_in;              /* number of bytes available at next_in */
-    uLong    total_in;              /* total number of input bytes read so far */
+    const unsigned char   *next_in;   /* next input byte */
+    uint32_t              avail_in;   /* number of bytes available at next_in */
+    uint32_t              total_in;   /* total number of input bytes read so far */
 
-    unsigned char    *next_out;     /* next output byte should be put there */
-    uInt     avail_out;             /* remaining free space at next_out */
-    uLong    total_out;             /* total number of bytes output so far */
+    unsigned char         *next_out;  /* next output byte should be put there */
+    uint32_t              avail_out;  /* remaining free space at next_out */
+    uint32_t              total_out;  /* total number of bytes output so far */
 
-    const char *msg;                /* last error message, NULL if no error */
-    struct internal_state *state;   /* not visible by applications */
+    const char            *msg;       /* last error message, NULL if no error */
+    struct internal_state *state;     /* not visible by applications */
 
-    alloc_func zalloc;              /* used to allocate the internal state */
-    free_func  zfree;               /* used to free the internal state */
-    void      *opaque;              /* private data object passed to zalloc and zfree */
+    alloc_func            zalloc;     /* used to allocate the internal state */
+    free_func             zfree;      /* used to free the internal state */
+    void                  *opaque;    /* private data object passed to zalloc and zfree */
 
-    int     data_type;              /* best guess about the data type: binary or text */
-    uint32_t   adler;               /* adler32 value of the uncompressed data */
-    uLong   reserved;               /* reserved for future use */
+    int                   data_type;  /* best guess about the data type: binary or text */
+    uint32_t              adler;      /* adler32 value of the uncompressed data */
+    unsigned long         reserved;   /* reserved for future use */
 } z_stream;
 
 typedef z_stream *z_streamp;  // Obsolete type, retained for compatability only
@@ -117,19 +117,19 @@ typedef z_stream *z_streamp;  // Obsolete type, retained for compatability only
   for more details on the meanings of these fields.
 */
 typedef struct gz_header_s {
-    int     text;               /* true if compressed data believed to be text */
-    uLong   time;               /* modification time */
-    int     xflags;             /* extra flags (not used when writing a gzip file) */
-    int     os;                 /* operating system */
+    int             text;       /* true if compressed data believed to be text */
+    unsigned long   time;       /* modification time */
+    int             xflags;     /* extra flags (not used when writing a gzip file) */
+    int             os;         /* operating system */
     unsigned char   *extra;     /* pointer to extra field or Z_NULL if none */
-    uInt    extra_len;          /* extra field length (valid if extra != Z_NULL) */
-    uInt    extra_max;          /* space at extra (only when reading header) */
+    unsigned int    extra_len;  /* extra field length (valid if extra != Z_NULL) */
+    unsigned int    extra_max;  /* space at extra (only when reading header) */
     unsigned char   *name;      /* pointer to zero-terminated file name or Z_NULL */
-    uInt    name_max;           /* space at name (only when reading header) */
+    unsigned int    name_max;   /* space at name (only when reading header) */
     unsigned char   *comment;   /* pointer to zero-terminated comment or Z_NULL */
-    uInt    comm_max;           /* space at comment (only when reading header) */
-    int     hcrc;               /* true if there was or will be a header crc */
-    int     done;               /* true when done reading gzip header (not used when writing a gzip file) */
+    unsigned int    comm_max;   /* space at comment (only when reading header) */
+    int             hcrc;       /* true if there was or will be a header crc */
+    int             done;       /* true when done reading gzip header (not used when writing a gzip file) */
 } gz_header;
 
 typedef gz_header *gz_headerp;
@@ -591,7 +591,7 @@ ZEXTERN int ZEXPORT deflateInit2 (z_stream *strm,
 
 ZEXTERN int ZEXPORT deflateSetDictionary(z_stream *strm,
                                              const unsigned char *dictionary,
-                                             uInt  dictLength);
+                                             unsigned int dictLength);
 /*
      Initializes the compression dictionary from the given byte sequence
    without producing any compressed output.  When using the zlib format, this
@@ -707,7 +707,7 @@ ZEXTERN int ZEXPORT deflateTune(z_stream *strm, int good_length, int max_lazy, i
    returns Z_OK on success, or Z_STREAM_ERROR for an invalid deflate stream.
  */
 
-ZEXTERN uLong ZEXPORT deflateBound(z_stream *strm, uLong sourceLen);
+ZEXTERN unsigned long ZEXPORT deflateBound(z_stream *strm, unsigned long sourceLen);
 /*
      deflateBound() returns an upper bound on the compressed size after
    deflation of sourceLen bytes.  It must be called after deflateInit() or
@@ -721,7 +721,7 @@ ZEXTERN uLong ZEXPORT deflateBound(z_stream *strm, uLong sourceLen);
    than Z_FINISH or Z_NO_FLUSH are used.
 */
 
-ZEXTERN int ZEXPORT deflatePending(z_stream *strm, unsigned *pending, int *bits);
+ZEXTERN int ZEXPORT deflatePending(z_stream *strm, uint32_t *pending, int *bits);
 /*
      deflatePending() returns the number of bytes and bits of output that have
    been generated, but not yet provided in the available output.  The bytes not
@@ -821,7 +821,7 @@ ZEXTERN int ZEXPORT inflateInit2(z_stream *strm, int  windowBits);
    deferred until inflate() is called.
 */
 
-ZEXTERN int ZEXPORT inflateSetDictionary(z_stream *strm, const unsigned char *dictionary, uInt dictLength);
+ZEXTERN int ZEXPORT inflateSetDictionary(z_stream *strm, const unsigned char *dictionary, unsigned int dictLength);
 /*
      Initializes the decompression dictionary from the given uncompressed byte
    sequence.  This function must be called immediately after a call of inflate,
@@ -842,7 +842,7 @@ ZEXTERN int ZEXPORT inflateSetDictionary(z_stream *strm, const unsigned char *di
    inflate().
 */
 
-ZEXTERN int ZEXPORT inflateGetDictionary(z_stream *strm, unsigned char *dictionary, uInt *dictLength);
+ZEXTERN int ZEXPORT inflateGetDictionary(z_stream *strm, unsigned char *dictionary, unsigned int *dictLength);
 /*
      Returns the sliding dictionary being maintained by inflate.  dictLength is
    set to the number of bytes in the dictionary, and that many bytes are copied
@@ -1017,8 +1017,8 @@ ZEXTERN int ZEXPORT inflateBackInit (z_stream *strm, int windowBits, unsigned ch
    the version of the header file.
 */
 
-typedef unsigned (*in_func) (void *, const unsigned char * *);
-typedef int (*out_func) (void *, unsigned char *, unsigned);
+typedef uint32_t (*in_func) (void *, const unsigned char * *);
+typedef int (*out_func) (void *, unsigned char *, uint32_t);
 
 ZEXTERN int ZEXPORT inflateBack(z_stream *strm, in_func in, void *in_desc, out_func out, void *out_desc);
 /*
@@ -1096,12 +1096,12 @@ ZEXTERN int ZEXPORT inflateBackEnd(z_stream *strm);
    state was inconsistent.
 */
 
-ZEXTERN uLong ZEXPORT zlibCompileFlags(void);
+ZEXTERN unsigned long ZEXPORT zlibCompileFlags(void);
 /* Return flags indicating compile-time options.
 
     Type sizes, two bits each, 00 = 16 bits, 01 = 32, 10 = 64, 11 = other:
-     1.0: size of uInt
-     3.2: size of uLong
+     1.0: size of unsigned int
+     3.2: size of unsigned long
      5.4: size of void * (pointer)
      7.6: size of z_off_t
 
@@ -1148,7 +1148,7 @@ ZEXTERN uLong ZEXPORT zlibCompileFlags(void);
    you need special options.
 */
 
-ZEXTERN int ZEXPORT compress(unsigned char *dest, uLong *destLen, const unsigned char *source, uLong sourceLen);
+ZEXTERN int ZEXPORT compress(unsigned char *dest, unsigned long *destLen, const unsigned char *source, unsigned long sourceLen);
 /*
      Compresses the source buffer into the destination buffer.  sourceLen is
    the byte length of the source buffer.  Upon entry, destLen is the total size
@@ -1162,8 +1162,8 @@ ZEXTERN int ZEXPORT compress(unsigned char *dest, uLong *destLen, const unsigned
    buffer.
 */
 
-ZEXTERN int ZEXPORT compress2(unsigned char *dest, uLong *destLen, const unsigned char *source,
-                              uLong sourceLen, int level);
+ZEXTERN int ZEXPORT compress2(unsigned char *dest, unsigned long *destLen, const unsigned char *source,
+                              unsigned long sourceLen, int level);
 /*
      Compresses the source buffer into the destination buffer.  The level
    parameter has the same meaning as in deflateInit.  sourceLen is the byte
@@ -1177,14 +1177,14 @@ ZEXTERN int ZEXPORT compress2(unsigned char *dest, uLong *destLen, const unsigne
    Z_STREAM_ERROR if the level parameter is invalid.
 */
 
-ZEXTERN uLong ZEXPORT compressBound(uLong sourceLen);
+ZEXTERN unsigned long ZEXPORT compressBound(unsigned long sourceLen);
 /*
      compressBound() returns an upper bound on the compressed size after
    compress() or compress2() on sourceLen bytes.  It would be used before a
    compress() or compress2() call to allocate the destination buffer.
 */
 
-ZEXTERN int ZEXPORT uncompress(unsigned char *dest, uLong *destLen, const unsigned char *source, uLong sourceLen);
+ZEXTERN int ZEXPORT uncompress(unsigned char *dest, unsigned long *destLen, const unsigned char *source, unsigned long sourceLen);
 /*
      Decompresses the source buffer into the destination buffer.  sourceLen is
    the byte length of the source buffer.  Upon entry, destLen is the total size
@@ -1553,7 +1553,7 @@ ZEXTERN void ZEXPORT gzclearerr(gzFile file);
    library.
 */
 
-ZEXTERN uint32_t ZEXPORT adler32(uint32_t adler, const unsigned char *buf, uInt len);
+ZEXTERN uint32_t ZEXPORT adler32(uint32_t adler, const unsigned char *buf, uint32_t len);
 /*
      Update a running Adler-32 checksum with the bytes buf[0..len-1] and
    return the updated checksum.  If buf is Z_NULL, this function returns the
@@ -1583,7 +1583,7 @@ ZEXTERN uint32_t ZEXPORT adler32_combine(uint32_t adler1, uint32_t adler2, z_off
    negative, the result has no meaning or utility.
 */
 
-ZEXTERN uint32_t ZEXPORT crc32(uint32_t crc, const unsigned char *buf, uInt len);
+ZEXTERN uint32_t ZEXPORT crc32(uint32_t crc, const unsigned char *buf, z_off64_t len);
 /*
      Update a running CRC-32 with the bytes buf[0..len-1] and return the
    updated CRC-32.  If buf is Z_NULL, this function returns the required
@@ -1601,7 +1601,7 @@ ZEXTERN uint32_t ZEXPORT crc32(uint32_t crc, const unsigned char *buf, uInt len)
 */
 
 /*
-ZEXTERN uint32_t ZEXPORT crc32_combine(uint32_t crc1, uint32_t crc2, z_off_t len2);
+ZEXTERN uint32_t ZEXPORT crc32_combine(uint32_t crc1, uint32_t crc2, z_off64_t len2);
 
      Combine two CRC-32 check values into one.  For two sequences of bytes,
    seq1 and seq2 with lengths len1 and len2, CRC-32 check values were
@@ -1707,15 +1707,15 @@ ZEXTERN int ZEXPORT gzgetc_(gzFile file);  /* backward compatibility */
 
 
 /* undocumented functions */
-ZEXTERN const char * ZEXPORT zError(int);
-ZEXTERN int ZEXPORT inflateSyncPoint(z_stream *);
-ZEXTERN const uint32_t * ZEXPORT get_crc_table(void);
-ZEXTERN int ZEXPORT inflateUndermine(z_stream *, int);
-ZEXTERN int ZEXPORT inflateResetKeep(z_stream *);
-ZEXTERN int ZEXPORT deflateResetKeep(z_stream *);
+ZEXTERN const char     * ZEXPORT zError           (int);
+ZEXTERN int              ZEXPORT inflateSyncPoint (z_stream *);
+ZEXTERN const uint32_t * ZEXPORT get_crc_table    (void);
+ZEXTERN int              ZEXPORT inflateUndermine (z_stream *, int);
+ZEXTERN int              ZEXPORT inflateResetKeep (z_stream *);
+ZEXTERN int              ZEXPORT deflateResetKeep (z_stream *);
 
 #ifdef WITH_GZFILEOP
-# if (defined(_WIN32) || defined(__CYGWIN__) || defined(__MINGW__))
+# if (defined(WIN32) || defined(__CYGWIN__) || defined(__MINGW__))
     ZEXTERN gzFile ZEXPORT gzopen_w(const wchar_t *path, const char *mode);
 # endif
 ZEXTERN int ZEXPORTVA gzvprintf(gzFile file, const char *format, va_list va);

--- a/zutil.c
+++ b/zutil.c
@@ -30,18 +30,18 @@ const char * ZEXPORT zlibVersion(void)
     return ZLIB_VERSION;
 }
 
-uLong ZEXPORT zlibCompileFlags(void)
+unsigned long ZEXPORT zlibCompileFlags(void)
 {
-    uLong flags;
+    unsigned long flags;
 
     flags = 0;
-    switch ((int)(sizeof(uInt))) {
+    switch ((int)(sizeof(unsigned int))) {
     case 2:     break;
     case 4:     flags += 1;     break;
     case 8:     flags += 2;     break;
     default:    flags += 3;
     }
-    switch ((int)(sizeof(uLong))) {
+    switch ((int)(sizeof(unsigned long))) {
     case 2:     break;
     case 4:     flags += 1 << 2;        break;
     case 8:     flags += 2 << 2;        break;
@@ -111,7 +111,7 @@ const char * ZEXPORT zError(int err)
 void ZLIB_INTERNAL *zcalloc (void *opaque, unsigned items, unsigned size)
 {
     (void)opaque;
-    return sizeof(uInt) > 2 ? (void *)malloc(items * size) :
+    return sizeof(unsigned int) > 2 ? (void *)malloc(items * size) :
                               (void *)calloc(items, size);
 }
 

--- a/zutil.h
+++ b/zutil.h
@@ -79,7 +79,7 @@ extern const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
 #endif
 
 /* provide prototypes for these when building zlib without LFS */
-#if !defined(_WIN32) && (!defined(_LARGEFILE64_SOURCE) || _LFS64_LARGEFILE-0 == 0)
+#if !defined(WIN32) && (!defined(_LARGEFILE64_SOURCE) || _LFS64_LARGEFILE-0 == 0)
     ZEXTERN uint32_t ZEXPORT adler32_combine64(uint32_t, uint32_t, z_off_t);
     ZEXTERN uint32_t ZEXPORT crc32_combine64(uint32_t, uint32_t, z_off_t);
 #endif
@@ -131,7 +131,7 @@ void ZLIB_INTERNAL   zcfree(void *opaque, void *ptr);
 
 /* Reverse the bytes in a 32-bit value. Use compiler intrinsics when
    possible to take advantage of hardware implementations. */
-#if defined(_WIN32) && (_MSC_VER >= 1300)
+#if defined(WIN32) && (_MSC_VER >= 1300)
 #  pragma intrinsic(_byteswap_ulong)
 #  define ZSWAP32(q) _byteswap_ulong(q)
 


### PR DESCRIPTION
- Replace user-defined types with equivalent standard types.
- Use size_t for total counts as "long" can be 32-bit on some 64-bit platforms
