### PR TITLE
fix ASAN crash on test/minigzip

### DIFF
--- a/test/minigzip.c
+++ b/test/minigzip.c
@@ -14,6 +14,8 @@
 
 /* @(#) $Id$ */
 
+#define _POSIX_SOURCE 1  /* This file needs POSIX for fdopen(). */
+
 #include "zbuild.h"
 #ifdef ZLIB_COMPAT
 # include "zlib.h"


### PR DESCRIPTION
Before this patch, when configuring with address sanitizer:

./configure --with-sanitizers
make
make test

used to fail with the following error:

$ echo hello world | ./minigzip
ASAN:SIGSEGV
=================================================================
==17466==ERROR: AddressSanitizer: SEGV on unknown address 0x00000000fc80 (pc 0x7fcacddd46f8 bp 0x7ffd01ceb310 sp 0x7ffd01ceb290 T0)
    #0 0x7fcacddd46f7 in _IO_fwrite (/lib/x86_64-linux-gnu/libc.so.6+0x6e6f7)
    #1 0x402602 in zng_gzwrite /home/spop/s/zlib-ng/test/minigzip.c:180
    #2 0x403445 in gz_compress /home/spop/s/zlib-ng/test/minigzip.c:305
    #3 0x404724 in main /home/spop/s/zlib-ng/test/minigzip.c:509
    #4 0x7fcacdd8682f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)
    #5 0x4018d8 in _start (/work/spop/zlib-ng/minigzip+0x4018d8)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV ??:0 _IO_fwrite
==17466==ABORTING

During compilation the following warnings point to a missing definition:

/home/spop/s/zlib-ng/test/minigzip.c:154:31: warning: implicit declaration of function 'fdopen' is invalid in C99 [-Wimplicit-function-declaration]
    gz->file = path == NULL ? fdopen(fd, gz->write ? "wb" : "rb") :
                              ^
/home/spop/s/zlib-ng/test/minigzip.c:154:29: warning: pointer/integer type mismatch in conditional expression ('int' and 'FILE *' (aka 'struct _IO_FILE *')) [-Wconditional-type-mismatch]
    gz->file = path == NULL ? fdopen(fd, gz->write ? "wb" : "rb") :
                            ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/spop/s/zlib-ng/test/minigzip.c:504:36: warning: implicit declaration of function 'fileno' is invalid in C99 [-Wimplicit-function-declaration]
            file = PREFIX(gzdopen)(fileno(stdin), "rb");
                                   ^
/home/spop/s/zlib-ng/test/minigzip.c:508:36: warning: implicit declaration of function 'fileno' is invalid in C99 [-Wimplicit-function-declaration]
            file = PREFIX(gzdopen)(fileno(stdout), outmode);
                                   ^
/home/spop/s/zlib-ng/test/minigzip.c:534:48: warning: implicit declaration of function 'fileno' is invalid in C99 [-Wimplicit-function-declaration]
                        file = PREFIX(gzdopen)(fileno(stdout), outmode);
                                               ^
5 warnings generated.

and looking at stdio.h that defines fdopen we see that it is only defined under
__USE_POSIX:

 #ifdef	__USE_POSIX
/* Create a new stream that refers to an existing system file descriptor.  */
extern FILE *fdopen (int __fd, const char *__modes) __THROW __wur;
 #endif

This patch fixes the compiler warnings and the runtime ASAN error.