### PR TITLE
Remove BUILDFIXED and MAKEFIXED.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 /examplesh
 /libz.so*
 /libz-ng.so*
+/makefixed
 /minigzip
 /minigzip64
 /minigzipsh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -825,6 +825,9 @@ if (ZLIB_ENABLE_TESTS)
     add_executable(switchlevels test/switchlevels.c)
     configure_test_executable(switchlevels)
 
+    add_executable(makefixed tools/makefixed.c inftrees.c)
+    configure_test_executable(makefixed)
+
     if(HAVE_OFF64_T)
         add_executable(example64 test/example.c)
         configure_test_executable(example64)

--- a/Makefile.in
+++ b/Makefile.in
@@ -85,7 +85,7 @@ PIC_OBJS = $(PIC_OBJC)
 
 all: static shared
 
-static: example$(EXE) minigzip$(EXE) fuzzers
+static: example$(EXE) minigzip$(EXE) fuzzers makefixed$(EXE)
 
 shared: examplesh$(EXE) minigzipsh$(EXE)
 
@@ -193,6 +193,9 @@ example64.o:
 minigzip64.o:
 	$(CC) $(CFLAGS) -DWITH_GZFILEOP -D_FILE_OFFSET_BITS=64 $(INCLUDES) -c -o $@ $(SRCDIR)/test/minigzip.c
 
+makefixed.o:
+	$(CC) $(CFLAGS) $(INCLUDES) -c -o $@ $(SRCDIR)/tools/makefixed.c
+
 zlibrc.o: win32/zlib$(SUFFIX)1.rc
 	$(RC) $(RCFLAGS) -o $@ win32/zlib$(SUFFIX)1.rc
 
@@ -252,6 +255,12 @@ endif
 
 minigzip64$(EXE): minigzip64.o $(OBJG) $(STATICLIB)
 	$(CC) $(LDFLAGS) -o $@ minigzip64.o $(OBJG) $(TEST_LIBS) $(LDSHAREDLIBC)
+ifneq ($(STRIP),)
+	$(STRIP) $@
+endif
+
+makefixed$(EXE): makefixed.o $(OBJG) $(STATICLIB)
+	$(CC) $(LDFLAGS) -o $@ makefixed.o $(OBJG) $(TEST_LIBS) $(LDSHAREDLIBC)
 ifneq ($(STRIP),)
 	$(STRIP) $@
 endif
@@ -330,7 +339,7 @@ clean:
 	   example64$(EXE) minigzip64$(EXE) \
 	   checksum_fuzzer$(EXE) compress_fuzzer$(EXE) example_small_fuzzer$(EXE) example_large_fuzzer$(EXE) \
 	   example_flush_fuzzer$(EXE) example_dict_fuzzer$(EXE) minigzip_fuzzer$(EXE) \
-	   infcover \
+	   infcover makefixed$(EXE) \
 	   $(STATICLIB) $(IMPORTLIB) $(SHAREDLIB) $(SHAREDLIBV) $(SHAREDLIBM) \
 	   foo.gz so_locations \
 	   _match.s maketree

--- a/configure
+++ b/configure
@@ -1347,7 +1347,7 @@ sed < $SRCDIR/Makefile.in "
 " > Makefile
 
 # Append header files dependences.
