### PR TITLE
CMakeLists.txt: Fix cross-compiling.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ check_include_file(stddef.h    HAVE_STDDEF_H)
 #
 # Options parsing
 #
-set(ARCH ${CMAKE_HOST_SYSTEM_PROCESSOR})
+set(ARCH ${CMAKE_SYSTEM_PROCESSOR})
 message(STATUS "Architecture: ${ARCH}")
 
 option (ZLIB_COMPAT "Compile with zlib compatible API" OFF)


### PR DESCRIPTION
Using CMAKE_HOST_SYSTEM_PROCESSOR made build fail when architecture of compiler doesn't match architecture of the host building zlib-ng. We still need to use toolchain file or at minimum manually override CMAKE_SYSTEM_PROCESSOR for compilers that are not supported by currently installed cmake version.

At least now we agree with cmake manuals about how to detect correct target CPU architecture.

Tested with MinGW32 using Linaro gcc for arm and AArch64.