### PR TITLE
Loop on write() calls in gzwrite.c in case of non-blocking I/O.

### DIFF
--- a/gzwrite.c
+++ b/gzwrite.c
@@ -77,12 +77,14 @@ local int gz_comp(gz_statep state, int flush) {
 
     /* write directly if requested */
     if (state->direct) {
-        got = write(state->fd, strm->next_in, strm->avail_in);
-        if (got < 0 || (unsigned)got != strm->avail_in) {
-            gz_error(state, Z_ERRNO, zstrerror());
-            return -1;
+        while (strm->avail_in) {
+            if ((got = write(state->fd, strm->next_in, strm->avail_in)) < 0) {
+                gz_error(state, Z_ERRNO, zstrerror());
+                return -1;
+            }
+            strm->avail_in -= got;
+            strm->next_in += got;
         }
-        strm->avail_in = 0;
         return 0;
     }
 
@@ -92,16 +94,17 @@ local int gz_comp(gz_statep state, int flush) {
         /* write out current buffer contents if full, or if flushing, but if
            doing Z_FINISH then don't write until we get to Z_STREAM_END */
         if (strm->avail_out == 0 || (flush != Z_NO_FLUSH && (flush != Z_FINISH || ret == Z_STREAM_END))) {
-            have = (unsigned)(strm->next_out - state->x.next);
-            if (have && ((got = write(state->fd, state->x.next, have)) < 0 || (unsigned)got != have)) {
-                gz_error(state, Z_ERRNO, zstrerror());
-                return -1;
+            while (strm->next_out > state->x.next) {
+                if ((got = write(state->fd, state->x.next, strm->next_out - state->x.next)) < 0) {
+                    gz_error(state, Z_ERRNO, zstrerror());
+                    return -1;
+                }
+                state->x.next += got;
             }
             if (strm->avail_out == 0) {
                 strm->avail_out = state->size;
                 strm->next_out = state->out;
             }
-            state->x.next = strm->next_out;
         }
 
         /* compress */


### PR DESCRIPTION
Imported fix from madler/zlib.
