### PR TITLE
compile all files under arch/ with sanitizer flags

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -20,12 +20,6 @@ CFLAGS=-O
 #CFLAGS=-O3 -Wall -Wwrite-strings -Wpointer-arith -Wconversion \
 #           -Wstrict-prototypes -Wmissing-prototypes
 
-WITH_SANITIZERS=
-WITH_MSAN=
-WITH_FUZZERS=
-SANITIZERS_CFLAGS=
-MSAN_CFLAGS=
-
 SFLAGS=-O
 LDFLAGS=-L.
 LIBNAME1=libz-ng
@@ -118,25 +112,19 @@ $(ARCHDIR)/%.lo: $(SRCDIR)/$(ARCHDIR)/%.c
 test: all
 	$(MAKE) -C test
 
+# This variable is set by configure.
+WITH_FUZZERS=
+
 # By default, use our own standalone_fuzz_target_runner.
 # This runner does no fuzzing, but simply executes the inputs
 # provided via parameters.
 # Run e.g. "make all LIB_FUZZING_ENGINE=/path/to/libFuzzer.a"
 # to link the fuzzer(s) against a real fuzzing engine.
-ifneq (,$(LIB_FUZZING_ENGINE))
+ifeq (,$(LIB_FUZZING_ENGINE))
+  LIB_FUZZING_ENGINE = standalone_fuzz_target_runner.o
+else
   # OSS-Fuzz will define its own value for LIB_FUZZING_ENGINE.
   WITH_FUZZERS=1
-else
-  LIB_FUZZING_ENGINE = standalone_fuzz_target_runner.o
-  ifeq (1,$(WITH_SANITIZERS))
-  CFLAGS := $(CFLAGS) $(SANITIZERS_CFLAGS)
-  LDFLAGS := $(LDFLAGS) $(SANITIZERS_CFLAGS)
-  else
-    ifeq (1,$(WITH_MSAN))
-    CFLAGS := $(CFLAGS) $(MSAN_CFLAGS)
-    LDFLAGS := $(LDFLAGS) $(MSAN_CFLAGS)
-    endif
-  endif
 endif
 
 ifeq (1,$(WITH_FUZZERS))

--- a/configure
+++ b/configure
@@ -562,13 +562,13 @@ if test $with_sanitizers -eq 1; then
         fi
     done
 
-    SANITIZERS_CFLAGS=""
     if test -n "$sanitizers"; then
         echo "-fsanitize=$sanitizers" | tee -a configure.log
-        SANITIZERS_CFLAGS="-fsanitize=$sanitizers"
+        CFLAGS="$CFLAGS -fsanitize=$sanitizers"
+        SFLAGS="$SFLAGS -fsanitize=$sanitizers"
+        LDFLAGS="$LDFLAGS -fsanitize=$sanitizers"
     else
         echo No | tee -a configure.log
-        with_sanitizers=0
     fi
 
     echo >> configure.log
@@ -578,11 +578,11 @@ if test $with_msan -eq 1; then
     echo -n "Checking for MSan... " | tee -a configure.log
     if try $CC -c $CFLAGS $test.c -fsanitize=memory ; then
         echo "-fsanitize=memory" | tee -a configure.log
-        MSAN_CFLAGS="-fsanitize=memory"
+        CFLAGS="$CFLAGS -fsanitize=memory"
+        SFLAGS="$SFLAGS -fsanitize=memory"
+        LDFLAGS="$LDFLAGS -fsanitize=memory"
     else
         echo No | tee -a configure.log
-        MSAN_CFLAGS=""
-        with_msan=0
     fi
 
     echo >> configure.log
@@ -1205,11 +1205,7 @@ if [ "$SRCDIR" != "$BUILDDIR" ]; then INCLUDES="-I$BUILDDIR ${INCLUDES}"; fi
 sed < $SRCDIR/Makefile.in "
 /^CC *=/s#=.*#=$CC#
 /^CFLAGS *=/s#=.*#=$CFLAGS#
-/^WITH_SANITIZERS *=/s#=.*#=$with_sanitizers#
-/^WITH_MSAN *=/s#=.*#=$with_msan#
 /^WITH_FUZZERS *=/s#=.*#=$with_fuzzers#
-/^SANITIZERS_CFLAGS *=/s#=.*#=$SANITIZERS_CFLAGS#
-/^MSAN_CFLAGS *=/s#=.*#=$MSAN_CFLAGS#
 /^SFLAGS *=/s#=.*#=$SFLAGS#
 /^LDFLAGS *=/s#=.*#=$LDFLAGS#
 /^LDSHARED *=/s#=.*#=$LDSHARED#


### PR DESCRIPTION
With this patch `make test` passes when configured like this:
```
CC=clang ./configure --with-fuzzers --with-msan ; make clean && make -j ; make test
```