### PR TITLE
Avoid the use of ptrdiff_t.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,6 +330,29 @@ if(HAVE_BUILTIN_CTZL)
     add_definitions(-DHAVE_BUILTIN_CTZL)
 endif()
 
+#
+# check for ptrdiff_t support
+#
+check_c_source_compiles(
+    "#include <stddef.h>
+     int main() { ptrdiff_t *a; return 0; }"
+    HAVE_PTRDIFF_T
+)
+if(NOT HAVE_PTRDIFF_T)
+  set(NEED_PTRDIFF_T 1)
+
+  check_type_size("void *" SIZEOF_DATA_PTR)
+  message(STATUS "sizeof(void *) is ${SIZEOF_DATA_PTR} bytes")
+
+  if(${SIZEOF_DATA_PTR} MATCHES "4")
+    set(PTRDIFF_TYPE "uint32_t")
+  elseif(${SIZEOF_DATA_PTR} MATCHES "8")
+    set(PTRDIFF_TYPE "uint64_t")
+  else()
+    message(FATAL_ERROR "sizeof(void *) is neither 32 nor 64 bit")
+  endif()
+endif()
+
 # Macro to check if source compiles when cross-compiling
 # or runs when compiling natively
 macro(check_c_source_compile_or_run source flag)
@@ -561,8 +584,12 @@ macro(generate_cmakein input output)
     foreach(_line IN LISTS _lines)
         file(APPEND ${output} "${_line}\n")
 
-        if (_line STREQUAL "#define ZCONF_H")
+        if (_line STREQUAL "#define ZCONF_H" OR _line STREQUAL "#define ZCONFNG_H")
             file(APPEND ${output} "#cmakedefine Z_HAVE_UNISTD_H\n")
+            if(NOT HAVE_PTRDIFF_T)
+              file(APPEND ${output} "#cmakedefine NEED_PTRDIFF_T\n")
+              file(APPEND ${output} "#cmakedefine PTRDIFF_TYPE ${PTRDIFF_TYPE}\n")
+            endif()
         endif()
     endforeach()
 endmacro(generate_cmakein)

--- a/Makefile.in
+++ b/Makefile.in
@@ -364,11 +364,8 @@ distclean: clean
 # Reset zconf.h and zconf.h.cmakein if building inside source tree
 	@if [ -f zconf.h.in ]; then \
 	cp -p $(SRCDIR)/zconf.h.in zconf.h ; \
-	TEMPFILE=zconfh_$$ ; \
-	echo "/#define ZCONF_H/ a\\\n#cmakedefine Z_HAVE_UNISTD_H\\n" >> $$TEMPFILE &&\
-	sed -f $$TEMPFILE $(SRCDIR)/zconf.h.in > zconf.h.cmakein &&\
-	touch -r $(SRCDIR)/zconf.h.in zconf.h.cmakein &&\
-	rm $$TEMPFILE ; fi
+	grep -v '^#cmakedefine' $(SRCDIR)/zconf.h.in > zconf.h.cmakein &&\
+	touch -r $(SRCDIR)/zconf.h.in zconf.h.cmakein ; fi
 # Cleanup these files if building outside source tree
 	@if [ ! -f zlib.3 ]; then rm -f zlib.3.pdf Makefile; fi
 # Remove arch and test directory if building outside source tree

--- a/configure
+++ b/configure
@@ -709,6 +709,46 @@ fi
 
 echo >> configure.log
 
+# check for ptrdiff_t and save result in zconf.h
+echo -n "Checking for ptrdiff_t... " | tee -a configure.log
+cat > $test.c <<EOF
+#include <stddef.h>
+int fun(ptrdiff_t *a) { return 0; }
+EOF
+if try $CC -c $CFLAGS $test.c; then
+  echo "Yes." | tee -a configure.log
+else
+    echo "No." | tee -a configure.log
+    sed < zconf${SUFFIX}.h "/^#ifdef NEED_PTRDIFF_T.* may be/s/def NEED_PTRDIFF_T\(.*\) may be/ 1\1 was/" > zconf${SUFFIX}.temp.h
+    mv zconf${SUFFIX}.temp.h zconf${SUFFIX}.h
+
+    echo -n "Checking for sizeof(void *)... " | tee -a configure.log
+    cat > $test.c <<EOF
+#include <stdint.h>
+#define COMPILE_TIME_ASSERT(pred) struct s { int x: (pred) ? 1 : -1; };
+COMPILE_TIME_ASSERT(sizeof(int32_t) == sizeof(void *));
+EOF
+    if try $CC -c $CFLAGS $test.c; then
+        echo "sizeof(int32_t)." | tee -a configure.log
+        sed < zconf${SUFFIX}.h "s/^typedef PTRDIFF_TYPE ptrdiff_t;/typedef int32_t ptrdiff_t;/g" > zconf${SUFFIX}.temp.h
+        mv zconf${SUFFIX}.temp.h zconf${SUFFIX}.h
+    else
+        cat > $test.c <<EOF
+#include <stdint.h>
+#define COMPILE_TIME_ASSERT(pred) struct s { int x: (pred) ? 1 : -1; };
+COMPILE_TIME_ASSERT(sizeof(int64_t) == sizeof(void *));
+EOF
+        if try $CC -c $CFLAGS $test.c; then
+            echo "sizeof(int64_t)." | tee -a configure.log
+            sed < zconf${SUFFIX}.h "s/^typedef PTRDIFF_TYPE ptrdiff_t;/typedef int64_t ptrdiff_t;/g" > zconf${SUFFIX}.temp.h
+            mv zconf${SUFFIX}.temp.h zconf${SUFFIX}.h
+        else
+            echo "unknown." | tee -a configure.log
+            exit 1
+        fi
+    fi
+fi
+
 # if --zlib-compat was requested
 if test $compat -eq 1; then
   gzfileops=1

--- a/zconf-ng.h.in
+++ b/zconf-ng.h.in
@@ -111,6 +111,10 @@ typedef void       *voidp;
 #  define Z_HAVE_UNISTD_H
 #endif
 
+#ifdef NEED_PTRDIFF_T    /* may be set to #if 1 by ./configure */
+typedef PTRDIFF_TYPE ptrdiff_t;
+#endif
+
 #include <sys/types.h>      /* for off_t */
 #include <stdarg.h>         /* for va_list */
 

--- a/zconf.h.in
+++ b/zconf.h.in
@@ -111,6 +111,10 @@ typedef void       *voidp;
 #  define Z_HAVE_UNISTD_H
 #endif
 
+#ifdef NEED_PTRDIFF_T    /* may be set to #if 1 by ./configure */
+typedef PTRDIFF_TYPE ptrdiff_t;
+#endif
+
 #include <sys/types.h>      /* for off_t */
 #include <stdarg.h>         /* for va_list */
 


### PR DESCRIPTION
This isn't the right type anyway to assure that it contains a
pointer. That type would be intptr_t or uintptr_t. However the C99
standard says that those types are optional, so their use would not
be portable. This commit simply uses size_t or whatever configure
decided to use for size_t. That would be the same length as
ptrdiff_t, and so will work just as well. The code checks to see if
the length of the type used is the same as the length of a void
pointer, so there is already protection against the use of the
wrong type. The use of size_t (or ptrdiff_t) will almost always
work, as all modern architectures have an array size that is the
same as the pointer size. Only old segmented architectures would
have to fall back to the slower CRC-32 calculation, where the
amount of memory that can be accessed is larger than the maximum
array size.