### PR TITLE
Handle case where inflateSync used when header never processed.

### DIFF
--- a/inflate.c
+++ b/inflate.c
@@ -1408,6 +1408,8 @@ int ZEXPORT PREFIX(inflateSync)(PREFIX3(stream) *strm) {
     /* return no joy or set up to restart inflate() on a new block */
     if (state->have != 4)
         return Z_DATA_ERROR;
+    if (state->mode == HEAD)
+        state->wrap = 0;    /* never processed header, so assume raw */
     in = strm->total_in;
     out = strm->total_out;
     PREFIX(inflateReset)(strm);


### PR DESCRIPTION
If zlib and/or gzip header processing was requested, but a header
was never provided and inflateSync was used successfully, then the
inflate state would be inconsistent, trying to compute a check
value but with no flags set. This commit sets the inflate mode to
raw in this case, since there is no other assumption that can be
made if a header was requested but never seen.