### PR TITLE
Removed MAX_DIST2 which is incompatible with INFLATE_STRICT.

### DIFF
--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -20,8 +20,6 @@ struct match {
     unsigned int orgstart;
 };
 
-#define MAX_DIST2  ((1 << MAX_WBITS) - MIN_LOOKAHEAD)
-
 static int tr_tally_dist(deflate_state *s, int distance, int length) {
     return zng_tr_tally(s, distance, length);
 }
@@ -162,7 +160,7 @@ static void fizzle_matches(deflate_state *s, struct match *current, struct match
     n = *next;
 
     /* step one: try to move the "next" match to the left as much as possible */
-    limit = next->strstart > MAX_DIST2 ? next->strstart - MAX_DIST2 : 0;
+    limit = next->strstart > MAX_DIST(s) ? next->strstart - MAX_DIST(s) : 0;
 
     match = s->window + n.match_start - 1;
     orig = s->window + n.strstart - 1;
@@ -249,7 +247,7 @@ ZLIB_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
              * At this point we have always match_length < MIN_MATCH
              */
 
-            if (hash_head != 0 && s->strstart - hash_head <= MAX_DIST2) {
+            if (hash_head != 0 && s->strstart - hash_head <= MAX_DIST(s)) {
                 /* To simplify the code, we prevent matches with the string
                  * of window index 0 (in particular we have to avoid a match
                  * of the string with itself at the start of the input file).
@@ -281,7 +279,7 @@ ZLIB_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
             /* Find the longest match, discarding those <= prev_length.
              * At this point we have always match_length < MIN_MATCH
              */
-            if (hash_head != 0 && s->strstart - hash_head <= MAX_DIST2) {
+            if (hash_head != 0 && s->strstart - hash_head <= MAX_DIST(s)) {
                 /* To simplify the code, we prevent matches with the string
                  * of window index 0 (in particular we have to avoid a match
                  * of the string with itself at the start of the input file).


### PR DESCRIPTION
This PR removes `MAX_DIST2` in favor of `MAX_DIST(s)` which makes the output produced by deflate medium compatible when zlib is compiled with `INFLATE_STRICT` (see #492). It also fixes the check for proper bounds in zng_tr_tally as mentioned in #490 (so debug CI finally succeeds).

Once this is merged I can clean up or close the other 2 PRs.