### PR TITLE
[Travis] Add codecov.io and several new tests + misc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,14 @@ env:
 matrix:
   include:
     # Windows tests
+    #   clang/cmake
     - os: windows
       compiler: clang
       env:
         - GENERATOR="cmake . "
         - MAKER="cmake --build . --config Release"
         - TESTER="ctest --verbose -C Release"
+
     - os: windows
       compiler: clang
       env:
@@ -26,6 +28,8 @@ matrix:
         - MAKER="cmake --build . --config Release"
         - TESTER="ctest --verbose -C Release"
         - BUILDDIR=..\\build
+
+    #   gcc/cmake
     - os: windows
       compiler: gcc
       env:
@@ -33,46 +37,73 @@ matrix:
         - MAKER="cmake --build . --config Release"
         - TESTER="ctest --verbose -C Release"
 
+
     # Linux x86-64 tests
+    #   gcc/configure
     - os: linux
       compiler: gcc
       env: GENERATOR="./configure --warn"
+
     - os: linux
       compiler: gcc
-      env: GENERATOR="cmake . -DZLIB_COMPAT=OFF -DWITH_GZFILEOP=ON -DWITH_NEW_STRATEGIES=YES -DWITH_OPTIM=ON"
+      env: GENERATOR="./configure --warn --zlib-compat --without-optimizations --without-new-strategies"
+
     - os: linux
       compiler: gcc
       env:
         - GENERATOR="../zlib-ng/configure --warn --zlib-compat"
         - BUILDDIR=../build
-    - os: linux
-      compiler: gcc
-      env: GENERATOR="./configure --warn --zlib-compat --without-optimizations --without-new-strategies"
-    - os: linux
-      compiler: gcc
-      env: GENERATOR="cmake ."
+
+    #   gcc/cmake
     - os: linux
       compiler: gcc
       env:
-        - GENERATOR="cmake ../zlib-ng"
+        - GENERATOR="cmake ."
+        - TESTER="ctest --verbose -C Release"
+
+    - os: linux
+      compiler: gcc
+      env:
+        - GENERATOR="cmake . -DWITH_NEW_STRATEGIES=NO -DWITH_OPTIM=NO"
+        - TESTER="ctest --verbose -C Release"
+
+    - os: linux
+      compiler: gcc
+      env:
+        - GENERATOR="cmake ../zlib-ng -DZLIB_COMPAT=ON"
+        - TESTER="ctest --verbose -C Release"
         - BUILDDIR=../build
 
+    #   clang/configure
     - os: linux
       compiler: clang
       env: GENERATOR="./configure --warn --zlib-compat"
+
+    #   clang/cmake
     - os: linux
       compiler: clang
       env:
         - GENERATOR="cmake ../zlib-ng"
+        - TESTER="ctest --verbose -C Release"
         - BUILDDIR=../build
+
     - os: linux
       compiler: clang
       env:
         - GENERATOR="scan-build -v --status-bugs cmake ../zlib-ng"
         - MAKER="scan-build -v --status-bugs make"
+        - TESTER="ctest --verbose -C Release"
         - BUILDDIR=../build
 
-    # GCC-9 test
+    - os: linux
+      compiler: clang
+      env:
+        - GENERATOR="scan-build -v --status-bugs cmake ../zlib-ng -DZLIB_COMPAT=ON"
+        - MAKER="scan-build -v --status-bugs make"
+        - TESTER="ctest --verbose -C Release"
+        - BUILDDIR=../build
+
+    #   gcc-9/cmake
     - os: linux
       compiler: gcc-9
       addons:
@@ -82,51 +113,73 @@ matrix:
           packages:
             - gcc-9
       env:
-        - GENERATOR="./configure --warn"
         - CC=gcc-9
+        - GENERATOR="cmake ."
+        - TESTER="ctest --verbose -C Release"
+
 
     # OSX tests
+    #   gcc/configure
     - os: osx
       compiler: gcc
-      env: GENERATOR="./configure --warn --zlib-compat"
+      env: GENERATOR="./configure --warn"
+
     - os: osx
       compiler: gcc
       env:
         - GENERATOR="../zlib-ng/configure --warn --zlib-compat"
         - BUILDDIR=../build
+
+    #   gcc/cmake
     - os: osx
       compiler: gcc
-      env: GENERATOR="cmake ."
+      env:
+        - GENERATOR="cmake ."
+        - TESTER="ctest --verbose -C Release"
 
+    #   clang/configure
     - os: osx
       compiler: clang
       env: GENERATOR="./configure --warn --zlib-compat"
