### PR TITLE
Fix build on ARM and Linaro gcc 4.x.

### DIFF
--- a/gzendian.h
+++ b/gzendian.h
@@ -15,6 +15,8 @@
 # else
 #  error Unknown endianness!
 # endif
+#elif defined(__linux__)
+# include <endian.h>
 #elif defined(__APPLE__) || defined(__arm__) || defined(__aarch64__)
 # include <machine/endian.h>
 #elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__bsdi__) || defined(__DragonFly__)

--- a/inflate.c
+++ b/inflate.c
@@ -1349,7 +1349,7 @@ int ZEXPORT PREFIX(inflateGetHeader)(PREFIX3(stream) *strm, PREFIX(gz_headerp) h
    called again with more data and the *have state.  *have is initialized to
    zero for the first call.
  */
-static unsigned syncsearch(uint32_t *have, const unsigned char *buf, uint32_t len) {
+static uint32_t syncsearch(uint32_t *have, const unsigned char *buf, uint32_t len) {
     uint32_t got;
     uint32_t next;
 


### PR DESCRIPTION
* We need to test ```__linux__``` before ```__arm__``` or ```__aarch64__``` because Linaro toolchain arm-gnueabi has <machine/endian.h>, but Linux has <endian.h> and <bits/endian.h>
* Fix conflicting prototype of syncsearch()