### PR TITLE
Fixed float-abi detection command in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,7 +161,7 @@ else()
         endif()
     endif()
     if(__GNUC__ AND "${ARCH}" MATCHES "arm")
-        execute_process(COMMAND "${CC}" "-dumpmachine"
+        execute_process(COMMAND ${CMAKE_C_COMPILER} "-dumpmachine"
                         OUTPUT_VARIABLE GCC_MACHINE)
         if ("${GCC_MACHINE}" MATCHES "eabihf")
             set(FLOATABI "-mfloat-abi=hard")


### PR DESCRIPTION
Should have been using $ENV{CC} but using ${CMAKE_C_COMPILER} is more exact. CC environment variable appears to be something set by travis. We should use the CMAKE_C_COMPILER that cmake has detected when trying to determine float-abi support.