### PR TITLE
crc32: aarch64 accelerated crc32 calculate based on linux kernel

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -103,10 +103,14 @@ check: test
 
 .SECONDARY:
 
-$(ARCHDIR)/%.o: $(SRCDIR)/$(ARCHDIR)/%.c
+$(ARCHDIR)/%.o: $(SRCDIR)/$(ARCHDIR)/%.c 
+	$(MAKE) -C $(ARCHDIR) $(notdir $@)
+$(ARCHDIR)/%.o: $(SRCDIR)/$(ARCHDIR)/%.S
 	$(MAKE) -C $(ARCHDIR) $(notdir $@)
 
 $(ARCHDIR)/%.lo: $(SRCDIR)/$(ARCHDIR)/%.c
+	$(MAKE) -C $(ARCHDIR) $(notdir $@)
+$(ARCHDIR)/%.lo: $(SRCDIR)/$(ARCHDIR)/%.S
 	$(MAKE) -C $(ARCHDIR) $(notdir $@)
 
 %.o: $(ARCHDIR)/%.o
@@ -399,6 +403,7 @@ inftrees.o: $(SRCDIR)/zutil.h $(SRCDIR)/zlib$(SUFFIX).h zconf$(SUFFIX).h $(SRCDI
 trees.o: $(SRCDIR)/deflate.h $(SRCDIR)/zutil.h $(SRCDIR)/zlib$(SUFFIX).h zconf$(SUFFIX).h $(SRCDIR)/trees.h
 zutil.o: $(SRCDIR)/zutil.h $(SRCDIR)/gzguts.h $(SRCDIR)/zlib$(SUFFIX).h zconf$(SUFFIX).h
 arch/aarch64/adler32_neon.o: $(SRCDIR)/arch/aarch64/adler32_neon.h
+arch/aarch64/crc32_armv8_le.o: $(SRCDIR)/arch/aarch64/include/asm/assembler.h
 arch/aarch64/crc32_acle.o: zconf$(SUFFIX).h
 arch/aarch64/fill_window_arm.o: $(SRCDIR)/deflate.h $(SRCDIR)/deflate_p.h $(SRCDIR)/functable.h $(SRCDIR)/zutil.h $(SRCDIR)/zlib$(SUFFIX).h zconf$(SUFFIX).h
 arch/aarch64/insert_string_acle.o: $(SRCDIR)/deflate.h $(SRCDIR)/zutil.h $(SRCDIR)/zlib$(SUFFIX).h zconf$(SUFFIX).h
@@ -428,6 +433,7 @@ inftrees.lo: $(SRCDIR)/zutil.h $(SRCDIR)/zlib$(SUFFIX).h zconf$(SUFFIX).h $(SRCD
 trees.lo: $(SRCDIR)/deflate.h $(SRCDIR)/zutil.h $(SRCDIR)/zlib$(SUFFIX).h zconf$(SUFFIX).h $(SRCDIR)/trees.h
 zutil.lo: $(SRCDIR)/zutil.h $(SRCDIR)/gzguts.h $(SRCDIR)/zlib$(SUFFIX).h zconf$(SUFFIX).h
 arch/aarch64/adler32_neon.lo: $(SRCDIR)/arch/aarch64/adler32_neon.h
+arch/aarch64/crc32_armv8_le.o: $(SRCDIR)/arch/aarch64/include/asm/assembler.h
 arch/aarch64/crc32_acle.lo: zconf$(SUFFIX).h
 arch/aarch64/fill_window_arm.lo: $(SRCDIR)/deflate.h $(SRCDIR)/deflate_p.h $(SRCDIR)/functable.h $(SRCDIR)/zutil.h $(SRCDIR)/zlib$(SUFFIX).h zconf$(SUFFIX).h
 arch/aarch64/insert_string_acle.lo: $(SRCDIR)/deflate.h $(SRCDIR)/zutil.h $(SRCDIR)/zlib$(SUFFIX).h zconf$(SUFFIX).h

--- a/arch/aarch64/Makefile.in
+++ b/arch/aarch64/Makefile.in
@@ -12,7 +12,8 @@ SRCDIR=.
 SRCTOP=../..
 TOPDIR=$(SRCTOP)
 
-all: adler32_neon.o adler32_neon.lo armfeature.o armfeature.lo crc32_acle.o crc32_acle.lo fill_window_arm.o fill_window_arm.lo insert_string_acle.o insert_string_acle.lo
+
+all: adler32_neon.o adler32_neon.lo armfeature.o armfeature.lo crc32_armv8_le.o crc32_armv8_le.lo crc32_acle.o crc32_acle.lo fill_window_arm.o fill_window_arm.lo insert_string_acle.o insert_string_acle.lo
 
 adler32_neon.o: $(SRCDIR)/adler32_neon.c
 	$(CC) $(CFLAGS) $(INCLUDES) -c -o $@ $(SRCDIR)/adler32_neon.c
@@ -25,6 +26,12 @@ armfeature.o: $(SRCDIR)/armfeature.c
 
 armfeature.lo: $(SRCDIR)/armfeature.c
 	$(CC) $(CFLAGS) $(INCLUDES) -c -o $@ $(SRCDIR)/armfeature.c
+
+crc32_armv8_le.o: $(SRCDIR)/crc32_armv8_le.S
+	$(CC) $(CFLAGS) $(INCLUDES) -c -o $@ $(SRCDIR)/crc32_armv8_le.S
+
+crc32_armv8_le.lo: $(SRCDIR)/crc32_armv8_le.S
+	$(CC) $(SFLAGS) $(INCLUDES) -c -o $@ $(SRCDIR)/crc32_armv8_le.S
 
 crc32_acle.o: $(SRCDIR)/crc32_acle.c
 	$(CC) $(CFLAGS) $(INCLUDES) -c -o $@ $(SRCDIR)/crc32_acle.c
@@ -62,11 +69,13 @@ depend:
 # DO NOT DELETE THIS LINE -- make depend depends on it.
 
 adler32_neon.o: $(SRCDIR)/adler32_neon.h
+crc32_armv8_le.o: $(SRCDIR)/include/asm/assembler.h
 crc32_acle.o: $(TOPDIR)/zconf$(SUFFIX).h
 fill_window_arm.o: $(SRCTOP)/deflate.h $(SRCTOP)/deflate_p.h $(SRCTOP)/functable.h $(SRCTOP)/zutil.h $(SRCTOP)/zlib$(SUFFIX).h $(TOPDIR)/zconf$(SUFFIX).h
 insert_string_acle.o: $(SRCTOP)/deflate.h $(SRCTOP)/zutil.h $(SRCTOP)/zlib$(SUFFIX).h $(TOPDIR)/zconf$(SUFFIX).h
 
 adler32_neon.lo: $(SRCDIR)/adler32_neon.h
+crc32_armv8_le.lo: $(SRCDIR)/include/asm/assembler.h
 crc32_acle.lo: $(TOPDIR)/zconf$(SUFFIX).h
 fill_window_arm.lo: $(SRCTOP)/deflate.h $(SRCTOP)/deflate_p.h $(SRCTOP)/functable.h $(SRCTOP)/zutil.h $(SRCTOP)/zlib$(SUFFIX).h $(TOPDIR)/zconf$(SUFFIX).h
 insert_string_acle.lo: $(SRCTOP)/deflate.h $(SRCTOP)/zutil.h $(SRCTOP)/zlib$(SUFFIX).h $(TOPDIR)/zconf$(SUFFIX).h

--- a/arch/aarch64/crc32_armv8_le.S
+++ b/arch/aarch64/crc32_armv8_le.S
@@ -1,0 +1,102 @@
+/*
+ * Accelerated CRC32(C) using AArch64 CRC instructions
+ *
+ * Copyright (C) 2016 - 2018 Linaro Ltd <ard.biesheuvel@linaro.org>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+
+#include <include/asm/assembler.h>
+
+	.cpu		generic+crc
+
+	.macro		__crc32, c
+
+	mvn		w0, w0
+
+	cmp		x2, #16
+	b.lt		8f			// less than 16 bytes
+
+	and		x7, x2, #0x1f
+	and		x2, x2, #~0x1f
+	cbz		x7, 32f			// multiple of 32 bytes
+
+	and		x8, x7, #0xf
+	ldp		x3, x4, [x1]
+	add		x8, x8, x1
+	add		x1, x1, x7
+	ldp		x5, x6, [x8]
+CPU_BE(	rev		x3, x3		)
+CPU_BE(	rev		x4, x4		)
+CPU_BE(	rev		x5, x5		)
+CPU_BE(	rev		x6, x6		)
+
+	tst		x7, #8
+	crc32\c\()x	w8, w0, x3
+	csel		x3, x3, x4, eq
+	csel		w0, w0, w8, eq
+	tst		x7, #4
+	lsr		x4, x3, #32
+	crc32\c\()w	w8, w0, w3
+	csel		x3, x3, x4, eq
+	csel		w0, w0, w8, eq
+	tst		x7, #2
+	lsr		w4, w3, #16
+	crc32\c\()h	w8, w0, w3
+	csel		w3, w3, w4, eq
+	csel		w0, w0, w8, eq
+	tst		x7, #1
+	crc32\c\()b	w8, w0, w3
+	csel		w0, w0, w8, eq
+	tst		x7, #16
+	crc32\c\()x	w8, w0, x5
+	crc32\c\()x	w8, w8, x6
+	csel		w0, w0, w8, eq
+	cbz		x2, 0f
+
+32:	ldp		x3, x4, [x1], #32
+	sub		x2, x2, #32
+	ldp		x5, x6, [x1, #-16]
+CPU_BE(	rev		x3, x3		)
+CPU_BE(	rev		x4, x4		)
+CPU_BE(	rev		x5, x5		)
+CPU_BE(	rev		x6, x6		)
+	crc32\c\()x	w0, w0, x3
+	crc32\c\()x	w0, w0, x4
+	crc32\c\()x	w0, w0, x5
+	crc32\c\()x	w0, w0, x6
+	cbnz		x2, 32b
+0:	mvn     w0, w0
+    ret
+
+
+8:	tbz		x2, #3, 4f
+	ldr		x3, [x1], #8
+CPU_BE(	rev		x3, x3		)
+	crc32\c\()x	w0, w0, x3
+4:	tbz		x2, #2, 2f
+	ldr		w3, [x1], #4
+CPU_BE(	rev		w3, w3		)
+	crc32\c\()w	w0, w0, w3
+2:	tbz		x2, #1, 1f
+	ldrh		w3, [x1], #2
+CPU_BE(	rev16		w3, w3		)
+	crc32\c\()h	w0, w0, w3
+1:	tbz		x2, #0, 0f
+	ldrb		w3, [x1]
+	crc32\c\()b	w0, w0, w3
+0:  mvn     w0, w0
+    ret
+	.endm
+
+	.align		5
+ENTRY(crc32_armv8_le)
+	__crc32
+ENDPROC(crc32_armv8_le)
+
+	.align		5
+ENTRY(__crc32c_armv8_le)
+	__crc32		c
+ENDPROC(__crc32c_armv8_le)

--- a/arch/aarch64/include/asm/assembler.h
+++ b/arch/aarch64/include/asm/assembler.h
@@ -1,0 +1,72 @@
+#ifndef __ASSEMBLER_H__
+#define __ASSEMBLER_H__
+
+#ifndef __ALIGN
+#define __ALIGN     .align 4,0x90
+#define __ALIGN_STR ".align 4,0x90"
+#endif
+
+//#ifdef __ASSEMBLY__
+#ifndef ASM_NL
+#define ASM_NL       ;
+#endif
+
+#define ALIGN __ALIGN
+#define ALIGN_STR __ALIGN_STR
+
+#ifndef GLOBAL
+#define GLOBAL(name) \
+    .globl name ASM_NL \
+    name:
+#endif
+
+#ifndef ENTRY
+#define ENTRY(name) \
+    .globl name ASM_NL \
+    ALIGN ASM_NL \
+    name:
+#endif
+
+#ifndef WEAK
+#define WEAK(name)     \
+    .weak name ASM_NL   \
+    ALIGN ASM_NL \
+    name:
+#endif
+
+#ifndef END
+#define END(name) \
+    .size name, .-name
+#endif
+
+/* If symbol 'name' is treated as a subroutine (gets called, and returns)
+ * then please use ENDPROC to mark 'name' as STT_FUNC for the benefit of
+ * static analysis tools such as stack depth analyzer.
+ */
+#ifndef ENDPROC
+#define ENDPROC(name) \
+    .type name, @function ASM_NL \
+    END(name)
+#endif
+
+/*
+ * Select code when configured for BE.
+ */
+#ifdef CONFIG_BIG_ENDIAN
+#define CPU_BE(code...) code
+#else
+#define CPU_BE(code...)
+#endif
+
+/*
+ * Select code when configured for LE.
+ */
+#ifdef CONFIG_BIG_ENDIAN
+#define CPU_LE(code...)
+#else
+#define CPU_LE(code...) code
+#endif
+
+//#endif   /* __ASSEMBLY__ */
+
+#endif  /* __ASM_ASSEMBLER_H */

--- a/configure
+++ b/configure
@@ -96,6 +96,7 @@ compat=0
 cover=0
 build32=0
 build64=0
+buildhwcrc=0
 buildacle=0
 buildneon=0
 with_sanitizers=0
@@ -149,7 +150,7 @@ case "$1" in
       echo '    [--with-gzfileops]          Compiles with the gzfile parts of the API enabled' | tee -a configure.log
       echo '    [--without-optimizations]   Compiles without support for optional instruction sets' | tee -a configure.log
       echo '    [--without-new-strategies]  Compiles without using new additional deflate strategies' | tee -a configure.log
-      echo '    [--acle] [--neon]           Compiles with additional instruction set enabled' | tee -a configure.log
+      echo '    [--acle] [--neon] [--hwcrc] Compiles with additional instruction set enabled' | tee -a configure.log
       echo '    [--with-sanitizers]         Build with address sanitizer and all supported sanitizers other than memory sanitizer (disabled by default)' | tee -a configure.log
       echo '    [--with-msan]               Build with memory sanitizer (disabled by default)' | tee -a configure.log
       echo '    [--with-fuzzers]            Build test/fuzz (disabled by default)' | tee -a configure.log
@@ -171,6 +172,7 @@ case "$1" in
     --cover) cover=1; shift ;;
     -3* | --32) build32=1; shift ;;
     -6* | --64) build64=1; shift ;;
