### PR TITLE
Lazily initialize functable members.

### DIFF
--- a/adler32.c
+++ b/adler32.c
@@ -145,15 +145,11 @@ uint32_t adler32_c(uint32_t adler, const unsigned char *buf, size_t len) {
 }
 
 uint32_t ZEXPORT adler32_z(uint32_t adler, const unsigned char *buf, size_t len) {
-    if (functable.adler32 == NULL)
-        functableInit();
     return functable.adler32(adler, buf, len);
 }
 
 /* ========================================================================= */
 uint32_t ZEXPORT adler32(uint32_t adler, const unsigned char *buf, uint32_t len) {
-    if (functable.adler32 == NULL)
-        functableInit();
     return functable.adler32(adler, buf, len);
 }
 

--- a/deflate.c
+++ b/deflate.c
@@ -241,8 +241,6 @@ int ZEXPORT deflateInit2_(z_stream *strm, int level, int method, int windowBits,
     x86_check_features();
 #endif
 
-    functableInit();
-
     if (version == NULL || version[0] != my_version[0] || stream_size != sizeof(z_stream)) {
         return Z_VERSION_ERROR;
     }

--- a/functable.h
+++ b/functable.h
@@ -10,8 +10,6 @@
 
 uint32_t adler32_c(uint32_t adler, const unsigned char *buf, size_t len);
 
-void functableInit();
-
 struct functable_s {
     void     (* fill_window)    (deflate_state *s);
     Pos      (* insert_string)  (deflate_state *const s, const Pos str, unsigned int count);

--- a/inflate.c
+++ b/inflate.c
@@ -187,8 +187,6 @@ int ZEXPORT inflateInit2_(z_stream *strm, int windowBits, const char *version, i
     int ret;
     struct inflate_state *state;
 
-    functableInit();
-
     if (version == NULL || version[0] != ZLIB_VERSION[0] || stream_size != (int)(sizeof(z_stream)))
         return Z_VERSION_ERROR;
     if (strm == NULL)


### PR DESCRIPTION
* Split functableInit() function as separate functions for each functable member, so we don't need to initialize full functable in multiple places in the zlib-ng code, or to check for NULL on every invocation. 
* Optimized function for each functable member is detected on first invocation and the functable item is updated for subsequent invocations.
* Remove NULL check in adler32() and adler32_z() as it is no longer needed.