### PR TITLE
Added Linux ARM cmake to travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -129,9 +129,34 @@ matrix:
             - qemu
             - gcc-aarch64-linux-gnu
             - libc-dev-arm64-cross
+      # For all aarch64 implementations NEON is mandatory, while crypto/crc are not.
+      env:
+        - GENERATOR="cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-aarch64.cmake . -DZLIB_COMPAT=ON"
+        - MAKER="cmake --build . --config Release"
+        - TESTER="ctest --verbose -C Release"
+    - os: linux
+      compiler: aarch64-linux-gnu-gcc
+      addons:
+        apt:
+          packages:
+            - qemu
+            - gcc-aarch64-linux-gnu
+            - libc-dev-arm64-cross
       env:
         - GENERATOR="./configure --warn --zlib-compat"
         - CHOST=aarch64-linux-gnu
+    - os: linux
+      compiler: aarch64-linux-gnu-gcc
+      addons:
+        apt:
+          packages:
+            - qemu
+            - gcc-aarch64-linux-gnu
+            - libc-dev-arm64-cross
+      env:
+        - GENERATOR="cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-aarch64.cmake ."
+        - MAKER="cmake --build . --config Release"
+        - TESTER="ctest --verbose -C Release"
     # Hard-float subsets
     - os: linux
       compiler: arm-linux-gnueabihf-gcc
@@ -153,6 +178,18 @@ matrix:
             - gcc-arm-linux-gnueabihf
             - libc-dev-armhf-cross
       env:
+        - GENERATOR="cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-arm.cmake . -DCMAKE_C_COMPILER_TARGET=arm-linux-gnueabihf"
+        - MAKER="cmake --build . --config Release"
+        - TESTER="ctest --verbose -C Release"
+    - os: linux
+      compiler: arm-linux-gnueabihf-gcc
+      addons:
+        apt:
+          packages:
+            - qemu
+            - gcc-arm-linux-gnueabihf
+            - libc-dev-armhf-cross
+      env:
         - GENERATOR="./configure --warn --zlib-compat --without-neon"
         - CHOST=arm-linux-gnueabihf
     - os: linux
@@ -164,8 +201,32 @@ matrix:
             - gcc-arm-linux-gnueabihf
             - libc-dev-armhf-cross
       env:
+        - GENERATOR="cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-arm.cmake . -DZLIB_COMPAT=ON -DWITH_NEON=OFF -DCMAKE_C_COMPILER_TARGET=arm-linux-gnueabihf"
+        - MAKER="cmake --build . --config Release"
+        - TESTER="ctest --verbose -C Release"
+    - os: linux
+      compiler: arm-linux-gnueabihf-gcc
+      addons:
+        apt:
+          packages:
+            - qemu
+            - gcc-arm-linux-gnueabihf
+            - libc-dev-armhf-cross
+      env:
         - GENERATOR="./configure --warn --zlib-compat"
         - CHOST=arm-linux-gnueabihf
+    - os: linux
+      compiler: arm-linux-gnueabihf-gcc
+      addons:
+        apt:
+          packages:
+            - qemu
+            - gcc-arm-linux-gnueabihf
+            - libc-dev-armhf-cross
+      env:
+        - GENERATOR="cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-arm.cmake . -DZLIB_COMPAT=ON -DCMAKE_C_COMPILER_TARGET=arm-linux-gnueabihf"
+        - MAKER="cmake --build . --config Release"
+        - TESTER="ctest --verbose -C Release"
     # Soft-float subset
     - os: linux
       compiler: arm-linux-gnueabi-gcc
@@ -187,8 +248,32 @@ matrix:
             - gcc-arm-linux-gnueabi
             - libc-dev-armel-cross
       env:
+        - GENERATOR="cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-arm.cmake . -DCMAKE_C_COMPILER_TARGET=arm-linux-gnueabi"
+        - MAKER="cmake --build . --config Release"
+        - TESTER="ctest --verbose -C Release"
+    - os: linux
+      compiler: arm-linux-gnueabi-gcc
+      addons:
+        apt:
+          packages:
+            - qemu
+            - gcc-arm-linux-gnueabi
+            - libc-dev-armel-cross
+      env:
         - GENERATOR="./configure --zlib-compat"
         - CHOST=arm-linux-gnueabi
+    - os: linux
+      compiler: arm-linux-gnueabi-gcc
+      addons:
+        apt:
+          packages:
+            - qemu
+            - gcc-arm-linux-gnueabi
+            - libc-dev-armel-cross
+      env:
+        - GENERATOR="cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-arm.cmake . -DZLIB_COMPAT=ON -DCMAKE_C_COMPILER_TARGET=arm-linux-gnueabi"
+        - MAKER="cmake --build . --config Release"
+        - TESTER="ctest --verbose -C Release"
 
 script:
   - mkdir -p $BUILDDIR


### PR DESCRIPTION
This PR requires #350, #353, #355 and can be rebased after those have been merged in. It adds Linux ARM with cmake to the travis yaml. 