### PR TITLE
Added cmake tests to verify output of makefixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ CMakeFiles
 Testing
 *.cmake
 *.stackdump
+*._h
 zconf.h
 zconf.h.cmakein
 zconf.h.included

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -890,6 +890,18 @@ if (ZLIB_ENABLE_TESTS)
         add_test(NAME CVE-2003-0107 COMMAND CVE-2003-0107)
     endif()
 
+    set(MAKEFIXED_COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:makefixed>)
+    add_test(NAME makefixed
+        COMMAND ${CMAKE_COMMAND}
+        "-DCOMMAND=${MAKEFIXED_COMMAND}"
+        -DOUTPUT=${CMAKE_CURRENT_SOURCE_DIR}/inffixed._h
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/run-and-redirect.cmake)
+
+    add_test(NAME makefixed-cmp
+        COMMAND ${CMAKE_COMMAND} -E compare_files
+            ${CMAKE_CURRENT_SOURCE_DIR}/inffixed.h
+            ${CMAKE_CURRENT_SOURCE_DIR}/inffixed._h)
+
     set(GH_361_COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:minigzip> -4)
     add_test(NAME GH-361
         COMMAND ${CMAKE_COMMAND}

--- a/Makefile.in
+++ b/Makefile.in
@@ -347,6 +347,7 @@ clean:
 	rm -f *.gcda *.gcno *.gcov
 	rm -f a.out a.exe
 	rm -f *.pc
+	rm -f *._h
 
 maintainer-clean: distclean
 distclean: clean

--- a/cmake/run-and-redirect.cmake
+++ b/cmake/run-and-redirect.cmake
@@ -1,12 +1,20 @@
-if(WIN32)
-    set(DEVNULL NUL)
-else()
-    set(DEVNULL /dev/null)
+if(NOT OUTPUT)
+    if(WIN32)
+        set(OUTPUT NUL)
+    else()
+        set(OUTPUT /dev/null)
+    endif()
 endif()
-execute_process(COMMAND ${COMMAND}
-    RESULT_VARIABLE CMD_RESULT
-    INPUT_FILE ${INPUT}
-    OUTPUT_FILE ${DEVNULL})
+if(INPUT)
+    execute_process(COMMAND ${COMMAND}
+        RESULT_VARIABLE CMD_RESULT
+        INPUT_FILE ${INPUT}
+        OUTPUT_FILE ${OUTPUT})
+else()
+    execute_process(COMMAND ${COMMAND}
+        RESULT_VARIABLE CMD_RESULT
+        OUTPUT_FILE ${OUTPUT})
+endif()
 if(SUCCESS_EXIT)
     list(FIND SUCCESS_EXIT ${CMD_RESULT} _INDEX)
     if (${_INDEX} GREATER -1)


### PR DESCRIPTION
This PR adds two cmake tests, one that runs makefixed to output its result, and the second one that verifies that the output of makefixed is equal to the output of inffixed.h.