### PR TITLE
Fixed assert during inflate fast when len < sizeof(uint64_t).

### DIFF
--- a/inffast.c
+++ b/inffast.c
@@ -310,7 +310,7 @@ void ZLIB_INTERNAL zng_inflate_fast(PREFIX3(stream) *strm, unsigned long start) 
                     if (dist >= len || dist >= INFFAST_CHUNKSIZE)
                         out = chunkcopy(out, out - dist, len);
                     else
-                        out = chunkmemsetsafe(out, dist, len, len);
+                        out = chunkmemset(out, dist, len);
 #else
                     if (len < sizeof(uint64_t))
                       out = set_bytes(out, out - dist, dist, len);

--- a/inffast.c
+++ b/inffast.c
@@ -310,7 +310,7 @@ void ZLIB_INTERNAL zng_inflate_fast(PREFIX3(stream) *strm, unsigned long start) 
                     if (dist >= len || dist >= INFFAST_CHUNKSIZE)
                         out = chunkcopy(out, out - dist, len);
                     else
-                        out = chunkmemset(out, dist, len);
+                        out = chunkmemsetsafe(out, dist, len, len);
 #else
                     if (len < sizeof(uint64_t))
                       out = set_bytes(out, out - dist, dist, len);

--- a/memcopy.h
+++ b/memcopy.h
@@ -298,7 +298,7 @@ static inline unsigned char *chunkmemset(unsigned char *out, unsigned dist, unsi
 }
 
 static inline unsigned char* chunkmemsetsafe(unsigned char *out, unsigned dist, unsigned len, unsigned left) {
-    if (left < (unsigned)(3 * INFFAST_CHUNKSIZE)) {
+    if (len < sizeof(uint64_t) || left < (unsigned)(3 * INFFAST_CHUNKSIZE)) {
         while (len > 0) {
           *out = *(out - dist);
           out++;

--- a/memcopy.h
+++ b/memcopy.h
@@ -234,7 +234,8 @@ static inline unsigned char *chunkmemset_6(unsigned char *out, unsigned char *fr
 
 /* Copy DIST bytes from OUT - DIST into OUT + DIST * k, for 0 <= k < LEN/DIST. Return OUT + LEN. */
 static inline unsigned char *chunkmemset(unsigned char *out, unsigned dist, unsigned len) {
-    Assert(len >= sizeof(uint64_t), "chunkmemset should be called on larger chunks");
+    /* Debug performance related issues when len < sizeof(uint64_t): 
+       Assert(len >= sizeof(uint64_t), "chunkmemset should be called on larger chunks"); */
     Assert(dist > 0, "cannot have a distance 0");
 
     unsigned char *from = out - dist;
@@ -298,7 +299,7 @@ static inline unsigned char *chunkmemset(unsigned char *out, unsigned dist, unsi
 }
 
 static inline unsigned char* chunkmemsetsafe(unsigned char *out, unsigned dist, unsigned len, unsigned left) {
-    if (len < sizeof(uint64_t) || left < (unsigned)(3 * INFFAST_CHUNKSIZE)) {
+    if (left < (unsigned)(3 * INFFAST_CHUNKSIZE)) {
         while (len > 0) {
           *out = *(out - dist);
           out++;


### PR DESCRIPTION
This PR is for an issue that I am having on Windows where an `assert` will be hit inside of `chunkmemset` in memcopy.h:

```
static inline unsigned char *chunkmemset(unsigned char *out, unsigned dist, unsigned len) {
    Assert(len >= sizeof(uint64_t), "chunkmemset should be called on larger chunks");
```

It happens due to the fact that it is passed a len that is less than sizeof(uint64_t). 

Here in the following code, the comment says it is okay because we expect to have enough room to make the copy:
```
/* Whole reference is in range of current output.  No
    range checks are necessary because we start with room
    for at least 258 bytes of output, so unroll and roundoff
    operations can write beyond `out+len` so long as they
    stay within 258 bytes of `out`.
*/

if (dist >= len || dist >= INFFAST_CHUNKSIZE)
    out = chunkcopy(out, out - dist, len);
else
    out = chunkmemset(out, dist, len);
```

However, the assert will still be hit even though we have enough space, we are still passing in a len that is less than sizeof(uint64_t).

What I have done is change the `chunkmemset` call to `chunkmemsetsafe`. 

```
if (dist >= len || dist >= INFFAST_CHUNKSIZE)
    out = chunkcopy(out, out - dist, len);
else
    out = chunkmemsetsafe(out, dist, len, len);
```

And in `chunkmemsetsafe` I changed the first if statement from this:

```
 if (left < (unsigned)(3 * INFFAST_CHUNKSIZE)) {
```

To this, where it checks to see if the len is less than sizeof(uint64_t) and if so does a slow copy to avoid the assert:

```
if (len < sizeof(uint64_t) || left < (unsigned)(3 * INFFAST_CHUNKSIZE)) {
```