### PR TITLE
Return an error if the gzputs string length can't fit in an int.

### DIFF
--- a/gzwrite.c
+++ b/gzwrite.c
@@ -320,8 +320,7 @@ int ZEXPORT PREFIX(gzputc)(gzFile file, int c) {
 
 /* -- see zlib.h -- */
 int ZEXPORT PREFIX(gzputs)(gzFile file, const char *s) {
-    int ret;
-    size_t len;
+    size_t len, put;
     gz_state *state;
 
     /* get internal structure */
@@ -335,8 +334,12 @@ int ZEXPORT PREFIX(gzputs)(gzFile file, const char *s) {
 
     /* write string */
     len = strlen(s);
-    ret = (int)gz_write(state, s, len);
-    return ret == 0 && len != 0 ? -1 : ret;
+    if ((int)len < 0 || (unsigned)len != len) {
+        gz_error(state, Z_STREAM_ERROR, "string length does not fit in int");
+        return -1;
+    }
+    put = gz_write(state, s, len);
+    return put < len ? -1 : (int)len;
 }
 
 /* -- see zlib.h -- */


### PR DESCRIPTION
Tested with `configure --with-gzfileops`.