### PR TITLE
use relative header path

### DIFF
--- a/arch/arm/adler32_neon.c
+++ b/arch/arm/adler32_neon.c
@@ -19,7 +19,7 @@
 #include "adler32_neon.h"
 #if defined(__ARM_NEON__) || defined(__ARM_NEON)
 #include <arm_neon.h>
-#include "adler32_p.h"
+#include "../../adler32_p.h"
 
 static void NEON_accum32(uint32_t *s, const unsigned char *buf, size_t len) {
     static const uint8_t taps[32] = {

--- a/arch/arm/armfeature.c
+++ b/arch/arm/armfeature.c
@@ -1,4 +1,4 @@
-#include "zutil.h"
+#include "../../zutil.h"
 
 #if defined(__linux__)
 # include <sys/auxv.h>

--- a/arch/arm/fill_window_arm.c
+++ b/arch/arm/fill_window_arm.c
@@ -10,10 +10,10 @@
 
 /* @(#) $Id$ */
 
-#include "zbuild.h"
-#include "deflate.h"
-#include "deflate_p.h"
-#include "functable.h"
+#include "../../zbuild.h"
+#include "../../deflate.h"
+#include "../../deflate_p.h"
+#include "../../functable.h"
 
 extern ZLIB_INTERNAL int read_buf(PREFIX3(stream) *strm, unsigned char *buf, unsigned size);
 

--- a/arch/arm/insert_string_acle.c
+++ b/arch/arm/insert_string_acle.c
@@ -7,8 +7,8 @@
 
 #if defined(__ARM_FEATURE_CRC32) && defined(ARM_ACLE_CRC_HASH)
 #include <arm_acle.h>
-#include "zbuild.h"
-#include "deflate.h"
+#include "../../zbuild.h"
+#include "../../deflate.h"
 
 /* ===========================================================================
  * Insert string str in the dictionary and set match_head to the previous head

--- a/arch/s390/dfltcc_common.c
+++ b/arch/s390/dfltcc_common.c
@@ -1,6 +1,6 @@
 /* dfltcc_deflate.c - IBM Z DEFLATE CONVERSION CALL general support. */
 
-#include "zbuild.h"
+#include "../../zbuild.h"
 #include "dfltcc_common.h"
 #include "dfltcc_detail.h"
 

--- a/arch/s390/dfltcc_common.h
+++ b/arch/s390/dfltcc_common.h
@@ -2,11 +2,11 @@
 #define DFLTCC_COMMON_H
 
 #ifdef ZLIB_COMPAT
-#include "zlib.h"
+#include "../../zlib.h"
 #else
-#include "zlib-ng.h"
+#include "../../zlib-ng.h"
 #endif
-#include "zutil.h"
+#include "../../zutil.h"
 
 void ZLIB_INTERNAL *dfltcc_alloc_state(PREFIX3(streamp) strm, uInt items, uInt size);
 void ZLIB_INTERNAL dfltcc_copy_state(void *dst, const void *src, uInt size);

--- a/arch/s390/dfltcc_deflate.c
+++ b/arch/s390/dfltcc_deflate.c
@@ -13,9 +13,9 @@
         $ make
 */
 
-#include "zbuild.h"
-#include "zutil.h"
-#include "deflate.h"
+#include "../../zbuild.h"
+#include "../../zutil.h"
+#include "../../deflate.h"
 #include "dfltcc_deflate.h"
 #include "dfltcc_detail.h"
 

--- a/arch/s390/dfltcc_inflate.c
+++ b/arch/s390/dfltcc_inflate.c
@@ -13,10 +13,10 @@
         $ make
 */
 
-#include "zbuild.h"
-#include "zutil.h"
-#include "inftrees.h"
-#include "inflate.h"
+#include "../../zbuild.h"
+#include "../../zutil.h"
+#include "../../inftrees.h"
+#include "../../inflate.h"
 #include "dfltcc_inflate.h"
 #include "dfltcc_detail.h"
 

--- a/arch/x86/crc_folding.c
+++ b/arch/x86/crc_folding.c
@@ -18,7 +18,7 @@
 
 #ifdef X86_PCLMULQDQ_CRC
 
-#include "zbuild.h"
+#include "../../zbuild.h"
 #include <inttypes.h>
 #include <immintrin.h>
 #include <wmmintrin.h>

--- a/arch/x86/crc_folding.h
+++ b/arch/x86/crc_folding.h
@@ -10,7 +10,7 @@
 #ifndef CRC_FOLDING_H_
 #define CRC_FOLDING_H_
 
-#include "deflate.h"
+#include "../../deflate.h"
 
 ZLIB_INTERNAL void crc_fold_init(deflate_state *const);
 ZLIB_INTERNAL uint32_t crc_fold_512to32(deflate_state *const);

--- a/arch/x86/deflate_quick.c
+++ b/arch/x86/deflate_quick.c
@@ -17,13 +17,13 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-#include "zbuild.h"
+#include "../../zbuild.h"
 #include <immintrin.h>
 #ifdef _MSC_VER
 #  include <nmmintrin.h>
 #endif
-#include "deflate.h"
-#include "memcopy.h"
+#include "../../deflate.h"
+#include "../../memcopy.h"
 
 #ifdef ZLIB_DEBUG
 #include <ctype.h>

--- a/arch/x86/fill_window_sse.c
+++ b/arch/x86/fill_window_sse.c
@@ -10,11 +10,11 @@
  */
 #ifdef X86_SSE2
 
-#include "zbuild.h"
+#include "../../zbuild.h"
 #include <immintrin.h>
-#include "deflate.h"
-#include "deflate_p.h"
-#include "functable.h"
+#include "../../deflate.h"
+#include "../../deflate_p.h"
+#include "../../functable.h"
 
 extern int read_buf(PREFIX3(stream) *strm, unsigned char *buf, unsigned size);
 

--- a/arch/x86/insert_string_sse.c
+++ b/arch/x86/insert_string_sse.c
@@ -5,8 +5,8 @@
  *
  */
 
-#include "zbuild.h"
-#include "deflate.h"
+#include "../../zbuild.h"
+#include "../../deflate.h"
 
 /* ===========================================================================
  * Insert string str in the dictionary and set match_head to the previous head

--- a/arch/x86/x86.c
+++ b/arch/x86/x86.c
@@ -8,7 +8,7 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-#include "zutil.h"
+#include "../../zutil.h"
 
 #ifdef _MSC_VER
 #include <intrin.h>


### PR DESCRIPTION
so that header can be included without -I flag, which is potentially useful for embedding whole source.