### PR TITLE
[MSVC] Fix size_t/ssize_t when using ZLIB_COMPAT.

### DIFF
--- a/compress.c
+++ b/compress.c
@@ -60,7 +60,7 @@ int ZEXPORT PREFIX(compress2)(unsigned char *dest, z_size_t *destLen, const unsi
         err = PREFIX(deflate)(&stream, sourceLen ? Z_NO_FLUSH : Z_FINISH);
     } while (err == Z_OK);
 
-    *destLen = stream.total_out;
+    *destLen = (z_size_t)stream.total_out;
     PREFIX(deflateEnd)(&stream);
     return err == Z_STREAM_END ? Z_OK : err;
 }

--- a/test/example.c
+++ b/test/example.c
@@ -7,8 +7,10 @@
 
 #ifdef ZLIB_COMPAT
 #  include "zlib.h"
+#  define z_size_t unsigned long
 #else
 #  include "zlib-ng.h"
+#  define z_size_t size_t
 #endif
 
 #include <stdio.h>
@@ -38,7 +40,7 @@ void test_deflate       (unsigned char *compr, size_t comprLen);
 void test_inflate       (unsigned char *compr, size_t comprLen, unsigned char *uncompr, size_t uncomprLen);
 void test_large_deflate (unsigned char *compr, size_t comprLen, unsigned char *uncompr, size_t uncomprLen);
 void test_large_inflate (unsigned char *compr, size_t comprLen, unsigned char *uncompr, size_t uncomprLen);
-void test_flush         (unsigned char *compr, size_t *comprLen);
+void test_flush         (unsigned char *compr, z_size_t *comprLen);
 void test_sync          (unsigned char *compr, size_t comprLen, unsigned char *uncompr, size_t uncomprLen);
 void test_dict_deflate  (unsigned char *compr, size_t comprLen);
 void test_dict_inflate  (unsigned char *compr, size_t comprLen, unsigned char *uncompr, size_t uncomprLen);
@@ -48,18 +50,18 @@ int  main               (int argc, char *argv[]);
 static alloc_func zalloc = NULL;
 static free_func zfree = NULL;
 
-void test_compress      (unsigned char *compr, size_t comprLen,
-                            unsigned char *uncompr, size_t uncomprLen);
+void test_compress      (unsigned char *compr, z_size_t comprLen,
+                            unsigned char *uncompr, z_size_t uncomprLen);
 
 /* ===========================================================================
  * Test compress() and uncompress()
  */
