### PR TITLE
Import fix for a very rare potential crash in crc_folding_sse

### DIFF
--- a/arch/x86/crc_folding.c
+++ b/arch/x86/crc_folding.c
@@ -230,6 +230,7 @@ static void partial_fold(const size_t len, __m128i *xmm_crc0, __m128i *xmm_crc1,
 ZLIB_INTERNAL void crc_fold_copy(deflate_state *const s, unsigned char *dst, const unsigned char *src, long len) {
     unsigned long algn_diff;
     __m128i xmm_t0, xmm_t1, xmm_t2, xmm_t3;
+    char ALIGNED_(16) partial_buf[16] = { 0 };
 
     /* CRC_LOAD */
     __m128i xmm_crc0 = _mm_loadu_si128((__m128i *)s->crc0 + 0);
@@ -239,8 +240,6 @@ ZLIB_INTERNAL void crc_fold_copy(deflate_state *const s, unsigned char *dst, con
     __m128i xmm_crc_part;
 
     if (len < 16) {
-        char ALIGNED_(16) partial_buf[16] = { 0 };
-
         if (len == 0)
             return;
 
@@ -353,7 +352,9 @@ ZLIB_INTERNAL void crc_fold_copy(deflate_state *const s, unsigned char *dst, con
         xmm_crc_part = _mm_load_si128((__m128i *)src);
     }
 
-    _mm_storeu_si128((__m128i *)dst, xmm_crc_part);
+    _mm_storeu_si128((__m128i *)partial_buf, xmm_crc_part);
+    memcpy(dst, partial_buf, len);
+
 partial:
     partial_fold(len, &xmm_crc0, &xmm_crc1, &xmm_crc2, &xmm_crc3, &xmm_crc_part);
 done:

--- a/arch/x86/crc_folding.c
+++ b/arch/x86/crc_folding.c
@@ -239,9 +239,14 @@ ZLIB_INTERNAL void crc_fold_copy(deflate_state *const s, unsigned char *dst, con
     __m128i xmm_crc_part;
 
     if (len < 16) {
+        char ALIGNED_(16) partial_buf[16] = { 0 };
+
         if (len == 0)
             return;
-        xmm_crc_part = _mm_loadu_si128((__m128i *)src);
+
+        memcpy(partial_buf, src, len);
+        xmm_crc_part = _mm_loadu_si128((const __m128i *)partial_buf);
+        memcpy(dst, partial_buf, len);
         goto partial;
     }
 
@@ -348,8 +353,8 @@ ZLIB_INTERNAL void crc_fold_copy(deflate_state *const s, unsigned char *dst, con
         xmm_crc_part = _mm_load_si128((__m128i *)src);
     }
 
-partial:
     _mm_storeu_si128((__m128i *)dst, xmm_crc_part);
+partial:
     partial_fold(len, &xmm_crc0, &xmm_crc1, &xmm_crc2, &xmm_crc3, &xmm_crc_part);
 done:
     /* CRC_SAVE */


### PR DESCRIPTION
This comes at a slight performance penalty of around 0.2% for compression on a skylake with GCC-9