### PR TITLE
Fixed arithmetic overflow warnings on Windows

### DIFF
--- a/inffast.c
+++ b/inffast.c
@@ -12,7 +12,7 @@
 
 /* Return the low n bits of the bit accumulator (n < 16) */
 #define BITS(n) \
-    (hold & ((1U << (n)) - 1))
+    (hold & ((UINT64_C(1) << (n)) - 1))
 
 /* Remove n bits from the bit accumulator */
 #define DROPBITS(n) \
@@ -447,7 +447,7 @@ void ZLIB_INTERNAL inflate_fast(PREFIX3(stream) *strm, unsigned long start) {
     len = bits >> 3;
     in -= len;
     bits -= len << 3;
-    hold &= (1U << bits) - 1;
+    hold &= (UINT64_C(1) << bits) - 1;
 
     /* update state and return */
     strm->next_in = in;
@@ -458,7 +458,9 @@ void ZLIB_INTERNAL inflate_fast(PREFIX3(stream) *strm, unsigned long start) {
     strm->avail_out =
         (unsigned)(out < end ? (INFLATE_FAST_MIN_LEFT - 1) + (end - out)
                              : (INFLATE_FAST_MIN_LEFT - 1) - (out - end));
-    state->hold = hold;
+
+    Assert(state->bits <= 32, "Remaining bits greater than 32");
+    state->hold = (uint32_t)hold;
     state->bits = bits;
     return;
 }

--- a/inffast.c
+++ b/inffast.c
@@ -459,7 +459,7 @@ void ZLIB_INTERNAL inflate_fast(PREFIX3(stream) *strm, unsigned long start) {
         (unsigned)(out < end ? (INFLATE_FAST_MIN_LEFT - 1) + (end - out)
                              : (INFLATE_FAST_MIN_LEFT - 1) - (out - end));
 
-    Assert(state->bits <= 32, "Remaining bits greater than 32");
+    Assert(bits <= 32, "Remaining bits greater than 32");
     state->hold = (uint32_t)hold;
     state->bits = bits;
     return;


### PR DESCRIPTION
This cleans up my previous pull request #294 which I didn't realize was messed up by other things I had done. 
