### PR TITLE
Avoid a conversion error in gzseek when off_t type too small.

### DIFF
--- a/gzlib.c
+++ b/gzlib.c
@@ -6,7 +6,7 @@
 #include "zbuild.h"
 #include "gzguts.h"
 
-#if defined(WIN32) && !defined(__BORLANDC__) && !defined(__MINGW32__)
+#if defined(WIN32) && !defined(__BORLANDC__)
 #  define LSEEK _lseeki64
 #else
 #if defined(_LARGEFILE64_SOURCE) && _LFS64_LARGEFILE-0
@@ -312,7 +312,7 @@ z_off64_t ZEXPORT PREFIX(gzseek64)(gzFile file, z_off64_t offset, int whence) {
 
     /* if within raw area while reading, just go there */
     if (state->mode == GZ_READ && state->how == COPY && state->x.pos + offset >= 0) {
-        ret = LSEEK(state->fd, offset - state->x.have, SEEK_CUR);
+        ret = LSEEK(state->fd, offset - (z_off64_t)state->x.have, SEEK_CUR);
         if (ret == -1)
             return -1;
         state->x.have = 0;


### PR DESCRIPTION
This is a problem in the odd case that the second argument of
LSEEK is a larger type than off_t. Apparently MinGW defines off_t
to be 32 bits, but _lseeki64 has a 64-bit second argument.

Also undo a previous commit to permit MinGW to use _lseeki64.