### PR TITLE
Update x86 and x86_64 arch checks

### DIFF
--- a/arch/x86/deflate_quick.c
+++ b/arch/x86/deflate_quick.c
@@ -93,7 +93,7 @@ static inline long compare258(const unsigned char *const src0, const unsigned ch
         "cmp        $256 + 16, %[ax]\n\t"
         "jb         1b\n\t"
 
-# if !defined(__x86_64)
+# if !defined(__x86_64__)
         "movzwl     -16(%[src0], %[ax]), %[dx]\n\t"
 # else
         "movzwq     -16(%[src0], %[ax]), %[dx]\n\t"

--- a/deflate.c
+++ b/deflate.c
@@ -301,7 +301,7 @@ int ZEXPORT PREFIX(deflateInit2_)(PREFIX3(stream) *strm, int level, int method, 
 
     s->hash_size = 1 << s->hash_bits;
     s->hash_mask = s->hash_size - 1;
-#if !defined(__x86_64) && !defined(__i386_)
+#if !defined(__x86_64__) && !defined(_M_X64) && !defined(__i386) && !defined(_M_IX86)
     s->hash_shift =  ((s->hash_bits+MIN_MATCH-1)/MIN_MATCH);
 #endif
 

--- a/deflate.h
+++ b/deflate.h
@@ -154,7 +154,7 @@ typedef struct internal_state {
     unsigned int  hash_bits;         /* log2(hash_size) */
     unsigned int  hash_mask;         /* hash_size-1 */
 
-    #if !defined(__x86_64) && !defined(__i386_)
+    #if !defined(__x86_64__) && !defined(_M_X64) && !defined(__i386) && !defined(_M_IX86)
     unsigned int  hash_shift;
     #endif
     /* Number of bits by which ins_h must be shifted at each input
@@ -392,7 +392,7 @@ void ZLIB_INTERNAL bi_windup(deflate_state *s);
 #define TRIGGER_LEVEL 5
 #endif
 
-#if defined(__x86_64) || defined(__i386_)
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386) || defined(_M_IX86)
 #define UPDATE_HASH(s, h, i) \
     do {\
         if (s->level < TRIGGER_LEVEL) \


### PR DESCRIPTION
Update x86 and x86_64 arch checks to use the
recommended define names, resulting in improved compiler support.
Based on the overviews from several sites, such as:
http://nadeausoftware.com/articles/2012/02/c_c_tip_how_detect_processor_type_using_compiler_predefined_macros