### PR TITLE
Compatibility fix for crc32()

### DIFF
--- a/crc32.c
+++ b/crc32.c
@@ -64,9 +64,15 @@ ZLIB_INTERNAL uint32_t crc32_generic(uint32_t crc, const unsigned char *buf, uin
     return crc ^ 0xffffffff;
 }
 
+#ifdef ZLIB_COMPAT
+unsigned long ZEXPORT PREFIX(crc32)(unsigned long crc, const unsigned char *buf, unsigned int len) {
+    return (unsigned long) PREFIX(crc32_z)((uint32_t) crc, buf, len);
+}
+#else
 uint32_t ZEXPORT PREFIX(crc32)(uint32_t crc, const unsigned char *buf, uint32_t len) {
     return PREFIX(crc32_z)(crc, buf, len);
 }
+#endif
 
 /*
    This BYFOUR code accesses the passed unsigned char * buffer with a 32-bit

--- a/zlib.h
+++ b/zlib.h
@@ -1680,7 +1680,7 @@ ZEXTERN uint32_t ZEXPORT adler32_combine(uint32_t adler1, uint32_t adler2, z_off
    negative, the result has no meaning or utility.
 */
 
-ZEXTERN uint32_t ZEXPORT crc32(uint32_t crc, const unsigned char *buf, uint32_t len);
+ZEXTERN unsigned long ZEXPORT crc32(unsigned long crc, const unsigned char *buf, unsigned int len);
 /*
      Update a running CRC-32 with the bytes buf[0..len-1] and return the
    updated CRC-32.  If buf is NULL, this function returns the required


### PR DESCRIPTION
* Use "unsigned long" externally instead of "uint32_t" for crc
* Use "unsigned int" externally instead of "uint32_t" for len

Fixes #483