### PR TITLE
Fixed sed in configure script on macOS

### DIFF
--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -25,6 +25,7 @@ jobs:
           Ubuntu 18.04 Clang ARM HF Compat No Neon,
           Ubuntu 18.04 Clang AARCH64 Compat No Opt,
           Ubuntu 18.04 Clang AARCH64 Compat
+          macOS 10.14 GCC,
         ]
         include:
           - name: Ubuntu 18.04 Clang
@@ -126,6 +127,11 @@ jobs:
             configure-args: --warn --zlib-compat --without-optimizations --without-new-strategies
             asan-options: detect_leaks=0
             packages: qemu gcc-aarch64-linux-gnu libc-dev-arm64-cross
+
+          - name: macOS 10.14 GCC
+            os: macOS-10.14
+            compiler: gcc
+            configure-args: --warn
 
     steps:
     - uses: actions/checkout@v1

--- a/configure
+++ b/configure
@@ -1319,6 +1319,15 @@ echo ARCHDIR = ${ARCHDIR} >> configure.log
 echo ARCH_STATIC_OBJS = ${ARCH_STATIC_OBJS} >> configure.log
 echo ARCH_SHARED_OBJS = ${ARCH_SHARED_OBJS} >> configure.log
 
+# Handle sed incompatibilities when using -i
+replace_in_file() {
+  if [ "$OS" = 'Darwin' ]; then
+    sed -i '.tmp' -e "$1" "$2"
+  else
+    sed -i'.tmp' -e "$1" "$2"
+  fi
+}
+
 # update Makefile with the configure results
 
 INCLUDES="-I$SRCDIR"
@@ -1393,15 +1402,15 @@ for file in $(ls -1 $SRCDIR/*.c $SRCDIR/test/*.c $SRCDIR/test/fuzz/*.c $SRCDIR/$
 
     if grep -q "^$obj:" Makefile; then
         # Replace the existing line with a line with all dependences.
-        sed -i "s#$obj:.*#$obj: \$(SRCDIR)/$short_name $includes#g" Makefile
+        $(replace_in_file "s#$obj:.*#$obj: \$(SRCDIR)/$short_name $includes#g" Makefile)
 
         # Special case example64 and minigzip64.
         case "$obj" in
             example.o)
-                sed -i "s#example64.o:.*#example64.o: \$(SRCDIR)/$short_name $includes#g" Makefile
+                $(replace_in_file "s#example64.o:.*#example64.o: \$(SRCDIR)/$short_name $includes#g" Makefile)
                 ;;
             minigzip.o)
-                sed -i "s#minigzip64.o:.*#minigzip64.o: \$(SRCDIR)/$short_name $includes#g" Makefile
+                $(replace_in_file "s#minigzip64.o:.*#minigzip64.o: \$(SRCDIR)/$short_name $includes#g" Makefile)
                 ;;
         esac
     else
@@ -1418,7 +1427,7 @@ for file in $(ls -1 $SRCDIR/*.c $SRCDIR/test/*.c $SRCDIR/test/fuzz/*.c $SRCDIR/$
 
     if grep -q "^$lobj:" Makefile; then
         # Replace the existing line with a line with all dependences.
-        sed -i "s#$lobj:.*#$lobj: \$(SRCDIR)/$short_name $includes#g" Makefile
+        $(replace_in_file "s#$lobj:.*#$lobj: \$(SRCDIR)/$short_name $includes#g" Makefile)
     else
         # Append at the end of Makefile a new line with the header dependences.
         echo "$lobj: \$(SRCDIR)/$short_name $includes" >> Makefile
@@ -1465,7 +1474,7 @@ for file in $(ls -1 $SRCDIR/$ARCHDIR/*.c); do
     short_name=$(basename $file)
     if grep -q "^$obj:" $ARCHDIR/Makefile; then
         # Replace the existing line with a line with all dependences.
-        sed -i "s#$obj:.*#$obj: \$(SRCDIR)/$short_name $includes#g" $ARCHDIR/Makefile
+        $(replace_in_file "s#$obj:.*#$obj: \$(SRCDIR)/$short_name $includes#g" $ARCHDIR/Makefile)
     else
         # Append at the end of Makefile a new line with the header dependences.
         echo "$obj: \$(SRCDIR)/$short_name $includes" >> $ARCHDIR/Makefile
@@ -1473,7 +1482,7 @@ for file in $(ls -1 $SRCDIR/$ARCHDIR/*.c); do
 
     if grep -q "^$lobj:" $ARCHDIR/Makefile; then
         # Replace the existing line with a line with all dependences.
-        sed -i "s#$lobj:.*#$lobj: \$(SRCDIR)/$short_name $includes#g" $ARCHDIR/Makefile
+        $(replace_in_file "s#$lobj:.*#$lobj: \$(SRCDIR)/$short_name $includes#g" $ARCHDIR/Makefile)
     else
         # Append at the end of Makefile a new line with the header dependences.
         echo "$lobj: \$(SRCDIR)/$short_name $includes" >> $ARCHDIR/Makefile


### PR DESCRIPTION
Changes:

- Fixed configure script use of sed on macOS. (see #427)
- Added macOS configure build (which was used to test this PR against)
