### PR TITLE
bug #117: speed up inflate_fast

### DIFF
--- a/infback.c
+++ b/infback.c
@@ -453,7 +453,8 @@ int ZEXPORT PREFIX(inflateBack)(PREFIX3(stream) *strm, in_func in, void *in_desc
 
         case LEN:
             /* use inflate_fast() if we have enough input and output */
-            if (have >= 6 && left >= 258) {
+            if (have >= INFLATE_FAST_MIN_HAVE &&
+                left >= INFLATE_FAST_MIN_LEFT) {
                 RESTORE();
                 if (state->whave < state->wsize)
                     state->whave = state->wsize - left;

--- a/inffast.h
+++ b/inffast.h
@@ -19,4 +19,7 @@ typedef uint8x16_t inffast_chunk_t;
 #  define INFFAST_CHUNKSIZE sizeof(inffast_chunk_t)
 #endif
 
+#define INFLATE_FAST_MIN_HAVE 8
+#define INFLATE_FAST_MIN_LEFT 258
+
 #endif /* INFFAST_H_ */

--- a/inflate.c
+++ b/inflate.c
@@ -1016,7 +1016,8 @@ int ZEXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int flush) {
         case LEN_:
             state->mode = LEN;
         case LEN:
-            if (have >= 6 && left >= 258) {
+            if (have >= INFLATE_FAST_MIN_HAVE &&
+                left >= INFLATE_FAST_MIN_LEFT) {
                 RESTORE();
                 inflate_fast(strm, out);
                 LOAD();

--- a/memcopy.h
+++ b/memcopy.h
@@ -4,23 +4,15 @@
 #ifndef MEMCOPY_H_
 #define MEMCOPY_H_
 
-/* Load a short from IN and place the bytes at offset BITS in the result. */
-static inline uint32_t load_short(const unsigned char *in, unsigned bits) {
-    union {
-        uint16_t a;
-        uint8_t b[2];
-    } chunk;
-    MEMCPY(&chunk, in, sizeof(uint16_t));
+/* Load 64 bits from IN and place the bytes at offset BITS in the result. */
+static inline uint64_t load_64_bits(const unsigned char *in, unsigned bits) {
+  uint64_t chunk;
+  MEMCPY(&chunk, in, sizeof(chunk));
 
 #if BYTE_ORDER == LITTLE_ENDIAN
-    uint32_t res = chunk.a;
-    return res << bits;
+  return chunk << bits;
 #else
-    uint32_t c0 = chunk.b[0];
-    uint32_t c1 = chunk.b[1];
-    c0 <<= bits;
-    c1 <<= bits + 8;
-    return c0 + c1;
+  return ZSWAP64(chunk) << bits;
 #endif
 }
 


### PR DESCRIPTION
Based on a patch by Nigel Tao:
https://github.com/madler/zlib/pull/292/commits/e0ff1f330cc03ee04843f857869b4036593ab39d

This patch makes unzipping of files up to 1.2x faster on x86_64.  The other part
(1.3x speedup) of the patch by Nigel Tao is unsafe as discussed in the review of
that pull request.  zlib-ng already has a different way to optimize the memcpy
for that missing part.

The original patch was enabled only on little-endian machines. This patch adapts
the loading of 64 bits at a time to big endian machines.