-void test_compress(unsigned char *compr, size_t comprLen, unsigned char *uncompr, size_t uncomprLen)
+void test_compress(unsigned char *compr, z_size_t comprLen, unsigned char *uncompr, z_size_t uncomprLen)
 {
     int err;
     size_t len = strlen(hello)+1;
 
-    err = PREFIX(compress)(compr, &comprLen, (const unsigned char*)hello, len);
+    err = PREFIX(compress)(compr, &comprLen, (const unsigned char*)hello, (z_size_t)len);
     CHECK_ERR(err, "compress");
 
     strcpy((char*)uncompr, "garbage");
@@ -77,12 +79,12 @@ void test_compress(unsigned char *compr, size_t comprLen, unsigned char *uncompr
 
 #ifdef WITH_GZFILEOP
 void test_gzio          (const char *fname,
-                            unsigned char *uncompr, size_t uncomprLen);
+                            unsigned char *uncompr, z_size_t uncomprLen);
 
 /* ===========================================================================
  * Test read/write of .gz files
  */
-void test_gzio(const char *fname, unsigned char *uncompr, size_t uncomprLen)
+void test_gzio(const char *fname, unsigned char *uncompr, z_size_t uncomprLen)
 {
 #ifdef NO_GZCOMPRESS
     fprintf(stderr, "NO_GZCOMPRESS -- gz* functions cannot compress\n");
@@ -332,7 +334,7 @@ void test_large_inflate(unsigned char *compr, size_t comprLen, unsigned char *un
 /* ===========================================================================
  * Test deflate() with full flush
  */
-void test_flush(unsigned char *compr, size_t *comprLen)
+void test_flush(unsigned char *compr, z_size_t *comprLen)
 {
     PREFIX3(stream) c_stream; /* compression stream */
     int err;
@@ -362,7 +364,7 @@ void test_flush(unsigned char *compr, size_t *comprLen)
     err = PREFIX(deflateEnd)(&c_stream);
     CHECK_ERR(err, "deflateEnd");
 
-    *comprLen = c_stream.total_out;
+    *comprLen = (z_size_t)c_stream.total_out;
 }
 
 /* ===========================================================================
@@ -497,8 +499,8 @@ void test_dict_inflate(unsigned char *compr, size_t comprLen, unsigned char *unc
 int main(int argc, char *argv[])
 {
     unsigned char *compr, *uncompr;
-    size_t comprLen = 10000*sizeof(int); /* don't overflow on MSDOS */
-    size_t uncomprLen = comprLen;
+    z_size_t comprLen = 10000*sizeof(int); /* don't overflow on MSDOS */
+    z_size_t uncomprLen = comprLen;
     static const char* myVersion = PREFIX2(VERSION);
 
     if (zVersion()[0] != myVersion[0]) {

--- a/uncompr.c
+++ b/uncompr.c
@@ -73,7 +73,7 @@ int ZEXPORT PREFIX(uncompress2)(unsigned char *dest, z_size_t *destLen, const un
 
     *sourceLen -= len + stream.avail_in;
     if (dest != buf)
-        *destLen = stream.total_out;
+        *destLen = (z_size_t)stream.total_out;
     else if (stream.total_out && err == Z_BUF_ERROR)
         left = 1;
 

--- a/win32/Makefile.msc
+++ b/win32/Makefile.msc
@@ -31,14 +31,15 @@ DEFFILE = zlib.def
 RCFILE = zlib1.rc
 RESFILE = zlib1.res
 WITH_GZFILEOP =
+ZLIB_COMPAT =
 SUFFIX =
 
 OBJS = adler32.obj compress.obj crc32.obj deflate.obj deflate_fast.obj deflate_quick.obj deflate_slow.obj \
        functable.obj infback.obj inflate.obj inftrees.obj inffast.obj match.obj trees.obj uncompr.obj zutil.obj \
        x86.obj fill_window_sse.obj insert_string_sse.obj crc_folding.obj crc_pclmulqdq.obj
-!if "$(WITH_GZFILEOP)" != ""
-WFLAGS = $(WFLAGS) -DWITH_GZFILEOP
-OBJS = $(OBJS) gzclose.obj gzlib.obj gzread.obj gzwrite.obj
+!if "$(ZLIB_COMPAT)" != ""
+WITH_GZFILEOP = yes
+WFLAGS = $(WFLAGS) -DZLIB_COMPAT
 DEFFILE = zlibcompat.def
 !else
 STATICLIB = zlib-ng.lib
@@ -48,6 +49,11 @@ DEFFILE = zlib-ng.def
 RCFILE = zlib-ng1.rc
 RESFILE = zlib-ng1.res
 SUFFIX = -ng
+!endif
+
+!if "$(WITH_GZFILEOP)" != ""
+WFLAGS = $(WFLAGS) -DWITH_GZFILEOP
+OBJS = $(OBJS) gzclose.obj gzlib.obj gzread.obj gzwrite.obj
 !endif
 
 # targets

--- a/zconf.h.in
+++ b/zconf.h.in
@@ -84,6 +84,10 @@
 #    define ZEXPORT WINAPI
 #    define ZEXPORTVA WINAPIV
 #  endif
+#  if defined(_MSC_VER)
+#    include <windows.h>
+     typedef SSIZE_T ssize_t;
+#  endif
 #endif
 
 #ifndef ZEXTERN


### PR DESCRIPTION
* zconf.h.in wasn't including Windows.h, that is correct header to include definitions from BaseTsd.h, and such missing required type definition for ssize_t when compiling using MS Visual C++
* Various places need implicit casting to z_size_t to get around compatibility issues, this will truncate the result when ZLIB_COMPAT is defined, calling code should check for truncation.
* Update nmake Makefile to define ZLIB_COMPAT when WITH_GZFILEOP is defined as otherwise the build will fail due to including wrong config header.