### PR TITLE
Fixed read of one byte before buffer in fizzle_matches

### DIFF
--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -172,8 +172,6 @@ static void fizzle_matches(deflate_state *s, struct match *current, struct match
             break;
         if (n.match_length >= 256)
             break;
-        if (n.match_start <= 0)
-            break;
 
         n.strstart--;
         n.match_start--;
@@ -182,6 +180,9 @@ static void fizzle_matches(deflate_state *s, struct match *current, struct match
         match--;
         orig--;
         changed++;
+
+        if (n.match_start <= 0)
+            break;
     }
 
     if (!changed)

--- a/zbuild.h
+++ b/zbuild.h
@@ -12,7 +12,7 @@
 #  define PREFIX2(x) ZLIB_ ## x
 #  define PREFIX3(x) z_ ## x
 #  define zVersion zlibVersion
-#  define z_size_t size_t
+#  define z_size_t unsigned long
 #else
 #  define PREFIX(x) zng_ ## x
 #  define PREFIX2(x) ZLIBNG_ ## x

--- a/zbuild.h
+++ b/zbuild.h
@@ -12,7 +12,7 @@
 #  define PREFIX2(x) ZLIB_ ## x
 #  define PREFIX3(x) z_ ## x
 #  define zVersion zlibVersion
-#  define z_size_t unsigned long
+#  define z_size_t size_t
 #else
 #  define PREFIX(x) zng_ ## x
 #  define PREFIX2(x) ZLIBNG_ ## x

--- a/zlib.h
+++ b/zlib.h
@@ -31,6 +31,7 @@
 */
 
 #include <stdint.h>
+#include <stdarg.h>
 #include "zconf.h"
 
 #ifdef __cplusplus

--- a/zlib.h
+++ b/zlib.h
@@ -32,7 +32,7 @@
 
 #include <stdint.h>
 #include <stdarg.h>
-#include "zconf.h"
+#include <zconf.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Look for the test case here:

https://github.com/yandex/ClickHouse/pull/2854/commits/7e50c88538c705d97917d5dbd984340e0cd4f1de

