### PR TITLE
Fixed chunkmemset should be called on larger chunks assert

### DIFF
--- a/inffast.c
+++ b/inffast.c
@@ -307,7 +307,9 @@ void ZLIB_INTERNAL zng_inflate_fast(PREFIX3(stream) *strm, unsigned long start) 
                        operations can write beyond `out+len` so long as they
                        stay within 258 bytes of `out`.
                     */
-                    if (dist >= len || dist >= INFFAST_CHUNKSIZE)
+                    if (len < sizeof(uint64_t))
+                        out = chunkcopysafe(out, out - dist, len, safe);
+                    else if (dist >= len || dist >= INFFAST_CHUNKSIZE)
                         out = chunkcopy(out, out - dist, len);
                     else
                         out = chunkmemset(out, dist, len);

--- a/inflate.c
+++ b/inflate.c
@@ -990,7 +990,10 @@ int ZEXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int flush) {
                 if (copy > left)
                     copy = left;
 #if defined(INFFAST_CHUNKSIZE)
-                put = chunkmemsetsafe(put, state->offset, copy, left);
+                if (copy >= sizeof(uint64_t))
+                    put = chunkmemsetsafe(put, state->offset, copy, left);
+                else
+                    put = chunkcopysafe(put, put - state->offset, copy, put);
 #else
                 if (copy >= sizeof(uint64_t))
                     put = chunk_memset(put, put - state->offset, state->offset, copy);


### PR DESCRIPTION
When compressing fireworks.jpeg using deflate level 1 and mem level 1, during inflate the following assert would be hit:

```
chunkmemset should be called on larger chunks
```

This PR fixes that by providing a path for copying lengths that are less than _sizeof(uint64_t)_ when using INFFAST_CHUNKSIZE. Also see #284.