### PR TITLE
Fixed compiler warnings on Windows in release mode

### DIFF
--- a/deflate.h
+++ b/deflate.h
@@ -378,7 +378,7 @@ void ZLIB_INTERNAL flush_pending(PREFIX3(streamp) strm);
 #else
 #   define _tr_tally_lit(s, c, flush) flush = _tr_tally(s, 0, c)
 #   define _tr_tally_dist(s, distance, length, flush) \
-              flush = _tr_tally(s, distance, length)
+              flush = _tr_tally(s, (unsigned)distance, (unsigned)length)
 #endif
 
 /* ===========================================================================

--- a/deflate.h
+++ b/deflate.h
@@ -378,7 +378,7 @@ void ZLIB_INTERNAL flush_pending(PREFIX3(streamp) strm);
 #else
 #   define _tr_tally_lit(s, c, flush) flush = _tr_tally(s, 0, c)
 #   define _tr_tally_dist(s, distance, length, flush) \
-              flush = _tr_tally(s, (unsigned)distance, (unsigned)length)
+              flush = _tr_tally(s, (unsigned)(distance), (unsigned)(length))
 #endif
 
 /* ===========================================================================


### PR DESCRIPTION
This pull request attempts to fix some compiler warnings on Windows when compiled in Release mode.

```
"zlib-ng\ALL_BUILD.vcxproj" (default target) (1) ->
"zlib-ng\zlibstatic.vcxproj" (default target) (6) ->
  zlib-ng\deflate.c(1626): warning C4244: '=': conversion from 'uint16_t' to 'unsigned cha
r', possible loss of data [zlib-ng\zlibstatic.vcxproj]
  zlib-ng\deflate_fast.c(61): warning C4244: '=': conversion from 'uint16_t' to 'unsigned
char', possible loss of data [zlib-ng\zlibstatic.vcxproj]
  zlib-ng\deflate_slow.c(89): warning C4244: '=': conversion from 'uint16_t' to 'unsigned
char', possible loss of data [zlib-ng\zlibstatic.vcxproj]
```