### PR TITLE
zlib-ng.h syntax cleanup

### DIFF
--- a/zlib-ng.h
+++ b/zlib-ng.h
@@ -1,7 +1,6 @@
 #ifndef ZNGLIB_H_
 #define ZNGLIB_H_
-/* zlib-ng.h -- interface of the 'zlib-ng' compression library
-   Forked from and compatible with zlib 1.2.11
+/* zlib-ng.h -- interface of the 'zlib-ng' compression library, forked from zlib.
 
   Copyright (C) 1995-2016 Jean-loup Gailly and Mark Adler
 
@@ -204,7 +203,8 @@ typedef zng_gz_header *zng_gz_headerp;
 
                         /* basic functions */
 
-ZEXTERN const char * ZEXPORT zlibng_version(void);
+ZEXTERN ZEXPORT
+const char *zlibng_version(void);
 /* The application can compare zlibng_version and ZLIBNG_VERSION for consistency.
    If the first character differs, the library code actually used is not
    compatible with the zlib-ng.h header file used by the application.  This check
@@ -212,7 +212,8 @@ ZEXTERN const char * ZEXPORT zlibng_version(void);
  */
 
 /*
-ZEXTERN int ZEXPORT zng_deflateInit (zng_stream *strm, int level);
+ZEXTERN ZEXPORT
+int zng_deflateInit(zng_stream *strm, int level);
 
      Initializes the internal stream state for compression.  The fields
    zalloc, zfree and opaque must be initialized before by the caller.  If
@@ -234,7 +235,8 @@ ZEXTERN int ZEXPORT zng_deflateInit (zng_stream *strm, int level);
 */
 
 
-ZEXTERN int ZEXPORT zng_deflate(zng_stream *strm, int flush);
+ZEXTERN ZEXPORT
+int zng_deflate(zng_stream *strm, int flush);
 /*
     deflate compresses as much data as possible, and stops when the input
   buffer becomes empty or the output buffer becomes full.  It may introduce
@@ -347,7 +349,8 @@ ZEXTERN int ZEXPORT zng_deflate(zng_stream *strm, int flush);
 */
 
 
-ZEXTERN int ZEXPORT zng_deflateEnd(zng_stream *strm);
+ZEXTERN ZEXPORT
+int zng_deflateEnd(zng_stream *strm);
 /*
      All dynamically allocated data structures for this stream are freed.
    This function discards any unprocessed input and does not flush any pending
@@ -362,7 +365,8 @@ ZEXTERN int ZEXPORT zng_deflateEnd(zng_stream *strm);
 
 
 /*
-ZEXTERN int ZEXPORT zng_inflateInit (zng_stream *strm);
+ZEXTERN ZEXPORT
+int zng_inflateInit(zng_stream *strm);
 
      Initializes the internal stream state for decompression.  The fields
    next_in, avail_in, zalloc, zfree and opaque must be initialized before by
@@ -384,7 +388,8 @@ ZEXTERN int ZEXPORT zng_inflateInit (zng_stream *strm);
 */
 
 
-ZEXTERN int ZEXPORT zng_inflate(zng_stream *strm, int flush);
+ZEXTERN ZEXPORT
+int zng_inflate(zng_stream *strm, int flush);
 /*
     inflate decompresses as much data as possible, and stops when the input
   buffer becomes empty or the output buffer becomes full.  It may introduce
@@ -504,7 +509,8 @@ ZEXTERN int ZEXPORT zng_inflate(zng_stream *strm, int flush);
 */
 
 
-ZEXTERN int ZEXPORT zng_inflateEnd(zng_stream *strm);
+ZEXTERN ZEXPORT
+int zng_inflateEnd(zng_stream *strm);
 /*
      All dynamically allocated data structures for this stream are freed.
    This function discards any unprocessed input and does not flush any pending
@@ -522,12 +528,8 @@ ZEXTERN int ZEXPORT zng_inflateEnd(zng_stream *strm);
 */
 
 /*
-ZEXTERN int ZEXPORT zng_deflateInit2 (zng_stream *strm,
-                                     int  level,
-                                     int  method,
-                                     int  windowBits,
-                                     int  memLevel,
-                                     int  strategy);
+ZEXTERN ZEXPORT
+int zng_deflateInit2(zng_stream *strm, int  level, int  method, int  windowBits, int  memLevel, int  strategy);
 
      This is another version of deflateInit with more compression options.  The
    fields zalloc, zfree and opaque must be initialized before by the caller.
@@ -594,9 +596,8 @@ ZEXTERN int ZEXPORT zng_deflateInit2 (zng_stream *strm,
    compression: this will be done by deflate().
 */
 
-ZEXTERN int ZEXPORT zng_deflateSetDictionary(zng_stream *strm,
-                                             const unsigned char *dictionary,
-                                             unsigned int dictLength);
+ZEXTERN ZEXPORT
+int zng_deflateSetDictionary(zng_stream *strm, const unsigned char *dictionary, unsigned int dictLength);
 /*
      Initializes the compression dictionary from the given byte sequence
    without producing any compressed output.  When using the zlib format, this
@@ -638,7 +639,8 @@ ZEXTERN int ZEXPORT zng_deflateSetDictionary(zng_stream *strm,
    not perform any compression: this will be done by deflate().
 */
 
-ZEXTERN int ZEXPORT zng_deflateGetDictionary (zng_stream *strm, unsigned char *dictionary, unsigned int  *dictLength);
+ZEXTERN ZEXPORT
+int zng_deflateGetDictionary(zng_stream *strm, unsigned char *dictionary, unsigned int *dictLength);
 /*
      Returns the sliding dictionary being maintained by deflate.  dictLength is
    set to the number of bytes in the dictionary, and that many bytes are copied
@@ -658,7 +660,8 @@ ZEXTERN int ZEXPORT zng_deflateGetDictionary (zng_stream *strm, unsigned char *d
    stream state is inconsistent.
 */
 
-ZEXTERN int ZEXPORT zng_deflateCopy(zng_stream *dest, zng_stream *source);
+ZEXTERN ZEXPORT
+int zng_deflateCopy(zng_stream *dest, zng_stream *source);
 /*
      Sets the destination stream as a complete copy of the source stream.
 
@@ -675,7 +678,8 @@ ZEXTERN int ZEXPORT zng_deflateCopy(zng_stream *dest, zng_stream *source);
    destination.
 */
 
