### PR TITLE
IBM Z DFLTCC: fix STFLE usage 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,8 +110,8 @@ if("${ARCH}" MATCHES "arm" OR "${ARCH}" MATCHES "aarch64")
 endif()
 
 if("${ARCH}" MATCHES "s390x")
-    option(WITH_DFLTCC_DEFLATE "Use DEFLATE COMPRESSION CALL instruction for compression on IBM Z" OFF)
-    option(WITH_DFLTCC_INFLATE "Use DEFLATE COMPRESSION CALL instruction for decompression on IBM Z" OFF)
+    option(WITH_DFLTCC_DEFLATE "Use DEFLATE CONVERSION CALL instruction for compression on IBM Z" OFF)
+    option(WITH_DFLTCC_INFLATE "Use DEFLATE CONVERSION CALL instruction for decompression on IBM Z" OFF)
 endif()
 
 if(${CMAKE_C_COMPILER} MATCHES "icc" OR ${CMAKE_C_COMPILER} MATCHES "icpc" OR ${CMAKE_C_COMPILER} MATCHES "icl")

--- a/arch/s390/Makefile.in
+++ b/arch/s390/Makefile.in
@@ -1,4 +1,4 @@
-# Makefile for zlib
+# Makefile for zlib-ng
 # Copyright (C) 1995-2013 Jean-loup Gailly, Mark Adler
 # For conditions of distribution and use, see copyright notice in zlib.h
 

--- a/arch/s390/README.md
+++ b/arch/s390/README.md
@@ -1,8 +1,13 @@
-This directory contains IBM Z DEFLATE CONVERSION CALL support to
+This directory contains IBM Z DEFLATE CONVERSION CALL support for
 zlib-ng. In order to enable it, the following build commands should be
 used:
 
     $ ./configure --with-dfltcc-deflate --with-dfltcc-inflate
+    $ make
+
+or
+
+    $ cmake -DWITH_DFLTCC_DEFLATE=1 -DWITH_DFLTCC_INFLATE=1 .
     $ make
 
 When built like this, zlib-ng would compress in hardware on level 1,
@@ -53,9 +58,9 @@ than the one implemented in software. DEFLATE_BOUND_ADJUST_COMPLEN and
 DEFLATE_NEED_CONSERVATIVE_BOUND macros make deflateBound() return the
 correct results for the hardware implementation.
 
-Actual compression and decompression are handled by the new DEFLATE_HOOK
-and INFLATE_TYPEDO_HOOK macros. Since inflation with DFLTCC manages the
-window on its own, calling updatewindow() is suppressed using the new
+Actual compression and decompression are handled by DEFLATE_HOOK and
+INFLATE_TYPEDO_HOOK macros. Since inflation with DFLTCC manages the
+window on its own, calling updatewindow() is suppressed using
 INFLATE_NEED_UPDATEWINDOW() macro.
 
 In addition to compression, DFLTCC computes CRC-32 and Adler-32

--- a/arch/s390/dfltcc_common.c
+++ b/arch/s390/dfltcc_common.c
@@ -7,7 +7,7 @@
 /*
    Memory management.
 
-   DFLTCC requires parameter blocks and window to be aligned. zlib allows
+   DFLTCC requires parameter blocks and window to be aligned. zlib-ng allows
    users to specify their own allocation functions, so using e.g.
    `posix_memalign' is not an option. Thus, we overallocate and take the
    aligned portion of the buffer.
@@ -52,7 +52,7 @@ void ZLIB_INTERNAL dfltcc_reset(PREFIX3(streamp) strm, uInt size)
 void ZLIB_INTERNAL *dfltcc_alloc_state(PREFIX3(streamp) strm, uInt items, uInt size)
 {
     Assert((items * size) % 8 == 0,
-           "The size of zlib state must be a multiple of 8");
+           "The size of zlib-ng state must be a multiple of 8");
     return ZALLOC(strm, items * size + sizeof(struct dfltcc_state), sizeof(unsigned char));
 }
 

--- a/arch/s390/dfltcc_common.c
+++ b/arch/s390/dfltcc_common.c
@@ -15,13 +15,11 @@
 static inline int is_dfltcc_enabled(void)
 {
     uint64_t facilities[(DFLTCC_FACILITY / 64) + 1];
-    register int r0 __asm__("r0");
+    register uint8_t r0 __asm__("r0");
 
-    r0 = sizeof(facilities) / sizeof(facilities[0]);
-    __asm__ volatile("stfle %[facilities]\n"
-                     : [facilities] "=Q" (facilities)
-                     : [r0] "r" (r0)
-                     : "cc", "memory");
+    memset(facilities, 0, sizeof(facilities));
+    r0 = sizeof(facilities) / sizeof(facilities[0]) - 1;
+    __asm__ volatile("stfle %[facilities]\n" : [facilities] "=Q" (facilities), [r0] "+r" (r0) :: "cc");
     return is_bit_set((const char *)facilities, DFLTCC_FACILITY);
 }
 

--- a/configure
+++ b/configure
@@ -148,8 +148,8 @@ case "$1" in
       echo '    [--without-new-strategies]  Compiles without using new additional deflate strategies' | tee -a configure.log
       echo '    [--without-acle]            Compiles without ARM C Language Extensions' | tee -a configure.log
       echo '    [--without-neon]            Compiles without ARM Neon SIMD instruction set' | tee -a configure.log
-      echo '    [--with-dfltcc-deflate]     Use DEFLATE COMPRESSION CALL instruction for compression on IBM Z' | tee -a configure.log
-      echo '    [--with-dfltcc-inflate]     Use DEFLATE COMPRESSION CALL instruction for decompression on IBM Z' | tee -a configure.log
+      echo '    [--with-dfltcc-deflate]     Use DEFLATE CONVERSION CALL instruction for compression on IBM Z' | tee -a configure.log
+      echo '    [--with-dfltcc-inflate]     Use DEFLATE CONVERSION CALL instruction for decompression on IBM Z' | tee -a configure.log
       echo '    [--force-sse2]              Assume SSE2 instructions are always available (disabled by default on x86, enabled on x86_64)' | tee -a configure.log
       echo '    [--with-sanitizers]         Build with address sanitizer and all supported sanitizers other than memory sanitizer (disabled by default)' | tee -a configure.log
       echo '    [--with-msan]               Build with memory sanitizer (disabled by default)' | tee -a configure.log


### PR DESCRIPTION
QEMU maintainers have found and issue related to incorrect usage of
STFLE instruction [1], which is used to get features supported by the
machine. There are three potential problems with the current usage:

- R0 must contain the number of requested doublewords *minus one*. The
existing code lacks the "minus one" part.
- Older machines may not fill all the doublewords - this is fixed by
calling `memset`.
- STFLE updates R0, but we don't tell the compiler about this - this is
fixed by using a `+` constraint.
- Not really a problem, but it's enough to load 8 bits into R0, so its
type was changed to `uint8_t`. Also, STFLE only writes to `facilities`
variable, therefore memory clobber is unnecessary.

I also noticed a few trivial discrepancies in the documentation, which
I've decided to also send with this PR.

[1] https://lists.gnu.org/archive/html/qemu-devel/2019-06/msg00113.html