### PR TITLE
Remove compiler from Travis CI matrix for Windows builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,14 +15,14 @@ matrix:
     # Windows tests
     #   msvc/cmake
     - os: windows
-      compiler: msvc
+      compiler: cl
       env:
         - GENERATOR="cmake . "
         - MAKER="cmake --build . --config Release"
         - TESTER="ctest --verbose -C Release"
 
     - os: windows
-      compiler: msvc
+      compiler: cl
       env:
         - GENERATOR="cmake ..\\zlib-ng -DZLIB_COMPAT=ON"
         - MAKER="cmake --build . --config Release"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,29 +13,21 @@ env:
 matrix:
   include:
     # Windows tests
-    #   clang/cmake
+    #   msvc/cmake
     - os: windows
-      compiler: clang
+      compiler: msvc
       env:
         - GENERATOR="cmake . "
         - MAKER="cmake --build . --config Release"
         - TESTER="ctest --verbose -C Release"
 
     - os: windows
-      compiler: clang
+      compiler: msvc
       env:
         - GENERATOR="cmake ..\\zlib-ng -DZLIB_COMPAT=ON"
         - MAKER="cmake --build . --config Release"
         - TESTER="ctest --verbose -C Release"
         - BUILDDIR=..\\build
-
-    #   gcc/cmake
-    - os: windows
-      compiler: gcc
-      env:
-        - GENERATOR="cmake ."
-        - MAKER="cmake --build . --config Release"
-        - TESTER="ctest --verbose -C Release"
 
 
     # Linux x86-64 tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,14 +15,12 @@ matrix:
     # Windows tests
     #   msvc/cmake
     - os: windows
-      compiler: cl
       env:
         - GENERATOR="cmake . "
         - MAKER="cmake --build . --config Release"
         - TESTER="ctest --verbose -C Release"
 
     - os: windows
-      compiler: cl
       env:
         - GENERATOR="cmake ..\\zlib-ng -DZLIB_COMPAT=ON"
         - MAKER="cmake --build . --config Release"


### PR DESCRIPTION
Removes the _compiler:_ option from the matrix. It mislabels the test case as being compiled with gcc or clang, when in fact both are compiled with MSVC. Setting it to "msvc" shows an error of it not being found, same thing with setting it to "cl", so best to just remove it. Travis CI support for Windows is limited.