### PR TITLE
Travis and cmake changes to improve test coverage.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 /minigzip
 /minigzip64
 /minigzipsh
+/switchlevels
 /zlib.pc
 /zlib-ng.pc
 /CVE-2003-0107

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,14 @@
-language: c
-#cache: ccache  # cannot be used because it caches gcno(coverage) files
-dist: xenial
+# Notes:
+# - Fuzzers get automatically enabled when cmake detect CI
+# - ccache cannot be used because it caches gcno(coverage) files,
+#   and it is slow during travis network issues
+# - "language" selects what vm image is chosen
+#   - Linux, "C" selects the full generic image, we only need the minimal image
+#   - Windows builds require "c" image
+
+language: minimal
 bundler_args: --retry 5
+dist: bionic
 
 env:
   global:
@@ -11,36 +18,22 @@ env:
     - CFLAGS="-O2 -g --coverage"
     - LDFLAGS="--coverage"
 
+    - ASAN_OPTIONS="verbosity=1"
+    - TSAN_OPTIONS="verbosity=1"
+    - MSAN_OPTIONS="verbosity=1"
+    - LSAN_OPTIONS="verbosity=1"
+
     # Shorthand variables
+    - MSAN="-DWITH_MSAN=ON"
+    - SANI="-DWITH_SANITIZERS=ON"
     - TC_AARCH64="-DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-aarch64.cmake"
     - TC_ARM="-DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-arm.cmake"
     - T_ARMHF="-DCMAKE_C_COMPILER_TARGET=arm-linux-gnueabihf"
     - T_ARMSF="-DCMAKE_C_COMPILER_TARGET=arm-linux-gnueabi"
+    - CTEST="ctest -C Release --output-on-failure --max-width 120"
 
 matrix:
   include:
-    # Windows tests
-    #   msvc/cmake
-    - os: windows
-      env:
-        - GENERATOR="cmake . "
-        - MAKER="cmake --build . --config Release"
-        - TESTER="ctest --verbose -C Release"
-
-    - os: windows
-      env:
-        - GENERATOR="cmake . -A x64"
-        - MAKER="cmake --build . --config Release"
-        - TESTER="ctest --verbose -C Release"
-
-    - os: windows
-      env:
-        - GENERATOR="cmake ..\\zlib-ng -DZLIB_COMPAT=ON"
-        - MAKER="cmake --build . --config Release"
-        - TESTER="ctest --verbose -C Release"
-        - BUILDDIR=..\\build
-
-
     # Linux x86-64 tests
     #   gcc/configure
     - os: linux
@@ -61,49 +54,20 @@ matrix:
     - os: linux
       compiler: gcc
       env:
-        - GENERATOR="cmake ."
-        - TESTER="ctest --verbose -C Release"
+        - GENERATOR="cmake . $SANI"
+        - TESTER="$CTEST"
 
     - os: linux
       compiler: gcc
       env:
-        - GENERATOR="cmake . -DWITH_NEW_STRATEGIES=NO -DWITH_OPTIM=NO"
-        - TESTER="ctest --verbose -C Release"
+        - GENERATOR="cmake . -DWITH_NEW_STRATEGIES=NO -DWITH_OPTIM=NO $SANI"
+        - TESTER="$CTEST"
 
     - os: linux
       compiler: gcc
       env:
-        - GENERATOR="cmake ../zlib-ng -DZLIB_COMPAT=ON"
-        - TESTER="ctest --verbose -C Release"
-        - BUILDDIR=../build
-
-    #   clang/configure
-    - os: linux
-      compiler: clang
-      env: GENERATOR="./configure --warn --zlib-compat"
-
-    #   clang/cmake
-    - os: linux
-      compiler: clang
-      env:
-        - GENERATOR="cmake ../zlib-ng"
-        - TESTER="ctest --verbose -C Release"
-        - BUILDDIR=../build
-
-    - os: linux
-      compiler: clang
-      env:
-        - GENERATOR="scan-build -v --status-bugs cmake ../zlib-ng"
-        - MAKER="scan-build -v --status-bugs make"
-        - TESTER="ctest --verbose -C Release"
-        - BUILDDIR=../build
-
-    - os: linux
-      compiler: clang
-      env:
-        - GENERATOR="scan-build -v --status-bugs cmake ../zlib-ng -DZLIB_COMPAT=ON"
-        - MAKER="scan-build -v --status-bugs make"
-        - TESTER="ctest --verbose -C Release"
+        - GENERATOR="cmake ../zlib-ng -DZLIB_COMPAT=ON $SANI"
+        - TESTER="$CTEST"
         - BUILDDIR=../build
 
     #   gcc-9/cmake
