### PR TITLE
Fixed assert in standalone fuzz target runner

### DIFF
--- a/test/fuzz/standalone_fuzz_target_runner.c
+++ b/test/fuzz/standalone_fuzz_target_runner.c
@@ -11,7 +11,7 @@ int main(int argc, char **argv) {
   for (i = 1; i < argc; i++) {
     size_t len, n_read, err;
     unsigned char *buf;
-    FILE *f = fopen(argv[i], "r+");
+    FILE *f = fopen(argv[i], "rb+");
     if (!f) {
       /* Failed to open this file: it may be a directory. */
       fprintf(stderr, "Skipping: %s\n", argv[i]);


### PR DESCRIPTION
When passing certain files the fuzzer tests would throw an assert abort on line 25 of _standalone_fuzz_target_runner.c_, because the files were not being opened in binary mode. The returned value of `fread` was not what was expected because of the file mode it was opened in.