### PR TITLE
Do not define __builtin_ctzl for Clang on MSVC

### DIFF
--- a/match.c
+++ b/match.c
@@ -28,7 +28,7 @@
 #endif
 
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
 #include <intrin.h>
 /* This is not a general purpose replacement for __builtin_ctzl. The function expects that value is != 0
  * Because of that assumption trailing_zero is not initialized and the return value of _BitScanForward is not checked


### PR DESCRIPTION
Clang targeting MSVC and Clang/C2 provide __builtin_ctzl.
