### PR TITLE
Fix the bug about byte-order on Arm platforms

### DIFF
--- a/gzendian.h
+++ b/gzendian.h
@@ -15,7 +15,7 @@
 # else
 #  error Unknown endianness!
 # endif
-#elif defined(__APPLE__) || defined(__arm__) || defined(__aarch64__)
+#elif defined(__APPLE__)
 # include <machine/endian.h>
 #elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__bsdi__) || defined(__DragonFly__)
 # include <sys/endian.h>


### PR DESCRIPTION
Zlib-ng tries to locate endian.h from <machine/endian.h> if __arm__
or __aarch64__ is defined.But it fails to find it and error comes.

This patch fixes the problem by relocating endian.h when __arm__ or
__aarch64__ is defined.

Change-Id: Ib35dd0992d03767d7321ef5db14246f5524c3f77

Signed-off-by: Richael Zhuang <richael.zhuang@arm.com>