### PR TITLE
Fix the bug in crc32_acle

### DIFF
--- a/arch/aarch64/crc32_acle.c
+++ b/arch/aarch64/crc32_acle.c
@@ -42,16 +42,16 @@ uint32_t crc32_acle(uint32_t crc, const unsigned char *buf, size_t len) {
 
 #ifndef UNROLL_LESS
     while (len >= 32) {
-        c = __crc32b(c, *buf8++);
-        c = __crc32b(c, *buf8++);
-        c = __crc32b(c, *buf8++);
-        c = __crc32b(c, *buf8++);
+        c = __crc32d(c, *buf8++);
+        c = __crc32d(c, *buf8++);
+        c = __crc32d(c, *buf8++);
+        c = __crc32d(c, *buf8++);
         len -= 32;
     }
 #endif
 
     while (len >= 8) {
-        c = __crc32b(c, *buf8++);
+        c = __crc32d(c, *buf8++);
         len -= 8;
     }
 


### PR DESCRIPTION
On armv8-a platforms if --acle is enabled, zlib-ng will use crc32_acle
instead of the default crc32. However, in crc32_acle the __crc32b() is
used to calculate the crc result of two variables with types uint32_t
and uint64_t, which gives an error result.The correct function used
should be __crc32d().

Signed-off-by: Richael Zhuang <richael.zhuang@arm.com>