### PR TITLE
fix bug #210: split statement in two to avoid substract overflow

### DIFF
--- a/trees.c
+++ b/trees.c
@@ -479,7 +479,8 @@ static void gen_bitlen(deflate_state *s, tree_desc *desc) {
                 continue;
             if (tree[m].Len != bits) {
                 Trace((stderr, "code %d bits %d->%u\n", m, tree[m].Len, bits));
-                s->opt_len += (unsigned long)((bits - tree[m].Len) * tree[m].Freq);
+                s->opt_len += (unsigned long)(bits * tree[m].Freq);
+                s->opt_len -= (unsigned long)(tree[m].Len * tree[m].Freq);
                 tree[m].Len = (uint16_t)bits;
             }
             n--;


### PR DESCRIPTION
make check used to fail with:
trees.c:482:53: runtime error: unsigned integer overflow: 6 - 7 cannot be represented in type 'unsigned int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior trees.c:482:53 in

Patch from Mika Lindqvist.