@@ -112,72 +76,117 @@ matrix:
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
+            - sourceline: 'ppa:ubuntu-toolchain-r/test'
           packages:
             - gcc-9
       env:
         - CC=gcc-9
-        - GENERATOR="cmake ."
-        - TESTER="ctest --verbose -C Release"
-
-
-    # OSX tests
-    #   gcc/configure
-    - os: osx
-      compiler: gcc
-      env: GENERATOR="./configure --warn"
-
-    - os: osx
-      compiler: gcc
-      env:
-        - GENERATOR="../zlib-ng/configure --warn --zlib-compat"
-        - BUILDDIR=../build
-
-    #   gcc/cmake
-    - os: osx
-      compiler: gcc
-      env:
-        - GENERATOR="cmake ."
-        - TESTER="ctest --verbose -C Release"
+        - GENERATOR="cmake . $SANI"
+        - TESTER="$CTEST"
 
     #   clang/configure
-    - os: osx
+    - os: linux
       compiler: clang
       env: GENERATOR="./configure --warn --zlib-compat"
 
     #   clang/cmake
-    - os: osx
+    - os: linux
       compiler: clang
       env:
         - GENERATOR="cmake ../zlib-ng"
-        - TESTER="ctest --verbose -C Release"
+        - TESTER="$CTEST"
+        - BUILDDIR=../build
+
+    - os: linux
+      compiler: clang
+      env:
+        - GENERATOR="scan-build -v --status-bugs cmake ../zlib-ng $MSAN"
+        - MAKER="scan-build -v --status-bugs make"
+        - TESTER="$CTEST"
+        - BUILDDIR=../build
+
+    - os: linux
+      compiler: clang
+      env:
+        - GENERATOR="scan-build -v --status-bugs cmake ../zlib-ng -DZLIB_COMPAT=ON $SANI"
+        - MAKER="scan-build -v --status-bugs make"
+        - TESTER="$CTEST"
         - BUILDDIR=../build
 
 
     # Linux ppc64le
     #   gcc/cmake
     - os: linux-ppc64le
-      compiler: gcc
-      env: GENERATOR="cmake ."
+      dist: xenial
+      compiler: gcc-9
+      addons:
+        apt:
+          sources:
+            - sourceline: 'ppa:ubuntu-toolchain-r/test'
+          packages:
+            - gcc-9
+      env:
+        - CC=gcc-9
+        - GENERATOR="cmake . $SANI"
 
     - os: linux-ppc64le
-      compiler: gcc
+      dist: xenial
+      compiler: gcc-9
+      addons:
+        apt:
+          sources:
+            - sourceline: 'ppa:ubuntu-toolchain-r/test'
+          packages:
+            - gcc-9
       env:
-        - GENERATOR="cmake ../zlib-ng -DZLIB_COMPAT=ON"
-        - TESTER="ctest --verbose -C Release"
+        - CC=gcc-9
+        - GENERATOR="cmake ../zlib-ng -DZLIB_COMPAT=ON -DWITH_NEW_STRATEGIES=NO -DWITH_OPTIM=NO $SANI"
+        - TESTER="$CTEST"
         - BUILDDIR=../build
 
     #   clang/configure
     - os: linux-ppc64le
-      compiler: clang
-      env: GENERATOR="./configure --warn --zlib-compat"
+      dist: xenial
+      compiler: clang-6.0
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-xenial-6.0
+          packages:
+            - clang-6.0
+      env:
+        - CC=clang-6.0
+        - GENERATOR="./configure --warn --zlib-compat"
 
     #   clang/cmake
     - os: linux-ppc64le
-      compiler: clang
+      dist: xenial
+      compiler: clang-6.0
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-xenial-6.0
+          packages:
+            - clang-6.0
       env:
-        - GENERATOR="cmake ../zlib-ng"
-        - TESTER="ctest --verbose -C Release"
+        - CC=clang-6.0
+        - GENERATOR="cmake . $SANI"
+        - TESTER="$CTEST"
+
+    #   clang/cmake
+    - os: linux-ppc64le
+      dist: xenial
+      compiler: clang-6.0
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-xenial-6.0
+          packages:
+            - clang-6.0
+      env:
+        - CC=clang-6.0
+        - GENERATOR="cmake ../zlib-ng -DZLIB_COMPAT=ON -DWITH_NEW_STRATEGIES=NO -DWITH_OPTIM=NO"
+        - TESTER="$CTEST"
         - BUILDDIR=../build
 
 
