### PR TITLE
Reset CMAKE_REQUIRED_FLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,6 +303,8 @@ else()
         }"
         HAVE_SSE2_INTRIN
     )
+    set(CMAKE_REQUIRED_FLAGS)
+
     if(WITH_NATIVE_INSTRUCTIONS)
         set(CMAKE_REQUIRED_FLAGS "${NATIVEFLAG}")
     else()
@@ -329,6 +331,8 @@ else()
         }"
         HAVE_SSE42CRC_INTRIN
     )
+    set(CMAKE_REQUIRED_FLAGS)
+
     if(WITH_NATIVE_INSTRUCTIONS)
         set(CMAKE_REQUIRED_FLAGS "${NATIVEFLAG}")
     else()
@@ -352,6 +356,7 @@ else()
     else()
         set(HAVE_PCLMULQDQ_INTRIN NO)
     endif()
+    set(CMAKE_REQUIRED_FLAGS)
 endif()
 
 #


### PR DESCRIPTION
Reset CMAKE_REQUIRED_FLAGS after each check to avoid the following
checks being influenced by the previous results.

Change-Id: I2e34f6127ef1c617f4eea363a2cb80bc49b3bcab
Signed-off-by: Richael Zhuang <richael.zhuang@arm.com>