### PR TITLE
Fix endianness detection in memcopy.h

### DIFF
--- a/memcopy.h
+++ b/memcopy.h
@@ -4,6 +4,8 @@
 #ifndef MEMCOPY_H_
  #define MEMCOPY_H_
 
+ #include "gzendian.h"
+
 /* Load 64 bits from IN and place the bytes at offset BITS in the result. */
 static inline uint64_t load_64_bits(const unsigned char *in, unsigned bits) {
   uint64_t chunk;


### PR DESCRIPTION
When memcopy.h is included into inffast.c, endianness-related
preperocessor defines are not set, which leads to
BYTE_ORDER == LITTLE_ENDIAN condition being always true. This breaks
decompression at least on s390x.