### PR TITLE
Increase verbosity required to warn about bit length overflow.

### DIFF
--- a/trees.c
+++ b/trees.c
@@ -449,7 +449,7 @@ static void gen_bitlen(deflate_state *s, tree_desc *desc) {
     if (overflow == 0)
         return;
 
-    Trace((stderr, "\nbit length overflow\n"));
+    Tracev((stderr, "\nbit length overflow\n"));
     /* This happens for example on obj2 and pic of the Calgary corpus */
 
     /* Find the first bit length which could increase: */
@@ -478,7 +478,7 @@ static void gen_bitlen(deflate_state *s, tree_desc *desc) {
             if (m > max_code)
                 continue;
             if (tree[m].Len != bits) {
-                Trace((stderr, "code %d bits %d->%u\n", m, tree[m].Len, bits));
+                Tracev((stderr, "code %d bits %d->%u\n", m, tree[m].Len, bits));
                 s->opt_len += (unsigned long)(bits * tree[m].Freq);
                 s->opt_len -= (unsigned long)(tree[m].Len * tree[m].Freq);
                 tree[m].Len = (uint16_t)bits;


### PR DESCRIPTION
This is a cherry-pick of https://github.com/madler/zlib/commit/21c66cd5ac8876f48a19882074933c6275eaa022.
I found it useful to have when debugging zlib-ng.

---

When debugging the Huffman coding would warn about resulting codes
greater than 15 bits in length. This is handled properly, and is
not uncommon. This increases the verbosity of the warning by one,
so that it is not displayed by default.