### PR TITLE
fix #187: remove errors exposed by undefined behavior sanitizer

### DIFF
--- a/adler32.c
+++ b/adler32.c
@@ -88,7 +88,8 @@ uint32_t adler32_c(uint32_t adler, const unsigned char *buf, size_t len) {
 
     /* in case short lengths are provided, keep it somewhat fast */
     if (len < 16) {
-        while (len--) {
+        while (len) {
+            --len;
             adler += *buf++;
             sum2 += adler;
         }
@@ -133,7 +134,8 @@ uint32_t adler32_c(uint32_t adler, const unsigned char *buf, size_t len) {
             buf += 8;
 #endif
         }
-        while (len--) {
+        while (len) {
+            --len;
             adler += *buf++;
             sum2 += adler;
         }

--- a/arch/x86/deflate_quick.c
+++ b/arch/x86/deflate_quick.c
@@ -230,7 +230,7 @@ ZLIB_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
             hash_head = quick_insert_string(s, s->strstart);
             dist = s->strstart - hash_head;
 
-            if ((dist-1) < (s->w_size - 1)) {
+            if (dist > 0 && (dist-1) < (s->w_size - 1)) {
                 match_len = compare258(s->window + s->strstart, s->window + s->strstart - dist);
 
                 if (match_len >= MIN_MATCH) {

--- a/arch/x86/fill_window_sse.c
+++ b/arch/x86/fill_window_sse.c
@@ -49,7 +49,7 @@ ZLIB_INTERNAL void fill_window_sse(deflate_state *s) {
          */
         if (s->strstart >= wsize+MAX_DIST(s)) {
             memcpy(s->window, s->window+wsize, (unsigned)wsize);
-            s->match_start -= wsize;
+            s->match_start = (s->match_start >= wsize) ? s->match_start - wsize : 0;
             s->strstart    -= wsize; /* we now have strstart >= MAX_DIST */
             s->block_start -= (long) wsize;
 

--- a/inflate.c
+++ b/inflate.c
@@ -969,8 +969,10 @@ int ZEXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int flush) {
                         state->mode = BAD;
                         break;
                     }
-                    while (copy--)
+                    while (copy) {
+                        --copy;
                         state->lens[state->have++] = (uint16_t)len;
+                    }
                 }
             }
 


### PR DESCRIPTION
Move decrement in loop to avoid the following errors:
adler32.c:91:19: runtime error: unsigned integer overflow: 0 - 1 cannot be represented in type 'size_t' (aka 'unsigned long')
adler32.c:136:19: runtime error: unsigned integer overflow: 0 - 1 cannot be represented in type 'size_t' (aka 'unsigned long')
inflate.c:972:32: runtime error: unsigned integer overflow: 0 - 1 cannot be represented in type 'unsigned int'

Fix the following bugs as recommended by Mika Lindqvist:
arch/x86/deflate_quick.c:233:22: runtime error: unsigned integer overflow: 0 - 1 cannot be represented in type 'unsigned int'
arch/x86/fill_window_sse.c:52:28: runtime error: unsigned integer overflow: 1 - 8192 cannot be represented in type 'unsigned int'