### PR TITLE
fix bug #207: avoid undefined integer overflow

### DIFF
--- a/deflate_slow.c
+++ b/deflate_slow.c
@@ -108,11 +108,13 @@ ZLIB_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
 #else
             {
                 unsigned int mov_fwd = s->prev_length - 2;
-                unsigned int insert_cnt = mov_fwd;
-                if (unlikely(insert_cnt > max_insert - s->strstart))
-                    insert_cnt = max_insert - s->strstart;
+                if (max_insert > s->strstart) {
+                    unsigned int insert_cnt = mov_fwd;
+                    if (unlikely(insert_cnt > max_insert - s->strstart))
+                        insert_cnt = max_insert - s->strstart;
 
-                functable.insert_string(s, s->strstart + 1, insert_cnt);
+                    functable.insert_string(s, s->strstart + 1, insert_cnt);
+                }
                 s->prev_length = 0;
                 s->match_available = 0;
                 s->match_length = MIN_MATCH-1;


### PR DESCRIPTION
zlib-ng used to fail when compiled with UBSan with this error:
deflate_slow.c:112:21: runtime error: unsigned integer overflow: 45871 - 45872 cannot be represented in type 'unsigned int'

The bug occurs in the code under `#ifndef NOT_TWEAK_COMPILER`.
When `lookahead < MIN_MATCH` we now go back to the original
step by step computation under `#ifdef NOT_TWEAK_COMPILER`.