### PR TITLE
Add public zng_deflate{Set,Get}Params() API functions

### DIFF
--- a/arch/s390/README.md
+++ b/arch/s390/README.md
@@ -20,7 +20,10 @@ Two DFLTCC compression calls produce the same results only when they
 both are made on machines of the same generation, and when the
 respective buffers have the same offset relative to the start of the
 page. Therefore care should be taken when using hardware compression
-when reproducible results are desired.
+when reproducible results are desired. In particular, zlib-ng-specific
+zng_deflateSetParams call allows setting Z_DEFLATE_REPRODUCIBLE
+parameter, which would disable DFLTCC if reproducible results are
+required.
 
 DFLTCC does not support every single zlib-ng feature, in particular:
 
@@ -67,3 +70,11 @@ In addition to compression, DFLTCC computes CRC-32 and Adler-32
 checksums, therefore, whenever it's used, software checksumming is
 suppressed using DEFLATE_NEED_CHECKSUM and INFLATE_NEED_CHECKSUM
 macros.
+
+While software always produces reproducible compression results, this
+is not the case for DFLTCC. Therefore, zlib-ng users are given the
+ability to specify whether or not reproducible compression results
+are required. While it is always possible to specify this setting
+before the compression begins, it is not always possible to do so in
+the middle of a deflate stream - the exact conditions for that are
+determined by DEFLATE_CAN_SET_REPRODUCIBLE macro.

--- a/arch/s390/dfltcc_deflate.h
+++ b/arch/s390/dfltcc_deflate.h
@@ -6,6 +6,7 @@
 int ZLIB_INTERNAL dfltcc_can_deflate(PREFIX3(streamp) strm);
 int ZLIB_INTERNAL dfltcc_deflate(PREFIX3(streamp) strm, int flush, block_state *result);
 int ZLIB_INTERNAL dfltcc_deflate_params(PREFIX3(streamp) strm, int level, int strategy);
+int ZLIB_INTERNAL dfltcc_can_set_reproducible(PREFIX3(streamp) strm, int reproducible);
 int ZLIB_INTERNAL dfltcc_deflate_set_dictionary(PREFIX3(streamp) strm,
                                                 const unsigned char *dictionary, uInt dict_length);
 int ZLIB_INTERNAL dfltcc_deflate_get_dictionary(PREFIX3(streamp) strm, unsigned char *dictionary, uInt* dict_length);
