### PR TITLE
Added a new longest_match method

### DIFF
--- a/configure
+++ b/configure
@@ -111,6 +111,7 @@ sse4flag="-msse4"
 pclmulflag="-mpclmul"
 without_optimizations=0
 without_new_strategies=0
+use_distant_search=0
 gcc=0
 warn=0
 debug=0
@@ -145,6 +146,7 @@ case "$1" in
       echo '  configure [--zlib-compat] [--prefix=PREFIX]  [--eprefix=EXPREFIX]' | tee -a configure.log
       echo '    [--static] [--32] [--64] [--libdir=LIBDIR] [--sharedlibdir=LIBDIR]' | tee -a configure.log
       echo '    [--includedir=INCLUDEDIR] [--archs="-arch i386 -arch x86_64"]' | tee -a configure.log
+      echo '    [--without-new-strategies] [--use_distant_search]' | tee -a configure.log
         exit 0 ;;
     -p*=* | --prefix=*) prefix=`echo $1 | sed 's/.*=//'`; shift ;;
     -e*=* | --eprefix=*) exec_prefix=`echo $1 | sed 's/.*=//'`; shift ;;
@@ -168,6 +170,7 @@ case "$1" in
     --localstatedir=*) echo "ignored option: --localstatedir" | tee -a configure.log; shift ;;
     -noopt | --without-optimizations) without_optimizations=1; shift;;
     -oldstrat | --without-new-strategies) without_new_strategies=1; shift;;
+    -distant | --use_distant_search) use_distant_search=1; shift;;
     -w* | --warn) warn=1; shift ;;
     -d* | --debug) debug=1; shift ;;
     *)
@@ -741,6 +744,12 @@ fi
 if test $without_new_strategies -eq 0; then
     CFLAGS="${CFLAGS} -DMEDIUM_STRATEGY"
     SFLAGS="${SFLAGS} -DMEDIUM_STRATEGY"
+fi
+
+# Enable distant_search for deflate_slow
+if test $use_distant_search -eq 1; then
+    CFLAGS="${CFLAGS} -DUSE_DISTANT_SEARCH"
+    SFLAGS="${SFLAGS} -DUSE_DISTANT_SEARCH"
 fi
 
 ARCHDIR='arch/generic'

--- a/match.c
+++ b/match.c
@@ -16,7 +16,11 @@
       non-gcc compilers since the __builtin_ctzl() function might not be optimized. */
 #  if defined(__GNUC__) && defined(HAVE_BUILTIN_CTZL) && ((__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) \
         || defined(__LITTLE_ENDIAN__))
+#ifndef USE_DISTANT_SEARCH
 #    define std3_longest_match
+#else
+#    define std4_longest_match
+#endif
 #  elif(defined(_MSC_VER) && defined(_WIN32))
 #    define std3_longest_match
 #  else
