### PR TITLE
Fix CLEAR_HASH macro to be usable as a single statement.

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -153,9 +153,10 @@ static const config configuration_table[10] = {
  * Initialize the hash table (avoiding 64K overflow for 16 bit systems).
  * prev[] will be initialized on the fly.
  */
-#define CLEAR_HASH(s) \
-    s->head[s->hash_size-1] = NIL; \
-    memset((unsigned char *)s->head, 0, (unsigned)(s->hash_size-1)*sizeof(*s->head));
+#define CLEAR_HASH(s) do {                                                                \
+    s->head[s->hash_size - 1] = NIL;                                                      \
+    memset((unsigned char *)s->head, 0, (unsigned)(s->hash_size - 1) * sizeof(*s->head)); \
+  } while (0)
 
 /* ===========================================================================
  * Slide the hash table when sliding the window down (could be avoided with 32


### PR DESCRIPTION
As it is used in deflateParams().