### PR TITLE
Fixed use of uninitialized value found by memory sanitizer

### DIFF
--- a/gzwrite.c
+++ b/gzwrite.c
@@ -26,6 +26,7 @@ static int gz_init(gz_state *state) {
         gz_error(state, Z_MEM_ERROR, "out of memory");
         return -1;
     }
+    memset(state->in, 0, state->want << 1);
 
     /* only need output buffer and deflate state if compressing */
     if (!state->direct) {


### PR DESCRIPTION
This issue has shown itself after duplicate gz functions was removed from the test code. Now all the test code is using the same gzip functions and one code path.

See conversation in #348. Credit to @sebpop for fixing it.