### PR TITLE
Make travis retry its operations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: c
 cache: ccache
 dist: xenial
+bundler_args: --retry 5
 
 env:
   global:
@@ -369,4 +370,4 @@ script:
   - $TESTER
 
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
+  - bash <(curl -s https://codecov.io/bash --connect-timeout 10 --retry 8 --retry-delay 10) -U "--connect-timeout 10 --retry 8 --retry-delay 10"


### PR DESCRIPTION
attempt to avoid many of the failed builds due to silly things like git failed to look up github.com
or apt failed to install deps due to network timeout, etc.