### PR TITLE
Add detection for 64bit long int to support padding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,6 +217,23 @@ check_include_file(unistd.h Z_HAVE_UNISTD_H)
 check_include_file(stdarg.h Z_HAVE_STDARG_H)
 
 #
+# Check for 64bit long int
+#
+check_c_source_runs(
+    "int main(void)
+    {
+        if(sizeof(long int) == 8)
+            return 0;
+        else
+            return 1;
+    }"
+    IS_64BIT_LONG
+)
+if(IS_64BIT_LONG)
+    add_definitions(-DIS_64BIT_LONG)
+endif()
+
+#
 # Check if we can hide zlib internal symbols that are linked between separate source files using hidden
 #
 check_c_source_compiles(
@@ -368,7 +385,7 @@ set(ZLIB_ARCH_SRCS)
 set(ARCHDIR "arch/generic")
 if("${ARCH}" MATCHES "x86_64" OR "${ARCH}" MATCHES "AMD64")
     set(ARCHDIR "arch/x86")
-    add_definitions(-DX86_64 -DX86_NOCHECK_SSE2 -DUNALIGNED_OK -DUNROLL_LESS)
+    add_definitions(-DX86_NOCHECK_SSE2 -DUNALIGNED_OK -DUNROLL_LESS)
     add_feature_info(SSE2 1 "Use the SSE2 instruction set, using \"${SSE2FLAG}\"")
 elseif("${ARCH}" MATCHES "arm")
     set(ARCHDIR "arch/arm")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,9 +229,6 @@ check_c_source_runs(
     }"
     IS_64BIT_LONG
 )
-if(IS_64BIT_LONG)
-    add_definitions(-DIS_64BIT_LONG)
-endif()
 
 #
 # Check if we can hide zlib internal symbols that are linked between separate source files using hidden
@@ -385,14 +382,20 @@ set(ZLIB_ARCH_SRCS)
 set(ARCHDIR "arch/generic")
 if("${ARCH}" MATCHES "x86_64" OR "${ARCH}" MATCHES "AMD64")
     set(ARCHDIR "arch/x86")
-    add_definitions(-DX86_NOCHECK_SSE2 -DUNALIGNED_OK -DUNROLL_LESS)
+    add_definitions(-DX86_64 -DX86_NOCHECK_SSE2 -DUNALIGNED_OK -DUNROLL_LESS)
     add_feature_info(SSE2 1 "Use the SSE2 instruction set, using \"${SSE2FLAG}\"")
 elseif("${ARCH}" MATCHES "arm")
     set(ARCHDIR "arch/arm")
     add_definitions(-DUNALIGNED_OK -DUNROLL_LESS)
+    if(IS_64BIT_LONG)
+        add_definitions(-DARM_64BIT_LONG)
+    endif()
 elseif("${ARCH}" MATCHES "aarch64")
     set(ARCHDIR "arch/aarch64")
     add_definitions(-DUNALIGNED_OK -DUNROLL_LESS)
+    if(IS_64BIT_LONG)
+        add_definitions(-DARM_64BIT_LONG)
+    endif()
 else()
     set(ARCHDIR "arch/x86")
     add_definitions(-DX86 -DUNALIGNED_OK -DUNROLL_LESS)

--- a/configure
+++ b/configure
@@ -762,13 +762,14 @@ int main(void) {
 EOF
 if try ${CC} ${CFLAGS} -o $test $test.c; then
     if try ./$test; then
-        CFLAGS="$CFLAGS -DIS_64BIT_LONG"
-        SFLAGS="$SFLAGS -DIS_64BIT_LONG"
+        IS_64BIT_LONG=1
         echo "Checking for 64bit long int ... Yes." | tee -a configure.log
     else
+        IS_64BIT_LONG=0
         echo "Checking for 64bit long int ... No." | tee -a configure.log
     fi
 else
+    IS_64BIT_LONG=0
     echo "Checking for 64bit long int ... No." | tee -a configure.log
 fi
 
@@ -790,8 +791,8 @@ case "${ARCH}" in
 
         case "${ARCH}" in
             x86_64)
-                CFLAGS="${CFLAGS} -DX86_NOCHECK_SSE2"
-                SFLAGS="${SFLAGS} -DX86_NOCHECK_SSE2"
+                CFLAGS="${CFLAGS} -DX86_64 -DX86_NOCHECK_SSE2"
+                SFLAGS="${SFLAGS} -DX86_64 -DX86_NOCHECK_SSE2"
             ;;
             i386 | i486 | i586 | i686)
                 CFLAGS="${CFLAGS} -DX86"
@@ -855,6 +856,11 @@ case "${ARCH}" in
                 floatabi="-mfloat-abi=softfp" ;;
         esac
 
