### PR TITLE
fix bug #184: clear out buf to avoid msan use-of-uninitialized-value

### DIFF
--- a/test/minigzip.c
+++ b/test/minigzip.c
@@ -291,6 +291,9 @@ void gz_compress(FILE   *in, gzFile out)
      */
     if (gz_compress_mmap(in, out) == Z_OK) return;
 #endif
+    /* Clear out the contents of buf before reading from the file to avoid
+       MemorySanitizer: use-of-uninitialized-value warnings. */
+    memset(buf, 0, sizeof(buf));
     for (;;) {
         len = (int)fread(buf, 1, sizeof(buf), in);
         if (ferror(in)) {


### PR DESCRIPTION
Do not use bzero as suggested by Mika Lindqvist:
> You shouldn't use bzero() in new code as some compilers, like Visual C++,
> don't have it... New code should just use memset().