@@ -220,9 +229,10 @@ matrix:
             - libc-dev-arm64-cross
       # For all aarch64 implementations NEON is mandatory, while crypto/crc are not.
       env:
-        - GENERATOR="cmake . $TC_AARCH64 -DZLIB_COMPAT=ON"
+        - ASAN_OPTIONS=detect_leaks=0  # Crashes under qemu
+        - GENERATOR="cmake . $TC_AARCH64 -DZLIB_COMPAT=ON $SANI"
         - MAKER="cmake --build . --config Release"
-        - TESTER="ctest --verbose -C Release"
+        - TESTER="$CTEST"
 
     - os: linux
       compiler: aarch64-linux-gnu-gcc
@@ -233,9 +243,10 @@ matrix:
             - gcc-aarch64-linux-gnu
             - libc-dev-arm64-cross
       env:
-        - GENERATOR="cmake . $TC_AARCH64"
+        - ASAN_OPTIONS=detect_leaks=0  # Crashes under qemu
+        - GENERATOR="cmake . $TC_AARCH64 -DWITH_NEW_STRATEGIES=NO -DWITH_OPTIM=NO $SANI"
         - MAKER="cmake --build . --config Release"
-        - TESTER="ctest --verbose -C Release"
+        - TESTER="$CTEST"
 
     # Linux ARM Hard-float, cross compiled + qemu
     #   gcc/configure
@@ -285,9 +296,9 @@ matrix:
             - gcc-arm-linux-gnueabihf
             - libc-dev-armhf-cross
       env:
-        - GENERATOR="cmake . $TC_ARM $T_ARMHF"
+        - GENERATOR="cmake . $TC_ARM $T_ARMHF $SANI"
         - MAKER="cmake --build . --config Release"
-        - TESTER="ctest --verbose -C Release"
+        - TESTER="$CTEST"
 
     - os: linux
       compiler: arm-linux-gnueabihf-gcc
@@ -298,9 +309,9 @@ matrix:
             - gcc-arm-linux-gnueabihf
             - libc-dev-armhf-cross
       env:
-        - GENERATOR="cmake . $TC_ARM $T_ARMHF -DZLIB_COMPAT=ON -DWITH_NEON=OFF"
+        - GENERATOR="cmake . $TC_ARM $T_ARMHF -DZLIB_COMPAT=ON -DWITH_NEON=OFF $SANI"
         - MAKER="cmake --build . --config Release"
-        - TESTER="ctest --verbose -C Release"
+        - TESTER="$CTEST"
 
     - os: linux
       compiler: arm-linux-gnueabihf-gcc
@@ -311,9 +322,9 @@ matrix:
             - gcc-arm-linux-gnueabihf
             - libc-dev-armhf-cross
       env:
-        - GENERATOR="cmake . $TC_ARM $T_ARMHF -DZLIB_COMPAT=ON"
+        - GENERATOR="cmake . $TC_ARM $T_ARMHF -DWITH_NEW_STRATEGIES=NO -DWITH_OPTIM=NO $SANI"
         - MAKER="cmake --build . --config Release"
-        - TESTER="ctest --verbose -C Release"
+        - TESTER="$CTEST"
 
     # Linux ARM Soft-float, cross compiled + qemu
     #   gcc/configure
@@ -351,9 +362,9 @@ matrix:
             - gcc-arm-linux-gnueabi
             - libc-dev-armel-cross
       env:
-        - GENERATOR="cmake . $TC_ARM $T_ARMSF"
+        - GENERATOR="cmake . $TC_ARM $T_ARMSF $SANI"
         - MAKER="cmake --build . --config Release"
-        - TESTER="ctest --verbose -C Release"
+        - TESTER="$CTEST"
 
     - os: linux
       compiler: arm-linux-gnueabi-gcc
@@ -364,9 +375,9 @@ matrix:
             - gcc-arm-linux-gnueabi
             - libc-dev-armel-cross
       env:
-        - GENERATOR="cmake . $TC_ARM $T_ARMSF -DZLIB_COMPAT=ON"
+        - GENERATOR="cmake . $TC_ARM $T_ARMSF -DZLIB_COMPAT=ON $SANI"
         - MAKER="cmake --build . --config Release"