-ZEXTERN int ZEXPORT zng_deflateReset(zng_stream *strm);
+ZEXTERN ZEXPORT
+int zng_deflateReset(zng_stream *strm);
 /*
      This function is equivalent to deflateEnd followed by deflateInit, but
    does not free and reallocate the internal compression state.  The stream
@@ -686,7 +690,8 @@ ZEXTERN int ZEXPORT zng_deflateReset(zng_stream *strm);
    stream state was inconsistent (such as zalloc or state being NULL).
 */
 
-ZEXTERN int ZEXPORT zng_deflateParams(zng_stream *strm, int level, int strategy);
+ZEXTERN ZEXPORT
+int zng_deflateParams(zng_stream *strm, int level, int strategy);
 /*
      Dynamically update the compression level and compression strategy.  The
    interpretation of level and strategy is as in deflateInit2().  This can be
@@ -722,7 +727,8 @@ ZEXTERN int ZEXPORT zng_deflateParams(zng_stream *strm, int level, int strategy)
    retried with more output space.
 */
 
-ZEXTERN int ZEXPORT zng_deflateTune(zng_stream *strm, int good_length, int max_lazy, int nice_length, int max_chain);
+ZEXTERN ZEXPORT
+int zng_deflateTune(zng_stream *strm, int good_length, int max_lazy, int nice_length, int max_chain);
 /*
      Fine tune deflate's internal compression parameters.  This should only be
    used by someone who understands the algorithm used by zlib's deflate for
@@ -735,7 +741,8 @@ ZEXTERN int ZEXPORT zng_deflateTune(zng_stream *strm, int good_length, int max_l
    returns Z_OK on success, or Z_STREAM_ERROR for an invalid deflate stream.
  */
 
-ZEXTERN unsigned long ZEXPORT zng_deflateBound(zng_stream *strm, unsigned long sourceLen);
+ZEXTERN ZEXPORT
+unsigned long zng_deflateBound(zng_stream *strm, unsigned long sourceLen);
 /*
      deflateBound() returns an upper bound on the compressed size after
    deflation of sourceLen bytes.  It must be called after deflateInit() or
@@ -749,7 +756,8 @@ ZEXTERN unsigned long ZEXPORT zng_deflateBound(zng_stream *strm, unsigned long s
    than Z_FINISH or Z_NO_FLUSH are used.
 */
 
-ZEXTERN int ZEXPORT zng_deflatePending(zng_stream *strm, uint32_t *pending, int *bits);
+ZEXTERN ZEXPORT
+int zng_deflatePending(zng_stream *strm, uint32_t *pending, int *bits);
 /*
      deflatePending() returns the number of bytes and bits of output that have
    been generated, but not yet provided in the available output.  The bytes not
@@ -762,7 +770,8 @@ ZEXTERN int ZEXPORT zng_deflatePending(zng_stream *strm, uint32_t *pending, int 
    stream state was inconsistent.
  */
 
-ZEXTERN int ZEXPORT zng_deflatePrime(zng_stream *strm, int bits, int value);
+ZEXTERN ZEXPORT
+int zng_deflatePrime(zng_stream *strm, int bits, int value);
 /*
      deflatePrime() inserts bits in the deflate output stream.  The intent
    is that this function is used to start off the deflate output with the bits
@@ -777,7 +786,8 @@ ZEXTERN int ZEXPORT zng_deflatePrime(zng_stream *strm, int bits, int value);
    source stream state was inconsistent.
 */
 
-ZEXTERN int ZEXPORT zng_deflateSetHeader(zng_stream *strm, zng_gz_headerp head);
+ZEXTERN ZEXPORT
+int zng_deflateSetHeader(zng_stream *strm, zng_gz_headerp head);
 /*
      deflateSetHeader() provides gzip header information for when a gzip
    stream is requested by deflateInit2().  deflateSetHeader() may be called
@@ -801,7 +811,8 @@ ZEXTERN int ZEXPORT zng_deflateSetHeader(zng_stream *strm, zng_gz_headerp head);
 */
 
 /*
-ZEXTERN int ZEXPORT zng_inflateInit2(zng_stream *strm, int  windowBits);
+ZEXTERN ZEXPORT
+int zng_inflateInit2(zng_stream *strm, int  windowBits);
 
      This is another version of inflateInit with an extra parameter.  The
    fields next_in, avail_in, zalloc, zfree and opaque must be initialized
@@ -854,7 +865,8 @@ ZEXTERN int ZEXPORT zng_inflateInit2(zng_stream *strm, int  windowBits);
    deferred until inflate() is called.
 */
 
-ZEXTERN int ZEXPORT zng_inflateSetDictionary(zng_stream *strm, const unsigned char *dictionary, unsigned int dictLength);
+ZEXTERN ZEXPORT
+int zng_inflateSetDictionary(zng_stream *strm, const unsigned char *dictionary, unsigned int dictLength);
 /*
      Initializes the decompression dictionary from the given uncompressed byte
    sequence.  This function must be called immediately after a call of inflate,
@@ -875,7 +887,8 @@ ZEXTERN int ZEXPORT zng_inflateSetDictionary(zng_stream *strm, const unsigned ch
    inflate().
 */
 
-ZEXTERN int ZEXPORT zng_inflateGetDictionary(zng_stream *strm, unsigned char *dictionary, unsigned int *dictLength);
+ZEXTERN ZEXPORT
+int zng_inflateGetDictionary(zng_stream *strm, unsigned char *dictionary, unsigned int *dictLength);
 /*
      Returns the sliding dictionary being maintained by inflate.  dictLength is
    set to the number of bytes in the dictionary, and that many bytes are copied
@@ -888,7 +901,8 @@ ZEXTERN int ZEXPORT zng_inflateGetDictionary(zng_stream *strm, unsigned char *di
    stream state is inconsistent.
 */
 
-ZEXTERN int ZEXPORT zng_inflateSync(zng_stream *strm);
+ZEXTERN ZEXPORT
+int zng_inflateSync(zng_stream *strm);
 /*
      Skips invalid compressed data until a possible full flush point (see above
    for the description of deflate with Z_FULL_FLUSH) can be found, or until all
@@ -907,7 +921,8 @@ ZEXTERN int ZEXPORT zng_inflateSync(zng_stream *strm);
    input each time, until success or end of the input data.
 */
 
