### PR TITLE
Fixed unresolved external symbols in maketrees

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -895,7 +895,7 @@ if (ZLIB_ENABLE_TESTS)
     add_executable(makefixed tools/makefixed.c inftrees.c)
     target_include_directories(makefixed PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 
-    add_executable(maketrees tools/maketrees.c trees.c)
+    add_executable(maketrees tools/maketrees.c trees.c zutil.c)
     target_include_directories(maketrees PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 
     add_executable(makecrct tools/makecrct.c)


### PR DESCRIPTION
See #456. I have moved `send_bits()` from deflate.c to trees.c and added zutil.c to maketrees project.