### PR TITLE
fix bugs #186 and #191, oss-fuzz/9831: use-of-uninitialized-value

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -1150,6 +1150,7 @@ static void lm_init(deflate_state *s) {
     s->insert = 0;
     s->match_length = s->prev_length = MIN_MATCH-1;
     s->match_available = 0;
+    s->match_start = 0;
     s->ins_h = 0;
 }
 


### PR DESCRIPTION
==1==WARNING: MemorySanitizer: use-of-uninitialized-value
  #0 0x59fa93 in deflate_medium zlib-ng/deflate_medium.c:259:21
  #1 0x590905 in zng_deflate zlib-ng/deflate.c:951:18
  #2 0x587095 in zng_compress2 zlib-ng/compress.c:59:15
  #3 0x5866e3 in check_compress_level zlib-ng/test/fuzz/compress_fuzzer.c:18:3
  #4 0x5862fd in LLVMFuzzerTestOneInput zlib-ng/test/fuzz/compress_fuzzer.c:38:3
  #5 0x4e9b48 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /src/libfuzzer/FuzzerLoop.cpp:575:15
  #6 0x4a2f66 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) /src/libfuzzer/FuzzerDriver.cpp:280:6
  #7 0x4b3adb in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/libfuzzer/FuzzerDriver.cpp:715:9
  #8 0x4a2091 in main /src/libfuzzer/FuzzerMain.cpp:20:10
  #9 0x7fea2fea482f in __libc_start_main /build/glibc-Cl5G7W/glibc-2.23/csu/libc-start.c:291
  #10 0x41ec68 in _start
Uninitialized value was created by a heap allocation
  #0 0x45f2a0 in malloc /src/llvm/projects/compiler-rt/lib/msan/msan_interceptors.cc:910
  #1 0x587d42 in zng_deflateInit2_ zlib-ng/deflate.c:284:27
  #2 0x5874fa in zng_deflateInit_ zlib-ng/deflate.c:224:12
  #3 0x586c95 in zng_compress2 zlib-ng/compress.c:41:11
  #4 0x5866e3 in check_compress_level zlib-ng/test/fuzz/compress_fuzzer.c:18:3
  #5 0x5862fd in LLVMFuzzerTestOneInput zlib-ng/test/fuzz/compress_fuzzer.c:38:3
  #6 0x4e9b48 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /src/libfuzzer/FuzzerLoop.cpp:575:15
  #7 0x4a2f66 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) /src/libfuzzer/FuzzerDriver.cpp:280:6
  #8 0x4b3adb in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/libfuzzer/FuzzerDriver.cpp:715:9
  #9 0x4a2091 in main /src/libfuzzer/FuzzerMain.cpp:20:10
  #10 0x7fea2fea482f in __libc_start_main /build/glibc-Cl5G7W/glibc-2.23/csu/libc-start.c:291