### PR TITLE
Fix clang scan-build "zlib-ng/memcopy.h:298:5: warning: Value stored to 'from' is never read"

### DIFF
--- a/memcopy.h
+++ b/memcopy.h
@@ -295,7 +295,6 @@ static inline unsigned char *byte_memset(unsigned char *out, unsigned len) {
     unsigned rem = len % sz;
     len /= sz;
     out += rem;
-    from += rem;
 
     unsigned by8 = len % 8;
     len -= by8;


### PR DESCRIPTION
Addresses bug in #188 