### PR TITLE
configure: For Windows builds, add the CROSS_PREFIX to $RC and $STRIP.

### DIFF
--- a/configure
+++ b/configure
@@ -284,10 +284,10 @@ if test "$gcc" -eq 1 && ($cc $CFLAGS -c $test.c) >> configure.log 2>&1; then
         LDSHAREDFLAGS="-shared -Wl,--out-implib,${IMPORTLIB},--version-script,${SRCDIR}/zlib.map"
         LDSHAREDLIBC=""
         DEFFILE='win32/zlib.def'
-        RC='windres'
+        RC="${CROSS_PREFIX}windres"
         RCFLAGS='--define GCC_WINDRES'
         RCOBJS='zlibrc.o'
-        STRIP='strip'
+        STRIP="${CROSS_PREFIX}strip"
         EXE='.exe' ;;
   MSYS* | msys*)
         ARFLAGS="rcs"
@@ -303,10 +303,10 @@ if test "$gcc" -eq 1 && ($cc $CFLAGS -c $test.c) >> configure.log 2>&1; then
         LDSHAREDFLAGS="-shared -Wl,--out-implib,${IMPORTLIB}"
         LDSHAREDLIBC=""
         DEFFILE='win32/zlib.def'
-        RC='windres'
+        RC="${CROSS_PREFIX}windres"
         RCFLAGS='--define GCC_WINDRES'
         RCOBJS='zlibrc.o'
-        STRIP='strip'
+        STRIP="${CROSS_PREFIX}strip"
         EXE='.exe' ;;
   MINGW* | mingw*)
         ARFLAGS="rcs"
@@ -323,7 +323,7 @@ if test "$gcc" -eq 1 && ($cc $CFLAGS -c $test.c) >> configure.log 2>&1; then
         LDSHAREDFLAGS="-shared -Wl,--out-implib=${IMPORTLIB} -Wl,--version-script=${SRCDIR}/zlib.map"
         LDSHAREDLIBC=""
         DEFFILE='win32/zlib.def'
-        RC='windres'
+        RC="${CROSS_PREFIX}windres"
         RCFLAGS='--define GCC_WINDRES'
         if [ "$CC" == "mingw32-gcc" ]; then
           case $ARCH in
@@ -331,7 +331,7 @@ if test "$gcc" -eq 1 && ($cc $CFLAGS -c $test.c) >> configure.log 2>&1; then
           esac;
         fi
         RCOBJS='zlibrc.o'
-        STRIP='strip'
+        STRIP="${CROSS_PREFIX}strip"
         EXE='.exe' ;;
   QNX*)  # This is for QNX6. I suppose that the QNX rule below is for QNX2,QNX4
          # (alain.bonnefoy@icbt.com)


### PR DESCRIPTION
zlib's original win32/Makefile.gcc did the same, but this was removed in 7d17132436431d5f62cf5089623073d72d07deb0. It is kind of essential for cross-compiling a Win32 build on Linux, since `windres` most certainly doesn't exist, and the regular `strip` may not be able to handle DLLs.

It should probably actually be something like

	RC="${RC-${CROSS_PREFIX}windres}"

and

	STRIP="${STRIP-${CROSS_PREFIX}strip}"

to be consistent with the assignments of $AR, $RANLIB and $NM, but this didn't work for some reason.