### PR TITLE
Enable clang scan build static analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: c
 cache: ccache
-dist: trusty
+dist: xenial
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,61 +6,64 @@ matrix:
   include:
     - os: linux
       compiler: gcc
-      env: BUILDDIR=. TOOL="./configure --warn"
+      env: MAKE="make" BUILDDIR=. TOOL="./configure --warn"
     - os: linux
       compiler: gcc
-      env: BUILDDIR=. TOOL="cmake . -DZLIB_COMPAT=OFF -DWITH_GZFILEOP=ON -DWITH_NEW_STRATEGIES=YES -DWITH_OPTIM=ON"
+      env: MAKE="make" BUILDDIR=. TOOL="cmake . -DZLIB_COMPAT=OFF -DWITH_GZFILEOP=ON -DWITH_NEW_STRATEGIES=YES -DWITH_OPTIM=ON"
     - os: linux
       compiler: gcc
-      env: BUILDDIR=../build TOOL="../zlib-ng/configure --warn --zlib-compat"
+      env: MAKE="make" BUILDDIR=../build TOOL="../zlib-ng/configure --warn --zlib-compat"
     - os: linux
       compiler: gcc
-      env: BUILDDIR=. TOOL="./configure --warn --zlib-compat --without-optimizations --without-new-strategies"
+      env: MAKE="make" BUILDDIR=. TOOL="./configure --warn --zlib-compat --without-optimizations --without-new-strategies"
     - os: linux
       compiler: gcc
-      env: BUILDDIR=. TOOL="cmake ."
+      env: MAKE="make" BUILDDIR=. TOOL="cmake ."
     - os: linux
       compiler: gcc
-      env: BUILDDIR=../build TOOL="cmake ../zlib-ng"
+      env: MAKE="make" BUILDDIR=../build TOOL="cmake ../zlib-ng"
 
     - os: linux
       compiler: clang
-      env: BUILDDIR=. TOOL="./configure --warn --zlib-compat"
+      env: MAKE="make" BUILDDIR=. TOOL="./configure --warn --zlib-compat"
     - os: linux
       compiler: clang
-      env: BUILDDIR=../build TOOL="cmake ../zlib-ng"
+      env: MAKE="make" BUILDDIR=../build TOOL="cmake ../zlib-ng"
+    - os: linux
+      compiler: clang
+      env: MAKE="scan-build -v --status-bugs make" BUILDDIR=../build TOOL="scan-build -v --status-bugs cmake ../zlib-ng"
 
     - os: osx
       compiler: gcc
-      env: BUILDDIR=. TOOL="./configure --warn --zlib-compat"
+      env: MAKE="make" BUILDDIR=. TOOL="./configure --warn --zlib-compat"
     - os: osx
       compiler: gcc
-      env: BUILDDIR=../build TOOL="../zlib-ng/configure --warn --zlib-compat"
+      env: MAKE="make" BUILDDIR=../build TOOL="../zlib-ng/configure --warn --zlib-compat"
     - os: osx
       compiler: gcc
-      env: BUILDDIR=. TOOL="cmake ."
+      env: MAKE="make" BUILDDIR=. TOOL="cmake ."
 
     - os: osx
       compiler: clang
-      env: BUILDDIR=. TOOL="./configure --warn --zlib-compat"
+      env: MAKE="make" BUILDDIR=. TOOL="./configure --warn --zlib-compat"
     - os: osx
       compiler: clang
-      env: BUILDDIR=../build TOOL="cmake ../zlib-ng"
+      env: MAKE="make" BUILDDIR=../build TOOL="cmake ../zlib-ng"
 
     # compiling for linux-ppc64le variants
     - os: linux-ppc64le
       compiler: gcc
-      env: BUILDDIR=. TOOL="cmake ."
+      env: MAKE="make" BUILDDIR=. TOOL="cmake ."
     - os: linux-ppc64le
       compiler: gcc
-      env: BUILDDIR=../build TOOL="cmake ../zlib-ng"
+      env: MAKE="make" BUILDDIR=../build TOOL="cmake ../zlib-ng"
 
     - os: linux-ppc64le
       compiler: clang
-      env: BUILDDIR=. TOOL="./configure --warn --zlib-compat"
+      env: MAKE="make" BUILDDIR=. TOOL="./configure --warn --zlib-compat"
     - os: linux-ppc64le
       compiler: clang
-      env: BUILDDIR=../build TOOL="cmake ../zlib-ng"
+      env: MAKE="make" BUILDDIR=../build TOOL="cmake ../zlib-ng"
 
     # Cross compiling for arm variants
     - os: linux
