### PR TITLE
Fix infcover.c build

### DIFF
--- a/test/infcover.c
+++ b/test/infcover.c
@@ -14,6 +14,7 @@
 /* get definition of internal structure so we can mess with it (see pull()),
    and so we can call inflate_trees() (see cover5()) */
 #define ZLIB_INTERNAL
+#include "zbuild.h"
 #include "inftrees.h"
 #include "inflate.h"
 


### PR DESCRIPTION
infcover.c includes inflate.h, which makes use of PREFIX3 macro. This
macro is defined in zbuild.h, which is not included.