+
+    #   clang/cmake
     - os: osx
       compiler: clang
       env:
         - GENERATOR="cmake ../zlib-ng"
+        - TESTER="ctest --verbose -C Release"
         - BUILDDIR=../build
 
-    # compiling for linux-ppc64le variants
+
+    # Linux ppc64le
+    #   gcc/cmake
     - os: linux-ppc64le
       compiler: gcc
       env: GENERATOR="cmake ."
+
     - os: linux-ppc64le
       compiler: gcc
       env:
-        - GENERATOR="cmake ../zlib-ng"
+        - GENERATOR="cmake ../zlib-ng -DZLIB_COMPAT=ON"
+        - TESTER="ctest --verbose -C Release"
         - BUILDDIR=../build
 
+    #   clang/configure
     - os: linux-ppc64le
       compiler: clang
       env: GENERATOR="./configure --warn --zlib-compat"
+
+    #   clang/cmake
     - os: linux-ppc64le
       compiler: clang
       env:
         - GENERATOR="cmake ../zlib-ng"
+        - TESTER="ctest --verbose -C Release"
         - BUILDDIR=../build
 
-    # Cross compiling for arm variants
+
+    # Linux AARCH64, cross compiled + qemu
+    #   gcc/configure
     - os: linux
       compiler: aarch64-linux-gnu-gcc
       addons:
@@ -137,8 +190,23 @@ matrix:
             - libc-dev-arm64-cross
       # For all aarch64 implementations NEON is mandatory, while crypto/crc are not.
       env:
-        - GENERATOR="./configure --warn --zlib-compat"
+        - GENERATOR="./configure --warn"
         - CHOST=aarch64-linux-gnu
+
+    - os: linux
+      compiler: aarch64-linux-gnu-gcc
+      addons:
+        apt:
+          packages:
+            - qemu
+            - gcc-aarch64-linux-gnu
+            - libc-dev-arm64-cross
+      env:
+        - GENERATOR="../zlib-ng/configure --warn --zlib-compat"
+        - CHOST=aarch64-linux-gnu
+        - BUILDDIR=../build
+
+    #   gcc/cmake
     - os: linux
       compiler: aarch64-linux-gnu-gcc
       addons:
@@ -152,17 +220,7 @@ matrix:
         - GENERATOR="cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-aarch64.cmake . -DZLIB_COMPAT=ON"
         - MAKER="cmake --build . --config Release"
         - TESTER="ctest --verbose -C Release"
-    - os: linux
-      compiler: aarch64-linux-gnu-gcc
-      addons:
-        apt:
-          packages:
-            - qemu
-            - gcc-aarch64-linux-gnu
-            - libc-dev-arm64-cross
-      env:
-        - GENERATOR="./configure --warn --zlib-compat"
-        - CHOST=aarch64-linux-gnu
+
     - os: linux
       compiler: aarch64-linux-gnu-gcc
       addons:
@@ -175,7 +233,9 @@ matrix:
         - GENERATOR="cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-aarch64.cmake ."
         - MAKER="cmake --build . --config Release"
         - TESTER="ctest --verbose -C Release"
-    # Hard-float subsets
+
+    # Linux ARM Hard-float, cross compiled + qemu
+    #   gcc/configure
     - os: linux
       compiler: arm-linux-gnueabihf-gcc
       addons:
@@ -187,6 +247,32 @@ matrix:
       env:
         - GENERATOR="./configure --warn"
         - CHOST=arm-linux-gnueabihf
+
+    - os: linux
+      compiler: arm-linux-gnueabihf-gcc
+      addons:
+        apt:
+          packages:
+            - qemu
+            - gcc-arm-linux-gnueabihf
+            - libc-dev-armhf-cross
+      env:
+        - GENERATOR="./configure --warn --zlib-compat --without-neon"
+        - CHOST=arm-linux-gnueabihf
+
+    - os: linux
+      compiler: arm-linux-gnueabihf-gcc
+      addons:
+        apt:
+          packages:
+            - qemu
+            - gcc-arm-linux-gnueabihf
+            - libc-dev-armhf-cross
+      env:
+        - GENERATOR="./configure --warn --zlib-compat"
+        - CHOST=arm-linux-gnueabihf
+
+    #   gcc/cmake
     - os: linux
       compiler: arm-linux-gnueabihf-gcc
       addons:
@@ -199,17 +285,7 @@ matrix:
         - GENERATOR="cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-arm.cmake . -DCMAKE_C_COMPILER_TARGET=arm-linux-gnueabihf"
         - MAKER="cmake --build . --config Release"
         - TESTER="ctest --verbose -C Release"
