### PR TITLE
Fixed conversion warnings in zng_tr_tally_dist on Windows

### DIFF
--- a/deflate.h
+++ b/deflate.h
@@ -365,7 +365,7 @@ void ZLIB_INTERNAL flush_pending(PREFIX3(streamp) strm);
   }
 # define zng_tr_tally_dist(s, distance, length, flush) \
   { unsigned char len = (unsigned char)(length); \
-    uint16_t dist = (uint16_t)(distance); \
+    unsigned dist = (unsigned)(distance); \
     s->sym_buf[s->sym_next++] = dist; \
     s->sym_buf[s->sym_next++] = dist >> 8; \
     s->sym_buf[s->sym_next++] = len; \


### PR DESCRIPTION
See #440. This uses the same type as `zng_tr_tally` in trees.c And also the same type `zng_tr_tally_dist` when `ZLIB_DEBUG` is defined in deflate.h.