### PR TITLE
fix oss-fuzz/11323: clear out s->prev buffer

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -313,6 +313,7 @@ int ZEXPORT PREFIX(deflateInit2_)(PREFIX3(stream) *strm, int level, int method, 
 
     s->window = (unsigned char *) ZALLOC(strm, s->w_size + window_padding, 2*sizeof(unsigned char));
     s->prev   = (Pos *)  ZALLOC(strm, s->w_size, sizeof(Pos));
+    memset(s->prev, 0, s->w_size * sizeof(Pos));
     s->head   = (Pos *)  ZALLOC(strm, s->hash_size, sizeof(Pos));
 
     s->high_water = 0;      /* nothing written to s->window yet */


### PR DESCRIPTION
zlib-ng compiled with MSAN used to fail with:

SUMMARY: MemorySanitizer: use-of-uninitialized-value /src/zlib-ng/match.c:473:60 in longest_match
Exiting

  Uninitialized value was stored to memory at
    #0 0x7fcaced77645 in fill_window_sse /src/zlib-ng/arch/x86/fill_window_sse.c:84:17
    #1 0x7fcaced7d3d4 in deflate_quick /src/zlib-ng/arch/x86/deflate_quick.c:230:13
    #2 0x7fcaced2f54b in zng_deflate /src/zlib-ng/deflate.c:951:18
    #3 0x4a04e9 in test_large_deflate /src/zlib-ng/test/example.c:266:11
    #4 0x4a38d2 in main /src/zlib-ng/test/example.c:539:5
    #5 0x7fcace96a82f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)

  Uninitialized value was created by a heap allocation
    #0 0x45bf70 in malloc /src/llvm/projects/compiler-rt/lib/msan/msan_interceptors.cc:910
    #1 0x7fcaced26cd9 in zng_deflateInit2_ /src/zlib-ng/deflate.c:315:26
    #2 0x7fcaced2605a in zng_deflateInit_ /src/zlib-ng/deflate.c:224:12
    #3 0x4a03c5 in test_large_deflate /src/zlib-ng/test/example.c:255:11
    #4 0x4a38d2 in main /src/zlib-ng/test/example.c:539:5
    #5 0x7fcace96a82f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)