@@ -465,5 +469,122 @@ ZLIB_INTERNAL unsigned longest_match(deflate_state *const s, IPos cur_match) {
     if ((unsigned int)best_len <= s->lookahead)
         return (unsigned int)best_len;
     return s->lookahead;
+}
+#endif
+
+#ifdef std4_longest_match
+static inline long get_match_len(const unsigned char *a, const unsigned char *b, long max)
+{
+    register int len = 0;
+    register unsigned long xor = 0;
+    register int check_loops = max/sizeof(unsigned long);
+    while(check_loops-- > 0) {
+        xor = (*(unsigned long *)(a+len)) ^ (*(unsigned long *)(b+len));
+        if (xor) break;
+        len += sizeof(unsigned long);
+    }
+    if (unlikely(0 == xor)) {
+        while (len < max) {
+            if (a[len] != b[len]) break;
+            len++;
+        }
+        return len;
+    }
+    xor = __builtin_ctzl(xor)>>3;
+    return len + xor;
+}
+
+/*
+ * This implementation is based on algorithm described at:
+ * http://www.gildor.org/en/projects/zlib
+ * It uses the hash chain indexed by the most distant hash code to
+ * reduce number of checks.
+ * This also eliminates the those unnecessary check loops in legacy
+ * longest_match's do..while loop if the "most distant code" is out
+ * of search buffer
+ *
+ */
+ZLIB_INTERNAL unsigned longest_match(deflate_state *const s, IPos cur_match) {
+    unsigned chain_length = s->max_chain_length;/* max hash chain length */
+    register unsigned char *scan = s->window + s->strstart; /* current string */
+    register unsigned char *match;                       /* matched string */
+    register unsigned int len;                  /* length of current match */
+    unsigned int best_len = s->prev_length;     /* best match length so far */
+    unsigned int nice_match = s->nice_match;    /* stop if match long enough */
+    IPos limit = s->strstart > (IPos)MAX_DIST(s) ?
+        s->strstart - (IPos)MAX_DIST(s) : NIL;
+    /* Stop when cur_match becomes <= limit. To simplify the code,
+     * we prevent matches with the string of window index 0.
+     */
+    int offset = 0;  /* offset of the head[most_distant_hash] from IN cur_match */
+    Pos *prev = s->prev;
+    unsigned int wmask = s->w_mask;
+    unsigned char *scan_buf_base = s->window;
+
+    /* The code is optimized for HASH_BITS >= 8 and MAX_MATCH-2 multiple of 16.
+     * It is easy to get rid of this optimization if necessary.
+     */
+    Assert(s->hash_bits >= 8 && MAX_MATCH == 258, "Code too clever");
+
+    /* Do not look for matches beyond the end of the input. This is necessary
+     * to make deflate deterministic.
+     */
+    if ((unsigned int)nice_match > s->lookahead) nice_match = s->lookahead;
+
+    Assert((unsigned long)s->strstart <= s->window_size-MIN_LOOKAHEAD, "need lookahead");
+
+    /* find most distant hash code for lazy_match */
+    if (best_len > MIN_MATCH) {
+        /* search for most distant hash code */
+        register int i;
+        register uint16_t hash = 0;
+        register IPos pos;
+
+        UPDATE_HASH(s, hash, scan[1]);
+        UPDATE_HASH(s, hash, scan[2]);
+        for (i = 3; i <= best_len; i++) {
+            UPDATE_HASH(s, hash, scan[i]);
+            /* get head IPos of hash calced by scan[i-2..i] */
+            pos = s->head[hash];
+            /* compare it to current "farthest hash" IPos */
+            if (pos <= cur_match) {
+                /* we have a new "farthest hash" now */
+                offset = i - 2;
+                cur_match = pos;
+            }
+        }
+
+        /* update variables to correspond offset */
+        limit += offset;
+        /*
+         * check if the most distant code's offset is out of search buffer
+         * if it is true, then this means scan[offset..offset+2] are not presented
+         * in the search buffer. So we just return best_len we've found.
+         */
+        if (cur_match < limit) return best_len;
+
+        scan_buf_base -= offset;
+        /* reduce hash search depth based on best_len */
+        chain_length /= best_len - MIN_MATCH;
+    }
+
+    do {
+        Assert(cur_match < s->strstart, "no future");
+
+        /* Determine matched length at current pos */
+        match = scan_buf_base + cur_match;
+        len = get_match_len(match, scan, MAX_MATCH);
+
+        if (len > best_len) {
+            /* found longer string */
+            s->match_start = cur_match - offset;
+            best_len = len;
+            /* good enough? */
+            if (len >= nice_match) break;
+        }
+        /* move to prev pos in this hash chain */
+    } while ((cur_match = prev[cur_match & wmask]) > limit && --chain_length != 0);
+
+    return (best_len <= s->lookahead)? best_len : s->lookahead;
 }
 #endif


### PR DESCRIPTION
This method uses "farthest hash" to reduce check loops. The idea is based on algorithm described at:
http://www.gildor.org/en/projects/zlib
 Benchmarked it with lzbench against Silesia's corpus. The performance gain can be at ~150% max. For most cases in level6-9 it can get 40%~60% compression speed up.