### PR TITLE
ARM: remove configure flags --neon and --acle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,6 @@ matrix:
             - gcc-aarch64-linux-gnu
             - libc-dev-arm64-cross
       # For all aarch64 implementations NEON is mandatory, while crypto/crc are not.
-      # So for aarch64 NEON should be automatically enabled, and "acle" should be explicitly defined
       env: CHOST=aarch64-linux-gnu BUILDDIR=. TOOL="./configure --warn --zlib-compat"
     - os: linux
       compiler: aarch64-linux-gnu-gcc
@@ -89,12 +88,6 @@ matrix:
             - qemu
             - gcc-aarch64-linux-gnu
             - libc-dev-arm64-cross
-      # AArch64 toolchain in Trusty is 4.8.2, which doesn't support acle intrinsics.
-      # Until TravisCI provides Xenial dist (which comes with gcc-aarch64-5.3.1) 'acle' option cannot
-      # be enabled in subset. But the command
-      # "CHOST=aarch64-linux-gnu ./configure --warn --zlib-compat --acle"
-      # should work if manually test it in a dist with gcc-aarch64 5.1 or higher
-      # env: CHOST=aarch64-linux-gnu BUILDDIR=. TOOL="./configure --warn --zlib-compat --acle"
       env: CHOST=aarch64-linux-gnu BUILDDIR=. TOOL="./configure --warn --zlib-compat"
     # Hard-float subsets
     - os: linux
@@ -114,7 +107,7 @@ matrix:
             - qemu
             - gcc-arm-linux-gnueabihf
             - libc-dev-armhf-cross
-      env: CHOST=arm-linux-gnueabihf BUILDDIR=. TOOL="./configure --warn --zlib-compat --neon"
+      env: CHOST=arm-linux-gnueabihf BUILDDIR=. TOOL="./configure --warn --zlib-compat --without-neon"
     - os: linux
       compiler: arm-linux-gnueabihf-gcc
       addons:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,8 +103,8 @@ option(WITH_NEW_STRATEGIES "Use new strategies" ON)
 option(WITH_NATIVE_INSTRUCTIONS
     "Instruct the compiler to use the full instruction set on this host (gcc/clang -march=native)" OFF)
 if("${ARCH}" MATCHES "arm" OR "${ARCH}" MATCHES "aarch64")
-    option(WITH_ACLE "Build with ACLE CRC" OFF)
-    option(WITH_NEON "Build with NEON intrinsics" OFF)
+    option(WITH_ACLE "Build with ACLE CRC" ON)
+    option(WITH_NEON "Build with NEON intrinsics" ON)
 endif()
 
 if(${CMAKE_C_COMPILER} MATCHES "icc" OR ${CMAKE_C_COMPILER} MATCHES "icpc" OR ${CMAKE_C_COMPILER} MATCHES "icl")

--- a/configure
+++ b/configure
@@ -96,8 +96,8 @@ compat=0
 cover=0
 build32=0
 build64=0
-buildacle=0
-buildneon=0
+buildacle=1
+buildneon=1
 with_sanitizers=0
 with_msan=0
 with_fuzzers=0
@@ -171,8 +171,8 @@ case "$1" in
     --cover) cover=1; shift ;;
     -3* | --32) build32=1; shift ;;
     -6* | --64) build64=1; shift ;;
-    --acle) buildacle=1; shift ;;
-    --neon) buildneon=1; shift ;;
+    --without-acle) buildacle=0; shift ;;
+    --without-neon) buildneon=0; shift ;;
     -n | --native) native=1; shift ;;
     -a*=* | --archs=*) ARCHS=`echo $1 | sed 's/.*=//'`; shift ;;
     --sysconfdir=*) echo "ignored option: --sysconfdir" | tee -a configure.log; shift ;;


### PR DESCRIPTION
This patch series enables NEON vectorization on ARM processors by default without having to explicitly configure with --neon and --acle.  This makes configure for ARM processors symmetric to the way configure works for x86 processors.  The patches also make the configure flag --without-optimization work for ARM the same way the configure flag works for x86.