### PR TITLE
use memcpy instead of MEMCPY

### DIFF
--- a/arch/x86/deflate_quick.c
+++ b/arch/x86/deflate_quick.c
@@ -152,7 +152,7 @@ static inline void quick_send_bits(deflate_state *const s,
     s->bi_valid = width - (bytes_out * 8);
 
     /* Taking advantage of the fact that LSB comes first, write to output buffer */
-    MEMCPY(s->pending_buf + s->pending, &out, sizeof(out));
+    memcpy(s->pending_buf + s->pending, &out, sizeof(out));
 
     s->pending += bytes_out;
 }

--- a/deflate.h
+++ b/deflate.h
@@ -307,7 +307,7 @@ static inline void put_short(deflate_state *s, uint16_t w) {
 #if BYTE_ORDER == BIG_ENDIAN
   w = ZSWAP16(w);
 #endif
-  MEMCPY(&(s->pending_buf[s->pending]), &w, sizeof(uint16_t));
+  memcpy(&(s->pending_buf[s->pending]), &w, sizeof(uint16_t));
   s->pending += 2;
 }
 

--- a/inffast.c
+++ b/inffast.c
@@ -28,7 +28,7 @@
  */
 static inline inffast_chunk_t loadchunk(unsigned char const* s) {
     inffast_chunk_t c;
-    __builtin_memcpy(&c, s, sizeof(c));
+    memcpy(&c, s, sizeof(c));
     return c;
 }
 
