### PR TITLE
Fix the problem about rule to make target "zconf.h" on Arm platforms

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -335,11 +335,11 @@ inftrees.o: $(SRCDIR)/zutil.h $(SRCDIR)/zlib$(SUFFIX).h zconf$(SUFFIX).h $(SRCDI
 trees.o: $(SRCDIR)/deflate.h $(SRCDIR)/zutil.h $(SRCDIR)/zlib$(SUFFIX).h zconf$(SUFFIX).h $(SRCDIR)/trees.h
 zutil.o: $(SRCDIR)/zutil.h $(SRCDIR)/gzguts.h $(SRCDIR)/zlib$(SUFFIX).h zconf$(SUFFIX).h
 arch/aarch64/adler32_neon.o: $(SRCDIR)/arch/aarch64/adler32_neon.h
-arch/aarch64/crc32_acle.o: zconf.h
+arch/aarch64/crc32_acle.o: zconf$(SUFFIX).h
 arch/aarch64/fill_window_arm.o: $(SRCDIR)/deflate.h $(SRCDIR)/deflate_p.h $(SRCDIR)/functable.h $(SRCDIR)/zutil.h $(SRCDIR)/zlib$(SUFFIX).h zconf$(SUFFIX).h
 arch/aarch64/insert_string_acle.o: $(SRCDIR)/deflate.h $(SRCDIR)/zutil.h $(SRCDIR)/zlib$(SUFFIX).h zconf$(SUFFIX).h
 arch/arm/adler32_neon.o: $(SRCDIR)/arch/arm/adler32_neon.h
-arch/arm/crc32_acle.o: zconf.h
+arch/arm/crc32_acle.o: zconf$(SUFFIX).h
 arch/arm/fill_window_arm.o: $(SRCDIR)/deflate.h $(SRCDIR)/deflate_p.h $(SRCDIR)/functable.h $(SRCDIR)/zutil.h $(SRCDIR)/zlib$(SUFFIX).h zconf$(SUFFIX).h
 arch/arm/insert_string_acle.o: $(SRCDIR)/deflate.h $(SRCDIR)/zutil.h $(SRCDIR)/zlib$(SUFFIX).h zconf$(SUFFIX).h
 arch/x86/crc_folding.o: $(SRCDIR)/arch/x86/crc_folding.h $(SRCDIR)/deflate.h $(SRCDIR)/zutil.h $(SRCDIR)/zlib$(SUFFIX).h zconf$(SUFFIX).h
@@ -364,11 +364,11 @@ inftrees.lo: $(SRCDIR)/zutil.h $(SRCDIR)/zlib$(SUFFIX).h zconf$(SUFFIX).h $(SRCD
 trees.lo: $(SRCDIR)/deflate.h $(SRCDIR)/zutil.h $(SRCDIR)/zlib$(SUFFIX).h zconf$(SUFFIX).h $(SRCDIR)/trees.h
 zutil.lo: $(SRCDIR)/zutil.h $(SRCDIR)/gzguts.h $(SRCDIR)/zlib$(SUFFIX).h zconf$(SUFFIX).h
 arch/aarch64/adler32_neon.lo: $(SRCDIR)/arch/aarch64/adler32_neon.h
-arch/aarch64/crc32_acle.lo: zconf.h
+arch/aarch64/crc32_acle.lo: zconf$(SUFFIX).h
 arch/aarch64/fill_window_arm.lo: $(SRCDIR)/deflate.h $(SRCDIR)/deflate_p.h $(SRCDIR)/functable.h $(SRCDIR)/zutil.h $(SRCDIR)/zlib$(SUFFIX).h zconf$(SUFFIX).h
 arch/aarch64/insert_string_acle.lo: $(SRCDIR)/deflate.h $(SRCDIR)/zutil.h $(SRCDIR)/zlib$(SUFFIX).h zconf$(SUFFIX).h
 arch/arm/adler32_neon.lo: $(SRCDIR)/arch/arm/adler32_neon.h
-arch/arm/crc32_acle.lo: zconf.h
+arch/arm/crc32_acle.lo: zconf$(SUFFIX).h
 arch/arm/fill_window_arm.lo: $(SRCDIR)/deflate.h $(SRCDIR)/deflate_p.h $(SRCDIR)/functable.h $(SRCDIR)/zutil.h $(SRCDIR)/zlib$(SUFFIX).h zconf$(SUFFIX).h
 arch/arm/insert_string_acle.lo: $(SRCDIR)/deflate.h $(SRCDIR)/zutil.h $(SRCDIR)/zlib$(SUFFIX).h zconf$(SUFFIX).h
 arch/x86/crc_folding.lo: $(SRCDIR)/arch/x86/crc_folding.h $(SRCDIR)/deflate.h $(SRCDIR)/zutil.h $(SRCDIR)/zlib$(SUFFIX).h zconf$(SUFFIX).h

--- a/arch/aarch64/crc32_acle.c
+++ b/arch/aarch64/crc32_acle.c
@@ -7,7 +7,11 @@
 
 #ifdef __ARM_FEATURE_CRC32
 #include <arm_acle.h>
-#include "zconf.h"
+#ifdef ZLIB_COMPAT
+#  include <zconf.h>
+#else
+#  include <zconf-ng.h>
+#endif
 #ifdef __linux__
 #  include <stddef.h>
 #endif

--- a/arch/arm/crc32_acle.c
+++ b/arch/arm/crc32_acle.c
@@ -7,7 +7,11 @@
 
 #ifdef __ARM_FEATURE_CRC32
 #include <arm_acle.h>
-#include "zconf.h"
+#ifdef ZLIB_COMPAT
+#  include <zconf.h>
+#else
+#  include <zconf-ng.h>
+#endif
 #ifdef __linux__
 #  include <stddef.h>
 #endif


### PR DESCRIPTION
If building zlib-ng with --acle option on Arm platforms, the building
process will stop in the meantime with the message "No rule to make
target zconf.h needed by crc32_acle.o".

This patch fixes the problem by including zconf.h or zconf-ng.h
according to the fact that whether ZLIB_COMPAT is defined or not in
crc32_acle.c.

Change-Id: Ib050c5b0e65d86210c8babdff5dbe670729fc63a

Signed-off-by: Richael Zhuang <richael.zhuang@arm.com>