-ZEXTERN int ZEXPORT zng_inflateCopy(zng_stream *dest, zng_stream *source);
+ZEXTERN ZEXPORT
+int zng_inflateCopy(zng_stream *dest, zng_stream *source);
 /*
      Sets the destination stream as a complete copy of the source stream.
 
@@ -922,7 +937,8 @@ ZEXTERN int ZEXPORT zng_inflateCopy(zng_stream *dest, zng_stream *source);
    destination.
 */
 
-ZEXTERN int ZEXPORT zng_inflateReset(zng_stream *strm);
+ZEXTERN ZEXPORT
+int zng_inflateReset(zng_stream *strm);
 /*
      This function is equivalent to inflateEnd followed by inflateInit,
    but does not free and reallocate the internal decompression state.  The
@@ -932,7 +948,8 @@ ZEXTERN int ZEXPORT zng_inflateReset(zng_stream *strm);
    stream state was inconsistent (such as zalloc or state being NULL).
 */
 
-ZEXTERN int ZEXPORT zng_inflateReset2(zng_stream *strm, int windowBits);
+ZEXTERN ZEXPORT
+int zng_inflateReset2(zng_stream *strm, int windowBits);
 /*
      This function is the same as inflateReset, but it also permits changing
    the wrap and window size requests.  The windowBits parameter is interpreted
@@ -945,7 +962,8 @@ ZEXTERN int ZEXPORT zng_inflateReset2(zng_stream *strm, int windowBits);
    the windowBits parameter is invalid.
 */
 
-ZEXTERN int ZEXPORT zng_inflatePrime(zng_stream *strm, int bits, int value);
+ZEXTERN ZEXPORT
+int zng_inflatePrime(zng_stream *strm, int bits, int value);
 /*
      This function inserts bits in the inflate input stream.  The intent is
    that this function is used to start inflating at a bit position in the
@@ -964,7 +982,8 @@ ZEXTERN int ZEXPORT zng_inflatePrime(zng_stream *strm, int bits, int value);
    stream state was inconsistent.
 */
 
-ZEXTERN long ZEXPORT zng_inflateMark(zng_stream *strm);
+ZEXTERN ZEXPORT
+long zng_inflateMark(zng_stream *strm);
 /*
      This function returns two values, one in the lower 16 bits of the return
    value, and the other in the remaining upper bits, obtained by shifting the
@@ -992,7 +1011,8 @@ ZEXTERN long ZEXPORT zng_inflateMark(zng_stream *strm);
    source stream state was inconsistent.
 */
 
-ZEXTERN int ZEXPORT zng_inflateGetHeader(zng_stream *strm, zng_gz_headerp head);
+ZEXTERN ZEXPORT
+int zng_inflateGetHeader(zng_stream *strm, zng_gz_headerp head);
 /*
      inflateGetHeader() requests that gzip header information be stored in the
    provided zng_gz_header structure.  inflateGetHeader() may be called after
@@ -1032,7 +1052,8 @@ ZEXTERN int ZEXPORT zng_inflateGetHeader(zng_stream *strm, zng_gz_headerp head);
 */
 
 /*
-ZEXTERN int ZEXPORT zng_inflateBackInit (zng_stream *strm, int windowBits, unsigned char *window);
+ZEXTERN ZEXPORT
+int zng_inflateBackInit(zng_stream *strm, int windowBits, unsigned char *window);
 
      Initialize the internal stream state for decompression using inflateBack()
    calls.  The fields zalloc, zfree and opaque in strm must be initialized
@@ -1055,7 +1076,8 @@ ZEXTERN int ZEXPORT zng_inflateBackInit (zng_stream *strm, int windowBits, unsig
 typedef uint32_t (*in_func) (void *, const unsigned char * *);
 typedef int (*out_func) (void *, unsigned char *, uint32_t);
 
-ZEXTERN int ZEXPORT zng_inflateBack(zng_stream *strm, in_func in, void *in_desc, out_func out, void *out_desc);
+ZEXTERN ZEXPORT
+int zng_inflateBack(zng_stream *strm, in_func in, void *in_desc, out_func out, void *out_desc);
 /*
      inflateBack() does a raw inflate with a single call using a call-back
    interface for input and output.  This is potentially more efficient than
@@ -1123,7 +1145,8 @@ ZEXTERN int ZEXPORT zng_inflateBack(zng_stream *strm, in_func in, void *in_desc,
    cannot return Z_OK.
 */
 
-ZEXTERN int ZEXPORT zng_inflateBackEnd(zng_stream *strm);
+ZEXTERN ZEXPORT
+int zng_inflateBackEnd(zng_stream *strm);
 /*
      All memory allocated by inflateBackInit() is freed.
 
@@ -1131,7 +1154,8 @@ ZEXTERN int ZEXPORT zng_inflateBackEnd(zng_stream *strm);
    state was inconsistent.
 */
 
-ZEXTERN unsigned long ZEXPORT zng_zlibCompileFlags(void);
+ZEXTERN ZEXPORT
+unsigned long zng_zlibCompileFlags(void);
 /* Return flags indicating compile-time options.
 
     Type sizes, two bits each, 00 = 16 bits, 01 = 32, 10 = 64, 11 = other:
@@ -1183,7 +1207,8 @@ ZEXTERN unsigned long ZEXPORT zng_zlibCompileFlags(void);
    you need special options.
 */
 
-ZEXTERN int ZEXPORT zng_compress(unsigned char *dest, size_t *destLen, const unsigned char *source, size_t sourceLen);
+ZEXTERN ZEXPORT
+int zng_compress(unsigned char *dest, size_t *destLen, const unsigned char *source, size_t sourceLen);
 /*
      Compresses the source buffer into the destination buffer.  sourceLen is
    the byte length of the source buffer.  Upon entry, destLen is the total size
@@ -1197,8 +1222,8 @@ ZEXTERN int ZEXPORT zng_compress(unsigned char *dest, size_t *destLen, const uns
    buffer.
 */
 
