### PR TITLE
bug #266: select std2 for gcc/clang ARM 32-bit builds

### DIFF
--- a/match_p.h
+++ b/match_p.h
@@ -13,10 +13,13 @@
 
 #if (defined(UNALIGNED_OK) && MAX_MATCH == 258)
 
+   /* ARM 32-bit clang/gcc builds perform better, on average, with std2. Both gcc and clang and define __GNUC__. */
+#  if defined(__GNUC__) && defined(__arm__) && !defined(__aarch64__)
+#    define std2_longest_match
    /* Only use std3_longest_match for little_endian systems, also avoid using it with
       non-gcc compilers since the __builtin_ctzl() function might not be optimized. */
-#  if defined(__GNUC__) && defined(HAVE_BUILTIN_CTZL) && ((__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) \
-        || defined(__LITTLE_ENDIAN__))
+#  elif(defined(__GNUC__) && defined(HAVE_BUILTIN_CTZL) && ((__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) \
+        || defined(__LITTLE_ENDIAN__)))
 #    define std3_longest_match
 #  elif(defined(_MSC_VER) && defined(_WIN32))
 #    define std3_longest_match


### PR DESCRIPTION
Running the Chromium zlib benchmark tool on a Hikey 970 device
showed uplifts for both gcc and clang when using std2 (larger is
better):

arm_h02_std3_gcc_0ca47588bd2e38/score.out  =  7.964881
arm_h02_std3_llvm_2e8efbb084ae87/score.out =  9.522024
arm_h02_std1_gcc_0ca47588bd2e38/score.out  =  9.641071
arm_h02_std2_gcc_0ca47588bd2e38/score.out  =  9.919345
arm_h02_std1_llvm_2e8efbb084ae87/score.out =  9.925893
arm_h02_std2_llvm_2e8efbb084ae87/score.out = 10.049107