### PR TITLE
Improvements to pending buffer functions

### DIFF
--- a/trees.c
+++ b/trees.c
@@ -799,7 +799,7 @@ static void compress_block(deflate_state *s, const ct_data *ltree, const ct_data
             } /* literal or match pair ? */
 
             /* Check that the overlay between pending_buf and sym_buf is ok: */
-            Assert(s->pending < s->lit_bufsize + sx, "pendingBuf overflow");
+            Assert(s->pending < s->lit_bufsize + sx, "pending_buf overflow");
         } while (sx < s->sym_next);
     }
 


### PR DESCRIPTION
- Moved put_short_msb to deflate.h along with the rest of the put functions and renamed it to be consistent with other put function naming.
- Added put_uint32 and put_uint32_msb.
- Replaced instances of put_byte with put_short or put_uint32.

This sanitizer checks should pass once  #498 is merged.