### PR TITLE
fix all ASan errors on aarch64

### DIFF
--- a/arch/arm/insert_string_acle.c
+++ b/arch/arm/insert_string_acle.c
@@ -29,10 +29,8 @@ Pos insert_string_acle(deflate_state *const s, const Pos str, unsigned int count
     lp = str + count - 1; /* last position */
 
     for (p = str; p <= lp; p++) {
-        unsigned *ip, val, h, hm;
-
-        ip = (unsigned *)&s->window[p];
-        val = *ip;
+        uint32_t val, h, hm;
+        memcpy(&val, &s->window[p], sizeof(val));
 
         if (s->level >= TRIGGER_LEVEL)
             val &= 0xFFFFFF;

--- a/match_p.h
+++ b/match_p.h
@@ -192,7 +192,7 @@ static inline unsigned longest_match(deflate_state *const s, IPos cur_match) {
         chain_length >>= 2;
 
     /*
-     * Do not looks for matches beyond the end of the input. This is
+     * Do not look for matches beyond the end of the input. This is
      * necessary to make deflate deterministic
      */
     nice_match = (unsigned int)s->nice_match > s->lookahead ? s->lookahead : s->nice_match;
@@ -205,8 +205,8 @@ static inline unsigned longest_match(deflate_state *const s, IPos cur_match) {
 
     scan = s->window + s->strstart;
     strend = s->window + s->strstart + MAX_MATCH - 1;
-    scan_start = *(uint16_t *)scan;
-    scan_end = *(uint16_t *)(scan + best_len-1);
+    memcpy(&scan_start, scan, sizeof(scan_start));
+    memcpy(&scan_end, scan + best_len - 1, sizeof(scan_end));
 
     Assert((unsigned long)s->strstart <= s->window_size - MIN_LOOKAHEAD, "need lookahead");
     do {
@@ -226,9 +226,13 @@ static inline unsigned longest_match(deflate_state *const s, IPos cur_match) {
          * is limited to the lookahead, so the output of deflate is not
          * affected by the uninitialized values.
          */
-        if (likely((*(uint16_t *)(match + best_len - 1) != scan_end)))
+        uint16_t val;
+        memcpy(&val, match + best_len - 1, sizeof(val));
+        if (likely(val != scan_end))
             continue;
-        if (*(uint16_t *)match != scan_start)
+
+        memcpy(&val, match, sizeof(val));
+        if (val != scan_start)
             continue;
 
         /* It is not necessary to compare scan[2] and match[2] since
@@ -246,11 +250,36 @@ static inline unsigned longest_match(deflate_state *const s, IPos cur_match) {
         match++;
 
         do {
-        } while (*(uint16_t *)(scan += 2)== *(uint16_t *)(match += 2) &&
-                 *(uint16_t *)(scan += 2)== *(uint16_t *)(match += 2) &&
-                 *(uint16_t *)(scan += 2)== *(uint16_t *)(match += 2) &&
-                 *(uint16_t *)(scan += 2)== *(uint16_t *)(match += 2) &&
-                 scan < strend);
+            uint16_t mval, sval;
+
+            memcpy(&mval, match, sizeof(mval));
+            memcpy(&sval, scan, sizeof(sval));
+            if (mval != sval)
+              break;
+            match += sizeof(mval);
+            scan += sizeof(sval);
+
+            memcpy(&mval, match, sizeof(mval));
+            memcpy(&sval, scan, sizeof(sval));
+            if (mval != sval)
+              break;
+            match += sizeof(mval);
+            scan += sizeof(sval);
+
+            memcpy(&mval, match, sizeof(mval));
+            memcpy(&sval, scan, sizeof(sval));
+            if (mval != sval)
+              break;
+            match += sizeof(mval);
+            scan += sizeof(sval);
+
+            memcpy(&mval, match, sizeof(mval));
+            memcpy(&sval, scan, sizeof(sval));
+            if (mval != sval)
+              break;
+            match += sizeof(mval);
+            scan += sizeof(sval);
+        } while (scan < strend);
 
         /*
          * Here, scan <= window + strstart + 257
@@ -267,7 +296,7 @@ static inline unsigned longest_match(deflate_state *const s, IPos cur_match) {
             best_len = len;
             if (len >= nice_match)
                 break;
-            scan_end = *(uint16_t *)(scan + best_len - 1);
+            memcpy(&scan_end, scan + best_len - 1, sizeof(scan_end));
         } else {
             /*
              * The probability of finding a match later if we here


### PR DESCRIPTION
when running `./configure --with-sanitizers --with-fuzzers && make && make test`
there were several errors of the form:

arch/aarch64/insert_string_acle.c:35:13: runtime error: load of misaligned address 0xffff90614801 for type 'unsigned int'

This patch fixes all those errors by using the MEMCPY builtin.