-ZEXTERN int ZEXPORT zng_compress2(unsigned char *dest, size_t *destLen, const unsigned char *source,
-                              size_t sourceLen, int level);
+ZEXTERN ZEXPORT
+int zng_compress2(unsigned char *dest, size_t *destLen, const unsigned char *source, size_t sourceLen, int level);
 /*
      Compresses the source buffer into the destination buffer.  The level
    parameter has the same meaning as in deflateInit.  sourceLen is the byte
@@ -1212,14 +1237,16 @@ ZEXTERN int ZEXPORT zng_compress2(unsigned char *dest, size_t *destLen, const un
    Z_STREAM_ERROR if the level parameter is invalid.
 */
 
-ZEXTERN size_t ZEXPORT zng_compressBound(size_t sourceLen);
+ZEXTERN ZEXPORT
+size_t zng_compressBound(size_t sourceLen);
 /*
      compressBound() returns an upper bound on the compressed size after
    compress() or compress2() on sourceLen bytes.  It would be used before a
    compress() or compress2() call to allocate the destination buffer.
 */
 
-ZEXTERN int ZEXPORT zng_uncompress(unsigned char *dest, size_t *destLen, const unsigned char *source, size_t sourceLen);
+ZEXTERN ZEXPORT
+int zng_uncompress(unsigned char *dest, size_t *destLen, const unsigned char *source, size_t sourceLen);
 /*
      Decompresses the source buffer into the destination buffer.  sourceLen is
    the byte length of the source buffer.  Upon entry, destLen is the total size
@@ -1237,8 +1264,8 @@ ZEXTERN int ZEXPORT zng_uncompress(unsigned char *dest, size_t *destLen, const u
 */
 
 
-ZEXTERN int ZEXPORT zng_uncompress2 (unsigned char *dest,         size_t *destLen,
-                                 const unsigned char *source, size_t *sourceLen);
+ZEXTERN ZEXPORT
+int zng_uncompress2(unsigned char *dest, size_t *destLen, const unsigned char *source, size_t *sourceLen);
 /*
      Same as uncompress, except that sourceLen is a pointer, where the
    length of the source is *sourceLen.  On return, *sourceLen is the number of
@@ -1259,7 +1286,8 @@ ZEXTERN int ZEXPORT zng_uncompress2 (unsigned char *dest,         size_t *destLe
 typedef struct gzFile_s *gzFile;    /* semi-opaque gzip file descriptor */
 
 /*
-ZEXTERN gzFile ZEXPORT zng_gzopen(const char *path, const char *mode);
+ZEXTERN ZEXPORT
+gzFile zng_gzopen(const char *path, const char *mode);
 
      Opens a gzip (.gz) file for reading or writing.  The mode parameter is as
    in fopen ("rb" or "wb") but can also include a compression level ("wb9") or
@@ -1296,7 +1324,8 @@ ZEXTERN gzFile ZEXPORT zng_gzopen(const char *path, const char *mode);
    file could not be opened.
 */
 
-ZEXTERN gzFile ZEXPORT zng_gzdopen(int fd, const char *mode);
+ZEXTERN ZEXPORT
+gzFile zng_gzdopen(int fd, const char *mode);
 /*
      gzdopen associates a gzFile with the file descriptor fd.  File descriptors
    are obtained from calls like open, dup, creat, pipe or fileno (if the file
@@ -1319,7 +1348,8 @@ ZEXTERN gzFile ZEXPORT zng_gzdopen(int fd, const char *mode);
    will not detect if fd is invalid (unless fd is -1).
 */
 
-ZEXTERN int ZEXPORT zng_gzbuffer(gzFile file, unsigned size);
+ZEXTERN ZEXPORT
+int zng_gzbuffer(gzFile file, unsigned size);
 /*
      Set the internal buffer size used by this library's functions.  The
    default buffer size is 8192 bytes.  This function must be called after
@@ -1335,7 +1365,8 @@ ZEXTERN int ZEXPORT zng_gzbuffer(gzFile file, unsigned size);
    too late.
 */
 
-ZEXTERN int ZEXPORT zng_gzsetparams(gzFile file, int level, int strategy);
+ZEXTERN ZEXPORT
+int zng_gzsetparams(gzFile file, int level, int strategy);
 /*
      Dynamically update the compression level or strategy.  See the description
    of deflateInit2 for the meaning of these parameters.  Previously provided
@@ -1346,7 +1377,8 @@ ZEXTERN int ZEXPORT zng_gzsetparams(gzFile file, int level, int strategy);
    or Z_MEM_ERROR if there is a memory allocation error.
 */
 
-ZEXTERN int ZEXPORT zng_gzread(gzFile file, void *buf, unsigned len);
+ZEXTERN ZEXPORT
+int zng_gzread(gzFile file, void *buf, unsigned len);
 /*
      Reads the given number of uncompressed bytes from the compressed file.  If
    the input file is not in gzip format, gzread copies the given number of
@@ -1376,7 +1408,8 @@ ZEXTERN int ZEXPORT zng_gzread(gzFile file, void *buf, unsigned len);
    Z_STREAM_ERROR.
 */
 
-ZEXTERN size_t ZEXPORT zng_gzfread (void *buf, size_t size, size_t nitems, gzFile file);
+ZEXTERN ZEXPORT
+size_t zng_gzfread(void *buf, size_t size, size_t nitems, gzFile file);
 /*
      Read up to nitems items of size size from file to buf, otherwise operating
    as gzread() does.  This duplicates the interface of stdio's fread(), with
@@ -1399,14 +1432,16 @@ ZEXTERN size_t ZEXPORT zng_gzfread (void *buf, size_t size, size_t nitems, gzFil
    file, reseting and retrying on end-of-file, when size is not 1.
 */
 
-ZEXTERN int ZEXPORT zng_gzwrite(gzFile file, void const *buf, unsigned len);
+ZEXTERN ZEXPORT
+int zng_gzwrite(gzFile file, void const *buf, unsigned len);
 /*
      Writes the given number of uncompressed bytes into the compressed file.
    gzwrite returns the number of uncompressed bytes written or 0 in case of
    error.
 */
 
