### PR TITLE
Fixes for MinGW w64 and MSYS2.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ CMakeCache.txt
 CMakeFiles
 Testing
 *.cmake
+*.stackdump
 zconf.h
 zconf.h.cmakein
 zconf.h.included

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,11 @@ endif()
 check_type_size(off64_t OFF64_T)
 if(HAVE_OFF64_T)
    add_definitions(-D_LARGEFILE64_SOURCE=1)
+else()
+   check_type_size(_off64_t _OFF64_T)
+   if (HAVE__OFF64_T)
+      add_definitions(-D_LARGEFILE64_SOURCE=1)
+   endif()
 endif()
 set(CMAKE_REQUIRED_DEFINITIONS) # clear variable
 
@@ -170,7 +175,7 @@ else (WITH_GZFILEOP)
 endif (WITH_GZFILEOP)
 
 
-if(NOT MINGW)
+if(NOT MINGW AND NOT MSYS)
     set(ZLIB_DLL_SRCS
         win32/zlib1.rc # If present will override custom build rule below.
     )
@@ -181,7 +186,7 @@ file(READ ${CMAKE_CURRENT_SOURCE_DIR}/zlib.h _zlib_h_contents)
 string(REGEX REPLACE ".*#define[ \t]+ZLIB_VERSION[ \t]+\"([-0-9A-Za-z.]+)\".*"
     "\\1" ZLIB_FULL_VERSION ${_zlib_h_contents})
 
-if(MINGW)
+if(MINGW OR MSYS)
     # This gets us DLL resource information when compiling on MinGW.
     if(NOT CMAKE_RC_COMPILER)
         set(CMAKE_RC_COMPILER windres.exe)
@@ -195,7 +200,7 @@ if(MINGW)
                             -o ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj
                             -i ${CMAKE_CURRENT_SOURCE_DIR}/win32/zlib1.rc)
     set(ZLIB_DLL_SRCS ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj)
-endif(MINGW)
+endif(MINGW OR MSYS)
 
 add_library(zlib SHARED ${ZLIB_SRCS} ${ZLIB_GZFILE_SRCS} ${ZLIB_ASMS} ${ZLIB_DLL_SRCS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
 add_library(zlibstatic STATIC ${ZLIB_SRCS} ${ZLIB_GZFILE_SRCS} ${ZLIB_ASMS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})

--- a/configure
+++ b/configure
@@ -455,6 +455,9 @@ echo >> configure.log
 # check for large file support, and if none, check for fseeko()
 cat > $test.c <<EOF
 #include <sys/types.h>
+#ifdef __MSYS__
+#  define off64_t _off64_t
+#endif
 off64_t dummy = 0;
 EOF
 if try $CC -c $CFLAGS -D_LARGEFILE64_SOURCE=1 $test.c; then

--- a/gzlib.c
+++ b/gzlib.c
@@ -5,7 +5,7 @@
 
 #include "gzguts.h"
 
-#if defined(WIN32) && !defined(__BORLANDC__)
+#if defined(WIN32) && !defined(__BORLANDC__) && !defined(__MINGW32__)
 #  define LSEEK _lseeki64
 #else
 #if defined(_LARGEFILE64_SOURCE) && _LFS64_LARGEFILE-0

--- a/zconf.h.in
+++ b/zconf.h.in
@@ -164,7 +164,9 @@ typedef void       *voidp;
 #if !defined(WIN32) && defined(Z_LARGE64)
 #  define z_off64_t off64_t
 #else
-#  if defined(WIN32) && !defined(__GNUC__)
+#  if defined(__MSYS__)
+#    define z_off64_t _off64_t
+#  elif defined(WIN32) && !defined(__GNUC__)
 #    define z_off64_t __int64
 #  else
 #    define z_off64_t z_off_t

--- a/zutil.h
+++ b/zutil.h
@@ -79,7 +79,7 @@ extern const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
 #endif
 
 /* provide prototypes for these when building zlib without LFS */
-#if !defined(WIN32) && (!defined(_LARGEFILE64_SOURCE) || _LFS64_LARGEFILE-0 == 0)
+#if !defined(WIN32) && !defined(__MSYS__) && (!defined(_LARGEFILE64_SOURCE) || _LFS64_LARGEFILE-0 == 0)
     ZEXTERN uint32_t ZEXPORT adler32_combine64(uint32_t, uint32_t, z_off_t);
     ZEXTERN uint32_t ZEXPORT crc32_combine64(uint32_t, uint32_t, z_off_t);
 #endif


### PR DESCRIPTION
In MinGW w64 and MSYS2, off64_t is defined as _off64_t only.
