### PR TITLE
Fix the bug when using arm-eabi as the tool chain

### DIFF
--- a/configure
+++ b/configure
@@ -268,12 +268,10 @@ if test "$gcc" -eq 1 && ($cc $CFLAGS -c $test.c) >> configure.log 2>&1; then
       if test "${uname}" = "eabi"; then
         uname=arm
       fi
-      if test $buildacle -eq 1; then
-        if test $native -eq 0; then
-          ARCH=armv8-a+crc
-        else
-          ARCH=native
-        fi
+      if test $native -eq 0; then
+        ARCH=armv7-a
+      else
+        ARCH=native
       fi ;;
     aarch64)
       if test "${uname}" = "elf"; then


### PR DESCRIPTION
Arm-eabi's target ARCH is ARMv7 bare-metal, not armv8-a.

Change-Id: Id2cd32515be09b40d3fd0866f8f65a2b6f775a4e

Signed-off-by: Richael Zhuang <richael.zhuang@arm.com>