### PR TITLE
fix oss-fuzz/13863

### DIFF
--- a/inffast.c
+++ b/inffast.c
@@ -138,7 +138,7 @@ void ZLIB_INTERNAL inflate_fast(PREFIX3(stream) *strm, unsigned long start) {
     end = out + (strm->avail_out - (INFLATE_FAST_MIN_LEFT - 1));
 
 #ifdef INFFAST_CHUNKSIZE
-    safe = out + (strm->avail_out - INFFAST_CHUNKSIZE);
+    safe = out + strm->avail_out;
 #endif
 #ifdef INFLATE_STRICT
     dmax = state->dmax;


### PR DESCRIPTION
The oss fuzzers started failing with the following assert
```
ASSERT: 0 == memcmp(data + offset, buf, len)
```
after the following patch has been pulled in the tree:

```
commit 20ca64fa5d2d8a7421ed86b68709ef971dcfbddf
Author: Sebastian Pop <s.pop@samsung.com>
Date:   Wed Mar 6 14:16:20 2019 -0600

    define and use chunkmemset instead of byte_memset for INFFAST_CHUNKSIZE
```

The function chunkcopysafe is assuming that the input `len` is less than 16 bytes:
```
    if ((safe - out) < (ptrdiff_t)INFFAST_CHUNKSIZE) {
```
but we were called with `len = 22` because `safe` was defined too small:

```
-    safe = out + (strm->avail_out - INFFAST_CHUNKSIZE);
```
and the difference `safe - out` was 16 bytes smaller than the actual `len`.
The patch fixes the initialization of `safe` to:
```
+    safe = out + strm->avail_out;
```