### PR TITLE
Fix: unknown type name 'va_list'

### DIFF
--- a/zlib.h
+++ b/zlib.h
@@ -31,6 +31,7 @@
 */
 
 #include <stdint.h>
+#include <stdarg.h>
 #include "zconf.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
Fix: unknown type name 'va_list' on linux build (gcc 7.3.1 on Centos 7)