### PR TITLE
fix bug #208: let the compiler generate code for unaligned stores

### DIFF
--- a/arch/x86/deflate_quick.c
+++ b/arch/x86/deflate_quick.c
@@ -23,6 +23,7 @@
 #  include <nmmintrin.h>
 #endif
 #include "deflate.h"
+#include "memcopy.h"
 
 #ifdef ZLIB_DEBUG
 #include <ctype.h>
@@ -151,7 +152,7 @@ static inline void quick_send_bits(deflate_state *const s,
     s->bi_valid = width - (bytes_out * 8);
 
     /* Taking advantage of the fact that LSB comes first, write to output buffer */
-    *(unsigned *)(s->pending_buf + s->pending) = out;
+    MEMCPY(s->pending_buf + s->pending, &out, sizeof(out));
 
     s->pending += bytes_out;
 }


### PR DESCRIPTION
to avoid this error:
zlib-ng/arch/x86/deflate_quick.c:154:5: runtime error: store to misaligned address 0x631000014801 for type 'unsigned int', which requires 4 byte alignment
0x631000014801: note: pointer points here
00 80 02  d3 07 00 00 be be be be  be be be be be be be be  be be be be be be be be  be be be be be
               ^
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior zlib-ng/arch/x86/deflate_quick.c:154:5 in