@@ -73,7 +76,7 @@ matrix:
             - libc-dev-arm64-cross
       # For all aarch64 implementations NEON is mandatory, while crypto/crc are not.
       # So for aarch64 NEON should be automatically enabled, and "acle" should be explicitly defined
-      env: CHOST=aarch64-linux-gnu BUILDDIR=. TOOL="./configure --warn --zlib-compat"
+      env: CHOST=aarch64-linux-gnu MAKE="make" BUILDDIR=. TOOL="./configure --warn --zlib-compat"
     - os: linux
       compiler: aarch64-linux-gnu-gcc
       addons:
@@ -87,8 +90,8 @@ matrix:
       # be enabled in subset. But the command
       # "CHOST=aarch64-linux-gnu ./configure --warn --zlib-compat --acle"
       # should work if manually test it in a dist with gcc-aarch64 5.1 or higher
-      # env: CHOST=aarch64-linux-gnu BUILDDIR=. TOOL="./configure --warn --zlib-compat --acle"
-      env: CHOST=aarch64-linux-gnu BUILDDIR=. TOOL="./configure --warn --zlib-compat"
+      # env: CHOST=aarch64-linux-gnu MAKE="make" BUILDDIR=. TOOL="./configure --warn --zlib-compat --acle"
+      env: CHOST=aarch64-linux-gnu MAKE="make" BUILDDIR=. TOOL="./configure --warn --zlib-compat"
     # Hard-float subsets
     - os: linux
       compiler: arm-linux-gnueabihf-gcc
@@ -98,7 +101,7 @@ matrix:
             - qemu
             - gcc-arm-linux-gnueabihf
             - libc-dev-armhf-cross
-      env: CHOST=arm-linux-gnueabihf BUILDDIR=. TOOL="./configure --warn"
+      env: CHOST=arm-linux-gnueabihf MAKE="make" BUILDDIR=. TOOL="./configure --warn"
     - os: linux
       compiler: arm-linux-gnueabihf-gcc
       addons:
@@ -107,7 +110,7 @@ matrix:
             - qemu
             - gcc-arm-linux-gnueabihf
             - libc-dev-armhf-cross
-      env: CHOST=arm-linux-gnueabihf BUILDDIR=. TOOL="./configure --warn --zlib-compat --neon"
+      env: CHOST=arm-linux-gnueabihf MAKE="make" BUILDDIR=. TOOL="./configure --warn --zlib-compat --neon"
     - os: linux
       compiler: arm-linux-gnueabihf-gcc
       addons:
@@ -116,7 +119,7 @@ matrix:
             - qemu
             - gcc-arm-linux-gnueabihf
             - libc-dev-armhf-cross
-      env: CHOST=arm-linux-gnueabihf BUILDDIR=. TOOL="./configure --warn --zlib-compat"
+      env: CHOST=arm-linux-gnueabihf MAKE="make" BUILDDIR=. TOOL="./configure --warn --zlib-compat"
     # Soft-float subset
     - os: linux
       compiler: arm-linux-gnueabi-gcc
@@ -126,7 +129,7 @@ matrix:
             - qemu
             - gcc-arm-linux-gnueabi
             - libc-dev-armel-cross
-      env: CHOST=arm-linux-gnueabi BUILDDIR=. TOOL="./configure"
+      env: CHOST=arm-linux-gnueabi MAKE="make" BUILDDIR=. TOOL="./configure"
     - os: linux
       compiler: arm-linux-gnueabi-gcc
       addons:
@@ -135,6 +138,6 @@ matrix:
             - qemu
             - gcc-arm-linux-gnueabi
             - libc-dev-armel-cross
-      env: CHOST=arm-linux-gnueabi BUILDDIR=. TOOL="./configure --zlib-compat"
+      env: CHOST=arm-linux-gnueabi MAKE="make" BUILDDIR=. TOOL="./configure --zlib-compat"
 
-script: mkdir -p $BUILDDIR && cd $BUILDDIR && $TOOL && make -j2 && make test
+script: mkdir -p $BUILDDIR && cd $BUILDDIR && $TOOL && $MAKE -j2 && $MAKE test


### PR DESCRIPTION
Enable the scan-build function for clang-based builds.

The ``--status-bugs`` option marks the build as "failed" if scan-build detects any bugs.

scan-build currently finds one bug:
```
In file included from zlib-ng/inflate.c:88:
zlib-ng/memcopy.h:298:5: warning: Value stored to 'from' is never read
    from += rem;
    ^       ~~~
1 warning generated.
```