@@ -46,5 +47,7 @@ int ZLIB_INTERNAL dfltcc_deflate_get_dictionary(PREFIX3(streamp) strm, unsigned 
 #define DEFLATE_HOOK dfltcc_deflate
 
 #define DEFLATE_NEED_CHECKSUM(strm) (!dfltcc_can_deflate((strm)))
+
+#define DEFLATE_CAN_SET_REPRODUCIBLE dfltcc_can_set_reproducible
 
 #endif

--- a/deflate.h
+++ b/deflate.h
@@ -284,6 +284,9 @@ typedef struct internal_state {
      * This is set to 1 if there is an active block, or 0 if the block was just
      * closed.
      */
+    int reproducible;
+    /* Whether reproducible compression results are required.
+     */
 
 } deflate_state;
 

--- a/win32/zlib-ng.def
+++ b/win32/zlib-ng.def
@@ -17,6 +17,8 @@ EXPORTS
     zng_deflatePending
     zng_deflatePrime
     zng_deflateSetHeader
+    zng_deflateSetParams
+    zng_deflateGetParams
     zng_inflateSetDictionary
     zng_inflateGetDictionary
     zng_inflateSync

--- a/zlib-ng.h
+++ b/zlib-ng.h
@@ -1793,6 +1793,13 @@ ZEXTERN int ZEXPORT zng_gzgetc_(gzFile file);  /* backward compatibility */
 typedef enum {
     Z_DEFLATE_LEVEL = 0,         /* compression level, represented as an int */
     Z_DEFLATE_STRATEGY = 1,      /* compression strategy, represented as an int */
+    Z_DEFLATE_REPRODUCIBLE = 2,
+    /*
+         Whether reproducible compression results are required. Represented as an int, where 0 means that it is allowed
+       to trade reproducibility for e.g. improved performance or compression ratio, and non-0 means that
+       reproducibility is strictly required. Reproducibility is guaranteed only when using an identical zlib-ng build.
+       Default is 0.
+    */
 } zng_deflate_param;
 
 typedef struct {

--- a/zlib-ng.h
+++ b/zlib-ng.h
@@ -1790,6 +1790,46 @@ ZEXTERN int ZEXPORT zng_gzgetc_(gzFile file);  /* backward compatibility */
 #endif /* WITH_GZFILEOP */
 
 
+typedef enum {
+    Z_DEFLATE_LEVEL = 0,         /* compression level, represented as an int */
+    Z_DEFLATE_STRATEGY = 1,      /* compression strategy, represented as an int */
+} zng_deflate_param;
+
+typedef struct {
+    zng_deflate_param param;  /* parameter ID */
+    void *buf;                /* parameter value */
+    size_t size;              /* parameter value size */
+    int status;               /* result of the last set/get call */
+} zng_deflate_param_value;
+
+ZEXTERN int ZEXPORT zng_deflateSetParams(zng_stream *strm, zng_deflate_param_value *params, size_t count);
+/*
+     Sets the values of the given zlib-ng deflate stream parameters. All the buffers are copied internally, so the
+   caller still owns them after this function returns. Returns Z_OK if success.
+
+     If the size of at least one of the buffers is too small to hold the entire value of the corresponding parameter,
+   or if the same parameter is specified multiple times, Z_BUF_ERROR is returned. The caller may inspect status fields
+   in order to determine which of the parameters caused this error. No other changes are performed.
+
+     If the stream state is inconsistent or if at least one of the values cannot be updated, Z_STREAM_ERROR is
+   returned. The caller may inspect status fields in order to determine which of the parameters caused this error.
+   Parameters, whose status field is equal to Z_OK, have been applied successfully. If all status fields are not equal
+   to Z_STREAM_ERROR, then the error was caused by a stream state inconsistency.
+
+     If there are no other errors, but at least one parameter is not supported by the current zlib-ng version,
+   Z_VERSION_ERROR is returned. The caller may inspect status fields in order to determine which of the parameters
+   caused this error.
+*/
+
+ZEXTERN int ZEXPORT zng_deflateGetParams(zng_stream *strm, zng_deflate_param_value *params, size_t count);
+/*
+     Copies the values of the given zlib-ng deflate stream parameters into the user-provided buffers. Returns Z_OK if
+   success, Z_VERSION_ERROR if at least one parameter is not supported by the current zlib-ng version, Z_STREAM_ERROR
+   if the stream state is inconsistent, and Z_BUF_ERROR if the size of at least one buffer is too small to hold the
+   entire value of the corresponding parameter.
+*/
+
+
 /* provide 64-bit offset functions if _LARGEFILE64_SOURCE defined, and/or
  * change the regular functions to 64 bits if _FILE_OFFSET_BITS is 64 (if
  * both are true, the application gets the *64 functions, and the regular

--- a/zlib-ng.map
+++ b/zlib-ng.map
@@ -19,6 +19,7 @@ ZLIB_NG_1.9.9 {
     zng_deflateCopy;
     zng_deflateEnd;
     zng_deflateGetDictionary;
+    zng_deflateGetParams;
     zng_deflateInit_;
     zng_deflateInit2_;
     zng_deflateParams;
@@ -28,6 +29,7 @@ ZLIB_NG_1.9.9 {
     zng_deflateResetKeep;
     zng_deflateSetDictionary;
     zng_deflateSetHeader;
+    zng_deflateSetParams;
     zng_deflateTune;
     zng_get_crc_table;
     zng_inflate;


### PR DESCRIPTION
These functions allow zlib-ng callers to modify and query the
compression parameters in a future-proof way. When the caller requests a
parameter, which is not supported by the current zlib-ng version, this
situation is detected and reported to the caller. The caller may modify
or query multiple parameters at once. Currently only "level" and
"strategy" parameters are supported. It is planned to add a
"reproducible" parameter, which would affect whether IBM Z DEFLATE
CONVERSION CALL is used.

Passing enum and void * buffer was chosen over passing strings, because
of simplicity for the caller. If strings were used, C callers would have
to call snprintf() and strtoul() for setting and getting integer-valued
parameters respectively, which is quite tedious.

Bulk updates were chosen over updating individual parameters separately,
because it might make sense to apply some parameters atomically, e.g.
level and strategy.

The new functions are defined only for zlib-ng, but not compat zlib.