-ZEXTERN size_t ZEXPORT zng_gzfwrite(void const *buf, size_t size, size_t nitems, gzFile file);
+ZEXTERN ZEXPORT
+size_t zng_gzfwrite(void const *buf, size_t size, size_t nitems, gzFile file);
 /*
      gzfwrite() writes nitems items of size size from buf to file, duplicating
    the interface of stdio's fwrite(), with size_t request and return types.
@@ -1417,7 +1452,8 @@ ZEXTERN size_t ZEXPORT zng_gzfwrite(void const *buf, size_t size, size_t nitems,
    is returned, and the error state is set to Z_STREAM_ERROR.
 */
 
-ZEXTERN int ZEXPORTVA zng_gzprintf(gzFile file, const char *format, ...);
+ZEXTERN ZEXPORTVA
+int zng_gzprintf(gzFile file, const char *format, ...);
 /*
      Converts, formats, and writes the arguments to the compressed file under
    control of the format string, as in fprintf.  gzprintf returns the number of
@@ -1432,7 +1468,8 @@ ZEXTERN int ZEXPORTVA zng_gzprintf(gzFile file, const char *format, ...);
    This can be determined using zlibCompileFlags().
 */
 
-ZEXTERN int ZEXPORT zng_gzputs(gzFile file, const char *s);
+ZEXTERN ZEXPORT
+int zng_gzputs(gzFile file, const char *s);
 /*
      Writes the given null-terminated string to the compressed file, excluding
    the terminating null character.
@@ -1440,7 +1477,8 @@ ZEXTERN int ZEXPORT zng_gzputs(gzFile file, const char *s);
      gzputs returns the number of characters written, or -1 in case of error.
 */
 
-ZEXTERN char * ZEXPORT zng_gzgets(gzFile file, char *buf, int len);
+ZEXTERN ZEXPORT
+char * zng_gzgets(gzFile file, char *buf, int len);
 /*
      Reads bytes from the compressed file until len-1 characters are read, or a
    newline character is read and transferred to buf, or an end-of-file
@@ -1453,13 +1491,15 @@ ZEXTERN char * ZEXPORT zng_gzgets(gzFile file, char *buf, int len);
    buf are indeterminate.
 */
 
-ZEXTERN int ZEXPORT zng_gzputc(gzFile file, int c);
+ZEXTERN ZEXPORT
+int zng_gzputc(gzFile file, int c);
 /*
      Writes c, converted to an unsigned char, into the compressed file.  gzputc
    returns the value that was written, or -1 in case of error.
 */
 
-ZEXTERN int ZEXPORT zng_gzgetc(gzFile file);
+ZEXTERN ZEXPORT
+int zng_gzgetc(gzFile file);
 /*
      Reads one byte from the compressed file.  gzgetc returns this byte or -1
    in case of end of file or error.  This is implemented as a macro for speed.
@@ -1468,7 +1508,8 @@ ZEXTERN int ZEXPORT zng_gzgetc(gzFile file);
    points to has been clobbered or not.
 */
 
-ZEXTERN int ZEXPORT zng_gzungetc(int c, gzFile file);
+ZEXTERN ZEXPORT
+int zng_gzungetc(int c, gzFile file);
 /*
      Push one character back onto the stream to be read as the first character
    on the next read.  At least one character of push-back is allowed.
@@ -1480,7 +1521,8 @@ ZEXTERN int ZEXPORT zng_gzungetc(int c, gzFile file);
    gzseek() or gzrewind().
 */
 
-ZEXTERN int ZEXPORT zng_gzflush(gzFile file, int flush);
+ZEXTERN ZEXPORT
+int zng_gzflush(gzFile file, int flush);
 /*
      Flushes all pending output into the compressed file.  The parameter flush
    is as in the deflate() function.  The return value is the zlib error number
@@ -1496,7 +1538,8 @@ ZEXTERN int ZEXPORT zng_gzflush(gzFile file, int flush);
 */
 
 /*
-ZEXTERN z_off_t ZEXPORT zng_gzseek (gzFile file, z_off_t offset, int whence);
+ZEXTERN ZEXPORT
+z_off_t zng_gzseek(gzFile file, z_off_t offset, int whence);
 
      Sets the starting position for the next gzread or gzwrite on the given
    compressed file.  The offset represents a number of bytes in the
@@ -1514,7 +1557,8 @@ ZEXTERN z_off_t ZEXPORT zng_gzseek (gzFile file, z_off_t offset, int whence);
    would be before the current position.
 */
 
-ZEXTERN int ZEXPORT zng_gzrewind(gzFile file);
+ZEXTERN ZEXPORT
+int zng_gzrewind(gzFile file);
 /*
      Rewinds the given file. This function is supported only for reading.
 
@@ -1522,7 +1566,8 @@ ZEXTERN int ZEXPORT zng_gzrewind(gzFile file);
 */
 
 /*
-ZEXTERN z_off_t ZEXPORT zng_gztell(gzFile file);
+ZEXTERN ZEXPORT
+z_off_t zng_gztell(gzFile file);
 
      Returns the starting position for the next gzread or gzwrite on the given
    compressed file.  This position represents a number of bytes in the
@@ -1533,7 +1578,8 @@ ZEXTERN z_off_t ZEXPORT zng_gztell(gzFile file);
 */
 
 /*
-ZEXTERN z_off_t ZEXPORT zng_gzoffset(gzFile file);
+ZEXTERN ZEXPORT
+z_off_t zng_gzoffset(gzFile file);
 
      Returns the current offset in the file being read or written.  This offset
    includes the count of bytes that precede the gzip stream, for example when
@@ -1542,7 +1588,8 @@ ZEXTERN z_off_t ZEXPORT zng_gzoffset(gzFile file);
    for a progress indicator.  On error, gzoffset() returns -1.
 */
 
-ZEXTERN int ZEXPORT zng_gzeof(gzFile file);
+ZEXTERN ZEXPORT
+int zng_gzeof(gzFile file);
 /*
      Returns true (1) if the end-of-file indicator has been set while reading,
    false (0) otherwise.  Note that the end-of-file indicator is set only if the
@@ -1557,7 +1604,8 @@ ZEXTERN int ZEXPORT zng_gzeof(gzFile file);
    has grown since the previous end of file was detected.
 */
 
-ZEXTERN int ZEXPORT zng_gzdirect(gzFile file);
+ZEXTERN ZEXPORT
+int zng_gzdirect(gzFile file);
 /*
      Returns true (1) if file is being copied directly while reading, or false
    (0) if file is a gzip stream being decompressed.
@@ -1578,7 +1626,8 @@ ZEXTERN int ZEXPORT zng_gzdirect(gzFile file);
    gzip file reading and decompression, which may not be desired.)
 */
 
