### PR TITLE
[deflate_quick] try to consume available data if Z_FINISH is used

### DIFF
--- a/arch/x86/deflate_quick.c
+++ b/arch/x86/deflate_quick.c
@@ -230,7 +230,9 @@ ZLIB_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
     do {
         if (s->pending + 4 >= s->pending_buf_size) {
             flush_pending(s->strm);
-            return need_more;
+            if (flush != Z_FINISH) {
+                return need_more;
+            }
         }
 
         if (s->lookahead < MIN_LOOKAHEAD) {


### PR DESCRIPTION
the following test program fails with `zng_deflateEnd -3` without this patch.

```c
#include <stdio.h>
#include <sys/stat.h>
#include "zlib-ng.h"
int main(){
	FILE *f=fopen("FAQ.zlib","rb");
	struct stat st;
	fstat(fileno(f),&st);
	char *buf=malloc(st.st_size);
	char *compbuf=malloc(st.st_size);
	fread(buf,1,st.st_size,f);
	fclose(f);

	zng_stream z;
	int status;
	z.zalloc = Z_NULL;
	z.zfree = Z_NULL;
	z.opaque = Z_NULL;
	const int level=1;

	if((status=zng_deflateInit2(
		&z, level , Z_DEFLATED, -MAX_WBITS, level, Z_DEFAULT_STRATEGY
	)) != Z_OK){
		return status;
	}

	z.next_in = buf;
	z.avail_in = st.st_size;
	z.next_out = compbuf;
	z.avail_out = st.st_size;

	status = zng_deflate(&z, Z_FINISH);
	int csize = st.st_size - z.avail_out;
	status = zng_deflateEnd(&z);
	if(status != Z_OK){
		printf("zng_deflateEnd %d\n",status);
		return 1;
	}
	fwrite(compbuf,1,csize,stdout);
}
```