### PR TITLE
Added missing headers for intrinsics in insert_string_sse.c

### DIFF
--- a/arch/x86/insert_string_sse.c
+++ b/arch/x86/insert_string_sse.c
@@ -6,6 +6,10 @@
  */
 
 #include "../../zbuild.h"
+#include <immintrin.h>
+#ifdef _MSC_VER
+#  include <nmmintrin.h>
+#endif
 #include "../../deflate.h"
 
 /* ===========================================================================


### PR DESCRIPTION
These headers are included in deflate_quick.c but missing from insert_string_sse.c.