### PR TITLE
fix bug #192, oss-fuzz/9827 : MemorySanitizer:DEADLYSIGNAL

### DIFF
--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -172,7 +172,7 @@ static void fizzle_matches(deflate_state *s, struct match *current, struct match
             break;
         if (n.match_length >= 256)
             break;
-        if (n.match_start <= 0)
+        if (n.match_start <= 1)
             break;
 
         n.strstart--;


### PR DESCRIPTION
==4908==ERROR: MemorySanitizer: SEGV on unknown address 0x730fffffffff (pc 0x0000004b1b97 bp 0x7ffd4bf59a00 sp 0x7ffd4bf598a0 T4908)
==4908==The signal is caused by a READ memory access.
  #0 0x5a0599 in fizzle_matches zlib-ng/deflate_medium.c:168:12
  #1 0x59ea27 in deflate_medium zlib-ng/deflate_medium.c:296:21
  #2 0x5901c5 in zng_deflate zlib-ng/deflate.c:951:18
  #3 0x586955 in zng_compress2 zlib-ng/compress.c:59:15
  #4 0x5861eb in LLVMFuzzerTestOneInput zlib-ng/test/fuzz/compress_fuzzer.c:18:3
  #5 0x4e9b48 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /src/libfuzzer/FuzzerLoop.cpp:575:15
  #6 0x4a2f66 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) /src/libfuzzer/FuzzerDriver.cpp:280:6
  #7 0x4b3adb in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/libfuzzer/FuzzerDriver.cpp:715:9
  #8 0x4a2091 in main /src/libfuzzer/FuzzerMain.cpp:20:10
  #9 0x7fa3d7ff582f in __libc_start_main /build/glibc-Cl5G7W/glibc-2.23/csu/libc-start.c:291
  #10 0x41ec68 in _start