### PR TITLE
Enable deflate_medium by default.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -434,8 +434,8 @@ set(CMAKE_REQUIRED_FLAGS)
 #
 # Enable deflate_medium at level 4-6
 #
-if(WITH_NEW_STRATEGIES)
-    add_definitions(-DMEDIUM_STRATEGY)
+if(NOT WITH_NEW_STRATEGIES)
+    add_definitions(-DNO_MEDIUM_STRATEGY)
 endif()
 
 #

--- a/configure
+++ b/configure
@@ -881,9 +881,9 @@ else
 fi
 
 # Enable deflate_medium at level 4-6
-if test $without_new_strategies -eq 0; then
-    CFLAGS="${CFLAGS} -DMEDIUM_STRATEGY"
-    SFLAGS="${SFLAGS} -DMEDIUM_STRATEGY"
+if test $without_new_strategies -eq 1; then
+    CFLAGS="${CFLAGS} -DNO_MEDIUM_STRATEGY"
+    SFLAGS="${SFLAGS} -DNO_MEDIUM_STRATEGY"
 fi
 
 fi

--- a/deflate.c
+++ b/deflate.c
@@ -75,7 +75,7 @@ static void slide_hash            (deflate_state *s);
 static block_state deflate_stored (deflate_state *s, int flush);
 ZLIB_INTERNAL block_state deflate_fast         (deflate_state *s, int flush);
 ZLIB_INTERNAL block_state deflate_quick        (deflate_state *s, int flush);
-#ifdef MEDIUM_STRATEGY
+#ifndef NO_MEDIUM_STRATEGY
 ZLIB_INTERNAL block_state deflate_medium       (deflate_state *s, int flush);
 #endif
 ZLIB_INTERNAL block_state deflate_slow         (deflate_state *s, int flush);
@@ -126,14 +126,14 @@ static const config configuration_table[10] = {
 
 /* 3 */ {4,    6, 32,   32, deflate_fast},
 
-#ifdef MEDIUM_STRATEGY
-/* 4 */ {4,    4, 16,   16, deflate_medium},  /* lazy matches */
-/* 5 */ {8,   16, 32,   32, deflate_medium},
-/* 6 */ {8,   16, 128, 128, deflate_medium},
-#else
+#ifdef NO_MEDIUM_STRATEGY
 /* 4 */ {4,    4, 16,   16, deflate_slow},  /* lazy matches */
 /* 5 */ {8,   16, 32,   32, deflate_slow},
 /* 6 */ {8,   16, 128, 128, deflate_slow},
+#else
+/* 4 */ {4,    4, 16,   16, deflate_medium},  /* lazy matches */
+/* 5 */ {8,   16, 32,   32, deflate_medium},
+/* 6 */ {8,   16, 128, 128, deflate_medium},
 #endif
 
 /* 7 */ {8,   32, 128,  256, deflate_slow},

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -6,7 +6,7 @@
  *
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
-#ifdef MEDIUM_STRATEGY
+#ifndef NO_MEDIUM_STRATEGY
 #include "zbuild.h"
 #include "deflate.h"
 #include "deflate_p.h"


### PR DESCRIPTION
Let deflate_medium be enabled by default when compiling without using our configure or cmake scripts.
Also cuts down on the defines we send to the compiler by default.