### PR TITLE
Align in 16-byte boundary when UNALIGNED_OK is undefined.

### DIFF
--- a/test/minigzip.c
+++ b/test/minigzip.c
@@ -30,6 +30,10 @@
 #  include <sys/stat.h>
 #endif
 
+#ifndef UNALIGNED_OK
+#  include <malloc.h>
+#endif
+
 #if defined(WIN32) || defined(__CYGWIN__)
 #  include <fcntl.h>
 #  include <io.h>
@@ -70,7 +74,11 @@ void myfree (void *, void *);
 void *myalloc(void *q, unsigned n, unsigned m)
 {
     (void)q;
+#ifndef UNALIGNED_OK
+    return memalign(16, n * m);
+#else
     return calloc(n, m);
+#endif
 }
 
 void myfree(void *q, void *p)

--- a/zutil.c
+++ b/zutil.c
@@ -9,6 +9,9 @@
 #ifdef WITH_GZFILEOP
 #  include "gzguts.h"
 #endif
+#ifndef UNALIGNED_OK
+#  include "malloc.h"
+#endif
 
 const char * const z_errmsg[10] = {
     (const char *)"need dictionary",     /* Z_NEED_DICT       2  */
@@ -119,8 +122,12 @@ const char * ZEXPORT PREFIX(zError)(int err)
 void ZLIB_INTERNAL *zcalloc (void *opaque, unsigned items, unsigned size)
 {
     (void)opaque;
+#ifndef UNALIGNED_OK
+    return memalign(16, items * size);
+#else
     return sizeof(unsigned int) > 2 ? (void *)malloc(items * size) :
                               (void *)calloc(items, size);
+#endif
 }
 
 void ZLIB_INTERNAL zcfree (void *opaque, void *ptr)


### PR DESCRIPTION
Normal memory allocation is guaranteed to be aligned either in 4- or 8-byte boundary but that is not enough for vector reads and writes.