-ZEXTERN int ZEXPORT zng_gzclose(gzFile file);
+ZEXTERN ZEXPORT
+int zng_gzclose(gzFile file);
 /*
      Flushes all pending output if necessary, closes the compressed file and
    deallocates the (de)compression state.  Note that once file is closed, you
@@ -1591,8 +1640,10 @@ ZEXTERN int ZEXPORT zng_gzclose(gzFile file);
    last read ended in the middle of a gzip stream, or Z_OK on success.
 */
 
-ZEXTERN int ZEXPORT zng_gzclose_r(gzFile file);
-ZEXTERN int ZEXPORT zng_gzclose_w(gzFile file);
+ZEXTERN ZEXPORT
+int zng_gzclose_r(gzFile file);
+ZEXTERN ZEXPORT
+int zng_gzclose_w(gzFile file);
 /*
      Same as gzclose(), but gzclose_r() is only for use when reading, and
    gzclose_w() is only for use when writing or appending.  The advantage to
@@ -1603,7 +1654,8 @@ ZEXTERN int ZEXPORT zng_gzclose_w(gzFile file);
    zlib library.
 */
 
-ZEXTERN const char * ZEXPORT zng_gzerror(gzFile file, int *errnum);
+ZEXTERN ZEXPORT
+const char * zng_gzerror(gzFile file, int *errnum);
 /*
      Returns the error message for the last error which occurred on the given
    compressed file.  errnum is set to zlib error number.  If an error occurred
@@ -1619,7 +1671,8 @@ ZEXTERN const char * ZEXPORT zng_gzerror(gzFile file, int *errnum);
    functions above that do not distinguish those cases in their return values.
 */
 
-ZEXTERN void ZEXPORT zng_gzclearerr(gzFile file);
+ZEXTERN ZEXPORT
+void zng_gzclearerr(gzFile file);
 /*
      Clears the error and end-of-file flags for file.  This is analogous to the
    clearerr() function in stdio.  This is useful for continuing to read a gzip
@@ -1636,7 +1689,8 @@ ZEXTERN void ZEXPORT zng_gzclearerr(gzFile file);
    library.
 */
 
-ZEXTERN uint32_t ZEXPORT zng_adler32(uint32_t adler, const unsigned char *buf, uint32_t len);
+ZEXTERN ZEXPORT
+uint32_t zng_adler32(uint32_t adler, const unsigned char *buf, uint32_t len);
 /*
      Update a running Adler-32 checksum with the bytes buf[0..len-1] and
    return the updated checksum.  If buf is NULL, this function returns the
@@ -1655,13 +1709,15 @@ ZEXTERN uint32_t ZEXPORT zng_adler32(uint32_t adler, const unsigned char *buf, u
      if (adler != original_adler) error();
 */
 
-ZEXTERN uint32_t ZEXPORT zng_adler32_z (uint32_t adler, const unsigned char *buf, size_t len);
+ZEXTERN ZEXPORT
+uint32_t zng_adler32_z(uint32_t adler, const unsigned char *buf, size_t len);
 /*
      Same as adler32(), but with a size_t length.
 */
 
 /*
-ZEXTERN uint32_t ZEXPORT zng_adler32_combine(uint32_t adler1, uint32_t adler2, z_off_t len2);
+ZEXTERN ZEXPORT
+uint32_t zng_adler32_combine(uint32_t adler1, uint32_t adler2, z_off_t len2);
 
      Combine two Adler-32 checksums into one.  For two sequences of bytes, seq1
    and seq2 with lengths len1 and len2, Adler-32 checksums were calculated for
@@ -1671,7 +1727,8 @@ ZEXTERN uint32_t ZEXPORT zng_adler32_combine(uint32_t adler1, uint32_t adler2, z
    negative, the result has no meaning or utility.
 */
 
-ZEXTERN uint32_t ZEXPORT zng_crc32(uint32_t crc, const unsigned char *buf, uint32_t len);
+ZEXTERN ZEXPORT
+uint32_t zng_crc32(uint32_t crc, const unsigned char *buf, uint32_t len);
 /*
      Update a running CRC-32 with the bytes buf[0..len-1] and return the
    updated CRC-32.  If buf is NULL, this function returns the required
@@ -1688,13 +1745,15 @@ ZEXTERN uint32_t ZEXPORT zng_crc32(uint32_t crc, const unsigned char *buf, uint3
      if (crc != original_crc) error();
 */
 
-ZEXTERN uint32_t ZEXPORT zng_crc32_z (uint32_t crc, const unsigned char *buf, size_t len);
+ZEXTERN ZEXPORT
+uint32_t zng_crc32_z(uint32_t crc, const unsigned char *buf, size_t len);
 /*
      Same as crc32(), but with a size_t length.
 */
 
 /*
-ZEXTERN uint32_t ZEXPORT zng_crc32_combine(uint32_t crc1, uint32_t crc2, z_off64_t len2);
+ZEXTERN ZEXPORT
+uint32_t zng_crc32_combine(uint32_t crc1, uint32_t crc2, z_off64_t len2);
 
      Combine two CRC-32 check values into one.  For two sequences of bytes,
    seq1 and seq2 with lengths len1 and len2, CRC-32 check values were
@@ -1704,15 +1763,16 @@ ZEXTERN uint32_t ZEXPORT zng_crc32_combine(uint32_t crc1, uint32_t crc2, z_off64
 */
 
 /*
-ZEXTERN void ZEXPORT zng_crc32_combine_gen(uint32_t op[32], z_off_t len2);
+ZEXTERN ZEXPORT
+void zng_crc32_combine_gen(uint32_t op[32], z_off_t len2);
 
      Generate the operator op corresponding to length len2, to be used with
    crc32_combine_op(). op must have room for 32 uint32_t values. (32 is the
    number of bits in the CRC.)
 */
 
