### PR TITLE
Don't update prev if old head is same as new.

### DIFF
--- a/arch/x86/insert_string_sse.c
+++ b/arch/x86/insert_string_sse.c
@@ -39,9 +39,12 @@ Pos insert_string_sse(deflate_state *const s, const Pos str, unsigned int count)
         );
 #endif
 
-        ret = s->prev[(str+idx) & s->w_mask] = s->head[h & s->hash_mask];
-        s->head[h & s->hash_mask] = str+idx;
+        if (s->head[h & s->hash_mask] != str+idx) {
+            s->prev[(str+idx) & s->w_mask] = s->head[h & s->hash_mask];
+            s->head[h & s->hash_mask] = str+idx;
+        }
     }
+    ret = s->prev[(str+count-1) & s->w_mask];
     return ret;
 }
 #endif

--- a/deflate_p.h
+++ b/deflate_p.h
@@ -42,9 +42,12 @@ local inline Pos insert_string_c(deflate_state *const s, const Pos str, uInt cou
 
     for (idx = 0; idx < count; idx++) {
         UPDATE_HASH(s, s->ins_h, str+idx);
-        ret = s->prev[(str+idx) & s->w_mask] = s->head[s->ins_h];
-        s->head[s->ins_h] = str+idx;
+        if (s->head[s->ins_h] != str+idx) {
+            s->prev[(str+idx) & s->w_mask] = s->head[s->ins_h];
+            s->head[s->ins_h] = str+idx;
+        }
     }
+    ret = s->prev[(str+count-1) & s->w_mask];
     return ret;
 }
 


### PR DESCRIPTION
When updating hash, make sure previous string index and current string index are different. This increases compression rate as it avoids attempt to match against itself.
