### PR TITLE
avoid double definitions for LITTLE_ENDIAN and BYTE_ORDER

### DIFF
--- a/gzendian.h
+++ b/gzendian.h
@@ -8,11 +8,19 @@
 /* First check whether the compiler knows the target __BYTE_ORDER__. */
 #if defined(__BYTE_ORDER__)
 # if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-#  define LITTLE_ENDIAN __ORDER_LITTLE_ENDIAN__
-#  define BYTE_ORDER LITTLE_ENDIAN
+#  if !defined(LITTLE_ENDIAN)
+#   define LITTLE_ENDIAN __ORDER_LITTLE_ENDIAN__
+#  endif
+#  if !defined(BYTE_ORDER)
+#   define BYTE_ORDER LITTLE_ENDIAN
+#  endif
 # elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-#  define BIG_ENDIAN __ORDER_BIG_ENDIAN__
-#  define BYTE_ORDER BIG_ENDIAN
+#  if !defined(BIG_ENDIAN)
+#   define BIG_ENDIAN __ORDER_BIG_ENDIAN__
+#  endif
+#  if !defined(BYTE_ORDER)
+#   define BYTE_ORDER BIG_ENDIAN
+#  endif
 # endif
 #elif defined(__MINGW32__)
 # include <sys/param.h>


### PR DESCRIPTION
When compiling with `cmake; make` the compiler used to warn about double
definitions:

```
../gzendian.h:11:0: warning: "LITTLE_ENDIAN" redefined
 #  define LITTLE_ENDIAN __ORDER_LITTLE_ENDIAN__
 ^
In file included from /usr/include/x86_64-linux-gnu/bits/string2.h:51:0,
                 from /usr/include/string.h:630,
                 from ../zutil.h:24,
                 from ../deflate.h:15,
                 from ../functable.h:9,
                 from ../functable.c:7:
/usr/include/endian.h:45:0: note: this is the location of the previous definition
 # define LITTLE_ENDIAN __LITTLE_ENDIAN
 ^
In file included from ../deflate.h:16:0,
                 from ../functable.h:9,
                 from ../functable.c:7:
../gzendian.h:12:0: warning: "BYTE_ORDER" redefined
 #  define BYTE_ORDER LITTLE_ENDIAN
 ^
In file included from /usr/include/x86_64-linux-gnu/bits/string2.h:51:0,
                 from /usr/include/string.h:630,
                 from ../zutil.h:24,
                 from ../deflate.h:15,
                 from ../functable.h:9,
                 from ../functable.c:7:
/usr/include/endian.h:48:0: note: this is the location of the previous definition
 # define BYTE_ORDER __BYTE_ORDER
 ^
```