-ZEXTERN uint32_t ZEXPORT zng_crc32_combine_op(uint32_t crc1, uint32_t crc2,
-                                              const uint32_t *op);
+ZEXTERN ZEXPORT
+uint32_t zng_crc32_combine_op(uint32_t crc1, uint32_t crc2, const uint32_t *op);
 /*
      Give the same result as crc32_combine(), using op in place of len2. op is
    is generated from len2 by crc32_combine_gen(). This will be faster than
@@ -1724,13 +1784,14 @@ ZEXTERN uint32_t ZEXPORT zng_crc32_combine_op(uint32_t crc1, uint32_t crc2,
 /* zng_deflateInit and zng_inflateInit are macros to allow checking the zlib version
  * and the compiler's view of zng_stream:
  */
-ZEXTERN int ZEXPORT zng_deflateInit_(zng_stream *strm, int level, const char *version, int stream_size);
-ZEXTERN int ZEXPORT zng_inflateInit_(zng_stream *strm, const char *version, int stream_size);
-ZEXTERN int ZEXPORT zng_deflateInit2_(zng_stream *strm, int  level, int  method, int windowBits, int memLevel,
-                                   int strategy, const char *version, int stream_size);
-ZEXTERN int ZEXPORT zng_inflateInit2_(zng_stream *strm, int  windowBits, const char *version, int stream_size);
-ZEXTERN int ZEXPORT zng_inflateBackInit_(zng_stream *strm, int windowBits, unsigned char *window,
-                                      const char *version, int stream_size);
+ZEXTERN ZEXPORT int zng_deflateInit_(zng_stream *strm, int level, const char *version, int stream_size);
+ZEXTERN ZEXPORT int zng_inflateInit_(zng_stream *strm, const char *version, int stream_size);
+ZEXTERN ZEXPORT int zng_deflateInit2_(zng_stream *strm, int  level, int  method, int windowBits, int memLevel,
+                                      int strategy, const char *version, int stream_size);
+ZEXTERN ZEXPORT int zng_inflateInit2_(zng_stream *strm, int  windowBits, const char *version, int stream_size);
+ZEXTERN ZEXPORT int zng_inflateBackInit_(zng_stream *strm, int windowBits, unsigned char *window,
+                                         const char *version, int stream_size);
+
 #define zng_deflateInit(strm, level) zng_deflateInit_((strm), (level), ZLIBNG_VERSION, (int)sizeof(zng_stream))
 #define zng_inflateInit(strm) zng_inflateInit_((strm), ZLIBNG_VERSION, (int)sizeof(zng_stream))
 #define zng_deflateInit2(strm, level, method, windowBits, memLevel, strategy) \
@@ -1754,7 +1815,7 @@ struct gzFile_s {
     unsigned char *next;
     z_off64_t pos;
 };
-ZEXTERN int ZEXPORT zng_gzgetc_(gzFile file);  /* backward compatibility */
+ZEXTERN ZEXPORT int zng_gzgetc_(gzFile file);  /* backward compatibility */
 #  define zng_gzgetc(g) ((g)->have ? ((g)->have--, (g)->pos++, *((g)->next)++) : (zng_gzgetc)(g))
 
 /* provide 64-bit offset functions if _LARGEFILE64_SOURCE defined, and/or
@@ -1764,10 +1825,10 @@ ZEXTERN int ZEXPORT zng_gzgetc_(gzFile file);  /* backward compatibility */
  * without large file support, _LFS64_LARGEFILE must also be true
  */
 #ifdef Z_LARGE64
-   ZEXTERN gzFile ZEXPORT zng_gzopen64(const char *, const char *);
-   ZEXTERN z_off64_t ZEXPORT zng_gzseek64(gzFile, z_off64_t, int);
-   ZEXTERN z_off64_t ZEXPORT zng_gztell64(gzFile);
-   ZEXTERN z_off64_t ZEXPORT zng_gzoffset64(gzFile);
+    ZEXTERN ZEXPORT gzFile zng_gzopen64(const char *, const char *);
+    ZEXTERN ZEXPORT z_off64_t zng_gzseek64(gzFile, z_off64_t, int);
+    ZEXTERN ZEXPORT z_off64_t zng_gztell64(gzFile);
+    ZEXTERN ZEXPORT z_off64_t zng_gzoffset64(gzFile);
 #endif
 
 #if !defined(ZLIB_INTERNAL) && defined(Z_WANT64)
@@ -1776,16 +1837,16 @@ ZEXTERN int ZEXPORT zng_gzgetc_(gzFile file);  /* backward compatibility */
 #    define zng_gztell zng_gztell64
 #    define zng_gzoffset zng_gzoffset64
 #  ifndef Z_LARGE64
-     ZEXTERN gzFile ZEXPORT zng_gzopen64(const char *, const char *);
-     ZEXTERN z_off_t ZEXPORT zng_gzseek64(gzFile, z_off_t, int);
-     ZEXTERN z_off_t ZEXPORT zng_gztell64(gzFile);
-     ZEXTERN z_off_t ZEXPORT zng_gzoffset64(gzFile);
+     ZEXTERN ZEXPORT gzFile zng_gzopen64(const char *, const char *);
+     ZEXTERN ZEXPORT z_off_t zng_gzseek64(gzFile, z_off_t, int);
+     ZEXTERN ZEXPORT z_off_t zng_gztell64(gzFile);
+     ZEXTERN ZEXPORT z_off_t zng_gzoffset64(gzFile);
 #  endif
 #else
-   ZEXTERN gzFile ZEXPORT zng_gzopen(const char *, const char *);
-   ZEXTERN z_off_t ZEXPORT zng_gzseek(gzFile, z_off_t, int);
-   ZEXTERN z_off_t ZEXPORT zng_gztell(gzFile);
-   ZEXTERN z_off_t ZEXPORT zng_gzoffset(gzFile);
+    ZEXTERN ZEXPORT gzFile zng_gzopen(const char *, const char *);
+    ZEXTERN ZEXPORT z_off_t zng_gzseek(gzFile, z_off_t, int);
+    ZEXTERN ZEXPORT z_off_t zng_gztell(gzFile);
+    ZEXTERN ZEXPORT z_off_t zng_gzoffset(gzFile);
 #endif
 #endif /* WITH_GZFILEOP */
 
@@ -1809,7 +1870,8 @@ typedef struct {
     int status;               /* result of the last set/get call */
 } zng_deflate_param_value;
 
