### PR TITLE
Changes based on CloudFlare's fork

### DIFF
--- a/arch/s390/dfltcc_deflate.c
+++ b/arch/s390/dfltcc_deflate.c
@@ -79,7 +79,7 @@ static inline void send_eobs(PREFIX3(streamp) strm, const struct dfltcc_param_v0
 {
     deflate_state *state = (deflate_state *)strm->state;
 
-    send_bits(state, bi_reverse(param->eobs >> (15 - param->eobl), param->eobl), param->eobl);
+    send_bits(state, bi_reverse(param->eobs >> (15 - param->eobl), param->eobl), param->eobl, s->bi_buf, s->bi_valid);
     flush_pending(strm);
     if (state->pending != 0) {
         /* The remaining data is located in pending_out[0:pending]. If someone

--- a/arch/x86/deflate_quick.c
+++ b/arch/x86/deflate_quick.c
@@ -177,14 +177,14 @@ static void static_emit_tree(deflate_state *const s, const int flush) {
 
     last = flush == Z_FINISH ? 1 : 0;
     Tracev((stderr, "\n--- Emit Tree: Last: %u\n", last));
-    send_bits(s, (STATIC_TREES << 1)+ last, 3);
+    send_bits(s, (STATIC_TREES << 1)+ last, 3, s->bi_buf, s->bi_valid);
 #ifdef ZLIB_DEBUG
     s->compressed_len += 3;
 #endif
 }
 
 static void static_emit_end_block(deflate_state *const s, int last) {
-    send_code(s, END_BLOCK, static_ltree);
+    send_code(s, END_BLOCK, static_ltree, s->bi_buf, s->bi_valid);
 #ifdef ZLIB_DEBUG
     s->compressed_len += 7;  /* 7 bits for EOB */
 #endif

--- a/deflate.c
+++ b/deflate.c
@@ -1687,32 +1687,6 @@ static block_state deflate_huff(deflate_state *s, int flush) {
     return block_done;
 }
 
-#ifdef ZLIB_DEBUG
-/* ===========================================================================
- * Send a value on a given number of bits.
- * IN assertion: length <= 16 and value fits in length bits.
- */
-void send_bits(deflate_state *s, int value, int length) {
-    Tracevv((stderr, " l %2d v %4x ", length, value));
-    Assert(length > 0 && length <= 15, "invalid length");
-    s->bits_sent += (unsigned long)length;
-
-    /* If not enough room in bi_buf, use (valid) bits from bi_buf and
-     * (16 - bi_valid) bits from value, leaving (width - (16-bi_valid))
-     * unused bits in value.
-     */
-    if (s->bi_valid > (int)Buf_size - length) {
-        s->bi_buf |= (uint16_t)value << s->bi_valid;
-        put_short(s, s->bi_buf);
-        s->bi_buf = (uint16_t)value >> (Buf_size - s->bi_valid);
-        s->bi_valid += length - Buf_size;
-    } else {
-        s->bi_buf |= (uint16_t)value << s->bi_valid;
-        s->bi_valid += length;
-    }
-}
-#endif
-
 #ifndef ZLIB_COMPAT
 /* =========================================================================
  * Checks whether buffer size is sufficient and whether this parameter is a duplicate.

--- a/deflate.h
+++ b/deflate.h
@@ -437,7 +437,9 @@ void ZLIB_INTERNAL flush_pending(PREFIX3(streamp) strm);
  * (16 - bit_valid) bits from value, leaving (width - (16-bit_valid))
  * unused bits in value.
  */
-#define send_bits(s, val, len, bit_buf, bits_valid) {\
+#define send_bits(s, t_val, t_len, bit_buf, bits_valid) {\
+    int val = t_val;\
+    int len = t_len;\
     send_debug_trace(s, val, len);\
     if (bits_valid > (int)Buf_size - len) {\
         bit_buf |= (uint16_t)val << bits_valid;\

--- a/match_p.h
+++ b/match_p.h
@@ -432,7 +432,8 @@ static inline unsigned longest_match(deflate_state *const s, IPos cur_match) {
         int cont = 1;
         do {
             match = window + cur_match;
-            if (likely(memcmp(match+best_len-1, &scan_end, sizeof(scan_end)) != 0)) {
+            if (likely(memcmp(match+best_len-1, &scan_end, sizeof(scan_end)) != 0
+                || memcmp(match, &scan_start, sizeof(scan_start)) != 0)) {
                 if ((cur_match = prev[cur_match & wmask]) > limit
                     && --chain_length != 0) {
                     continue;
@@ -445,9 +446,6 @@ static inline unsigned longest_match(deflate_state *const s, IPos cur_match) {
 
         if (!cont)
             break;
-
-        if (memcmp(match, &scan_start, sizeof(scan_start)) != 0)
-            continue;
 
         /* It is not necessary to compare scan[2] and match[2] since they are
          * always equal when the other bytes match, given that the hash keys


### PR DESCRIPTION
The first commit (match_p.h) is simply moving a if check earlier, and is identical to what CF did.

The second commit is based on the idea of what CF did, but I did not just unroll the define, I changed the define to hopefully achieve the same improvement, while keeping the ability to enable debugging.
For the debugging variant, there is no longer a function that duplicates the define's content, but the necessary debugging code is inserted into the top of the define instead. This is not for performance, but for simplicity, so we don't need to maintain as much duplicated code.

I am uncertain about merging this though, as I was unable to see any performance difference in my local tests, however those were done on x86_64 with GCC 9.1. There might be performance differences on other architectures or compiler, or older GCC versions might not be able to optimize this as much.

I also removed the following lines from the define, as I don't see why they are needed. Did we remove the need at some point when changing types perhaps?
int len = length;
int val = (int)value;

So, I am looking for feedback here, does this change make any sense to you?
And does it make any difference in performance on your platforms?