### PR TITLE
Using correct format specifiers

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -1032,7 +1032,7 @@ void check_match(deflate_state *s, IPos start, IPos match, int length) {
         z_error("invalid match");
     }
     if (z_verbose > 1) {
-        fprintf(stderr, "\\[%d,%d]", start-match, length);
+        fprintf(stderr, "\\[%u,%d]", start-match, length);
         do {
             putc(s->window[start++], stderr);
         } while (--length != 0);

--- a/trees.c
+++ b/trees.c
@@ -279,12 +279,12 @@ void gen_trees_header() {
 
     fprintf(header, "local const int base_length[LENGTH_CODES] = {\n");
     for (i = 0; i < LENGTH_CODES; i++) {
-        fprintf(header, "%1u%s", base_length[i], SEPARATOR(i, LENGTH_CODES-1, 20));
+        fprintf(header, "%d%s", base_length[i], SEPARATOR(i, LENGTH_CODES-1, 20));
     }
 
     fprintf(header, "local const int base_dist[D_CODES] = {\n");
     for (i = 0; i < D_CODES; i++) {
-        fprintf(header, "%5u%s", base_dist[i], SEPARATOR(i, D_CODES-1, 10));
+        fprintf(header, "%5d%s", base_dist[i], SEPARATOR(i, D_CODES-1, 10));
     }
 
     fclose(header);
@@ -474,7 +474,7 @@ local void gen_bitlen(deflate_state *s, tree_desc *desc) {
             if (m > max_code)
                 continue;
             if (tree[m].Len != bits) {
-                Trace((stderr, "code %d bits %d->%d\n", m, tree[m].Len, bits));
+                Trace((stderr, "code %d bits %d->%u\n", m, tree[m].Len, bits));
                 s->opt_len += (long)((bits - tree[m].Len) * tree[m].Freq);
                 tree[m].Len = (uint16_t)bits;
             }
@@ -749,7 +749,7 @@ local int build_bl_tree(deflate_state *s) {
     }
     /* Update opt_len to include the bit length tree and counts */
     s->opt_len += 3*(max_blindex+1) + 5+5+4;
-    Tracev((stderr, "\ndyn trees: dyn %ld, stat %ld", s->opt_len, s->static_len));
+    Tracev((stderr, "\ndyn trees: dyn %lu, stat %lu", s->opt_len, s->static_len));
 
     return max_blindex;
 }
@@ -769,16 +769,16 @@ local void send_all_trees(deflate_state *s, int lcodes, int dcodes, int blcodes)
     send_bits(s, dcodes-1,   5);
     send_bits(s, blcodes-4,  4); /* not -3 as stated in appnote.txt */
     for (rank = 0; rank < blcodes; rank++) {
-        Tracev((stderr, "\nbl code %2d ", bl_order[rank]));
+        Tracev((stderr, "\nbl code %2u ", bl_order[rank]));
         send_bits(s, s->bl_tree[bl_order[rank]].Len, 3);
     }
-    Tracev((stderr, "\nbl tree: sent %ld", s->bits_sent));
+    Tracev((stderr, "\nbl tree: sent %lu", s->bits_sent));
 
     send_tree(s, (ct_data *)s->dyn_ltree, lcodes-1); /* literal tree */
-    Tracev((stderr, "\nlit tree: sent %ld", s->bits_sent));
+    Tracev((stderr, "\nlit tree: sent %lu", s->bits_sent));
 
     send_tree(s, (ct_data *)s->dyn_dtree, dcodes-1); /* distance tree */
-    Tracev((stderr, "\ndist tree: sent %ld", s->bits_sent));
+    Tracev((stderr, "\ndist tree: sent %lu", s->bits_sent));
 }
 
 /* ===========================================================================
@@ -835,10 +835,10 @@ void ZLIB_INTERNAL _tr_flush_block(deflate_state *s, char *buf, unsigned long st
 
         /* Construct the literal and distance trees */
         build_tree(s, (tree_desc *)(&(s->l_desc)));
-        Tracev((stderr, "\nlit data: dyn %ld, stat %ld", s->opt_len, s->static_len));
+        Tracev((stderr, "\nlit data: dyn %lu, stat %lu", s->opt_len, s->static_len));
 
         build_tree(s, (tree_desc *)(&(s->d_desc)));
-        Tracev((stderr, "\ndist data: dyn %ld, stat %ld", s->opt_len, s->static_len));
+        Tracev((stderr, "\ndist data: dyn %lu, stat %lu", s->opt_len, s->static_len));
         /* At this point, opt_len and static_len are the total bit lengths of
          * the compressed block data, excluding the tree representations.
          */


### PR DESCRIPTION
Fixes bug #73. 

Changing code from unsigned to int in compress_block should not cause any issues, since the value never exceeds 285 in that function and is never less than 0.
