### PR TITLE
Cleanup configure and Makefile.in

### DIFF
--- a/arch/x86/deflate_quick.c
+++ b/arch/x86/deflate_quick.c
@@ -123,7 +123,7 @@ static const unsigned quick_len_codes[MAX_MATCH-MIN_MATCH+1];
 static const unsigned quick_dist_codes[8192];
 
 static inline void quick_send_bits(deflate_state *const s, const int value, const int length) {
-    unsigned code, out, width, bytes_out;
+    unsigned out, width, bytes_out;
 
     /* Concatenate the new bits with the bits currently in the buffer */
     out = s->bi_buf | (value << s->bi_valid);

--- a/gzread.c
+++ b/gzread.c
@@ -286,7 +286,7 @@ static size_t gz_read(gz_statep state, void *buf, size_t len) {
         /* set n to the maximum amount of len that fits in an unsigned int */
         n = -1;
         if (n > len)
-            n = len;
+            n = (unsigned)len;
 
         /* first just try copying data from the output buffer */
         if (state->x.have) {
@@ -363,7 +363,7 @@ int ZEXPORT gzread(gzFile file, void *buf, unsigned len) {
     }
 
     /* read len or fewer bytes to buf */
-    len = gz_read(state, buf, len);
+    len = (unsigned)gz_read(state, buf, len);
 
     /* check for an error */
     if (len == 0 && state->err != Z_OK && state->err != Z_BUF_ERROR)
@@ -423,7 +423,7 @@ int ZEXPORT gzgetc(gzFile file) {
     }
 
     /* nothing there -- try gz_read() */
-    ret = gz_read(state, buf, 1);
+    ret = (int)gz_read(state, buf, 1);
     return ret < 1 ? -1 : buf[0];
 }
 

--- a/gzwrite.c
+++ b/gzwrite.c
@@ -187,7 +187,7 @@ static size_t gz_write(gz_statep state, void const *buf, size_t len) {
                               state->in);
             copy = state->size - have;
             if (copy > len)
-                copy = len;
+                copy = (unsigned)len;
             memcpy(state->in + have, buf, copy);
             state->strm.avail_in += copy;
             state->x.pos += copy;
@@ -206,7 +206,7 @@ static size_t gz_write(gz_statep state, void const *buf, size_t len) {
         do {
             unsigned n = (unsigned)-1;
             if (n > len)
-                n = len;
+                n = (unsigned)len;
             state->strm.avail_in = n;
             state->x.pos += n;
             if (gz_comp(state, Z_NO_FLUSH) == -1)
@@ -330,7 +330,7 @@ int ZEXPORT gzputs(gzFile file, const char *str) {
 
     /* write string */
     len = strlen(str);
-    ret = gz_write(state, str, len);
+    ret = (int)gz_write(state, str, len);
     return ret == 0 && len != 0 ? -1 : ret;
 }
 

--- a/win32/zlib.def
+++ b/win32/zlib.def
@@ -35,38 +35,7 @@ EXPORTS
     compressBound
     uncompress
     uncompress2
-    gzopen
-    gzdopen
-    gzbuffer
-    gzsetparams
-    gzread
-    gzfread
-    gzwrite
-    gzfwrite
-    gzprintf
-    gzvprintf
-    gzputs
-    gzgets
-    gzputc
-    gzgetc
-    gzungetc
-    gzflush
-    gzseek
-    gzrewind
-    gztell
-    gzoffset
-    gzeof
-    gzdirect
-    gzclose
-    gzclose_r
-    gzclose_w
-    gzerror
-    gzclearerr
 ; large file functions
-    gzopen64
-    gzseek64
-    gztell64
-    gzoffset64
     adler32_combine64
     crc32_combine64
 ; checksum functions
@@ -82,7 +51,6 @@ EXPORTS
     inflateInit_
     inflateInit2_
     inflateBackInit_
-    gzgetc_
     zError
     inflateSyncPoint
     get_crc_table
@@ -91,4 +59,3 @@ EXPORTS
     inflateCodesUsed
     inflateResetKeep
     deflateResetKeep
-    gzopen_w

--- a/win32/zlibcompat.def
+++ b/win32/zlibcompat.def
@@ -8,6 +8,7 @@ EXPORTS
     inflateEnd
 ; advanced functions
     deflateSetDictionary
+    deflateGetDictionary
     deflateCopy
     deflateReset
     deflateParams
@@ -33,12 +34,15 @@ EXPORTS
     compress2
     compressBound
     uncompress
+    uncompress2
     gzopen
     gzdopen
     gzbuffer
     gzsetparams
     gzread
+    gzfread
     gzwrite
+    gzfwrite
     gzprintf
     gzvprintf
     gzputs
@@ -67,7 +71,9 @@ EXPORTS
     crc32_combine64
 ; checksum functions
     adler32
+    adler32_z
     crc32
+    crc32_z
     adler32_combine
     crc32_combine
 ; various hacks, don't look :)
@@ -81,6 +87,8 @@ EXPORTS
     inflateSyncPoint
     get_crc_table
     inflateUndermine
+    inflateValidate
+    inflateCodesUsed
     inflateResetKeep
     deflateResetKeep
     gzopen_w


### PR DESCRIPTION
* Makefile.in was using same flags for compiler and linker, which did break build on some systems
* Dependency tracking didn't work at all for arch-dependent files
* Add support for --native flag as it was already added when building with cmake