-for file in $(ls -1 $SRCDIR/*.c $SRCDIR/test/*.c $SRCDIR/test/fuzz/*.c $SRCDIR/$ARCHDIR/*.c); do
+for file in $(ls -1 $SRCDIR/*.c $SRCDIR/test/*.c $SRCDIR/test/fuzz/*.c $SRCDIR/$ARCHDIR/*.c $SRCDIR/tools/*.c); do
     short_name=$(echo $file | sed -e "s#$SRCDIR/##g")
     incs=$(grep -h include $file | sed -n 's/# *\include *"\(.*\.h\)".*/\1/p' | sort | uniq)
     includes=$(for i in $incs; do

--- a/inflate.c
+++ b/inflate.c
@@ -641,6 +641,7 @@ int ZEXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int flush) {
             INITBITS();
             break;
 #ifdef GUNZIP
+
         case FLAGS:
             NEEDBITS(16);
             state->flags = (int)(hold);
@@ -660,6 +661,7 @@ int ZEXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int flush) {
                 CRC2(state->check, hold);
             INITBITS();
             state->mode = TIME;
+
         case TIME:
             NEEDBITS(32);
             if (state->head != NULL)
@@ -668,6 +670,7 @@ int ZEXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int flush) {
                 CRC4(state->check, hold);
             INITBITS();
             state->mode = OS;
+
         case OS:
             NEEDBITS(16);
             if (state->head != NULL) {
@@ -678,6 +681,7 @@ int ZEXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int flush) {
                 CRC2(state->check, hold);
             INITBITS();
             state->mode = EXLEN;
+
         case EXLEN:
             if (state->flags & 0x0400) {
                 NEEDBITS(16);
@@ -691,6 +695,7 @@ int ZEXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int flush) {
                 state->head->extra = NULL;
             }
             state->mode = EXTRA;
+
         case EXTRA:
             if (state->flags & 0x0400) {
                 copy = state->length;
@@ -715,6 +720,7 @@ int ZEXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int flush) {
             }
             state->length = 0;
             state->mode = NAME;
+
         case NAME:
             if (state->flags & 0x0800) {
                 if (have == 0) goto inf_leave;
@@ -735,6 +741,7 @@ int ZEXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int flush) {
             }
             state->length = 0;
             state->mode = COMMENT;
+
         case COMMENT:
             if (state->flags & 0x1000) {
                 if (have == 0) goto inf_leave;
@@ -755,6 +762,7 @@ int ZEXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int flush) {
                 state->head->comment = NULL;
             }
             state->mode = HCRC;
+
         case HCRC:
             if (state->flags & 0x0200) {
                 NEEDBITS(16);
@@ -778,6 +786,7 @@ int ZEXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int flush) {
             strm->adler = state->check = ZSWAP32(hold);
             INITBITS();
             state->mode = DICT;
+
         case DICT:
             if (state->havedict == 0) {
                 RESTORE();
@@ -785,10 +794,13 @@ int ZEXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int flush) {
             }
             strm->adler = state->check = functable.adler32(0L, NULL, 0);
             state->mode = TYPE;
+
         case TYPE:
             if (flush == Z_BLOCK || flush == Z_TREES)
                 goto inf_leave;
+
         case TYPEDO:
+            /* determine and dispatch block type */
             INFLATE_TYPEDO_HOOK(strm, flush);  /* hook for IBM Z DFLTCC */
             if (state->last) {
                 BYTEBITS();
@@ -822,7 +834,9 @@ int ZEXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int flush) {
             }
             DROPBITS(2);
             break;
+
         case STORED:
+            /* get and verify stored block length */
             BYTEBITS();                         /* go to byte boundary */
             NEEDBITS(32);
             if ((hold & 0xffff) != ((hold >> 16) ^ 0xffff)) {
@@ -836,9 +850,12 @@ int ZEXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int flush) {
             state->mode = COPY_;
             if (flush == Z_TREES)
                 goto inf_leave;
+
         case COPY_:
             state->mode = COPY;
+
         case COPY:
+            /* copy stored block from input to output */
             copy = state->length;
             if (copy) {
                 if (copy > have) copy = have;
@@ -855,7 +872,9 @@ int ZEXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int flush) {
             Tracev((stderr, "inflate:       stored end\n"));
             state->mode = TYPE;
             break;
+
         case TABLE:
+            /* get dynamic table entries descriptor */
             NEEDBITS(14);
             state->nlen = BITS(5) + 257;
             DROPBITS(5);
@@ -873,7 +892,9 @@ int ZEXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int flush) {
             Tracev((stderr, "inflate:       table sizes ok\n"));
             state->have = 0;
             state->mode = LENLENS;
+
         case LENLENS:
+            /* get code length code lengths (not a typo) */
             while (state->have < state->ncode) {
                 NEEDBITS(3);
                 state->lens[order[state->have++]] = (uint16_t)BITS(3);
@@ -893,7 +914,9 @@ int ZEXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int flush) {
             Tracev((stderr, "inflate:       code lengths ok\n"));
             state->have = 0;
             state->mode = CODELENS;
+
         case CODELENS:
+            /* get length and distance code code lengths */
             while (state->have < state->nlen + state->ndist) {
                 for (;;) {
                     here = state->lencode[BITS(state->lenbits)];
@@ -976,9 +999,12 @@ int ZEXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int flush) {
             state->mode = LEN_;
             if (flush == Z_TREES)
                 goto inf_leave;
+
         case LEN_:
             state->mode = LEN;
+
         case LEN:
+            /* use inflate_fast() if we have enough input and output */
             if (have >= INFLATE_FAST_MIN_HAVE &&
                 left >= INFLATE_FAST_MIN_LEFT) {
                 RESTORE();
@@ -989,6 +1015,8 @@ int ZEXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int flush) {
                 break;
             }
             state->back = 0;
+
+            /* get a literal, length, or end-of-block code */
             for (;;) {
                 here = state->lencode[BITS(state->lenbits)];
                 if (here.bits <= bits)
@@ -1009,6 +1037,8 @@ int ZEXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int flush) {
             DROPBITS(here.bits);
             state->back += here.bits;
             state->length = here.val;
+
+            /* process literal */
             if ((int)(here.op) == 0) {
                 Tracevv((stderr, here.val >= 0x20 && here.val < 0x7f ?
                         "inflate:         literal '%c'\n" :
@@ -1016,20 +1046,28 @@ int ZEXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int flush) {
                 state->mode = LIT;
                 break;
             }
+
+            /* process end of block */
             if (here.op & 32) {
                 Tracevv((stderr, "inflate:         end of block\n"));
                 state->back = -1;
                 state->mode = TYPE;
                 break;
             }
+
+            /* invalid code */
             if (here.op & 64) {
                 strm->msg = (char *)"invalid literal/length code";
                 state->mode = BAD;
                 break;
             }
+
+            /* length code */
             state->extra = (here.op & 15);
             state->mode = LENEXT;
+
         case LENEXT:
+            /* get extra bits, if any */
             if (state->extra) {
                 NEEDBITS(state->extra);
                 state->length += BITS(state->extra);
@@ -1039,7 +1077,9 @@ int ZEXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int flush) {
             Tracevv((stderr, "inflate:         length %u\n", state->length));
             state->was = state->length;
             state->mode = DIST;
+
         case DIST:
+            /* get distance code */
             for (;;) {
                 here = state->distcode[BITS(state->distbits)];
                 if (here.bits <= bits)
@@ -1067,7 +1107,9 @@ int ZEXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int flush) {
             state->offset = here.val;
             state->extra = (here.op & 15);
             state->mode = DISTEXT;
+
         case DISTEXT:
+            /* get distance extra bits, if any */
             if (state->extra) {
                 NEEDBITS(state->extra);
                 state->offset += BITS(state->extra);
@@ -1083,7 +1125,9 @@ int ZEXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int flush) {
 #endif
             Tracevv((stderr, "inflate:         distance %u\n", state->offset));
             state->mode = MATCH;
+
         case MATCH:
+            /* copy match from window to output */
             if (left == 0) goto inf_leave;
             copy = out - left;
             if (state->offset > copy) {         /* copy from window */
@@ -1147,6 +1191,7 @@ int ZEXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int flush) {
             if (state->length == 0)
                 state->mode = LEN;
             break;
+
         case LIT:
             if (left == 0)
                 goto inf_leave;
@@ -1154,6 +1199,7 @@ int ZEXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int flush) {
             left--;
             state->mode = LEN;
             break;
+
         case CHECK:
             if (state->wrap) {
                 NEEDBITS(32);
@@ -1177,6 +1223,7 @@ int ZEXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int flush) {
             }
 #ifdef GUNZIP
             state->mode = LENGTH;
+
         case LENGTH:
             if (state->wrap && state->flags) {
                 NEEDBITS(32);
@@ -1190,16 +1237,22 @@ int ZEXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int flush) {
             }
 #endif
             state->mode = DONE;
+
         case DONE:
+            /* inflate stream terminated properly */
             ret = Z_STREAM_END;
             goto inf_leave;
+
         case BAD:
             ret = Z_DATA_ERROR;
             goto inf_leave;
+
         case MEM:
             return Z_MEM_ERROR;
+
         case SYNC:
-        default:
+
+        default:                 /* can't happen, but makes compilers happy */
             return Z_STREAM_ERROR;
         }
 

--- a/inflate.c
+++ b/inflate.c
@@ -86,6 +86,7 @@
 #include "inflate.h"
 #include "inffast.h"
 #include "inflate_p.h"
+#include "inffixed.h"
 #include "memcopy.h"
 #include "functable.h"
 
@@ -114,21 +115,10 @@
 #  define INFLATE_MARK_HOOK(strm) do {} while (0)
 #endif
 
-#ifdef MAKEFIXED
-#  ifndef BUILDFIXED
-#    define BUILDFIXED
-#  endif
-#endif
-
 /* function prototypes */
 static int inflateStateCheck(PREFIX3(stream) *strm);
 static int updatewindow(PREFIX3(stream) *strm, const unsigned char *end, uint32_t copy);
 static uint32_t syncsearch(uint32_t *have, const unsigned char *buf, uint32_t len);
-#ifdef BUILDFIXED
-    void makefixed(void);
-#else
-#   include "inffixed.h"
-#endif
 
 static int inflateStateCheck(PREFIX3(stream) *strm) {
     struct inflate_state *state;
@@ -276,116 +266,15 @@ int ZEXPORT PREFIX(inflatePrime)(PREFIX3(stream) *strm, int bits, int value) {
 
 /*
    Return state with length and distance decoding tables and index sizes set to
-   fixed code decoding.  Normally this returns fixed tables from inffixed.h.
-   If BUILDFIXED is defined, then instead this routine builds the tables the
-   first time it's called, and returns those tables the first time and
-   thereafter.  This reduces the size of the code by about 2K bytes, in
-   exchange for a little execution time.  However, BUILDFIXED should not be
-   used for threaded applications, since the rewriting of the tables and virgin
-   may not be thread-safe.
+   fixed code decoding.  This returns fixed tables from inffixed.h.
  */
 
 void ZLIB_INTERNAL fixedtables(struct inflate_state *state) {
-#ifdef BUILDFIXED
-    static int virgin = 1;
-    static code *lenfix, *distfix;
-    static code fixed[544];
-
-    /* build fixed huffman tables if first call (may not be thread safe) */
-    if (virgin) {
-        unsigned sym, bits;
-        static code *next;
-
-        /* literal/length table */
-        sym = 0;
-        while (sym < 144) state->lens[sym++] = 8;
-        while (sym < 256) state->lens[sym++] = 9;
-        while (sym < 280) state->lens[sym++] = 7;
-        while (sym < 288) state->lens[sym++] = 8;
-        next = fixed;
-        lenfix = next;
-        bits = 9;
-        zng_inflate_table(LENS, state->lens, 288, &(next), &(bits), state->work);
-
-        /* distance table */
-        sym = 0;
-        while (sym < 32) state->lens[sym++] = 5;
-        distfix = next;
-        bits = 5;
-        zng_inflate_table(DISTS, state->lens, 32, &(next), &(bits), state->work);
-
-        /* do this just once */
-        virgin = 0;
-    }
-#endif /* BUILDFIXED */
     state->lencode = lenfix;
     state->lenbits = 9;
     state->distcode = distfix;
     state->distbits = 5;
 }
-
-#ifdef MAKEFIXED
-#include <stdio.h>
-
-/*
-   Write out the inffixed.h that is #include'd above.  Defining MAKEFIXED also
-   defines BUILDFIXED, so the tables are built on the fly.  makefixed() writes
-   those tables to stdout, which would be piped to inffixed.h.  A small program
-   can simply call makefixed to do this:
-
-    void makefixed(void);
-
-    int main(void)
-    {
-        makefixed();
-        return 0;
-    }
-
-   Then that can be linked with zlib built with MAKEFIXED defined and run:
-
-    a.out > inffixed.h
- */
-void makefixed(void) {
-    unsigned low, size;
-    struct inflate_state state;
-
-    fixedtables(&state);
-    puts("    /* inffixed.h -- table for decoding fixed codes");
-    puts("     * Generated automatically by makefixed().");
-    puts("     */");
-    puts("");
-    puts("    /* WARNING: this file should *not* be used by applications.");
-    puts("       It is part of the implementation of this library and is");
-    puts("       subject to change. Applications should only use zlib.h.");
-    puts("     */");
-    puts("");
-    size = 1U << 9;
-    printf("    static const code lenfix[%u] = {", size);
-    low = 0;
-    for (;;) {
-        if ((low % 7) == 0)
-            printf("\n        ");
-        printf("{%u,%u,%d}", (low & 127) == 99 ? 64 : state.lencode[low].op,
-            state.lencode[low].bits, state.lencode[low].val);
-        if (++low == size)
-            break;
-        putchar(',');
-    }
-    puts("\n    };");
-    size = 1U << 5;
-    printf("\n    static const code distfix[%u] = {", size);
-    low = 0;
-    for (;;) {
-        if ((low % 6) == 0)
-            printf("\n        ");
-        printf("{%u,%u,%d}", state.distcode[low].op, state.distcode[low].bits, state.distcode[low].val);
-        if (++low == size)
-            break;
-        putchar(',');
-    }
-    puts("\n    };");
-}
-#endif /* MAKEFIXED */
 
 int ZLIB_INTERNAL inflate_ensure_window(struct inflate_state *state)
 {

--- a/tools/makefixed.c
+++ b/tools/makefixed.c
@@ -1,0 +1,89 @@
+#include <stdio.h>
+#include "zbuild.h"
+#include "zutil.h"
+#include "inftrees.h"
+#include "inflate.h"
+
+// Build and return state with length and distance decoding tables and index sizes set to fixed code decoding.
+void ZLIB_INTERNAL buildfixedtables(struct inflate_state *state) {
+    static code *lenfix, *distfix;
+    static code fixed[544];
+
+    // build fixed huffman tables
+    unsigned sym, bits;
+    static code *next;
+
+    // literal/length table
+    sym = 0;
+    while (sym < 144) state->lens[sym++] = 8;
+    while (sym < 256) state->lens[sym++] = 9;
+    while (sym < 280) state->lens[sym++] = 7;
+    while (sym < 288) state->lens[sym++] = 8;
+    next = fixed;
+    lenfix = next;
+    bits = 9;
+    zng_inflate_table(LENS, state->lens, 288, &(next), &(bits), state->work);
+
+    // distance table
+    sym = 0;
+    while (sym < 32) state->lens[sym++] = 5;
+    distfix = next;
+    bits = 5;
+    zng_inflate_table(DISTS, state->lens, 32, &(next), &(bits), state->work);
+
+    state->lencode = lenfix;
+    state->lenbits = 9;
+    state->distcode = distfix;
+    state->distbits = 5;
+}
+
+
+//  Create fixed tables on the fly and write out a inffixed.h file that is #include'd above.
+//  makefixed() writes those tables to stdout, which would be piped to inffixed.h.
+void makefixed(void) {
+    unsigned low, size;
+    struct inflate_state state;
+
+    buildfixedtables(&state);
+    puts("    /* inffixed.h -- table for decoding fixed codes");
+    puts("     * Generated automatically by makefixed().");
+    puts("     */");
+    puts("");
+    puts("    /* WARNING: this file should *not* be used by applications.");
+    puts("       It is part of the implementation of this library and is");
+    puts("       subject to change. Applications should only use zlib.h.");
+    puts("     */");
+    puts("");
+    size = 1U << 9;
+    printf("    static const code lenfix[%u] = {", size);
+    low = 0;
+    for (;;) {
+        if ((low % 7) == 0)
+            printf("\n        ");
+        printf("{%u,%u,%d}", (low & 127) == 99 ? 64 : state.lencode[low].op,
+            state.lencode[low].bits, state.lencode[low].val);
+        if (++low == size)
+            break;
+        putchar(',');
+    }
+    puts("\n    };");
+    size = 1U << 5;
+    printf("\n    static const code distfix[%u] = {", size);
+    low = 0;
+    for (;;) {
+        if ((low % 6) == 0)
+            printf("\n        ");
+        printf("{%u,%u,%d}", state.distcode[low].op, state.distcode[low].bits, state.distcode[low].val);
+        if (++low == size)
+            break;
+        putchar(',');
+    }
+    puts("\n    };");
+}
+
+// The output of this application can be piped out to recreate inffixed.h
+int main(void) {
+    makefixed();
+    return 0;
+}
+

--- a/zlib-ng.h
+++ b/zlib-ng.h
@@ -1147,7 +1147,7 @@ ZEXTERN unsigned long ZEXPORT zng_zlibCompileFlags(void);
      11: 0 (reserved)
 
     One-time table building (smaller code, but not thread-safe if true):
-     12: BUILDFIXED -- build static block decoding tables when needed
+     12: BUILDFIXED -- build static block decoding tables when needed (not supported by zlib-ng)
      13: DYNAMIC_CRC_TABLE -- build CRC calculation tables when needed
      14,15: 0 (reserved)
 

--- a/zlib.h
+++ b/zlib.h
@@ -1158,7 +1158,7 @@ ZEXTERN unsigned long ZEXPORT zlibCompileFlags(void);
      11: 0 (reserved)
 
     One-time table building (smaller code, but not thread-safe if true):
-     12: BUILDFIXED -- build static block decoding tables when needed
+     12: BUILDFIXED -- build static block decoding tables when needed (not supported by zlib-ng)
      13: DYNAMIC_CRC_TABLE -- build CRC calculation tables when needed
      14,15: 0 (reserved)
 

--- a/zutil.c
+++ b/zutil.c
@@ -77,9 +77,6 @@ unsigned long ZEXPORT PREFIX(zlibCompileFlags)(void)
 #ifdef ZLIB_WINAPI
     flags += 1 << 10;
 #endif
-#ifdef BUILDFIXED
-    flags += 1 << 12;
-#endif
 #ifdef DYNAMIC_CRC_TABLE
     flags += 1 << 13;
 #endif


### PR DESCRIPTION
- Remove BUILDFIXED support.
- Split out MAKEFIXED into a separate 'makefixed' util that is easy to use if we want to regenerate/verify inffixed.h

This builds on top of PR/374 and includes that commit, so please review only the second commit here.