### PR TITLE
Modified zng_tr_tally to check for proper bounds per strategy

### DIFF
--- a/deflate.h
+++ b/deflate.h
@@ -334,7 +334,7 @@ void ZLIB_INTERNAL slide_hash_c(deflate_state *s);
 
         /* in trees.c */
 void ZLIB_INTERNAL zng_tr_init(deflate_state *s);
-int ZLIB_INTERNAL zng_tr_tally(deflate_state *s, unsigned dist, unsigned lc);
+int ZLIB_INTERNAL zng_tr_tally(deflate_state *s, unsigned dist, unsigned lc, unsigned max_dist);
 void ZLIB_INTERNAL zng_tr_flush_block(deflate_state *s, char *buf, unsigned long stored_len, int last);
 void ZLIB_INTERNAL zng_tr_flush_bits(deflate_state *s);
 void ZLIB_INTERNAL zng_tr_align(deflate_state *s);
@@ -375,9 +375,9 @@ void ZLIB_INTERNAL flush_pending(PREFIX3(streamp) strm);
     flush = (s->sym_next == s->sym_end); \
   }
 #else
-#   define zng_tr_tally_lit(s, c, flush) flush = zng_tr_tally(s, 0, c)
+#   define zng_tr_tally_lit(s, c, flush) flush = zng_tr_tally(s, 0, c, MAX_DIST(s))
 #   define zng_tr_tally_dist(s, distance, length, flush) \
-              flush = zng_tr_tally(s, (unsigned)(distance), (unsigned)(length))
+              flush = zng_tr_tally(s, (unsigned)(distance), (unsigned)(length), MAX_DIST(s))
 #endif
 
 /* ===========================================================================

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -23,11 +23,11 @@ struct match {
 #define MAX_DIST2  ((1 << MAX_WBITS) - MIN_LOOKAHEAD)
 
 static int tr_tally_dist(deflate_state *s, int distance, int length) {
-    return zng_tr_tally(s, distance, length);
+    return zng_tr_tally(s, distance, length, MAX_DIST2);
 }
 
 static int tr_tally_lit(deflate_state *s, int c) {
-    return zng_tr_tally(s, 0, c);
+    return zng_tr_tally(s, 0, c, MAX_DIST2);
 }
 
 static int emit_match(deflate_state *s, struct match match) {

--- a/trees.c
+++ b/trees.c
@@ -730,7 +730,7 @@ void ZLIB_INTERNAL zng_tr_flush_block(deflate_state *s, char *buf, unsigned long
  * Save the match info and tally the frequency counts. Return true if
  * the current block must be flushed.
  */
-int ZLIB_INTERNAL zng_tr_tally(deflate_state *s, unsigned dist, unsigned lc) {
+int ZLIB_INTERNAL zng_tr_tally(deflate_state *s, unsigned dist, unsigned lc, unsigned max_dist) {
     /* dist: distance of matched string */
     /* lc: match length-MIN_MATCH or unmatched char (if dist==0) */
     s->sym_buf[s->sym_next++] = dist;
@@ -743,7 +743,7 @@ int ZLIB_INTERNAL zng_tr_tally(deflate_state *s, unsigned dist, unsigned lc) {
         s->matches++;
         /* Here, lc is the match length - MIN_MATCH */
         dist--;             /* dist = match distance - 1 */
-        Assert((uint16_t)dist < (uint16_t)MAX_DIST(s) &&
+        Assert((uint16_t)dist < max_dist &&
                (uint16_t)lc <= (uint16_t)(MAX_MATCH-MIN_MATCH) &&
                (uint16_t)d_code(dist) < (uint16_t)D_CODES,  "zng_tr_tally: bad match");
 


### PR DESCRIPTION
This should fix one of the debug asserts in #471. Since these functions only get called when `ZLIB_DEBUG` is defined, it shouldn't affect performance.