### PR TITLE
Fix issues with travis builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
-cache: ccache
+#cache: ccache  # cannot be used because it caches gcno(coverage) files
 dist: xenial
 bundler_args: --retry 5
 
@@ -10,6 +10,12 @@ env:
     - TESTER="make test"
     - CFLAGS="-O2 -g --coverage"
     - LDFLAGS="--coverage"
+
+    # Shorthand variables
+    - TC_AARCH64="-DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-aarch64.cmake"
+    - TC_ARM="-DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-arm.cmake"
+    - T_ARMHF="-DCMAKE_C_COMPILER_TARGET=arm-linux-gnueabihf"
+    - T_ARMSF="-DCMAKE_C_COMPILER_TARGET=arm-linux-gnueabi"
 
 matrix:
   include:
@@ -214,7 +220,7 @@ matrix:
             - libc-dev-arm64-cross
       # For all aarch64 implementations NEON is mandatory, while crypto/crc are not.
       env:
-        - GENERATOR="cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-aarch64.cmake . -DZLIB_COMPAT=ON"
+        - GENERATOR="cmake . $TC_AARCH64 -DZLIB_COMPAT=ON"
         - MAKER="cmake --build . --config Release"
         - TESTER="ctest --verbose -C Release"
 
@@ -227,7 +233,7 @@ matrix:
             - gcc-aarch64-linux-gnu
             - libc-dev-arm64-cross
       env:
-        - GENERATOR="cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-aarch64.cmake ."
+        - GENERATOR="cmake . $TC_AARCH64"
         - MAKER="cmake --build . --config Release"
         - TESTER="ctest --verbose -C Release"
 
@@ -279,7 +285,7 @@ matrix:
             - gcc-arm-linux-gnueabihf
             - libc-dev-armhf-cross
       env:
-        - GENERATOR="cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-arm.cmake . -DCMAKE_C_COMPILER_TARGET=arm-linux-gnueabihf"
+        - GENERATOR="cmake . $TC_ARM $T_ARMHF"
         - MAKER="cmake --build . --config Release"
         - TESTER="ctest --verbose -C Release"
 
@@ -292,7 +298,7 @@ matrix:
             - gcc-arm-linux-gnueabihf
             - libc-dev-armhf-cross
       env:
-        - GENERATOR="cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-arm.cmake . -DZLIB_COMPAT=ON -DWITH_NEON=OFF -DCMAKE_C_COMPILER_TARGET=arm-linux-gnueabihf"
+        - GENERATOR="cmake . $TC_ARM $T_ARMHF -DZLIB_COMPAT=ON -DWITH_NEON=OFF"
         - MAKER="cmake --build . --config Release"
         - TESTER="ctest --verbose -C Release"
 
@@ -305,7 +311,7 @@ matrix:
             - gcc-arm-linux-gnueabihf
             - libc-dev-armhf-cross
       env:
-        - GENERATOR="cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-arm.cmake . -DZLIB_COMPAT=ON -DCMAKE_C_COMPILER_TARGET=arm-linux-gnueabihf"
+        - GENERATOR="cmake . $TC_ARM $T_ARMHF -DZLIB_COMPAT=ON"
         - MAKER="cmake --build . --config Release"
         - TESTER="ctest --verbose -C Release"
 
@@ -320,7 +326,7 @@ matrix:
             - gcc-arm-linux-gnueabi
             - libc-dev-armel-cross
       env:
-        - GENERATOR="./configure"
+        - GENERATOR="./configure --warn"
         - CHOST=arm-linux-gnueabi
 
     - os: linux
@@ -332,7 +338,7 @@ matrix:
             - gcc-arm-linux-gnueabi
             - libc-dev-armel-cross
       env:
-        - GENERATOR="./configure --zlib-compat"
+        - GENERATOR="./configure --warn --zlib-compat"
         - CHOST=arm-linux-gnueabi
 
     #   gcc/cmake
@@ -345,7 +351,7 @@ matrix:
             - gcc-arm-linux-gnueabi
             - libc-dev-armel-cross
       env:
-        - GENERATOR="cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-arm.cmake . -DCMAKE_C_COMPILER_TARGET=arm-linux-gnueabi"
+        - GENERATOR="cmake . $TC_ARM $T_ARMSF"
         - MAKER="cmake --build . --config Release"
         - TESTER="ctest --verbose -C Release"
 
@@ -358,7 +364,20 @@ matrix:
             - gcc-arm-linux-gnueabi
             - libc-dev-armel-cross
       env:
-        - GENERATOR="cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-arm.cmake . -DZLIB_COMPAT=ON -DCMAKE_C_COMPILER_TARGET=arm-linux-gnueabi"
+        - GENERATOR="cmake . $TC_ARM $T_ARMSF -DZLIB_COMPAT=ON"
+        - MAKER="cmake --build . --config Release"
+        - TESTER="ctest --verbose -C Release"
+
+    - os: linux
+      compiler: arm-linux-gnueabi-gcc
+      addons:
+        apt:
+          packages:
+            - qemu
+            - gcc-arm-linux-gnueabi
+            - libc-dev-armel-cross
+      env:
+        - GENERATOR="cmake . $TC_ARM $T_ARMSF -DWITH_NEW_STRATEGIES=NO -DWITH_OPTIM=NO"
         - MAKER="cmake --build . --config Release"
         - TESTER="ctest --verbose -C Release"
 
@@ -371,3 +390,8 @@ script:
 
 after_success:
   - bash <(curl -s https://codecov.io/bash --connect-timeout 10 --retry 8 --retry-delay 10) -U "--connect-timeout 10 --retry 8 --retry-delay 10"
+
+after_failure:
+  - cd $BUILDDIR
+  - cat CMakeFiles/CMakeError.log || true
+  - cat configure.log || true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,6 +183,10 @@ else()
             message(STATUS "Ignoring WITH_NATIVE_INSTRUCTIONS; not implemented yet on this configuration")
         endif()
     endif()
+    # Enable warnings
+    if(__GNUC__)
+        set(WARNFLAGS "-Wall -Wno-implicit-fallthrough")
+    endif()
     # Check support for ARM floating point
     if("${ARCH}" MATCHES "arm")
         if (__GNUC__)
@@ -240,6 +244,8 @@ else()
         endif()
     endif()
 endif()
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${WARNFLAGS}")
 
 #
 # Check to see if we have large file support


### PR DESCRIPTION
This merges a subset of PR #408 

.travis.yml changes:
 - Add shorthand-variables for some of the long parameters often used.
 - Enable --warn in a couple configure tests that did not have it enabled.
 - Make travis print out CMakeError.log or configure.log in after_failure.
 - Reorder some cmake parameters to improve consistency.
 - Add another ARM soft-float test.
 - Disable ccache. Downloading and uploading the cache archive is quite slow,
   especially if travis is having network-connectivity issues.
   Also ccache caches gcno (coverage) files, making the coverage data wrong
   because it is being shared across builds, branches and PRs.

CmakeLists.txt changes:
 - Enable -Wall by default in cmake.