### PR TITLE
fix warning when compiling for AArch64

### DIFF
--- a/arch/arm/armfeature.c
+++ b/arch/arm/armfeature.c
@@ -17,22 +17,25 @@ static int arm_has_crc32() {
 #endif
 }
 
+/* AArch64 has neon. */
+#if !defined(__aarch64__)
 static inline int arm_has_neon()
 {
-#if defined(__linux__) && defined(HWCAP_NEON)
-  return (getauxval(AT_HWCAP) & HWCAP_NEON) != 0 ? 1 : 0;
-#elif defined(_M_ARM) && defined(WINAPI_FAMILY_PARTITION)
-# if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_PHONE_APP)
-  return 1; /* Always supported */
-# endif
-#endif
+ #if defined(__linux__) && defined(HWCAP_NEON)
+    return (getauxval(AT_HWCAP) & HWCAP_NEON) != 0 ? 1 : 0;
+ #elif defined(_M_ARM) && defined(WINAPI_FAMILY_PARTITION)
+  #if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_PHONE_APP)
+    return 1; /* Always supported */
+  #endif
+ #endif
 
-#if defined(ARM_NOCHECK_NEON)
-  return 1;
-#else
-  return 0;
-#endif
+ #if defined(ARM_NOCHECK_NEON)
+    return 1;
+ #else
+    return 0;
+ #endif
 }
+#endif
 
 ZLIB_INTERNAL int arm_cpu_has_neon;
 ZLIB_INTERNAL int arm_cpu_has_crc32;


### PR DESCRIPTION
gcc stopped warning about an unused function when I declared `arm_has_neon` as
`static inline`.  However clang still warns about an unused function:

```
arch/arm/armfeature.c:20:19: warning: unused function 'arm_has_neon' [-Wunused-function]
static inline int arm_has_neon()

                  ^
1 warning generated.
```

This patch moves the function under a preprocessor `#if !defined(__aarch64)`
which makes clang stop warn about it.