### PR TITLE
Zlib patch: prevent uninitialized use of state->check

### DIFF
--- a/inflate.c
+++ b/inflate.c
@@ -124,6 +124,7 @@ int ZEXPORT PREFIX(inflateResetKeep)(PREFIX3(stream) *strm) {
     if (state->wrap)        /* to support ill-conceived Java test suite */
         strm->adler = state->wrap & 1;
     state->mode = HEAD;
+    state->check = functable.adler32(0L, NULL, 0);
     state->last = 0;
     state->havedict = 0;
     state->dmax = 32768U;


### PR DESCRIPTION
This CL fixes a security bug in zlib. It was reported upstream long ago
and the testcase was shared upstream but it's yet unsolved. As a fix,
state->check is set to the same value as the adler32 of an empty string.

Upstream bug: madler/zlib#245

Bug: chromium:697481 https://crbug.com/697481
Reviewed-on: https://chromium-review.googlesource.com/601193
Reviewed-by: Tom Sepez <tsepez@chromium.org>
Reviewed-by: Adam Langley <agl@chromium.org>
Commit-Queue: Nicolás Peña <npm@chromium.org>