+    --hwcrc) buildhwcrc=1; shift ;;
     --acle) buildacle=1; shift ;;
     --neon) buildneon=1; shift ;;
     -n | --native) native=1; shift ;;
@@ -1152,6 +1154,15 @@ case "${ARCH}" in
           ARCH="armv8-a"
         else
           ARCH="native"
+        fi
+        if test $buildhwcrc -eq 1; then
+            if test $native -eq 0; then
+                ARCH="${ARCH}+crc"
+            fi
+            CFLAGS="${CFLAGS} -DARM_FAST_HW_CRC"
+            SFLAGS="${SFLAGS} -DARM_FAST_HW_CRC"
+            ARCH_STATIC_OBJS="${ARCH_STATIC_OBJS} crc32_armv8_le.o"
+            ARCH_SHARED_OBJS="${ARCH_SHARED_OBJS} crc32_armv8_le.lo"
         fi
         if test $buildacle -eq 1; then
            if test $native -eq 0; then

--- a/functable.c
+++ b/functable.c
@@ -40,6 +40,8 @@ extern uint32_t adler32_neon(uint32_t adler, const unsigned char *buf, size_t le
 
 ZLIB_INTERNAL uint32_t crc32_generic(uint32_t, const unsigned char *, uint64_t);
 
+extern uint32_t crc32_armv8_le(uint32_t, unsigned char const*, uint64_t);
+
 #ifdef __ARM_FEATURE_CRC32
 extern uint32_t crc32_acle(uint32_t, const unsigned char *, uint64_t);
 #endif
@@ -122,6 +124,10 @@ ZLIB_INTERNAL uint32_t crc32_stub(uint32_t crc, const unsigned char *buf, uint64
 #  if __ARM_FEATURE_CRC32 && defined(ARM_ACLE_CRC_HASH)
       if (arm_has_crc32())
         functable.crc32=crc32_acle;
+#  endif
+# ifdef ARM_FAST_HW_CRC
+      if (arm_has_crc32())
+        functable.crc32=crc32_armv8_le;
 #  endif
 #elif BYTE_ORDER == BIG_ENDIAN
         functable.crc32=crc32_big;


### PR DESCRIPTION
For arm64 plantform ,the hardware crc32 instructions will improve crc32 performance. base on the linux kernel crc32 acceletated calculation, we add it to arch/aarch64 and test on Cortex-A72 which get improvements for about 40%

Hope these patches would merged into zlib-ng mainline for others want to test on arm64.

Thanks & Best Regards.

cc: Ard Biesheuvel <ard.biesheuvel@linaro.org>