### PR TITLE
[compat] Don't check for ZLIB_COMPAT

### DIFF
--- a/zlib.h
+++ b/zlib.h
@@ -108,10 +108,7 @@ typedef struct z_stream_s {
 
     int                   data_type;  /* best guess about the data type: binary or text
                                          for deflate, or the decoding state for inflate */
-    uint32_t              adler;      /* Adler-32 or CRC-32 value of the uncompressed data */
-#if defined(ZLIB_COMPAT) && defined(X86_64)
-    uint32_t              padding;    /* pad out to the same size as the zlib struct */
-#endif
+    unsigned long         adler;      /* Adler-32 or CRC-32 value of the uncompressed data */
     unsigned long         reserved;   /* reserved for future use */
 } z_stream;
 


### PR DESCRIPTION
* ZLIB_COMPAT is always implied if using zlib.h
* Revert z_stream->adler to "unsigned long" to enforce correct alignment
  of struct members

Previous code incorrectly added padding only after "adler" struct member which caused offset of "adler" not be same in stock zlib and zlib-ng on 64-bit Intel/AMD processors using 64-bit operating system even though struct size was same due to implicit padding by compiler.