-    - os: linux
-      compiler: arm-linux-gnueabihf-gcc
-      addons:
-        apt:
-          packages:
-            - qemu
-            - gcc-arm-linux-gnueabihf
-            - libc-dev-armhf-cross
-      env:
-        - GENERATOR="./configure --warn --zlib-compat --without-neon"
-        - CHOST=arm-linux-gnueabihf
+
     - os: linux
       compiler: arm-linux-gnueabihf-gcc
       addons:
@@ -222,17 +298,7 @@ matrix:
         - GENERATOR="cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-arm.cmake . -DZLIB_COMPAT=ON -DWITH_NEON=OFF -DCMAKE_C_COMPILER_TARGET=arm-linux-gnueabihf"
         - MAKER="cmake --build . --config Release"
         - TESTER="ctest --verbose -C Release"
-    - os: linux
-      compiler: arm-linux-gnueabihf-gcc
-      addons:
-        apt:
-          packages:
-            - qemu
-            - gcc-arm-linux-gnueabihf
-            - libc-dev-armhf-cross
-      env:
-        - GENERATOR="./configure --warn --zlib-compat"
-        - CHOST=arm-linux-gnueabihf
+
     - os: linux
       compiler: arm-linux-gnueabihf-gcc
       addons:
@@ -245,7 +311,9 @@ matrix:
         - GENERATOR="cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-arm.cmake . -DZLIB_COMPAT=ON -DCMAKE_C_COMPILER_TARGET=arm-linux-gnueabihf"
         - MAKER="cmake --build . --config Release"
         - TESTER="ctest --verbose -C Release"
-    # Soft-float subset
+
+    # Linux ARM Soft-float, cross compiled + qemu
+    #   gcc/configure
     - os: linux
       compiler: arm-linux-gnueabi-gcc
       addons:
@@ -257,6 +325,20 @@ matrix:
       env:
         - GENERATOR="./configure"
         - CHOST=arm-linux-gnueabi
+
+    - os: linux
+      compiler: arm-linux-gnueabi-gcc
+      addons:
+        apt:
+          packages:
+            - qemu
+            - gcc-arm-linux-gnueabi
+            - libc-dev-armel-cross
+      env:
+        - GENERATOR="./configure --zlib-compat"
+        - CHOST=arm-linux-gnueabi
+
+    #   gcc/cmake
     - os: linux
       compiler: arm-linux-gnueabi-gcc
       addons:
@@ -269,17 +351,7 @@ matrix:
         - GENERATOR="cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-arm.cmake . -DCMAKE_C_COMPILER_TARGET=arm-linux-gnueabi"
         - MAKER="cmake --build . --config Release"
         - TESTER="ctest --verbose -C Release"
-    - os: linux
-      compiler: arm-linux-gnueabi-gcc
-      addons:
-        apt:
-          packages:
-            - qemu
-            - gcc-arm-linux-gnueabi
-            - libc-dev-armel-cross
-      env:
-        - GENERATOR="./configure --zlib-compat"
-        - CHOST=arm-linux-gnueabi
+
     - os: linux
       compiler: arm-linux-gnueabi-gcc
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,12 @@ env:
     - BUILDDIR=.
     - MAKER="make -j2"
     - TESTER="make test"
+    - CFLAGS="-O2 -g --coverage"
+    - LDFLAGS="--coverage"
 
 matrix:
   include:
+    # Windows tests
     - os: windows
       compiler: clang
       env:
@@ -30,6 +33,7 @@ matrix:
         - MAKER="cmake --build . --config Release"
         - TESTER="ctest --verbose -C Release"
 
+    # Linux x86-64 tests
     - os: linux
       compiler: gcc
       env: GENERATOR="./configure --warn"
@@ -68,6 +72,20 @@ matrix:
         - MAKER="scan-build -v --status-bugs make"
         - BUILDDIR=../build
 
+    # GCC-9 test
+    - os: linux
+      compiler: gcc-9
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-9
+      env:
+        - GENERATOR="./configure --warn"
+        - CC=gcc-9
+
+    # OSX tests
     - os: osx
       compiler: gcc
       env: GENERATOR="./configure --warn --zlib-compat"
@@ -281,3 +299,6 @@ script:
   - $GENERATOR
   - $MAKER
   - $TESTER
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Travis config changes:
- Add codecov.io coverage support
- Remove repeated identical test
- Add a GCC-9 test (one benefit is it gives much better warnings/error messages)
- Add some variety to some of the tests
- Add section comments and whitespace, making the config file more readable and using the same style for arm and other arches

See the two commits separately for easier reviewing, if anyone objects I can easily split these into several separate PRs.