+        if test $IS_64BIT_LONG -eq 1; then
+            CFLAGS="$CFLAGS -DARM_64BIT_LONG"
+            SFLAGS="$SFLAGS -DARM_64BIT_LONG"
+        fi
+
         case "${ARCH}" in
             armv6l | armv6hl)
                 # Tests done on Raspberry pi (armv6hl) indicate that UNALIGNED_OK and UNROLL_LESS both
@@ -897,6 +903,11 @@ case "${ARCH}" in
         ARCHDIR=arch/aarch64
         ARCH_STATIC_OBJS="${ARCH_STATIC_OBJS} fill_window_arm.o"
         ARCH_SHARED_OBJS="${ARCH_SHARED_OBJS} fill_window_arm.lo"
+
+        if test $IS_64BIT_LONG -eq 1; then
+            CFLAGS="$CFLAGS -DARM_64BIT_LONG"
+            SFLAGS="$SFLAGS -DARM_64BIT_LONG"
+        fi
 
         if test $native -eq 0; then
           ARCH="armv8-a"

--- a/configure
+++ b/configure
@@ -751,6 +751,27 @@ else
     HAVE_PCLMULQDQ_INTRIN=0
 fi
 
+# Check for 64bit long int
+cat > $test.c << EOF
+int main(void) {
+    if(sizeof(long int) == 8)
+        return 0;
+    else
+        return 1;
+}
+EOF
+if try ${CC} ${CFLAGS} -o $test $test.c; then
+    if try ./$test; then
+        CFLAGS="$CFLAGS -DIS_64BIT_LONG"
+        SFLAGS="$SFLAGS -DIS_64BIT_LONG"
+        echo "Checking for 64bit long int ... Yes." | tee -a configure.log
+    else
+        echo "Checking for 64bit long int ... No." | tee -a configure.log
+    fi
+else
+    echo "Checking for 64bit long int ... No." | tee -a configure.log
+fi
+
 # Enable deflate_medium at level 4-6
 if test $without_new_strategies -eq 0; then
     CFLAGS="${CFLAGS} -DMEDIUM_STRATEGY"
@@ -769,8 +790,8 @@ case "${ARCH}" in
 
         case "${ARCH}" in
             x86_64)
-                CFLAGS="${CFLAGS} -DX86_64 -DX86_NOCHECK_SSE2"
-                SFLAGS="${SFLAGS} -DX86_64 -DX86_NOCHECK_SSE2"
+                CFLAGS="${CFLAGS} -DX86_NOCHECK_SSE2"
+                SFLAGS="${SFLAGS} -DX86_NOCHECK_SSE2"
             ;;
             i386 | i486 | i586 | i686)
                 CFLAGS="${CFLAGS} -DX86"

--- a/zlib.h
+++ b/zlib.h
@@ -109,8 +109,9 @@ typedef struct z_stream_s {
     int                   data_type;  /* best guess about the data type: binary or text
                                          for deflate, or the decoding state for inflate */
     uint32_t              adler;      /* Adler-32 or CRC-32 value of the uncompressed data */
-#if defined(ZLIB_COMPAT) && defined(X86_64)
-    uint32_t              padding;    /* pad out to the same size as the zlib struct */
+#if defined(ZLIB_COMPAT) && defined(IS_64BIT_LONG)
+    uint32_t              padding;    /* pad out to the same size as the zlib struct: padding
+                                         is needed when the size of long int is 64 bits */
 #endif
     unsigned long         reserved;   /* reserved for future use */
 } z_stream;

--- a/zlib.h
+++ b/zlib.h
@@ -109,7 +109,7 @@ typedef struct z_stream_s {
     int                   data_type;  /* best guess about the data type: binary or text
                                          for deflate, or the decoding state for inflate */
     uint32_t              adler;      /* Adler-32 or CRC-32 value of the uncompressed data */
-#if defined(ZLIB_COMPAT) && defined(IS_64BIT_LONG)
+#if defined(ZLIB_COMPAT) && (defined(X86_64) || defined(ARM_64BIT_LONG))
     uint32_t              padding;    /* pad out to the same size as the zlib struct: padding
                                          is needed when the size of long int is 64 bits */
 #endif


### PR DESCRIPTION
Zlib-ng introduces a 32bit padding member in its data
struct to make zlib-ng compatible with zlib, without
which there will be runtime errors when making zlib-ng
a binary replacement of zlib. Now the padding is enabled
only when both ZLIB_COMPAT and X86_64 are defined, so it
needs support for other platforms where sizeof(long int)
is not equal to sizeof(int).

This patch fixes the problem by adding the detection for
64bit long int.

Signed-off-by: Richael Zhuang <richael.zhuang@arm.com>