### PR TITLE
Runtime crc32_z optimized implementation detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,6 +263,57 @@ if(HAVE_BUILTIN_CTZL)
     add_definitions(-DHAVE_BUILTIN_CTZL)
 endif()
 
+#
+# check for attribute(ifunc) support in the compiler
+#
+check_c_source_compiles(
+    "
+    static unsigned int crc32_real_optimized(unsigned int crc, unsigned char *p,
+                              unsigned long len)
+    {
+            return 1;
+    }
+
+    static unsigned int (*(crc32_ifunc(void)))(unsigned int, unsigned char *,unsigned long)
+    {
+      return crc32_real_optimized;
+    }
+
+    unsigned int crc32(unsigned int, unsigned char *,unsigned long)
+                        __attribute__ ((ifunc (\"crc32_ifunc\")));
+    "
+    HAVE_IFUNC_NATIVE
+)
+if(HAVE_IFUNC_NATIVE)
+    add_definitions(-DHAVE_IFUNC_NATIVE)
+endif()
+
+#
+# check for asm .type %gnu_indirect_function support in the compiler
+#
+check_c_source_compiles(
+    "
+    static unsigned int crc32_real_optimized(unsigned int crc, unsigned char *p,
+                              unsigned long len)
+    {
+            return 1;
+    }
+
+    static unsigned int (*(crc32_ifunc(void)))(unsigned int, unsigned char *,unsigned long)
+           __asm__ (\"crc32\");
+
+    static unsigned int (*(crc32_ifunc(void)))(unsigned int, unsigned char *,unsigned long)
+    {
+      return crc32_real_optimized;
+    }
+
+    __asm__(\".type crc32, %gnu_indirect_function\");
+    "
+    HAVE_IFUNC_ASM
+)
+if(HAVE_IFUNC_ASM AND NOT HAVE_IFUNC_NATIVE)
+    add_definitions(-DHAVE_IFUNC_ASM)
+endif()
 # Macro to check if source compiles when cross-compiling
 # or runs when compiling natively
 macro(check_c_source_compile_or_run source flag)

--- a/arch/aarch64/crc32_acle.c
+++ b/arch/aarch64/crc32_acle.c
@@ -18,6 +18,8 @@ uint32_t crc32_acle(uint32_t crc, const unsigned char *buf, size_t len) {
     register const uint32_t *buf4;
     register const uint64_t *buf8;
 
+    if (buf == NULL) return 0;
+
     c = ~crc;
     if (len && ((ptrdiff_t)buf & 1)) {
         c = __crc32b(c, *buf++);

--- a/arch/arm/crc32_acle.c
+++ b/arch/arm/crc32_acle.c
@@ -17,6 +17,8 @@ uint32_t crc32_acle(uint32_t crc, const unsigned char *buf, size_t len) {
     register const uint16_t *buf2;
     register const uint32_t *buf4;
 
+    if (buf == NULL) return 0;
+
     c = ~crc;
     if (len && ((ptrdiff_t)buf & 1)) {
         c = __crc32b(c, *buf++);

--- a/configure
+++ b/configure
@@ -713,6 +713,67 @@ if try ${CC} ${CFLAGS} $test.c $LDSHAREDLIBC; then
 else
     echo "Checking for __builtin_ctzl ... No." | tee -a configure.log
 fi
+# test to see if we can use a gnu indirection function to detect and load optimized code at runtime
+echo >> configure.log
+cat > $test.c <<EOF
+static unsigned int crc32_real_optimized(unsigned int crc, unsigned char *p,
+                          unsigned long len)
+{
+        return 1;
+}
+
+static unsigned int (*(crc32_ifunc(void)))(unsigned int, unsigned char *,unsigned long)
+{
+  return crc32_real_optimized;
+}
+
+unsigned int crc32(unsigned int, unsigned char *,unsigned long)
+                    __attribute__ ((ifunc ("crc32_ifunc")));
+
+int main(int argc, char *argv[])
+{
+        return crc32(0, (unsigned char *) argv[0], 0);
+}
+EOF
+
+if tryboth $CC -c $CFLAGS -Wno-unused-function $test.c; then
+  SFLAGS="${SFLAGS} -DHAVE_IFUNC_NATIVE"
+  echo "Checking for attribute(ifunc) support... Yes." | tee -a configure.log
+else
+  echo "Checking for attribute(ifunc) support... No." | tee -a configure.log
+
+  # alternately can we can use a gnu indirection using __asm__ attributes to detect and load optimized code at runtime
+  echo >> configure.log
+  cat > $test.c <<EOF
+static unsigned int crc32_real_optimized(unsigned int crc, unsigned char *p,
+                          unsigned long len)
+{
+        return 1;
+}
+
+static unsigned int (*(crc32_ifunc(void)))(unsigned int, unsigned char *,unsigned long)
+       __asm__ ("crc32");
+
+static unsigned int (*(crc32_ifunc(void)))(unsigned int, unsigned char *,unsigned long)
+{
+  return crc32_real_optimized;
+}
+
+__asm__(".type crc32, %gnu_indirect_function");
+
+int main(int argc, char *argv[])
+{
+        return crc32(0, (unsigned char *) argv[0], 0);
+}
+EOF
+
+  if tryboth $CC -c $CFLAGS -Wno-unused-function -Wno-implicit-function-declaration $test.c; then
+    SFLAGS="${SFLAGS} -DHAVE_IFUNC_ASM"
+    echo "Checking for asm .type %gnu_indirect_function support... Yes." | tee -a configure.log
+  else
+    echo "Checking for asm .type %gnu_indirect_function support... No." | tee -a configure.log
+  fi
+fi
 
 # Check for SSE2 intrinsics
 cat > $test.c << EOF


### PR DESCRIPTION
The commit message contains the means of the changes in a rather large amount of detail.

In short, this provided a GLIBC  way of resolving to an optimized routine on first usage without changing the API. In this detection and resolution its possible to perform initialisation. Non-glibc, static libraries etc will fall back to a function pointer implementation.

The avoid the need for detection routines in the middle of functions (e.g. getauxval in #109)

As you may have noticed this is the rework of one of the patches in https://github.com/madler/zlib/pull/335.

Feedback welcome. I'll continue to re-pack the Power optimized crc32 for here too.