### PR TITLE
Fix building with gcc 8.2.1 and -Wall -Wextra -pedantic -Werror

### DIFF
--- a/configure
+++ b/configure
@@ -718,7 +718,7 @@ echo >> configure.log
 echo -n "Checking for ptrdiff_t... " | tee -a configure.log
 cat > $test.c <<EOF
 #include <stddef.h>
-int fun(ptrdiff_t *a) { return 0; }
+int fun(ptrdiff_t *a) { (void)a; return 0; }
 EOF
 if try $CC -c $CFLAGS $test.c; then
   echo "Yes." | tee -a configure.log
@@ -730,7 +730,7 @@ else
     echo -n "Checking for sizeof(void *)... " | tee -a configure.log
     cat > $test.c <<EOF
 #include <stdint.h>
-#define COMPILE_TIME_ASSERT(pred) struct s { int x: (pred) ? 1 : -1; };
+#define COMPILE_TIME_ASSERT(pred) struct s { int x: (pred) ? 1 : -1; }
 COMPILE_TIME_ASSERT(sizeof(int32_t) == sizeof(void *));
 EOF
     if try $CC -c $CFLAGS $test.c; then
@@ -740,7 +740,7 @@ EOF
     else
         cat > $test.c <<EOF
 #include <stdint.h>
-#define COMPILE_TIME_ASSERT(pred) struct s { int x: (pred) ? 1 : -1; };
+#define COMPILE_TIME_ASSERT(pred) struct s { int x: (pred) ? 1 : -1; }
 COMPILE_TIME_ASSERT(sizeof(int64_t) == sizeof(void *));
 EOF
         if try $CC -c $CFLAGS $test.c; then

--- a/match_p.h
+++ b/match_p.h
@@ -75,7 +75,7 @@ static inline unsigned longest_match(deflate_state *const s, IPos cur_match) {
      * Do not looks for matches beyond the end of the input. This is
      * necessary to make deflate deterministic
      */
-    nice_match = (unsigned int)s->nice_match > s->lookahead ? s->lookahead : s->nice_match;
+    nice_match = (unsigned int)s->nice_match > s->lookahead ? s->lookahead : (unsigned int)s->nice_match;
 
     /*
      * Stop when cur_match becomes <= limit. To simplify the code,

--- a/memcopy.h
+++ b/memcopy.h
@@ -399,6 +399,7 @@ static inline unsigned char *set_bytes(unsigned char *out, unsigned char *from, 
     Assert(len < 8, "set_bytes should be called with less than 8 bytes");
 
  #ifndef UNALIGNED_OK
+    (void)dist;
     while (len--) {
         *out++ = *from++;
     }

--- a/test/example.c
+++ b/test/example.c
@@ -538,6 +538,9 @@ int main(int argc, char *argv[])
 #ifdef WITH_GZFILEOP
     test_gzio((argc > 1 ? argv[1] : TESTFILE),
               uncompr, uncomprLen);
+#else
+    (void)argc;
+    (void)argv;
 #endif
 
     test_deflate(compr, comprLen);

--- a/test/minigzip.c
+++ b/test/minigzip.c
@@ -15,6 +15,7 @@
 /* @(#) $Id$ */
 
 #define _POSIX_SOURCE 1  /* This file needs POSIX for fdopen(). */
+#define _POSIX_C_SOURCE 200112  /* For snprintf(). */
 
 #include "zbuild.h"
 #ifdef ZLIB_COMPAT


### PR DESCRIPTION
* ptrdiff_t check always failed because of unused parameter
* sizeof(void *) check always failed because of double semicolon
* Sign issue in nice_match assignment
* dist parameter of set_bytes may be unused
* Parameters of main may be unused in test/example.c
* snprintf requires a _POSIX_C_SOURCE #define in test/minigzip.c,
  because a _POSIX_SOURCE #define is present