### PR TITLE
Don't bother computing check value after successful inflateSync().

### DIFF
--- a/inflate.h
+++ b/inflate.h
@@ -89,7 +89,8 @@ struct inflate_state {
     int wrap;                   /* bit 0 true for zlib, bit 1 true for gzip,
                                    bit 2 true to validate check value */
     int havedict;               /* true if dictionary provided */
-    int flags;                  /* gzip header method and flags (0 if zlib) */
+    int flags;                  /* gzip header method and flags, 0 if zlib, or
+                                   -1 if raw or no header yet */
     unsigned dmax;              /* zlib header max distance (INFLATE_STRICT) */
     unsigned long check;        /* protected copy of check value */
     unsigned long total;        /* protected copy of output count */

--- a/test/example.c
+++ b/test/example.c
@@ -451,9 +451,8 @@ void test_sync(unsigned char *compr, size_t comprLen, unsigned char *uncompr, si
     CHECK_ERR(err, "inflateSync");
 
     err = PREFIX(inflate)(&d_stream, Z_FINISH);
-    if (err != Z_DATA_ERROR) {
-        fprintf(stderr, "inflate should report DATA_ERROR\n");
-        /* Because of incorrect adler32 */
+    if (err != Z_STREAM_END) {
+        fprintf(stderr, "inflate should report Z_STREAM_END\n");
         exit(1);
     }
     err = PREFIX(inflateEnd)(&d_stream);

--- a/test/fuzz/example_flush_fuzzer.c
+++ b/test/fuzz/example_flush_fuzzer.c
@@ -88,9 +88,8 @@ void test_sync(unsigned char *compr, size_t comprLen, unsigned char *uncompr, si
     CHECK_ERR(err, "inflateSync");
 
     err = PREFIX(inflate)(&d_stream, Z_FINISH);
-    if (err != Z_DATA_ERROR) {
-        fprintf(stderr, "inflate should report DATA_ERROR\n");
-        /* Because of incorrect adler32 */
+    if (err != Z_STREAM_END) {
+        fprintf(stderr, "inflate should report Z_STREAM_END\n");
         exit(1);
     }
     err = PREFIX(inflateEnd)(&d_stream);


### PR DESCRIPTION
PR for change from upstream zlib.

> inflateSync() is used to skip invalid deflate data, which means that the check value that was being computed is no longer useful. This commit turns off the check value computation, and furthermore
> allows a successful return if the compressed data terminated in a graceful manner. This commit also fixes a bug in the case that inflateSync() is used before a header is ever processed. In that
> case, there is no knowledge of a trailer, so the remainder is treated as raw.
> 