-ZEXTERN int ZEXPORT zng_deflateSetParams(zng_stream *strm, zng_deflate_param_value *params, size_t count);
+ZEXTERN ZEXPORT
+int zng_deflateSetParams(zng_stream *strm, zng_deflate_param_value *params, size_t count);
 /*
      Sets the values of the given zlib-ng deflate stream parameters. All the buffers are copied internally, so the
    caller still owns them after this function returns. Returns Z_OK if success.
@@ -1828,7 +1890,8 @@ ZEXTERN int ZEXPORT zng_deflateSetParams(zng_stream *strm, zng_deflate_param_val
    caused this error.
 */
 
-ZEXTERN int ZEXPORT zng_deflateGetParams(zng_stream *strm, zng_deflate_param_value *params, size_t count);
+ZEXTERN ZEXPORT
+int zng_deflateGetParams(zng_stream *strm, zng_deflate_param_value *params, size_t count);
 /*
      Copies the values of the given zlib-ng deflate stream parameters into the user-provided buffers. Returns Z_OK if
    success, Z_VERSION_ERROR if at least one parameter is not supported by the current zlib-ng version, Z_STREAM_ERROR
@@ -1844,9 +1907,9 @@ ZEXTERN int ZEXPORT zng_deflateGetParams(zng_stream *strm, zng_deflate_param_val
  * without large file support, _LFS64_LARGEFILE must also be true
  */
 #ifdef Z_LARGE64
-   ZEXTERN uint32_t ZEXPORT zng_adler32_combine64(uint32_t, uint32_t, z_off64_t);
-   ZEXTERN uint32_t ZEXPORT zng_crc32_combine64(uint32_t, uint32_t, z_off64_t);
-   ZEXTERN void ZEXPORT zng_crc32_combine_gen64(uint32_t *op, z_off64_t);
+    ZEXTERN ZEXPORT uint32_t zng_adler32_combine64(uint32_t, uint32_t, z_off64_t);
+    ZEXTERN ZEXPORT uint32_t zng_crc32_combine64(uint32_t, uint32_t, z_off64_t);
+    ZEXTERN ZEXPORT void zng_crc32_combine_gen64(uint32_t *op, z_off64_t);
 #endif
 
 #if !defined(ZLIB_INTERNAL) && defined(Z_WANT64)
@@ -1854,32 +1917,32 @@ ZEXTERN int ZEXPORT zng_deflateGetParams(zng_stream *strm, zng_deflate_param_val
 #    define zng_crc32_combine zng_crc32_combine64
 #    define zng_crc32_combine_gen zng_crc32_combine_gen64
 #  ifndef Z_LARGE64
-     ZEXTERN uint32_t ZEXPORT zng_adler32_combine64(uint32_t, uint32_t, z_off_t);
-     ZEXTERN uint32_t ZEXPORT zng_crc32_combine64(uint32_t, uint32_t, z_off_t);
-     ZEXTERN void ZEXPORT zng_crc32_combine_gen64(uint32_t *op, z_off64_t);
+     ZEXTERN ZEXPORT uint32_t zng_adler32_combine64(uint32_t, uint32_t, z_off_t);
+     ZEXTERN ZEXPORT uint32_t zng_crc32_combine64(uint32_t, uint32_t, z_off_t);
+     ZEXTERN ZEXPORT void zng_crc32_combine_gen64(uint32_t *op, z_off64_t);
 #  endif
 #else
-   ZEXTERN uint32_t ZEXPORT zng_adler32_combine(uint32_t, uint32_t, z_off_t);
-   ZEXTERN uint32_t ZEXPORT zng_crc32_combine(uint32_t, uint32_t, z_off_t);
-   ZEXTERN void ZEXPORT zng_crc32_combine_gen(uint32_t *op, z_off_t);
+   ZEXTERN ZEXPORT uint32_t zng_adler32_combine(uint32_t, uint32_t, z_off_t);
+   ZEXTERN ZEXPORT uint32_t zng_crc32_combine(uint32_t, uint32_t, z_off_t);
+   ZEXTERN ZEXPORT void zng_crc32_combine_gen(uint32_t *op, z_off_t);
 #endif
 
 
 /* undocumented functions */
-ZEXTERN const char     * ZEXPORT zng_zError           (int);
-ZEXTERN int              ZEXPORT zng_inflateSyncPoint (zng_stream *);
-ZEXTERN const uint32_t * ZEXPORT zng_get_crc_table    (void);
-ZEXTERN int              ZEXPORT zng_inflateUndermine (zng_stream *, int);
-ZEXTERN int              ZEXPORT zng_inflateValidate  (zng_stream *, int);
-ZEXTERN unsigned long    ZEXPORT zng_inflateCodesUsed (zng_stream *);
-ZEXTERN int              ZEXPORT zng_inflateResetKeep (zng_stream *);
-ZEXTERN int              ZEXPORT zng_deflateResetKeep (zng_stream *);
+ZEXTERN ZEXPORT const char *     zng_zError           (int);
+ZEXTERN ZEXPORT int              zng_inflateSyncPoint (zng_stream *);
+ZEXTERN ZEXPORT const uint32_t * zng_get_crc_table    (void);
+ZEXTERN ZEXPORT int              zng_inflateUndermine (zng_stream *, int);
+ZEXTERN ZEXPORT int              zng_inflateValidate  (zng_stream *, int);
+ZEXTERN ZEXPORT unsigned long    zng_inflateCodesUsed (zng_stream *);
+ZEXTERN ZEXPORT int              zng_inflateResetKeep (zng_stream *);
+ZEXTERN ZEXPORT int              zng_deflateResetKeep (zng_stream *);
 
 #ifdef WITH_GZFILEOP
 # if (defined(WIN32) || defined(__MINGW__))
-    ZEXTERN gzFile ZEXPORT zng_gzopen_w(const wchar_t *path, const char *mode);
+    ZEXTERN ZEXPORT gzFile zng_gzopen_w(const wchar_t *path, const char *mode);
 # endif
-ZEXTERN int ZEXPORTVA zng_gzvprintf(gzFile file, const char *format, va_list va);
+ZEXTERN ZEXPORTVA int zng_gzvprintf(gzFile file, const char *format, va_list va);
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
This reorders function attributes and puts them on a separate line, making most
function definitions fit on a single line and making function definition hints
easier to read in some IDEs.
Also contains some whitespace cleanup and a change to the file description.