### PR TITLE
Fixed GCC version for bswap intrinsics

### DIFF
--- a/zutil.h
+++ b/zutil.h
@@ -175,7 +175,7 @@ void ZLIB_INTERNAL   zng_cfree(void *opaque, void *ptr);
 #  define ZSWAP64(q) _byteswap_uint64(q)
 
 #elif defined(__Clang__) || (defined(__GNUC__) && \
-        (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3)))
+        (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)))
 #  define ZSWAP16(q) __builtin_bswap16(q)
 #  define ZSWAP32(q) __builtin_bswap32(q)
 #  define ZSWAP64(q) __builtin_bswap64(q)

--- a/zutil.h
+++ b/zutil.h
@@ -175,7 +175,7 @@ void ZLIB_INTERNAL   zng_cfree(void *opaque, void *ptr);
 #  define ZSWAP64(q) _byteswap_uint64(q)
 
 #elif defined(__Clang__) || (defined(__GNUC__) && \
-        (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 2)))
+        (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3)))
 #  define ZSWAP16(q) __builtin_bswap16(q)
 #  define ZSWAP32(q) __builtin_bswap32(q)
 #  define ZSWAP64(q) __builtin_bswap64(q)


### PR DESCRIPTION
according to https://stackoverflow.com/a/15034284/2641271 , 4.3 is least version supporting __builtin_bswap32. Also https://gcc.gnu.org/onlinedocs/gcc-4.8.0/gcc/Other-Builtins.html (and 4.7.0 manual) indicates __builtin_bswap16 is supported by gcc 4.8. For portability, I currently select 4.8.