### PR TITLE
Turn off enabling tests by default in cmake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,20 +13,20 @@ matrix:
     - os: windows
       compiler: clang
       env:
-        - GENERATOR="cmake . "
+        - GENERATOR="cmake . -DZLIB_ENABLE_TESTS=ON"
         - MAKER="cmake --build . --config Release"
         - TESTER="ctest --verbose -C Release"
     - os: windows
       compiler: clang
       env:
-        - GENERATOR="cmake ..\\zlib-ng -DZLIB_COMPAT=ON"
+        - GENERATOR="cmake ..\\zlib-ng -DZLIB_ENABLE_TESTS=ON -DZLIB_COMPAT=ON"
         - MAKER="cmake --build . --config Release"
         - TESTER="ctest --verbose -C Release"
         - BUILDDIR=..\\build
     - os: windows
       compiler: gcc
       env:
-        - GENERATOR="cmake ."
+        - GENERATOR="cmake . -DZLIB_ENABLE_TESTS=ON"
         - MAKER="cmake --build . --config Release"
         - TESTER="ctest --verbose -C Release"
 
@@ -35,7 +35,7 @@ matrix:
       env: GENERATOR="./configure --warn"
     - os: linux
       compiler: gcc
-      env: GENERATOR="cmake . -DZLIB_COMPAT=OFF -DWITH_GZFILEOP=ON -DWITH_NEW_STRATEGIES=YES -DWITH_OPTIM=ON"
+      env: GENERATOR="cmake . -DZLIB_ENABLE_TESTS=ON -DZLIB_COMPAT=OFF -DWITH_GZFILEOP=ON -DWITH_NEW_STRATEGIES=YES -DWITH_OPTIM=ON"
     - os: linux
       compiler: gcc
       env:
@@ -46,11 +46,11 @@ matrix:
       env: GENERATOR="./configure --warn --zlib-compat --without-optimizations --without-new-strategies"
     - os: linux
       compiler: gcc
-      env: GENERATOR="cmake ."
+      env: GENERATOR="cmake . -DZLIB_ENABLE_TESTS=ON"
     - os: linux
       compiler: gcc
       env:
-        - GENERATOR="cmake ../zlib-ng"
+        - GENERATOR="cmake ../zlib-ng -DZLIB_ENABLE_TESTS=ON"
         - BUILDDIR=../build
 
     - os: linux
@@ -59,12 +59,12 @@ matrix:
     - os: linux
       compiler: clang
       env:
-        - GENERATOR="cmake ../zlib-ng"
+        - GENERATOR="cmake ../zlib-ng -DZLIB_ENABLE_TESTS=ON"
         - BUILDDIR=../build
     - os: linux
       compiler: clang
       env:
-        - GENERATOR="scan-build -v --status-bugs cmake ../zlib-ng"
+        - GENERATOR="scan-build -v --status-bugs cmake ../zlib-ng -DZLIB_ENABLE_TESTS=ON"
         - MAKER="scan-build -v --status-bugs make"
         - BUILDDIR=../build
 
@@ -78,7 +78,7 @@ matrix:
         - BUILDDIR=../build
     - os: osx
       compiler: gcc
-      env: GENERATOR="cmake ."
+      env: GENERATOR="cmake . -DZLIB_ENABLE_TESTS=ON"
 
     - os: osx
       compiler: clang
@@ -86,17 +86,17 @@ matrix:
     - os: osx
       compiler: clang
       env:
-        - GENERATOR="cmake ../zlib-ng"
+        - GENERATOR="cmake ../zlib-ng -DZLIB_ENABLE_TESTS=ON"
         - BUILDDIR=../build
 
     # compiling for linux-ppc64le variants
     - os: linux-ppc64le
       compiler: gcc
-      env: GENERATOR="cmake ."
+      env: GENERATOR="cmake . -DZLIB_ENABLE_TESTS=ON"
     - os: linux-ppc64le
       compiler: gcc
       env:
-        - GENERATOR="cmake ../zlib-ng"
+        - GENERATOR="cmake ../zlib-ng -DZLIB_ENABLE_TESTS=ON"
         - BUILDDIR=../build
 
     - os: linux-ppc64le
@@ -105,7 +105,7 @@ matrix:
     - os: linux-ppc64le
       compiler: clang
       env:
-        - GENERATOR="cmake ../zlib-ng"
+        - GENERATOR="cmake ../zlib-ng -DZLIB_ENABLE_TESTS=ON"
         - BUILDDIR=../build
 
     # Cross compiling for arm variants
@@ -131,7 +131,7 @@ matrix:
             - libc-dev-arm64-cross
       # For all aarch64 implementations NEON is mandatory, while crypto/crc are not.
       env:
-        - GENERATOR="cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-aarch64.cmake . -DZLIB_COMPAT=ON"
+        - GENERATOR="cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-aarch64.cmake . -DZLIB_COMPAT=ON -DZLIB_ENABLE_TESTS=ON"
         - MAKER="cmake --build . --config Release"
         - TESTER="ctest --verbose -C Release"
     - os: linux
@@ -154,7 +154,7 @@ matrix:
             - gcc-aarch64-linux-gnu
             - libc-dev-arm64-cross
       env:
-        - GENERATOR="cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-aarch64.cmake ."
+        - GENERATOR="cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-aarch64.cmake . -DZLIB_ENABLE_TESTS=ON"
         - MAKER="cmake --build . --config Release"
         - TESTER="ctest --verbose -C Release"
     # Hard-float subsets
@@ -178,7 +178,7 @@ matrix:
             - gcc-arm-linux-gnueabihf
             - libc-dev-armhf-cross
       env:
-        - GENERATOR="cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-arm.cmake . -DCMAKE_C_COMPILER_TARGET=arm-linux-gnueabihf"
+        - GENERATOR="cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-arm.cmake . -DCMAKE_C_COMPILER_TARGET=arm-linux-gnueabihf -DZLIB_ENABLE_TESTS=ON"
         - MAKER="cmake --build . --config Release"
         - TESTER="ctest --verbose -C Release"
     - os: linux
@@ -201,7 +201,7 @@ matrix:
             - gcc-arm-linux-gnueabihf
             - libc-dev-armhf-cross
       env:
-        - GENERATOR="cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-arm.cmake . -DZLIB_COMPAT=ON -DWITH_NEON=OFF -DCMAKE_C_COMPILER_TARGET=arm-linux-gnueabihf"
+        - GENERATOR="cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-arm.cmake . -DCMAKE_C_COMPILER_TARGET=arm-linux-gnueabihf -DZLIB_ENABLE_TESTS=ON -DZLIB_COMPAT=ON -DWITH_NEON=OFF"
         - MAKER="cmake --build . --config Release"
         - TESTER="ctest --verbose -C Release"
     - os: linux
@@ -224,7 +224,7 @@ matrix:
             - gcc-arm-linux-gnueabihf
             - libc-dev-armhf-cross
       env:
-        - GENERATOR="cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-arm.cmake . -DZLIB_COMPAT=ON -DCMAKE_C_COMPILER_TARGET=arm-linux-gnueabihf"
+        - GENERATOR="cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-arm.cmake . -DCMAKE_C_COMPILER_TARGET=arm-linux-gnueabihf -DZLIB_ENABLE_TESTS=ON -DZLIB_COMPAT=ON"
         - MAKER="cmake --build . --config Release"
         - TESTER="ctest --verbose -C Release"
     # Soft-float subset
@@ -248,7 +248,7 @@ matrix:
             - gcc-arm-linux-gnueabi
             - libc-dev-armel-cross
       env:
-        - GENERATOR="cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-arm.cmake . -DCMAKE_C_COMPILER_TARGET=arm-linux-gnueabi"
+        - GENERATOR="cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-arm.cmake . -DCMAKE_C_COMPILER_TARGET=arm-linux-gnueabi -DZLIB_ENABLE_TESTS=ON"
         - MAKER="cmake --build . --config Release"
         - TESTER="ctest --verbose -C Release"
     - os: linux
@@ -271,7 +271,7 @@ matrix:
             - gcc-arm-linux-gnueabi
             - libc-dev-armel-cross
       env:
-        - GENERATOR="cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-arm.cmake . -DZLIB_COMPAT=ON -DCMAKE_C_COMPILER_TARGET=arm-linux-gnueabi"
+        - GENERATOR="cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-arm.cmake . -DCMAKE_C_COMPILER_TARGET=arm-linux-gnueabi -DZLIB_ENABLE_TESTS=ON -DZLIB_COMPAT=ON"
         - MAKER="cmake --build . --config Release"
         - TESTER="ctest --verbose -C Release"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ endif()
 #
 option(WITH_GZFILEOP "Compile with support for gzFile related functions" OFF)
 option(ZLIB_COMPAT "Compile with zlib compatible API" OFF)
-option(ZLIB_ENABLE_TESTS "Build test binaries" ON)
+option(ZLIB_ENABLE_TESTS "Build test binaries" OFF)
 option(WITH_SANITIZERS "Build with address sanitizer and all supported sanitizers other than memory sanitizer" OFF)
 option(WITH_MSAN "Build with memory sanitizer" OFF)
 option(WITH_FUZZERS "Build test/fuzz" OFF)
@@ -812,7 +812,6 @@ endif()
 # Example binaries
 #============================================================================
 
-option(ZLIB_ENABLE_TESTS "Build test binaries" ON)
 if (ZLIB_ENABLE_TESTS)
     enable_testing()
     macro(configure_test_executable target)

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ There are two ways to build zlib-ng:
 To build zlib-ng using the cross-platform makefile generator cmake.
 
 ```
-cmake .
+cmake . -DZLIB_ENABLE_TESTS=ON
 cmake --build . --config Release
 ctest --verbose -C Release
 ```
@@ -87,7 +87,7 @@ Build Options
 | CMake                    | configure                | Description                                                                                  | Default                          |
 |:-------------------------|:-------------------------|:---------------------------------------------------------------------------------------------|----------------------------------|
 | ZLIB_COMPAT              | --zlib-compat            | Compile with zlib compatible API                                                             | OFF                              |
-| ZLIB_ENABLE_TESTS        |                          | Build test binaries                                                                          | ON                               |
+| ZLIB_ENABLE_TESTS        |                          | Build test binaries                                                                          | OFF                              |
 | WITH_GZFILEOP            | --with-gzfileops         | Compile with support for gzFile related functions                                            | OFF                              |
 | WITH_MSAN                | --with-msan              | Build with memory sanitizer                                                                  | OFF                              |
 | WITH_OPTIM               | --without-optimizations  | Build with optimisations                                                                     | ON                               |


### PR DESCRIPTION
This change will turn off `ZLIB_ENABLE_TESTS` by default in cmake (also see #338). When incorporating zlib-ng's CMakeLists.txt it is sometimes not advantageous to build the tests by default. This would also likely need to be done to get a stable release out.

I have updated the travis.yml to set `-DZLIB_ENABLE_TESTS=ON` for cmake instances. There is no ./configure script equivalent.