### PR TITLE
[Issue #140] Use "/usr/bin/env bash" instead of /bin/sh in configure.

### DIFF
--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # configure script for zlib.
 #
 # Normally configure builds both a static and a shared library.


### PR DESCRIPTION
On systems where bash is not default shell, configure script will fail. As each shell has own way to handle variables, we should not assume bash is the default shell and explicitly say we want to use bash.