### PR TITLE
Fix test/example.c when compiled with ASAN

### DIFF
--- a/test/example.c
+++ b/test/example.c
@@ -238,6 +238,8 @@ void test_inflate(unsigned char *compr, size_t comprLen, unsigned char *uncompr,
     }
 }
 
+static unsigned int diff;
+
 /* ===========================================================================
  * Test deflate() with large buffers and dynamic change of compression level
  */
@@ -271,7 +273,8 @@ void test_large_deflate(unsigned char *compr, size_t comprLen, unsigned char *un
     /* Feed in already compressed data and switch to no compression: */
     PREFIX(deflateParams)(&c_stream, Z_NO_COMPRESSION, Z_DEFAULT_STRATEGY);
     c_stream.next_in = compr;
-    c_stream.avail_in = (unsigned int)comprLen/2;
+    diff = (unsigned int)(c_stream.next_out - compr);
+    c_stream.avail_in = diff;
     err = PREFIX(deflate)(&c_stream, Z_NO_FLUSH);
     CHECK_ERR(err, "deflate");
 
@@ -322,7 +325,7 @@ void test_large_inflate(unsigned char *compr, size_t comprLen, unsigned char *un
     err = PREFIX(inflateEnd)(&d_stream);
     CHECK_ERR(err, "inflateEnd");
 
-    if (d_stream.total_out != 2*uncomprLen + comprLen/2) {
+    if (d_stream.total_out != 2*uncomprLen + diff) {
         fprintf(stderr, "bad large inflate: %zu\n", d_stream.total_out);
         exit(1);
     } else {


### PR DESCRIPTION
Before this patch

cmake -DWITH_SANITIZERS=1
make
make test

used to fail with:

Running tests...
Test project /home/hansr/github/zlib/zlib-ng
    Start 1: example
1/2 Test #1: example ..........................***Failed    0.14 sec
    Start 2: example64
2/2 Test #2: example64 ........................***Failed    0.13 sec

==11605==ERROR: AddressSanitizer: memcpy-param-overlap: memory ranges [0x62e000000595,0x62e0000053b5) and [0x62e000000400, 0x62e000005220) overlap
    #0 0x7fab3bcc9662 in __asan_memcpy (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x8c662)
    #1 0x40f936 in memcpy /usr/include/x86_64-linux-gnu/bits/string3.h:53
    #2 0x40f936 in read_buf /home/spop/s/zlib-ng/deflate.c:1122
    #3 0x410458 in deflate_stored /home/spop/s/zlib-ng/deflate.c:1394
    #4 0x4133d7 in zng_deflate /home/spop/s/zlib-ng/deflate.c:945
    #5 0x402253 in test_large_deflate /home/spop/s/zlib-ng/test/example.c:275
    #6 0x4014e8 in main /home/spop/s/zlib-ng/test/example.c:536
    #7 0x7fab3b89382f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)
    #8 0x4018e8 in _start (/work/spop/zlib-ng/example+0x4018e8)

0x62e000000595 is located 405 bytes inside of 40000-byte region [0x62e000000400,0x62e00000a040)
allocated by thread T0 here:
    #0 0x7fab3bcd579a in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x9879a)
    #1 0x40147a in main /home/spop/s/zlib-ng/test/example.c:516

0x62e000000400 is located 0 bytes inside of 40000-byte region [0x62e000000400,0x62e00000a040)
allocated by thread T0 here:
    #0 0x7fab3bcd579a in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x9879a)
    #1 0x40147a in main /home/spop/s/zlib-ng/test/example.c:516

SUMMARY: AddressSanitizer: memcpy-param-overlap ??:0 __asan_memcpy
==11605==ABORTING

The abort is on the following call to deflate():

    c_stream.next_out = compr;
    c_stream.avail_out = (unsigned int)comprLen;
    [...]

    /* Feed in already compressed data and switch to no compression: */
    PREFIX(deflateParams)(&c_stream, Z_NO_COMPRESSION, Z_DEFAULT_STRATEGY);
    c_stream.next_in = compr;
    c_stream.avail_in = (unsigned int)comprLen/2;
    err = PREFIX(deflate)(&c_stream, Z_NO_FLUSH);

with c_stream.next_out and c_stream.next_in pointing to the same memory array.
The patch reduces the size of the array for in and out to not overlap.