### PR TITLE
Fix leak in example.c test_deflate_copy()

### DIFF
--- a/test/example.c
+++ b/test/example.c
@@ -633,7 +633,10 @@ void test_deflate_copy(unsigned char *compr, size_t comprLen)
     }
 
     err = PREFIX(deflateEnd)(&c_stream);
-    CHECK_ERR(err, "deflateEnd");
+    CHECK_ERR(err, "deflateEnd original");
+
+    err = PREFIX(deflateEnd)(&c_stream_copy);
+    CHECK_ERR(err, "deflateEnd copy");
 }
 
 /* ===========================================================================


### PR DESCRIPTION
In test_deflate_copy(), we free the original struct but forget to free the copy stuct.
Found by msan.