-        - TESTER="ctest --verbose -C Release"
+        - TESTER="$CTEST"
 
     - os: linux
       compiler: arm-linux-gnueabi-gcc
@@ -377,9 +388,70 @@ matrix:
             - gcc-arm-linux-gnueabi
             - libc-dev-armel-cross
       env:
-        - GENERATOR="cmake . $TC_ARM $T_ARMSF -DWITH_NEW_STRATEGIES=NO -DWITH_OPTIM=NO"
+        - GENERATOR="cmake . $TC_ARM $T_ARMSF -DWITH_NEW_STRATEGIES=NO -DWITH_OPTIM=NO $SANI"
         - MAKER="cmake --build . --config Release"
-        - TESTER="ctest --verbose -C Release"
+        - TESTER="$CTEST"
+
+
+    # Windows tests
+    #   msvc/cmake
+    - os: windows
+      language: c
+      env:
+        - GENERATOR="cmake . "
+        - MAKER="cmake --build . --config Release"
+        - TESTER="$CTEST"
+
+    - os: windows
+      language: c
+      env:
+        - GENERATOR="cmake . -A x64"
+        - MAKER="cmake --build . --config Release"
+        - TESTER="$CTEST"
+
+    - os: windows
+      language: c
+      env:
+        - GENERATOR="cmake ..\\zlib-ng -DZLIB_COMPAT=ON"
+        - MAKER="cmake --build . --config Release"
+        - TESTER="$CTEST"
+        - BUILDDIR=..\\build
+
+
+    # OSX tests
+    #   gcc/configure
+    - os: osx
+      compiler: gcc
+      env: GENERATOR="./configure --warn"
+
+    - os: osx
+      compiler: gcc
+      env:
+        - GENERATOR="../zlib-ng/configure --warn --zlib-compat"
+        - BUILDDIR=../build
+
+    #   gcc/cmake
+    - os: osx
+      compiler: gcc
+      env:
+        - GENERATOR="cmake . $SANI"
+        - TESTER="$CTEST"
+
+    #   clang/configure
+    - os: osx
+      compiler: clang
+      env: GENERATOR="./configure --warn --zlib-compat"
+
+    #   clang/cmake
+    - os: osx
+      compiler: clang
+      env:
+        - GENERATOR="cmake ../zlib-ng $SANI"
+        - TESTER="$CTEST"
+        - BUILDDIR=../build
+
+
+
 
 script:
   - mkdir -p $BUILDDIR

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,14 @@ else()
     add_feature_info(CMAKE_BUILD_TYPE 1 "Build type: ${CMAKE_BUILD_TYPE} (selected)")
 endif()
 
+if(DEFINED ENV{CI})
+    message(STATUS "CI detected, enabling maintainer mode.")
+    set(MAINTAINER ON)
+endif()
+if(MAINTAINER)
+    set(WITH_FUZZERS ON)
+endif()
+
 check_include_file(sys/types.h HAVE_SYS_TYPES_H)
 check_include_file(stdint.h    HAVE_STDINT_H)
 check_include_file(stddef.h    HAVE_STDDEF_H)
@@ -95,6 +103,7 @@ elseif(BASEARCH_S360_FOUND AND "${ARCH}" MATCHES "s390x")
     option(WITH_DFLTCC_DEFLATE "Use DEFLATE CONVERSION CALL instruction for compression on IBM Z" OFF)
     option(WITH_DFLTCC_INFLATE "Use DEFLATE CONVERSION CALL instruction for decompression on IBM Z" OFF)
 endif()
+option(MAINTAINER "Build with extra warnings and tests enabled" OFF)
 
 add_feature_info(ZLIB_COMPAT ZLIB_COMPAT "Provide a zlib-compatible API")
 add_feature_info(WITH_GZFILEOP WITH_GZFILEOP "Compile with support for gzFile-related functions")
@@ -107,6 +116,7 @@ if(BASEARCH_ARM_FOUND)
     add_feature_info(WITH_ACLE WITH_ACLE "Build with ACLE CRC")
     add_feature_info(WITH_NEON WITH_NEON "Build with NEON intrinsics")
 endif()
+add_feature_info(MAINTAINER MAINTAINER "Build with maintainer warnings and tests enabled")
 
 if (ZLIB_COMPAT)
     add_definitions(-DZLIB_COMPAT)
