### PR TITLE
Consistently use Z_NULL to initialize the opaque object.

### DIFF
--- a/compress.c
+++ b/compress.c
@@ -31,7 +31,7 @@ int ZEXPORT compress2(unsigned char *dest, size_t *destLen, const unsigned char 
 
     stream.zalloc = (alloc_func)0;
     stream.zfree = (free_func)0;
-    stream.opaque = NULL;
+    stream.opaque = Z_NULL;
 
     err = deflateInit(&stream, level);
     if (err != Z_OK)

--- a/deflate.c
+++ b/deflate.c
@@ -187,7 +187,7 @@ int ZEXPORT deflateInit2_(z_stream *strm, int level, int method, int windowBits,
     strm->msg = Z_NULL;
     if (strm->zalloc == (alloc_func)0) {
         strm->zalloc = zcalloc;
-        strm->opaque = NULL;
+        strm->opaque = Z_NULL;
     }
     if (strm->zfree == (free_func)0)
         strm->zfree = zcfree;

--- a/infback.c
+++ b/infback.c
@@ -36,7 +36,7 @@ int ZEXPORT inflateBackInit_(z_stream *strm, int windowBits, unsigned char *wind
     strm->msg = Z_NULL;                 /* in case we return an error */
     if (strm->zalloc == (alloc_func)0) {
         strm->zalloc = zcalloc;
-        strm->opaque = NULL;
+        strm->opaque = Z_NULL;
     }
     if (strm->zfree == (free_func)0)
         strm->zfree = zcfree;

--- a/inflate.c
+++ b/inflate.c
@@ -181,7 +181,7 @@ int ZEXPORT inflateInit2_(z_stream *strm, int windowBits, const char *version, i
     strm->msg = Z_NULL;                 /* in case we return an error */
     if (strm->zalloc == (alloc_func)0) {
         strm->zalloc = zcalloc;
-        strm->opaque = NULL;
+        strm->opaque = Z_NULL;
     }
     if (strm->zfree == (free_func)0)
         strm->zfree = zcfree;

--- a/test/example.c
+++ b/test/example.c
@@ -168,7 +168,7 @@ void test_deflate(unsigned char *compr, size_t comprLen)
 
     c_stream.zalloc = zalloc;
     c_stream.zfree = zfree;
-    c_stream.opaque = (void *)0;
+    c_stream.opaque = Z_NULL;
 
     err = deflateInit(&c_stream, Z_DEFAULT_COMPRESSION);
     CHECK_ERR(err, "deflateInit");
@@ -205,7 +205,7 @@ void test_inflate(unsigned char *compr, size_t comprLen, unsigned char *uncompr,
 
     d_stream.zalloc = zalloc;
     d_stream.zfree = zfree;
-    d_stream.opaque = (void *)0;
+    d_stream.opaque = Z_NULL;
 
     d_stream.next_in  = compr;
     d_stream.avail_in = 0;
@@ -242,7 +242,7 @@ void test_large_deflate(unsigned char *compr, size_t comprLen, unsigned char *un
 
     c_stream.zalloc = zalloc;
     c_stream.zfree = zfree;
-    c_stream.opaque = (void *)0;
+    c_stream.opaque = Z_NULL;
 
     err = deflateInit(&c_stream, Z_BEST_SPEED);
     CHECK_ERR(err, "deflateInit");
@@ -297,7 +297,7 @@ void test_large_inflate(unsigned char *compr, size_t comprLen, unsigned char *un
 
     d_stream.zalloc = zalloc;
     d_stream.zfree = zfree;
-    d_stream.opaque = (void *)0;
+    d_stream.opaque = Z_NULL;
 
     d_stream.next_in  = compr;
     d_stream.avail_in = (unsigned int)comprLen;
@@ -335,7 +335,7 @@ void test_flush(unsigned char *compr, size_t *comprLen)
 
     c_stream.zalloc = zalloc;
     c_stream.zfree = zfree;
-    c_stream.opaque = (void *)0;
+    c_stream.opaque = Z_NULL;
 
     err = deflateInit(&c_stream, Z_DEFAULT_COMPRESSION);
     CHECK_ERR(err, "deflateInit");
@@ -372,7 +372,7 @@ void test_sync(unsigned char *compr, size_t comprLen, unsigned char *uncompr, si
 
     d_stream.zalloc = zalloc;
     d_stream.zfree = zfree;
-    d_stream.opaque = (void *)0;
+    d_stream.opaque = Z_NULL;
 
     d_stream.next_in  = compr;
     d_stream.avail_in = 2; /* just read the zlib header */
@@ -412,7 +412,7 @@ void test_dict_deflate(unsigned char *compr, size_t comprLen)
 
     c_stream.zalloc = zalloc;
     c_stream.zfree = zfree;
-    c_stream.opaque = (void *)0;
+    c_stream.opaque = Z_NULL;
 
     err = deflateInit(&c_stream, Z_BEST_COMPRESSION);
     CHECK_ERR(err, "deflateInit");
@@ -449,7 +449,7 @@ void test_dict_inflate(unsigned char *compr, size_t comprLen, unsigned char *unc
 
     d_stream.zalloc = zalloc;
     d_stream.zfree = zfree;
-    d_stream.opaque = (void *)0;
+    d_stream.opaque = Z_NULL;
 
     d_stream.next_in  = compr;
     d_stream.avail_in = (unsigned int)comprLen;

--- a/uncompr.c
+++ b/uncompr.c
@@ -42,7 +42,7 @@ int ZEXPORT uncompress(unsigned char *dest, size_t *destLen, const unsigned char
     stream.avail_in = 0;
     stream.zalloc = (alloc_func)0;
     stream.zfree = (free_func)0;
-    stream.opaque = NULL;
+    stream.opaque = Z_NULL;
 
     err = inflateInit(&stream);
     if (err != Z_OK) return err;


### PR DESCRIPTION
There's also an actual benefit to this. When using the unmodified zconf.h.in, compress.c and uncompr.c end up without a definition for NULL in both GCC and Clang, when compiling for the x86_64-unknown-linux-gnu target. Using Z_NULL here allows zlib-ng (without the gzip parts) to be compiled under this setup by just symlinking zconf.h.in to zconf.h, without having to run ./configure or CMake before, which is especially useful for projects that statically link zlib-ng or use Git submodules.
