### PR TITLE
Fixed duplicate Z_FINISH block when using gzflush before gzclose.

### DIFF
--- a/gzguts.h
+++ b/gzguts.h
@@ -139,6 +139,7 @@ typedef struct {
         /* just for writing */
     int level;              /* compression level */
     int strategy;           /* compression strategy */
+    int reset;              /* true if a reset is pending after a Z_FINISH */
         /* seek request */
     z_off64_t skip;         /* amount to skip (already rewound if backwards) */
     int seek;               /* true if seek request pending */

--- a/gzlib.c
+++ b/gzlib.c
@@ -28,6 +28,8 @@ static void gz_reset(gz_state *state) {
         state->past = 0;            /* have not read past end yet */
         state->how = LOOK;          /* look for gzip header */
     }
+    else                            /* for writing ... */
+        state->reset = 0;           /* no deflateReset pending */
     state->seek = 0;                /* no seek request pending */
     gz_error(state, Z_OK, NULL);    /* clear error */
     state->x.pos = 0;               /* no uncompressed data yet */


### PR DESCRIPTION
See #449