### PR TITLE
Fix Coverity warnings.

### DIFF
--- a/arch/x86/deflate_quick.c
+++ b/arch/x86/deflate_quick.c
@@ -220,6 +220,9 @@ ZLIB_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
                     if (match_len > s->lookahead)
                         match_len = s->lookahead;
 
+                    if (match_len > MAX_MATCH)
+                        match_len = MAX_MATCH;
+
                     static_emit_ptr(s, match_len - MIN_MATCH, s->strstart - hash_head);
                     s->lookahead -= match_len;
                     s->strstart += match_len;

--- a/test/minigzip.c
+++ b/test/minigzip.c
@@ -65,13 +65,13 @@ void myfree (void *, void *);
 
 void *myalloc(void *q, unsigned n, unsigned m)
 {
-    q = Z_NULL;
+    (void)q;
     return calloc(n, m);
 }
 
 void myfree(void *q, void *p)
 {
-    q = Z_NULL;
+    (void)q;
     free(p);
 }
 


### PR DESCRIPTION
- Possible buffer overflow in arch/x86/deflate_quick.c
- Dead code in test/minigzip.c
