### PR TITLE
Dedup inflate macros, fixedtables() and inffixed.h contents

### DIFF
--- a/infback.c
+++ b/infback.c
@@ -17,9 +17,6 @@
 #include "inffast.h"
 #include "inflate_p.h"
 
-/* function prototypes */
-static void fixedtables(struct inflate_state *state);
-
 /*
    strm provides memory allocation functions in zalloc and zfree, or
    NULL to use the library memory allocation functions.
@@ -57,55 +54,6 @@ int ZEXPORT PREFIX(inflateBackInit_)(PREFIX3(stream) *strm, int windowBits, unsi
 }
 
 /*
-   Return state with length and distance decoding tables and index sizes set to
-   fixed code decoding.  Normally this returns fixed tables from inffixed.h.
-   If BUILDFIXED is defined, then instead this routine builds the tables the
-   first time it's called, and returns those tables the first time and
-   thereafter.  This reduces the size of the code by about 2K bytes, in
-   exchange for a little execution time.  However, BUILDFIXED should not be
-   used for threaded applications, since the rewriting of the tables and virgin
-   may not be thread-safe.
- */
-static void fixedtables(struct inflate_state *state) {
-#ifdef BUILDFIXED
-    static int virgin = 1;
-    static code *lenfix, *distfix;
-    static code fixed[544];
-
-    /* build fixed huffman tables if first call (may not be thread safe) */
-    if (virgin) {
-        unsigned sym, bits;
-        static code *next;
-
-        /* literal/length table */
-        sym = 0;
-        while (sym < 144) state->lens[sym++] = 8;
-        while (sym < 256) state->lens[sym++] = 9;
-        while (sym < 280) state->lens[sym++] = 7;
-        while (sym < 288) state->lens[sym++] = 8;
-        next = fixed;
-        lenfix = next;
-        bits = 9;
-        zng_inflate_table(LENS, state->lens, 288, &(next), &(bits), state->work);
-
-        /* distance table */
-        sym = 0;
-        while (sym < 32) state->lens[sym++] = 5;
-        distfix = next;
-        bits = 5;
-        zng_inflate_table(DISTS, state->lens, 32, &(next), &(bits), state->work);
-
-        /* do this just once */
-        virgin = 0;
-    }
-#else /* !BUILDFIXED */
-#   include "inffixed.h"
-#endif /* BUILDFIXED */
-    state->lencode = lenfix;
-    state->lenbits = 9;
-    state->distcode = distfix;
-    state->distbits = 5;
-}
    Private macros for inflateBack()
    Look in inflate_p.h for macros shared with inflate()
 */

--- a/infback.c
+++ b/infback.c
@@ -15,6 +15,7 @@
 #include "inftrees.h"
 #include "inflate.h"
 #include "inffast.h"
+#include "inflate_p.h"
 
 /* function prototypes */
 static void fixedtables(struct inflate_state *state);
@@ -105,37 +106,9 @@ static void fixedtables(struct inflate_state *state) {
     state->distcode = distfix;
     state->distbits = 5;
 }
-
-/* Macros for inflateBack(): */
-
-/* Load returned state from inflate_fast() */
-#define LOAD() \
-    do { \
-        put = strm->next_out; \
-        left = strm->avail_out; \
-        next = strm->next_in; \
-        have = strm->avail_in; \
-        hold = state->hold; \
-        bits = state->bits; \
-    } while (0)
-
-/* Set state from registers for inflate_fast() */
-#define RESTORE() \
-    do { \
-        strm->next_out = put; \
-        strm->avail_out = left; \
-        strm->next_in = next; \
-        strm->avail_in = have; \
-        state->hold = hold; \
-        state->bits = bits; \
-    } while (0)
-
-/* Clear the input bit accumulator */
-#define INITBITS() \
-    do { \
-        hold = 0; \
-        bits = 0; \
-    } while (0)
+   Private macros for inflateBack()
+   Look in inflate_p.h for macros shared with inflate()
+*/
 
 /* Assure that some input is available.  If input is requested, but denied,
    then return a Z_BUF_ERROR from inflateBack(). */
