### PR TITLE
[compat] Remove WITH_GZFILEOP from public headers, use unsigned long in compress-related functions.

### DIFF
--- a/compress.c
+++ b/compress.c
@@ -8,8 +8,10 @@
 #define ZLIB_INTERNAL
 #if defined(ZLIB_COMPAT)
 # include "zlib.h"
+# define z_size_t unsigned long
 #else
 # include "zlib-ng.h"
+# define z_size_t size_t
 #endif
 
 /* ===========================================================================
@@ -23,12 +25,12 @@
    memory, Z_BUF_ERROR if there was not enough room in the output buffer,
    Z_STREAM_ERROR if the level parameter is invalid.
 */
-int ZEXPORT PREFIX(compress2)(unsigned char *dest, size_t *destLen, const unsigned char *source,
-                        size_t sourceLen, int level) {
+int ZEXPORT PREFIX(compress2)(unsigned char *dest, z_size_t *destLen, const unsigned char *source,
+                        z_size_t sourceLen, int level) {
     PREFIX3(stream) stream;
     int err;
     const unsigned int max = (unsigned int)-1;
-    size_t left;
+    z_size_t left;
 
     left = *destLen;
     *destLen = 0;
@@ -65,7 +67,7 @@ int ZEXPORT PREFIX(compress2)(unsigned char *dest, size_t *destLen, const unsign
 
 /* ===========================================================================
  */
-int ZEXPORT PREFIX(compress)(unsigned char *dest, size_t *destLen, const unsigned char *source, size_t sourceLen) {
+int ZEXPORT PREFIX(compress)(unsigned char *dest, z_size_t *destLen, const unsigned char *source, z_size_t sourceLen) {
     return PREFIX(compress2)(dest, destLen, source, sourceLen, Z_DEFAULT_COMPRESSION);
 }
 
@@ -73,6 +75,6 @@ int ZEXPORT PREFIX(compress)(unsigned char *dest, size_t *destLen, const unsigne
    If the default memLevel or windowBits for deflateInit() is changed, then
    this function needs to be updated.
  */
-size_t ZEXPORT PREFIX(compressBound)(size_t sourceLen) {
+z_size_t ZEXPORT PREFIX(compressBound)(z_size_t sourceLen) {
     return sourceLen + (sourceLen >> 12) + (sourceLen >> 14) + (sourceLen >> 25) + 13;
 }

--- a/uncompr.c
+++ b/uncompr.c
@@ -8,8 +8,10 @@
 #define ZLIB_INTERNAL
 #ifdef ZLIB_COMPAT
 # include "zlib.h"
+# define z_size_t unsigned long
 #else
 # include "zlib-ng.h"
+# define z_size_t size_t
 #endif
 
 /* ===========================================================================
@@ -28,11 +30,11 @@
    Z_DATA_ERROR if the input data was corrupted, including if the input data is
    an incomplete zlib stream.
 */
-int ZEXPORT PREFIX(uncompress2)(unsigned char *dest, size_t *destLen, const unsigned char *source, size_t *sourceLen) {
+int ZEXPORT PREFIX(uncompress2)(unsigned char *dest, z_size_t *destLen, const unsigned char *source, z_size_t *sourceLen) {
     PREFIX3(stream) stream;
     int err;
     const unsigned int max = (unsigned int)-1;
-    size_t len, left;
+    z_size_t len, left;
     unsigned char buf[1];    /* for detection of incomplete stream when *destLen == 0 */
 
     len = *sourceLen;
@@ -82,7 +84,7 @@ int ZEXPORT PREFIX(uncompress2)(unsigned char *dest, size_t *destLen, const unsi
            err;
 }
 
-int ZEXPORT PREFIX(uncompress)(unsigned char *dest, size_t *destLen, const unsigned char *source, size_t sourceLen)
+int ZEXPORT PREFIX(uncompress)(unsigned char *dest, z_size_t *destLen, const unsigned char *source, z_size_t sourceLen)
 {
     return PREFIX(uncompress2)(dest, destLen, source, &sourceLen);
 }

--- a/zconf.h.in
+++ b/zconf.h.in
@@ -154,7 +154,7 @@ typedef void       *voidp;
 #  define Z_WANT64
 #endif
 
-#if !defined(SEEK_SET) && defined(WITH_GZFILEOP)
+#if !defined(SEEK_SET)
 #  define SEEK_SET        0       /* Seek from beginning of file.  */
 #  define SEEK_CUR        1       /* Seek from current position.  */
 #  define SEEK_END        2       /* Set file pointer to EOF plus "offset" */

--- a/zlib.h
+++ b/zlib.h
@@ -1194,7 +1194,7 @@ ZEXTERN unsigned long ZEXPORT zlibCompileFlags(void);
    you need special options.
 */
 
-ZEXTERN int ZEXPORT compress(unsigned char *dest, size_t *destLen, const unsigned char *source, size_t sourceLen);
+ZEXTERN int ZEXPORT compress(unsigned char *dest, unsigned long *destLen, const unsigned char *source, unsigned long sourceLen);
 /*
      Compresses the source buffer into the destination buffer.  sourceLen is
    the byte length of the source buffer.  Upon entry, destLen is the total size
@@ -1208,8 +1208,8 @@ ZEXTERN int ZEXPORT compress(unsigned char *dest, size_t *destLen, const unsigne
    buffer.
 */
 
-ZEXTERN int ZEXPORT compress2(unsigned char *dest, size_t *destLen, const unsigned char *source,
-                              size_t sourceLen, int level);
+ZEXTERN int ZEXPORT compress2(unsigned char *dest, unsigned long *destLen, const unsigned char *source,
+                              unsigned long sourceLen, int level);
 /*
      Compresses the source buffer into the destination buffer.  The level
    parameter has the same meaning as in deflateInit.  sourceLen is the byte
@@ -1223,14 +1223,14 @@ ZEXTERN int ZEXPORT compress2(unsigned char *dest, size_t *destLen, const unsign
    Z_STREAM_ERROR if the level parameter is invalid.
 */
 
-ZEXTERN size_t ZEXPORT compressBound(size_t sourceLen);
+ZEXTERN unsigned long ZEXPORT compressBound(unsigned long sourceLen);
 /*
      compressBound() returns an upper bound on the compressed size after
    compress() or compress2() on sourceLen bytes.  It would be used before a
    compress() or compress2() call to allocate the destination buffer.
 */
 
-ZEXTERN int ZEXPORT uncompress(unsigned char *dest, size_t *destLen, const unsigned char *source, size_t sourceLen);
+ZEXTERN int ZEXPORT uncompress(unsigned char *dest, unsigned long *destLen, const unsigned char *source, unsigned long sourceLen);
 /*
      Decompresses the source buffer into the destination buffer.  sourceLen is
    the byte length of the source buffer.  Upon entry, destLen is the total size
@@ -1248,8 +1248,8 @@ ZEXTERN int ZEXPORT uncompress(unsigned char *dest, size_t *destLen, const unsig
 */
 
 
-ZEXTERN int ZEXPORT uncompress2 (unsigned char *dest,         size_t *destLen,
-                                 const unsigned char *source, size_t *sourceLen);
+ZEXTERN int ZEXPORT uncompress2 (unsigned char *dest,         unsigned long *destLen,
+                                 const unsigned char *source, unsigned long *sourceLen);
 /*
      Same as uncompress, except that sourceLen is a pointer, where the
    length of the source is *sourceLen.  On return, *sourceLen is the number of

--- a/zlib.h
+++ b/zlib.h
@@ -1257,7 +1257,6 @@ ZEXTERN int ZEXPORT uncompress2 (unsigned char *dest,         size_t *destLen,
 */
 
 
-#ifdef WITH_GZFILEOP
                         /* gzip file access functions */
 
 /*
@@ -1637,7 +1636,6 @@ ZEXTERN void ZEXPORT gzclearerr(gzFile file);
    file that is being written concurrently.
 */
 
-#endif /* WITH_GZFILEOP */
 
                         /* checksum functions */
 
@@ -1736,7 +1734,6 @@ ZEXTERN int ZEXPORT inflateBackInit_(z_stream *strm, int windowBits, unsigned ch
 #define inflateBackInit(strm, windowBits, window) \
                         inflateBackInit_((strm), (windowBits), (window), ZLIB_VERSION, (int)sizeof(z_stream))
 
-#ifdef WITH_GZFILEOP
 
 /* gzgetc() macro and its supporting function and exposed data structure.  Note
  * that the real internal state is much larger than the exposed structure.
@@ -1783,7 +1780,6 @@ ZEXTERN int ZEXPORT gzgetc_(gzFile file);  /* backward compatibility */
    ZEXTERN z_off_t ZEXPORT gztell(gzFile);
    ZEXTERN z_off_t ZEXPORT gzoffset(gzFile);
 #endif
-#endif /* WITH_GZFILEOP */
 
 
 /* provide 64-bit offset functions if _LARGEFILE64_SOURCE defined, and/or
@@ -1820,12 +1816,10 @@ ZEXTERN unsigned long    ZEXPORT inflateCodesUsed (z_stream *);
 ZEXTERN int              ZEXPORT inflateResetKeep (z_stream *);
 ZEXTERN int              ZEXPORT deflateResetKeep (z_stream *);
 
-#ifdef WITH_GZFILEOP
-# if (defined(WIN32) || defined(__CYGWIN__) || defined(__MINGW__))
+#if (defined(WIN32) || defined(__CYGWIN__) || defined(__MINGW__))
     ZEXTERN gzFile ZEXPORT gzopen_w(const wchar_t *path, const char *mode);
-# endif
-ZEXTERN int ZEXPORTVA gzvprintf(gzFile file, const char *format, va_list va);
 #endif
+ZEXTERN int ZEXPORTVA gzvprintf(gzFile file, const char *format, va_list va);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
* Don't check for WITH_GZFILEOP in public headers as that is only defined when actually compiling zlib-ng
* Use unsigned long instead of size_t when passing size parameters to compress/compressBound/uncompress

Fixes #136.