@@ -37,7 +37,7 @@ static inline inffast_chunk_t loadchunk(unsigned char const* s) {
    instruction appropriate for the inffast_chunk_t type.
  */
 static inline void storechunk(unsigned char* d, inffast_chunk_t c) {
-    __builtin_memcpy(d, &c, sizeof(c));
+    memcpy(d, &c, sizeof(c));
 }
 
 /*

--- a/memcopy.h
+++ b/memcopy.h
@@ -177,22 +177,22 @@ static inline unsigned char *set_bytes(unsigned char *out, unsigned char *from, 
         unsigned char c = *from;
         switch (len) {
         case 7:
-            MEMSET(out, c, 7);
+            memset(out, c, 7);
             return out + 7;
         case 6:
-            MEMSET(out, c, 6);
+            memset(out, c, 6);
             return out + 6;
         case 5:
-            MEMSET(out, c, 5);
+            memset(out, c, 5);
             return out + 5;
         case 4:
-            MEMSET(out, c, 4);
+            memset(out, c, 4);
             return out + 4;
         case 3:
-            MEMSET(out, c, 3);
+            memset(out, c, 3);
             return out + 3;
         case 2:
-            MEMSET(out, c, 2);
+            memset(out, c, 2);
             return out + 2;
         default:
             Assert(0, "should not happen");
@@ -275,7 +275,7 @@ static inline unsigned char *byte_memset(unsigned char *out, unsigned len) {
     unsigned char c = *from;
 
     /* First, deal with the case when LEN is not a multiple of SZ. */
-    MEMSET(out, c, sz);
+    memset(out, c, sz);
     unsigned rem = len % sz;
     len /= sz;
     out += rem;
@@ -284,46 +284,46 @@ static inline unsigned char *byte_memset(unsigned char *out, unsigned len) {
     len -= by8;
     switch (by8) {
     case 7:
-        MEMSET(out, c, sz);
+        memset(out, c, sz);
         out += sz;
     case 6:
-        MEMSET(out, c, sz);
+        memset(out, c, sz);
         out += sz;
     case 5:
-        MEMSET(out, c, sz);
+        memset(out, c, sz);
         out += sz;
     case 4:
-        MEMSET(out, c, sz);
+        memset(out, c, sz);
         out += sz;
     case 3:
-        MEMSET(out, c, sz);
+        memset(out, c, sz);
         out += sz;
     case 2:
-        MEMSET(out, c, sz);
+        memset(out, c, sz);
         out += sz;
     case 1:
-        MEMSET(out, c, sz);
+        memset(out, c, sz);
         out += sz;
     }
 
     while (len) {
         /* When sz is a constant, the compiler replaces __builtin_memset with an
            inline version that does not incur a function call overhead. */
-        MEMSET(out, c, sz);
+        memset(out, c, sz);
         out += sz;
-        MEMSET(out, c, sz);
+        memset(out, c, sz);
         out += sz;
-        MEMSET(out, c, sz);
+        memset(out, c, sz);
         out += sz;
-        MEMSET(out, c, sz);
+        memset(out, c, sz);
         out += sz;
-        MEMSET(out, c, sz);
+        memset(out, c, sz);
         out += sz;
-        MEMSET(out, c, sz);
+        memset(out, c, sz);
         out += sz;
-        MEMSET(out, c, sz);
+        memset(out, c, sz);
         out += sz;
-        MEMSET(out, c, sz);
+        memset(out, c, sz);
         out += sz;
         len -= 8;
     }

--- a/memcopy.h
+++ b/memcopy.h
@@ -7,7 +7,7 @@
 /* Load 64 bits from IN and place the bytes at offset BITS in the result. */
 static inline uint64_t load_64_bits(const unsigned char *in, unsigned bits) {
   uint64_t chunk;
-  MEMCPY(&chunk, in, sizeof(chunk));
+  memcpy(&chunk, in, sizeof(chunk));
 
 #if BYTE_ORDER == LITTLE_ENDIAN
   return chunk << bits;
@@ -24,8 +24,8 @@ static inline unsigned char *copy_1_bytes(unsigned char *out, unsigned char *fro
 static inline unsigned char *copy_2_bytes(unsigned char *out, unsigned char *from) {
     uint16_t chunk;
     unsigned sz = sizeof(chunk);
-    MEMCPY(&chunk, from, sz);
-    MEMCPY(out, &chunk, sz);
+    memcpy(&chunk, from, sz);
+    memcpy(out, &chunk, sz);
     return out + sz;
 }
 
@@ -37,8 +37,8 @@ static inline unsigned char *copy_3_bytes(unsigned char *out, unsigned char *fro
 static inline unsigned char *copy_4_bytes(unsigned char *out, unsigned char *from) {
     uint32_t chunk;
     unsigned sz = sizeof(chunk);
-    MEMCPY(&chunk, from, sz);
-    MEMCPY(out, &chunk, sz);
+    memcpy(&chunk, from, sz);
+    memcpy(out, &chunk, sz);
     return out + sz;
 }
 
@@ -60,8 +60,8 @@ static inline unsigned char *copy_7_bytes(unsigned char *out, unsigned char *fro
 static inline unsigned char *copy_8_bytes(unsigned char *out, unsigned char *from) {
     uint64_t chunk;
     unsigned sz = sizeof(chunk);
-    MEMCPY(&chunk, from, sz);
-    MEMCPY(out, &chunk, sz);
+    memcpy(&chunk, from, sz);
+    memcpy(out, &chunk, sz);
     return out + sz;
 }
 

--- a/zutil.h
+++ b/zutil.h
@@ -238,12 +238,6 @@ void ZLIB_INTERNAL   zcfree(void *opaque, void *ptr);
 #endif
 #endif
 
-#if (defined(__GNUC__) || defined(__clang__))
-#define MEMSET __builtin_memset
-#else
-#define MEMSET memset
-#endif
-
 #if defined(X86_CPUID)
 # include "arch/x86/x86.h"
 #elif defined(__aarch64__)

--- a/zutil.h
+++ b/zutil.h
@@ -239,10 +239,8 @@ void ZLIB_INTERNAL   zcfree(void *opaque, void *ptr);
 #endif
 
 #if (defined(__GNUC__) || defined(__clang__))
-#define MEMCPY __builtin_memcpy
 #define MEMSET __builtin_memset
 #else
-#define MEMCPY memcpy
 #define MEMSET memset
 #endif
 


### PR DESCRIPTION
MEMCPY stands for __builtin_memcpy when that is supported by the compiler.
This patch systematically changes calls to memcpy to MEMCPY when the size of
the copied memory is known at compile time. This allows the compilers to
better optimize the code.