### PR TITLE
on x86_64 call libc's memset

### DIFF
--- a/memcopy.h
+++ b/memcopy.h
@@ -266,6 +266,11 @@ static inline unsigned char *chunk_memcpy(unsigned char *out, unsigned char *fro
     return out;
 }
 
+#undef CALL_MEMSET
+#if defined(__x86_64) || defined(__i386_)
+# define CALL_MEMSET 1
+#endif
+
 /* Memset LEN bytes in OUT with the value at OUT - 1. Return OUT + LEN. */
 static inline unsigned char *byte_memset(unsigned char *out, unsigned len) {
     unsigned sz = sizeof(uint64_t);
@@ -273,6 +278,11 @@ static inline unsigned char *byte_memset(unsigned char *out, unsigned len) {
 
     unsigned char *from = out - 1;
     unsigned char c = *from;
+
+#if defined(CALL_MEMSET)
+    MEMSET(out, c, len);
+    return out + len;
+#endif
 
     /* First, deal with the case when LEN is not a multiple of SZ. */
     MEMSET(out, c, sz);


### PR DESCRIPTION
On x86_64-linux by just calling libc's memset, we get faster inflate over all
the chromium benchmarks with up to 10% speedup.
https://gist.github.com/sebpop/326c5120b6fa6cffc0e5e2017e907383

On aarch64-linux calling libc's memset ends up being just regressions:
https://gist.github.com/sebpop/0260bf9f76b568f5b4763b5d5562790b