### PR TITLE
Fix that s->prev is not used uninitialized in insert_string_*

### DIFF
--- a/arch/aarch64/insert_string_acle.c
+++ b/arch/aarch64/insert_string_acle.c
@@ -20,12 +20,13 @@
  */
 #ifdef ARM_ACLE_CRC_HASH
 Pos insert_string_acle(deflate_state *const s, const Pos str, unsigned int count) {
-    Pos p, lp;
+    Pos p, lp, ret;
 
     if (unlikely(count == 0)) {
         return s->prev[str & s->w_mask];
     }
 
+    ret = 0;
     lp = str + count - 1; /* last position */
 
     for (p = str; p <= lp; p++) {
@@ -43,8 +44,11 @@ Pos insert_string_acle(deflate_state *const s, const Pos str, unsigned int count
         if (s->head[hm] != p) {
             s->prev[p & s->w_mask] = s->head[hm];
             s->head[hm] = p;
+            if (p == lp) {
+                ret = s->prev[lp & s->w_mask]);
+            }
         }
     }
-    return s->prev[lp & s->w_mask];
+    return ret;
 }
 #endif

--- a/arch/arm/insert_string_acle.c
+++ b/arch/arm/insert_string_acle.c
@@ -20,12 +20,13 @@
  */
 #ifdef ARM_ACLE_CRC_HASH
 Pos insert_string_acle(deflate_state *const s, const Pos str, unsigned int count) {
-    Pos p, lp;
+    Pos p, lp, ret;
 
     if (unlikely(count == 0)) {
         return s->prev[str & s->w_mask];
     }
 
+    ret = 0;
     lp = str + count - 1; /* last position */
 
     for (p = str; p <= lp; p++) {
@@ -43,8 +44,11 @@ Pos insert_string_acle(deflate_state *const s, const Pos str, unsigned int count
         if (s->head[hm] != p) {
             s->prev[p & s->w_mask] = s->head[hm];
             s->head[hm] = p;
+            if (p == lp) {
+                ret = s->prev[lp & s->w_mask]);
+            }
         }
     }
-    return s->prev[lp & s->w_mask];
+    return ret;
 }
 #endif

--- a/arch/x86/insert_string_sse.c
+++ b/arch/x86/insert_string_sse.c
@@ -42,9 +42,11 @@ ZLIB_INTERNAL Pos insert_string_sse(deflate_state *const s, const Pos str, unsig
         if (s->head[h & s->hash_mask] != str+idx) {
             s->prev[(str+idx) & s->w_mask] = s->head[h & s->hash_mask];
             s->head[h & s->hash_mask] = str+idx;
+            if (idx == count-1) {
+                ret = s->prev[(str+idx) & s->w_mask];
+            }
         }
     }
-    ret = s->prev[(str+count-1) & s->w_mask];
     return ret;
 }
 #endif

--- a/deflate_p.h
+++ b/deflate_p.h
@@ -40,9 +40,11 @@ static inline Pos insert_string_c(deflate_state *const s, const Pos str, unsigne
         if (s->head[s->ins_h] != str+idx) {
             s->prev[(str+idx) & s->w_mask] = s->head[s->ins_h];
             s->head[s->ins_h] = str+idx;
+            if (idx == count-1) {
+                ret = s->prev[(str+idx) & s->w_mask];
+            }
         }
     }
-    ret = s->prev[(str+count-1) & s->w_mask];
     return ret;
 }
 


### PR DESCRIPTION
As pointed out in issue #78, s->prev is used uninitialized if last byte of the string is already hashed as most recent in hash chain. The workaround forces returning 0 in such cases. s->prev will be initialized the next time same byte sequence is hashed further in the stream.