### PR TITLE
Add the check for -mfpu=neon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -354,6 +354,15 @@ else()
     endif()
 endif()
 
+#Check whether -mfpu=neon is available
+set(CMAKE_REQUIRED_FLAGS "-mfpu=neon")
+check_c_source_compiles(
+    "int main()
+    {
+      return 0;
+    }"
+    MFPU_NEON_AVAILABLE FAIL_REGEX "not supported")
+
 #
 # Enable deflate_medium at level 4-6
 #
@@ -411,7 +420,9 @@ if(WITH_OPTIM)
             add_feature_info(ACLE_CRC 1 "Support CRC hash generation using the ACLE instruction set, using \"${ACLEFLAG}\"")
         endif()
         if(WITH_NEON)
-            set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${NEONFLAG}")
+            if(MFPU_NEON_AVAILABLE)
+                set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${NEONFLAG}")
+            endif()
             add_definitions("-DARM_NEON_ADLER32")
             if(MSVC)
                 add_definitions("-D__ARM_NEON__=1")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,6 +362,7 @@ check_c_source_compiles(
       return 0;
     }"
     MFPU_NEON_AVAILABLE FAIL_REGEX "not supported")
+set(CMAKE_REQUIRED_FLAGS)
 
 #
 # Enable deflate_medium at level 4-6

--- a/configure
+++ b/configure
@@ -1004,13 +1004,17 @@ case "${ARCH}" in
                 fi
 
                 if test $buildneon -eq 1; then
+                    CFLAGS="${CFLAGS} ${floatabi}"
+                    SFLAGS="${SFLAGS} ${floatabi}"
+
                     if test $MFPU_NEON_AVAILABLE -eq 1;then
-                        CFLAGS="${CFLAGS} ${floatabi} -mfpu=neon -DARM_NEON_ADLER32"
-                        SFLAGS="${SFLAGS} ${floatabi} -mfpu=neon -DARM_NEON_ADLER32"
-                    else
-                        CFLAGS="${CFLAGS} ${floatabi} -DARM_NEON_ADLER32"
-                        SFLAGS="${SFLAGS} ${floatabi} -DARM_NEON_ADLER32"
+                        CFLAGS="${CFLAGS} -mfpu=neon"
+                        SFLAGS="${SFLAGS} -mfpu=neon"
                     fi
+
+                    CFLAGS="${CFLAGS} -DARM_NEON_ADLER32"
+                    SFLAGS="${SFLAGS} -DARM_NEON_ADLER32"
+
                     ARCH_STATIC_OBJS="${ARCH_STATIC_OBJS} adler32_neon.o"
                     ARCH_SHARED_OBJS="${ARCH_SHARED_OBJS} adler32_neon.lo"
                 fi
@@ -1023,13 +1027,17 @@ case "${ARCH}" in
                 ARCH_SHARED_OBJS="${ARCH_SHARED_OBJS} crc32_acle.lo insert_string_acle.lo"
 
                 if test $buildneon -eq 1; then
+                    CFLAGS="${CFLAGS} ${floatabi}"
+                    SFLAGS="${SFLAGS} ${floatabi}"
+
                     if test $MFPU_NEON_AVAILABLE -eq 1;then
-                        CFLAGS="${CFLAGS} ${floatabi} -mfpu=neon -DARM_NEON_ADLER32"
-                        SFLAGS="${SFLAGS} ${floatabi} -mfpu=neon -DARM_NEON_ADLER32"
-                    else
-                        CFLAGS="${CFLAGS} ${floatabi} -DARM_NEON_ADLER32"
-                        SFLAGS="${SFLAGS} ${floatabi} -DARM_NEON_ADLER32"
+                        CFLAGS="${CFLAGS} -mfpu=neon"
+                        SFLAGS="${SFLAGS} -mfpu=neon"
                     fi
+
+                    CFLAGS="${CFLAGS} -DARM_NEON_ADLER32"
+                    SFLAGS="${SFLAGS} -DARM_NEON_ADLER32"
+
                     ARCH_STATIC_OBJS="${ARCH_STATIC_OBJS} adler32_neon.o"
                     ARCH_SHARED_OBJS="${ARCH_SHARED_OBJS} adler32_neon.lo"
                 fi

--- a/configure
+++ b/configure
@@ -832,6 +832,18 @@ fi
 
 fi
 
+#Check whether -mfpu=neon is available
+cat > $test.c << EOF
+int main() { return 0; }
+EOF
+if try $CC -c $CFLAGS -mfpu=neon $test.c; then
+    MFPU_NEON_AVAILABLE=1
+    echo "Check whether -mfpu=neon is available ... Yes." | tee -a configure.log
+else
+    MFPU_NEON_AVAILABLE=0
+    echo "Check whether -mfpu=neon is available ... No." | tee -a configure.log
+fi
+
 ARCHDIR='arch/generic'
 ARCH_STATIC_OBJS=''
 ARCH_SHARED_OBJS=''
@@ -992,9 +1004,13 @@ case "${ARCH}" in
                 fi
 
                 if test $buildneon -eq 1; then
-                    CFLAGS="${CFLAGS} ${floatabi} -DARM_NEON_ADLER32"
-                    SFLAGS="${SFLAGS} ${floatabi} -DARM_NEON_ADLER32"
-
+                    if test $MFPU_NEON_AVAILABLE -eq 1;then
+                        CFLAGS="${CFLAGS} ${floatabi} -mfpu=neon -DARM_NEON_ADLER32"
+                        SFLAGS="${SFLAGS} ${floatabi} -mfpu=neon -DARM_NEON_ADLER32"
+                    else
+                        CFLAGS="${CFLAGS} ${floatabi} -DARM_NEON_ADLER32"
+                        SFLAGS="${SFLAGS} ${floatabi} -DARM_NEON_ADLER32"
+                    fi
                     ARCH_STATIC_OBJS="${ARCH_STATIC_OBJS} adler32_neon.o"
                     ARCH_SHARED_OBJS="${ARCH_SHARED_OBJS} adler32_neon.lo"
                 fi
@@ -1007,8 +1023,13 @@ case "${ARCH}" in
                 ARCH_SHARED_OBJS="${ARCH_SHARED_OBJS} crc32_acle.lo insert_string_acle.lo"
 
                 if test $buildneon -eq 1; then
-                    CFLAGS="${CFLAGS} ${floatabi} -DARM_NEON_ADLER32"
-                    SFLAGS="${SFLAGS} ${floatabi} -DARM_NEON_ADLER32"
+                    if test $MFPU_NEON_AVAILABLE -eq 1;then
+                        CFLAGS="${CFLAGS} ${floatabi} -mfpu=neon -DARM_NEON_ADLER32"
+                        SFLAGS="${SFLAGS} ${floatabi} -mfpu=neon -DARM_NEON_ADLER32"
+                    else
+                        CFLAGS="${CFLAGS} ${floatabi} -DARM_NEON_ADLER32"
+                        SFLAGS="${SFLAGS} ${floatabi} -DARM_NEON_ADLER32"
+                    fi
                     ARCH_STATIC_OBJS="${ARCH_STATIC_OBJS} adler32_neon.o"
                     ARCH_SHARED_OBJS="${ARCH_SHARED_OBJS} adler32_neon.lo"
                 fi


### PR DESCRIPTION
For 64bit armv8-a there's no need to use "-mfpu=neon" to enable NEON.
But for 32bit system "-mfpu=neon" is required.

This patch adds the detection for -mfpu=neon flag.

Change-Id: Iec4f9e29f78806ae0e7021187038bb0b99eec30b
Signed-off-by: Richael Zhuang <richael.zhuang@arm.com>