### PR TITLE
Modify cmake to use object libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -757,19 +757,15 @@ target_include_directories(zlibobj PUBLIC
         ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 
 if(NOT DEFINED BUILD_SHARED_LIBS)
-    add_library(zlib SHARED)
-    add_library(zlibstatic STATIC)
+    add_library(zlib SHARED $<TARGET_OBJECTS:zlibobj>)
+    add_library(zlibstatic STATIC $<TARGET_OBJECTS:zlibobj>)
 
     set(ZLIB_INSTALL_LIBRARIES zlib zlibstatic)
 else()
-    add_library(zlib)
+    add_library(zlib $<TARGET_OBJECTS:zlibobj>)
 
     set(ZLIB_INSTALL_LIBRARIES zlib)
 endif()
-
-foreach(ZLIB_INSTALL_LIBRARY ${ZLIB_INSTALL_LIBRARIES})
-    target_link_libraries(${ZLIB_INSTALL_LIBRARY} zlibobj)
-endforeach()
 
 if(NOT DEFINED BUILD_SHARED_LIBS OR BUILD_SHARED_LIBS)
     set_target_properties(zlib PROPERTIES DEFINE_SYMBOL ZLIB_DLL)
@@ -835,7 +831,7 @@ option(ZLIB_ENABLE_TESTS "Build test binaries" ON)
 if (ZLIB_ENABLE_TESTS)
     enable_testing()
     macro(configure_test_executable target)
-        target_link_libraries(${target} zlibobj)
+        target_sources(${target} PRIVATE $<TARGET_OBJECTS:zlibobj>)
         target_include_directories(${target} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
         if(NOT WITH_GZFILEOP)
             target_compile_definitions(${target} PUBLIC -DWITH_GZFILEOP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -745,25 +745,26 @@ if(MINGW OR MSYS)
     set(ZLIB_DLL_SRCS ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj)
 endif()
 
-set(ZLIB_ALL_SRCS ${ZLIB_SRCS} ${ZLIB_ARCH_SRCS} ${ZLIB_DLL_SRCS} 
+set(ZLIB_ALL_SRCS ${ZLIB_SRCS} ${ZLIB_ARCH_SRCS} ${ZLIB_DLL_SRCS}
     ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
 if(WITH_GZFILEOP)
     list(APPEND ZLIB_ALL_SRCS ${ZLIB_GZFILE_SRCS})
 endif()
-
+add_library(zlibobj OBJECT ${ZLIB_ALL_SRCS})
 if(NOT DEFINED BUILD_SHARED_LIBS)
-    add_library(zlib SHARED ${ZLIB_ALL_SRCS})
-    add_library(zlibstatic STATIC ${ZLIB_ALL_SRCS})
+    add_library(zlib SHARED)
+    add_library(zlibstatic STATIC)
 
     set(ZLIB_INSTALL_LIBRARIES zlib zlibstatic)
 else()
-    add_library(zlib ${ZLIB_ALL_SRCS})
+    add_library(zlib)
 
     set(ZLIB_INSTALL_LIBRARIES zlib)
 endif()
 
 foreach(ZLIB_INSTALL_LIBRARY ${ZLIB_INSTALL_LIBRARIES})
-    target_include_directories(${ZLIB_INSTALL_LIBRARY} PUBLIC 
+    target_link_libraries(${ZLIB_INSTALL_LIBRARY} zlibobj)
+    target_include_directories(${ZLIB_INSTALL_LIBRARY} PUBLIC
         ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 endforeach()
 
@@ -831,7 +832,7 @@ option(ZLIB_ENABLE_TESTS "Build test binaries" ON)
 if (ZLIB_ENABLE_TESTS)
     enable_testing()
     macro(configure_test_executable target)
-        target_link_libraries(${target} zlib)
+        target_link_libraries(${target} zlibobj)
         target_include_directories(${target} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
         if(NOT WITH_GZFILEOP)
             target_compile_definitions(${target} PUBLIC -DWITH_GZFILEOP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -753,6 +753,8 @@ endif()
 
 add_library(zlibobj OBJECT ${ZLIB_ALL_SRCS})
 set_property(TARGET zlibobj PROPERTY POSITION_INDEPENDENT_CODE ON)
+target_include_directories(zlibobj PUBLIC
+        ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 
 if(NOT DEFINED BUILD_SHARED_LIBS)
     add_library(zlib SHARED)
@@ -767,8 +769,6 @@ endif()
 
 foreach(ZLIB_INSTALL_LIBRARY ${ZLIB_INSTALL_LIBRARIES})
     target_link_libraries(${ZLIB_INSTALL_LIBRARY} zlibobj)
-    target_include_directories(${ZLIB_INSTALL_LIBRARY} PUBLIC
-        ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 endforeach()
 
 if(NOT DEFINED BUILD_SHARED_LIBS OR BUILD_SHARED_LIBS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,10 +133,6 @@ else()
     set(SUFFIX "-ng")
 endif()
 
-if(WITH_GZFILEOP)
-    add_definitions(-DWITH_GZFILEOP)
-endif()
-
 if(${CMAKE_C_COMPILER} MATCHES "icc" OR ${CMAKE_C_COMPILER} MATCHES "icpc" OR ${CMAKE_C_COMPILER} MATCHES "icl")
     if(WITH_NATIVE_INSTRUCTIONS)
         message(STATUS "Ignoring WITH_NATIVE_INSTRUCTIONS; not supported on this configuration")
@@ -745,16 +741,21 @@ if(MINGW OR MSYS)
     set(ZLIB_DLL_SRCS ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj)
 endif()
 
-set(ZLIB_ALL_SRCS ${ZLIB_SRCS} ${ZLIB_ARCH_SRCS} ${ZLIB_DLL_SRCS}
+# Object library for zlib sources
+add_library(zlibobj OBJECT ${ZLIB_SRCS} ${ZLIB_ARCH_SRCS} ${ZLIB_DLL_SRCS}
     ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
-if(WITH_GZFILEOP)
-    list(APPEND ZLIB_ALL_SRCS ${ZLIB_GZFILE_SRCS})
-endif()
-
-add_library(zlibobj OBJECT ${ZLIB_ALL_SRCS})
 set_property(TARGET zlibobj PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_include_directories(zlibobj PUBLIC
         ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+
+if(WITH_GZFILEOP OR ZLIB_ENABLE_TESTS)
+    # Object library for gz file sources
+    add_library(zlibgzobj OBJECT ${ZLIB_GZFILE_SRCS})
+    set_property(TARGET zlibgzobj PROPERTY POSITION_INDEPENDENT_CODE ON)
+    target_include_directories(zlibgzobj PUBLIC
+        ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+    target_compile_definitions(zlibgzobj PUBLIC -DWITH_GZFILEOP)
+endif()
 
 if(NOT DEFINED BUILD_SHARED_LIBS)
     add_library(zlib SHARED $<TARGET_OBJECTS:zlibobj>)
@@ -766,6 +767,13 @@ else()
 
     set(ZLIB_INSTALL_LIBRARIES zlib)
 endif()
+
+foreach(ZLIB_INSTALL_LIBRARY ${ZLIB_INSTALL_LIBRARIES})
+    if(WITH_GZFILEOP)
+        target_compile_definitions(${ZLIB_INSTALL_LIBRARY} PUBLIC -DWITH_GZFILEOP)
+        target_sources(${ZLIB_INSTALL_LIBRARY} PRIVATE $<TARGET_OBJECTS:zlibgzobj>)
+    endif()
+endforeach()
 
 if(NOT DEFINED BUILD_SHARED_LIBS OR BUILD_SHARED_LIBS)
     set_target_properties(zlib PROPERTIES DEFINE_SYMBOL ZLIB_DLL)
@@ -831,12 +839,9 @@ option(ZLIB_ENABLE_TESTS "Build test binaries" ON)
 if (ZLIB_ENABLE_TESTS)
     enable_testing()
     macro(configure_test_executable target)
-        target_sources(${target} PRIVATE $<TARGET_OBJECTS:zlibobj>)
+        target_sources(${target} PRIVATE $<TARGET_OBJECTS:zlibobj> $<TARGET_OBJECTS:zlibgzobj>)
         target_include_directories(${target} PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
-        if(NOT WITH_GZFILEOP)
-            target_compile_definitions(${target} PUBLIC -DWITH_GZFILEOP)
-            target_sources(${target} PRIVATE ${ZLIB_GZFILE_SRCS})
-        endif()
+        target_compile_definitions(${target} PUBLIC -DWITH_GZFILEOP)
     endmacro()
 
     add_executable(example test/example.c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -770,8 +770,8 @@ endif()
 
 foreach(ZLIB_INSTALL_LIBRARY ${ZLIB_INSTALL_LIBRARIES})
     if(WITH_GZFILEOP)
-        target_compile_definitions(${ZLIB_INSTALL_LIBRARY} PUBLIC -DWITH_GZFILEOP)
         target_sources(${ZLIB_INSTALL_LIBRARY} PRIVATE $<TARGET_OBJECTS:zlibgzobj>)
+        target_compile_definitions(${ZLIB_INSTALL_LIBRARY} PUBLIC -DWITH_GZFILEOP)
     endif()
 endforeach()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -832,7 +832,7 @@ if (ZLIB_ENABLE_TESTS)
     enable_testing()
     macro(configure_test_executable target)
         target_sources(${target} PRIVATE $<TARGET_OBJECTS:zlibobj>)
-        target_include_directories(${target} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+        target_include_directories(${target} PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
         if(NOT WITH_GZFILEOP)
             target_compile_definitions(${target} PUBLIC -DWITH_GZFILEOP)
             target_sources(${target} PRIVATE ${ZLIB_GZFILE_SRCS})
@@ -849,6 +849,7 @@ if (ZLIB_ENABLE_TESTS)
     add_executable(switchlevels test/switchlevels.c)
     configure_test_executable(switchlevels)
 
+    # Makefixed does not need to be linked against zlib sources
     add_executable(makefixed tools/makefixed.c inftrees.c)
     target_include_directories(makefixed PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -750,7 +750,10 @@ set(ZLIB_ALL_SRCS ${ZLIB_SRCS} ${ZLIB_ARCH_SRCS} ${ZLIB_DLL_SRCS}
 if(WITH_GZFILEOP)
     list(APPEND ZLIB_ALL_SRCS ${ZLIB_GZFILE_SRCS})
 endif()
+
 add_library(zlibobj OBJECT ${ZLIB_ALL_SRCS})
+set_property(TARGET zlibobj PROPERTY POSITION_INDEPENDENT_CODE ON)
+
 if(NOT DEFINED BUILD_SHARED_LIBS)
     add_library(zlib SHARED)
     add_library(zlibstatic STATIC)


### PR DESCRIPTION
This PR uses two object libraries to compile the source code. These are then used for linking the dynamic and static libraries. The benefit is that source code compilation only happens once. Previously, the source code libraries were compiled twice - once for the static library and once for the dynamic library. The down side is it makes the cmake file a bit more complicated and adds two new projects to the solution. Looking for feedback on whether we should merge it in.