@@ -128,18 +138,31 @@ if(${CMAKE_C_COMPILER} MATCHES "icc" OR ${CMAKE_C_COMPILER} MATCHES "icpc" OR ${
     if(WITH_NATIVE_INSTRUCTIONS)
         message(STATUS "Ignoring WITH_NATIVE_INSTRUCTIONS; not supported on this configuration")
     endif()
-    if(CMAKE_HOST_UNIX)
-        set(SSE2FLAG "-msse2")
-        set(SSE4FLAG "-msse4.2")
+    if(CMAKE_HOST_UNIX OR APPLE)
+        set(WARNFLAGS "-W3")
+        set(WARNFLAGS_MAINTAINER "-W4 -Wcheck")
+        set(WARNFLAGS_DISABLE "")
+        if(BASEARCH_X86_FOUND)
+            set(SSE2FLAG "-msse2")
+            set(SSE4FLAG "-msse4.2")
+        endif()
     else()
-        set(SSE2FLAG "/arch:SSE2")
-        set(SSE4FLAG "/arch:SSE4.2")
+        set(WARNFLAGS "/W3")
+        set(WARNFLAGS_MAINTAINER "/W4 /Wcheck")
+        set(WARNFLAGS_DISABLE "")
+        if(BASEARCH_X86_FOUND)
+            set(SSE2FLAG "/arch:SSE2")
+            set(SSE4FLAG "/arch:SSE4.2")
+        endif()
     endif()
 elseif(MSVC)
     # TODO. ICC can be used through MSVC. I'm not sure if we'd ever see that combination
     # (who'd use cmake from an IDE...) but checking for ICC before checking for MSVC should
     # avoid mistakes.
     # /Oi ?
+    set(WARNFLAGS "/W3")
+    set(WARNFLAGS_MAINTAINER "/W4")
+    set(WARNFLAGS_DISABLE "")
     if(BASEARCH_X86_FOUND)
         if(NOT ${ARCH} MATCHES "x86_64")
             set(SSE2FLAG "/arch:SSE2")
@@ -156,6 +179,12 @@ else()
     if(CMAKE_C_COMPILER_ID MATCHES "GNU" OR CMAKE_C_COMPILER_ID MATCHES "Clang")
         set(__GNUC__ ON)
     endif()
+    # Enable warnings in GCC and Clang
+    if(__GNUC__)
+        set(WARNFLAGS "-Wall")
+        set(WARNFLAGS_MAINTAINER "-Wextra -Wpedantic")
+        set(WARNFLAGS_DISABLE "-Wno-implicit-fallthrough")
+    endif()
     if(WITH_NATIVE_INSTRUCTIONS)
         if(__GNUC__)
             set(NATIVEFLAG "-march=native")
@@ -163,51 +192,47 @@ else()
             message(STATUS "Ignoring WITH_NATIVE_INSTRUCTIONS; not implemented yet on this configuration")
         endif()
     endif()
-    # Enable warnings
-    if(__GNUC__)
-        set(WARNFLAGS "-Wall -Wno-implicit-fallthrough")
-    endif()
-    # Check support for ARM floating point
-    if(BASEARCH_ARM_FOUND)
-        if (__GNUC__)
-            execute_process(COMMAND ${CMAKE_C_COMPILER} "-dumpmachine"
-                            OUTPUT_VARIABLE GCC_MACHINE)
-            if ("${GCC_MACHINE}" MATCHES "eabihf")
-                set(FLOATABI "-mfloat-abi=hard")
-            else()
-                set(FLOATABI "-mfloat-abi=softfp")
-            endif()
-        endif()
-        # Check whether -mfpu=neon is available
-        set(CMAKE_REQUIRED_FLAGS "-mfpu=neon")
-        check_c_source_compiles(
-            "int main() { return 0; }"
-            MFPU_NEON_AVAILABLE FAIL_REGEX "not supported")
-        set(CMAKE_REQUIRED_FLAGS)
-        if(MFPU_NEON_AVAILABLE)
-            set(NEONFLAG "${FLOATABI} -mfpu=neon")
-        else()
-            set(NEONFLAG "${FLOATABI}")
-        endif()
-    endif()
     if(NOT NATIVEFLAG)
-        if(__GNUC__)
+        if (__GNUC__)
             if(BASEARCH_X86_FOUND)
                 set(SSE2FLAG "-msse2")
                 set(SSE4FLAG "-msse4")
                 set(PCLMULFLAG "-mpclmul")
             elseif(BASEARCH_ARM_FOUND)
-                set(ACLEFLAG "-march=armv8-a+crc")
+                # Check support for ARM floating point
+                execute_process(COMMAND ${CMAKE_C_COMPILER} "-dumpmachine"
+                                OUTPUT_VARIABLE GCC_MACHINE)
+                if ("${GCC_MACHINE}" MATCHES "eabihf")
+                    set(FLOATABI "-mfloat-abi=hard")
+                else()
+                    set(FLOATABI "-mfloat-abi=softfp")
+                endif()
+                # NEON
                 if("${ARCH}" MATCHES "aarch64")
                     set(NEONFLAG "-march=armv8-a+crc+simd")
+                else()
+                    # Check whether -mfpu=neon is available
+                    set(CMAKE_REQUIRED_FLAGS "-mfpu=neon")
+                    check_c_source_compiles(
+                        "int main() { return 0; }"
+                        MFPU_NEON_AVAILABLE FAIL_REGEX "not supported")
+                    set(CMAKE_REQUIRED_FLAGS)
+                    if(MFPU_NEON_AVAILABLE)
+                        set(NEONFLAG "${FLOATABI} -mfpu=neon")
+                    else()
+                        set(NEONFLAG "${FLOATABI}")
+                    endif()
                 endif()
+                # ACLE
+                set(ACLEFLAG "-march=armv8-a+crc")
             endif()
         endif()
     else()
-        set(SSE2FLAG ${NATIVEFLAG})
-        set(SSE4FLAG ${NATIVEFLAG})
-        set(PCLMULFLAG ${NATIVEFLAG})
-        if(BASEARCH_ARM_FOUND)
+        if(BASEARCH_X86_FOUND)
+            set(SSE2FLAG ${NATIVEFLAG})
+            set(SSE4FLAG ${NATIVEFLAG})
+            set(PCLMULFLAG ${NATIVEFLAG})
+        elseif(BASEARCH_ARM_FOUND)
             set(ACLEFLAG "${NATIVEFLAG}")
             if("${ARCH}" MATCHES "aarch64")
                 set(NEONFLAG "${NATIVEFLAG}")
@@ -216,7 +241,12 @@ else()
     endif()
 endif()
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${WARNFLAGS}")
+# Apply warning flags to cflags
+if(MAINTAINER)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${WARNFLAGS} ${WARNFLAGS_MAINTAINER} ${WARNFLAGS_DISABLE}")
+else()
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${WARNFLAGS} ${WARNFLAGS_DISABLE}")
+endif()
 
 #
 # Check to see if we have large file support
@@ -268,14 +298,28 @@ endif()
 
 if(WITH_SANITIZERS)
     set(_sanitize_flags
-        bool
         address
+        alignment
         array-bounds
+        bool
+        bounds
+        builtin
+        enum
         float-divide-by-zero
         function
         integer-divide-by-zero
+        leak
+        null
+        nonnull-attribute
+        object-size
+        pointer-compare             # Depends on 'address'
+        pointer-overflow
+        pointer-subtract            # Depends on 'address'
         return
+        returns-nonnull-attribute
         shift
+        shift-base
+        shift-exponent
         signed-integer-overflow
         undefined
         unsigned-integer-overflow
@@ -284,18 +328,24 @@ if(WITH_SANITIZERS)
        )
     set(SANITIZERS_FLAGS "")
     foreach(_flag ${_sanitize_flags})
-        set(CMAKE_REQUIRED_FLAGS "-fsanitize=${_flag}")
-        check_c_source_compiles("int main() { return 0; }"
-          HAS_SANITIZER_${_flag} FAIL_REGEX "not supported")
-        if(${HAS_SANITIZER_${_flag}})
-            if("${SANITIZERS_FLAGS}" STREQUAL "")
-                set(SANITIZERS_FLAGS "-fsanitize=${_flag}")
-            else()
-                set(SANITIZERS_FLAGS "${SANITIZERS_FLAGS},${_flag}")
+        if(NOT (CMAKE_CROSSCOMPILING_EMULATOR AND ${_flag} STREQUAL "leak")) # LeakSanitizer crashes under qemu
+            set(CMAKE_REQUIRED_FLAGS "-fsanitize=${SANITIZERS_FLAGS},${_flag}")
+            check_c_source_compiles("int main() { return 0; }"
+              HAS_SANITIZER_${_flag} FAIL_REGEX "not supported")
+            if(${HAS_SANITIZER_${_flag}})
+                if("${SANITIZERS_FLAGS}" STREQUAL "")
+                    set(SANITIZERS_FLAGS "${_flag}")
+                else()
+                    set(SANITIZERS_FLAGS "${SANITIZERS_FLAGS},${_flag}")
+                endif()
             endif()
+            set(CMAKE_REQUIRED_FLAGS)
         endif()
-        set(CMAKE_REQUIRED_FLAGS)
     endforeach()
+    if(NOT "${SANITIZERS_FLAGS}" STREQUAL "")
+        set(SANITIZERS_FLAGS "-fsanitize=${SANITIZERS_FLAGS}")
+    endif()
+
     message(STATUS "Adding sanitizers flags: ${SANITIZERS_FLAGS}")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${SANITIZERS_FLAGS}")
 endif()
@@ -844,6 +894,7 @@ if (ZLIB_ENABLE_TESTS)
         file(GLOB ALL_SRC_FILES "${CMAKE_CURRENT_SOURCE_DIR}/*")
         foreach(FUZZER ${FUZZERS})
             add_executable(${FUZZER}_fuzzer test/fuzz/${FUZZER}_fuzzer.c test/fuzz/standalone_fuzz_target_runner.c)
+            configure_test_executable(${FUZZER}_fuzzer)
             set(FUZZER_COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:${FUZZER}_fuzzer> ${ALL_SRC_FILES})
             add_test(NAME ${FUZZER}_fuzzer COMMAND ${FUZZER_COMMAND})
         endforeach()

--- a/cmake/archdetect.c
+++ b/cmake/archdetect.c
@@ -17,7 +17,7 @@
 #elif defined(__arm__) || defined(__arm) || defined(_M_ARM) || defined(__TARGET_ARCH_ARM)
     #if defined(__ARM64_ARCH_8__) || defined(__ARMv8__) || defined(__ARMv8_A__)
         #error archfound armv8
-    #elif defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_7A__) || defined(__ARM_ARCH_7R__) || defined(__ARM_ARCH_7M__))
+    #elif defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_7A__) || defined(__ARM_ARCH_7R__) || defined(__ARM_ARCH_7M__)
         #error archfound armv7
     #elif defined(__ARM_ARCH_6__) || defined(__ARM_ARCH_6J__) || defined(__ARM_ARCH_6T2__) || defined(__ARM_ARCH_6Z__) || defined(__ARM_ARCH_6K__) || defined(__ARM_ARCH_6ZK__) || defined(__ARM_ARCH_6M__)
         #error archfound armv6

--- a/configure
+++ b/configure
@@ -338,7 +338,7 @@ if test "$gcc" -eq 1 && ($cc $CFLAGS -c $test.c) >> configure.log 2>&1; then
     SFLAGS="${SFLAGS} -march=native"
   fi
   if test "$warn" -eq 1; then
-    CFLAGS="${CFLAGS} -Wextra -Wpedantic"
+    CFLAGS="${CFLAGS} -Wextra -Wpedantic -Wno-implicit-fallthrough"
   fi
   if test $debug -eq 1; then
     CFLAGS="${CFLAGS} -DZLIB_DEBUG"


### PR DESCRIPTION
travis.yml changes:
 - Select minimal vm image instead of generic ('c'), reducing size and boot time.
   - Windows needs (lowercase) 'c' image to not hang on booting
 - Update from Xenial to Bionic for linux tests.
   - ppc64 images don't have Bionic, set to Xenial
   - ppc64 is having misc failures with Xenial tools, so use GCC-9 and Clang-6
   - ppc64 cannot run MSAN
 - Add another test for more complete testing across architectures.
 - Enable msan and/or sanitizers for various tests.
 - Disable ASAN leak detection on aarch64, since it crashes under qemu
 - Reorder tests to be better grouped and running windows/macox tests lasts.
 - Enable verbose messages from sanitizers

CmakeLists.txt changes:
 - Enable warnings by default.
 - Add MAINTAINER setting to cmake
   - Enables extra warnings.
   - Enables fuzzers.
 - Add CI detection to cmake, currently auto-enables MAINTAINER mode.
 - Add detection of several more sanitizer features.
 - Test sanitizer features together, not just alone.
   This also helps with their inter-dependencies.

.gitignore changes:
 - Add switchlevels.
