### PR TITLE
fix configure output when compiler is clang

### DIFF
--- a/configure
+++ b/configure
@@ -265,7 +265,7 @@ if test "$gcc" -eq 1 && ($cc $CFLAGS -c $test.c) >> configure.log 2>&1; then
   CFLAGS="${CFLAGS} -std=c99"
 
   # Re-check ARCH if the compiler is a cross-compiler.
-  if $CC -print-multiarch && test -n "$($CC -print-multiarch)" 1> /dev/null 2>&1; then
+  if $CC -print-multiarch 1> /dev/null 2>&1 && test -n "$($CC -print-multiarch)" 1> /dev/null 2>&1; then
       CC_ARCH=`$CC $CFLAGS -print-multiarch | sed 's/-.*//g'`
   else
       CC_ARCH=`$CC $CFLAGS -dumpmachine | sed 's/-.*//g'`


### PR DESCRIPTION
The patch cleans up the expected errors that clutter the output of configure:

$ CC=clang ./configure
Checking for compiler... clang-6.0
clang: error: unknown argument: '-print-multiarch'
clang: error: no input files

With this patch the last two lines disappear.