@@ -159,33 +132,6 @@ static void fixedtables(struct inflate_state *state) {
         have--; \
         hold += (*next++ << bits); \
         bits += 8; \
-    } while (0)
-
-/* Assure that there are at least n bits in the bit accumulator.  If there is
-   not enough available input to do that, then return from inflateBack() with
-   an error. */
-#define NEEDBITS(n) \
-    do { \
-        while (bits < (unsigned)(n)) \
-            PULLBYTE(); \
-    } while (0)
-
-/* Return the low n bits of the bit accumulator (n < 16) */
-#define BITS(n) \
-    (hold & ((1U << (n)) - 1))
-
-/* Remove n bits from the bit accumulator */
-#define DROPBITS(n) \
-    do { \
-        hold >>= (n); \
-        bits -= (unsigned)(n); \
-    } while (0)
-
-/* Remove zero to seven bits as needed to go to a byte boundary */
-#define BYTEBITS() \
-    do { \
-        hold >>= bits & 7; \
-        bits -= bits & 7; \
     } while (0)
 
 /* Assure that some output space is available, by writing out the window

--- a/inffast.c
+++ b/inffast.c
@@ -8,18 +8,8 @@
 #include "inftrees.h"
 #include "inflate.h"
 #include "inffast.h"
+#include "inflate_p.h"
 #include "memcopy.h"
-
-/* Return the low n bits of the bit accumulator (n < 16) */
-#define BITS(n) \
-    (hold & ((UINT64_C(1) << (n)) - 1))
-
-/* Remove n bits from the bit accumulator */
-#define DROPBITS(n) \
-    do { \
-        hold >>= (n); \
-        bits -= (unsigned)(n); \
-    } while (0)
 
 /*
    Decode literal, length, and distance codes and write out the resulting

--- a/inflate.c
+++ b/inflate.c
@@ -122,12 +122,13 @@
 
 /* function prototypes */
 static int inflateStateCheck(PREFIX3(stream) *strm);
-static void fixedtables(struct inflate_state *state);
 static int updatewindow(PREFIX3(stream) *strm, const unsigned char *end, uint32_t copy);
+static uint32_t syncsearch(uint32_t *have, const unsigned char *buf, uint32_t len);
 #ifdef BUILDFIXED
     void makefixed(void);
+#else
+#   include "inffixed.h"
 #endif
