### PR TITLE
fix bug #289: use strcpy instead of strncpy

### DIFF
--- a/test/example.c
+++ b/test/example.c
@@ -461,8 +461,7 @@ void test_dict_inflate(unsigned char *compr, size_t comprLen, unsigned char *unc
     int err;
     PREFIX3(stream) d_stream; /* decompression stream */
 
-    char garbage_str[] = "garbage garbage garbage";
-    strncpy((char*)uncompr, garbage_str, sizeof(garbage_str));
+    strcpy((char*)uncompr, "garbage garbage garbage");
 
     d_stream.zalloc = zalloc;
     d_stream.zfree = zfree;


### PR DESCRIPTION
to avoid a GCC 8 warning:

test/example.c:465:48: warning: argument to ‘sizeof’ in ‘strncpy’ call is the same expression as the source; did you mean to use the size of the destination? [-Wsizeof-pointer-memaccess]
     strncpy((char*)uncompr, garbage_str, sizeof(garbage_str));