### PR TITLE
Rename {in,de}flate_copyright -> zlibng_{in,de}flate_copyright.

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -55,7 +55,7 @@
 #include "match.h"
 #include "functable.h"
 
-const char deflate_copyright[] = " deflate 1.2.11.f Copyright 1995-2016 Jean-loup Gailly and Mark Adler ";
+const char zlibng_deflate_copyright[] = " deflate 1.2.11.f Copyright 1995-2016 Jean-loup Gailly and Mark Adler ";
 /*
   If you use the zlib library in a product, an acknowledgment is welcome
   in the documentation of your product. If for some reason you cannot

--- a/inftrees.c
+++ b/inftrees.c
@@ -9,7 +9,7 @@
 
 #define MAXBITS 15
 
-const char inflate_copyright[] = " inflate 1.2.11.f Copyright 1995-2016 Mark Adler ";
+const char zlibng_inflate_copyright[] = " inflate 1.2.11.f Copyright 1995-2016 Mark Adler ";
 /*
   If you use the zlib library in a product, an acknowledgment is welcome
   in the documentation of your product. If for some reason you cannot


### PR DESCRIPTION
If we compile zlib-ng in non-backward-compatible mode, and link both
zlib and zlibng into an application, we get duplicate symbol errors
on these names.