-static uint32_t syncsearch(uint32_t *have, const unsigned char *buf, uint32_t len);
 
 static int inflateStateCheck(PREFIX3(stream) *strm) {
     struct inflate_state *state;
@@ -283,7 +284,8 @@ int ZEXPORT PREFIX(inflatePrime)(PREFIX3(stream) *strm, int bits, int value) {
    used for threaded applications, since the rewriting of the tables and virgin
    may not be thread-safe.
  */
-static void fixedtables(struct inflate_state *state) {
+
+void ZLIB_INTERNAL fixedtables(struct inflate_state *state) {
 #ifdef BUILDFIXED
     static int virgin = 1;
     static code *lenfix, *distfix;
@@ -315,8 +317,6 @@ static void fixedtables(struct inflate_state *state) {
         /* do this just once */
         virgin = 0;
     }
-#else /* !BUILDFIXED */
-#   include "inffixed.h"
 #endif /* BUILDFIXED */
     state->lencode = lenfix;
     state->lenbits = 9;

--- a/inflate.h
+++ b/inflate.h
@@ -128,5 +128,6 @@ struct inflate_state {
 };
 
 int ZLIB_INTERNAL inflate_ensure_window(struct inflate_state *state);
+void ZLIB_INTERNAL fixedtables(struct inflate_state *state);
 
 #endif /* INFLATE_H_ */

--- a/inflate_p.h
+++ b/inflate_p.h
@@ -1,0 +1,94 @@
+/* inflate_p.h -- Private inline functions and macros shared with more than one deflate method
+ *
+ */
+
+#ifndef INFLATE_P_H
+#define INFLATE_P_H
+
+/*
+ *   Macros shared by inflate() and inflateBack()
+ */
+
+/* check function to use adler32() for zlib or crc32() for gzip */
+#ifdef GUNZIP
+#  define UPDATE(check, buf, len) \
+    (state->flags ? PREFIX(crc32)(check, buf, len) : functable.adler32(check, buf, len))
+#else
+#  define UPDATE(check, buf, len) functable.adler32(check, buf, len)
+#endif
+
+/* check macros for header crc */
+#ifdef GUNZIP
+#  define CRC2(check, word) \
+    do { \
+        hbuf[0] = (unsigned char)(word); \
+        hbuf[1] = (unsigned char)((word) >> 8); \
+        check = PREFIX(crc32)(check, hbuf, 2); \
+    } while (0)
+
+#  define CRC4(check, word) \
+    do { \
+        hbuf[0] = (unsigned char)(word); \
+        hbuf[1] = (unsigned char)((word) >> 8); \
+        hbuf[2] = (unsigned char)((word) >> 16); \
+        hbuf[3] = (unsigned char)((word) >> 24); \
+        check = PREFIX(crc32)(check, hbuf, 4); \
+    } while (0)
+#endif
+
+/* Load registers with state in inflate() for speed */
+#define LOAD() \
+    do { \
+        put = strm->next_out; \
+        left = strm->avail_out; \
+        next = strm->next_in; \
+        have = strm->avail_in; \
+        hold = state->hold; \
+        bits = state->bits; \
+    } while (0)
+
+/* Restore state from registers in inflate() */
+#define RESTORE() \
+    do { \
+        strm->next_out = put; \
+        strm->avail_out = left; \
+        strm->next_in = next; \
+        strm->avail_in = have; \
+        state->hold = hold; \
+        state->bits = bits; \
+    } while (0)
+
+/* Clear the input bit accumulator */
+#define INITBITS() \
+    do { \
+        hold = 0; \
+        bits = 0; \
+    } while (0)
+
+/* Ensure that there is at least n bits in the bit accumulator.  If there is
+   not enough available input to do that, then return from inflate()/inflateBack(). */
+#define NEEDBITS(n) \
+    do { \
+        while (bits < (unsigned)(n)) \
+            PULLBYTE(); \
+    } while (0)
+
+/* Return the low n bits of the bit accumulator (n < 16) */
+#define BITS(n) \
+    (hold & ((1U << (n)) - 1))
+
+/* Remove n bits from the bit accumulator */
+#define DROPBITS(n) \
+    do { \
+        hold >>= (n); \
+        bits -= (unsigned)(n); \
+    } while (0)
+
+/* Remove zero to seven bits as needed to go to a byte boundary */
+#define BYTEBITS() \
+    do { \
+        hold >>= bits & 7; \
+        bits -= bits & 7; \
+    } while (0)
+
+#endif


### PR DESCRIPTION
This removes a lot of lines of code from inflate.c, infback.c and inffast.c, moving those into inflate_p.h and making them easier to maintain and keep in sync.

Total number of lines reduced by 99.
Performance seems to be identical on x86_64.
Library size is reduced by 4120bytes or ~2.9%.

A couple of side notes:
- I am uncertain of whether inflate.c, infback.c and inffast.c are actually in sync currently. We don't actually ever test inflateBack(), do we? [I did not check]
- Do we actually want to support running zlib-ng with runtime-generated code tables? It is supposed to save around 2KiB of storage, so that should not be a problem since we are already much bigger than zlib ever was. Removing it would remove some of the maintenance burden, especially considering we don't even test this codepath. I do want to keep the functionality for generating the table files though.
This would also allow us to access the code tables directly instead of doing a state struct lookup on every access, so that could potentially end up a little faster as well.