### PR TITLE
Support unaligned reads in longest_match variants.

### DIFF
--- a/match_p.h
+++ b/match_p.h
@@ -11,7 +11,7 @@
 #include "zbuild.h"
 #include "deflate.h"
 
-#if (defined(UNALIGNED_OK) && MAX_MATCH == 258)
+#if (MAX_MATCH == 258)
 
    /* ARM 32-bit clang/gcc builds perform better, on average, with std2. Both gcc and clang and define __GNUC__. */
 #  if defined(__GNUC__) && defined(__arm__) && !defined(__aarch64__)
@@ -203,8 +203,8 @@ static inline unsigned longest_match(deflate_state *const s, IPos cur_match) {
 
     scan = s->window + s->strstart;
     strend = s->window + s->strstart + MAX_MATCH - 1;
-    memcpy(&scan_start, scan, sizeof(scan_start));
-    memcpy(&scan_end, scan + best_len - 1, sizeof(scan_end));
+    ZCOPY16(scan_start, scan);
+    ZCOPY16(scan_end, scan + best_len - 1);
 
     Assert((unsigned long)s->strstart <= s->window_size - MIN_LOOKAHEAD, "need lookahead");
     do {
@@ -225,11 +225,11 @@ static inline unsigned longest_match(deflate_state *const s, IPos cur_match) {
          * affected by the uninitialized values.
          */
         uint16_t val;
-        memcpy(&val, match + best_len - 1, sizeof(val));
+        ZCOPY16(val, match + best_len - 1);
         if (LIKELY(val != scan_end))
             continue;
 
-        memcpy(&val, match, sizeof(val));
+        ZCOPY16(val, match);
         if (val != scan_start)
             continue;
 
@@ -250,29 +250,29 @@ static inline unsigned longest_match(deflate_state *const s, IPos cur_match) {
         do {
             uint16_t mval, sval;
 
-            memcpy(&mval, match, sizeof(mval));
-            memcpy(&sval, scan, sizeof(sval));
+            ZCOPY16(mval, match);
+            ZCOPY16(sval, scan);
             if (mval != sval)
               break;
             match += sizeof(mval);
             scan += sizeof(sval);
 
-            memcpy(&mval, match, sizeof(mval));
-            memcpy(&sval, scan, sizeof(sval));
+            ZCOPY16(mval, match);
+            ZCOPY16(sval, scan);
             if (mval != sval)
               break;
             match += sizeof(mval);
             scan += sizeof(sval);
 
-            memcpy(&mval, match, sizeof(mval));
-            memcpy(&sval, scan, sizeof(sval));
+            ZCOPY16(mval, match);
+            ZCOPY16(sval, scan);
             if (mval != sval)
               break;
             match += sizeof(mval);
             scan += sizeof(sval);
 
-            memcpy(&mval, match, sizeof(mval));
-            memcpy(&sval, scan, sizeof(sval));
+            ZCOPY16(mval, match);
+            ZCOPY16(sval, scan);
             if (mval != sval)
               break;
             match += sizeof(mval);
@@ -294,7 +294,7 @@ static inline unsigned longest_match(deflate_state *const s, IPos cur_match) {
             best_len = len;
             if (len >= nice_match)
                 break;
-            memcpy(&scan_end, scan + best_len - 1, sizeof(scan_end));
+            ZCOPY16(scan_end, scan + best_len - 1);
         } else {
             /*
              * The probability of finding a match later if we here
@@ -397,8 +397,8 @@ static inline unsigned longest_match(deflate_state *const s, IPos cur_match) {
 
     uint16_t scan_start, scan_end;
 
-    memcpy(&scan_start, scan, sizeof(scan_start));
-    memcpy(&scan_end, scan+best_len-1, sizeof(scan_end));
+    ZCOPY16(scan_start, scan);
+    ZCOPY16(scan_end, scan+best_len-1);
 
     /* The code is optimized for HASH_BITS >= 8 and MAX_MATCH-2 multiple of 16.
      * It is easy to get rid of this optimization if necessary.
@@ -461,8 +461,8 @@ static inline unsigned longest_match(deflate_state *const s, IPos cur_match) {
         do {
             unsigned long sv, mv, xor;
 
-            memcpy(&sv, scan, sizeof(sv));
-            memcpy(&mv, match, sizeof(mv));
+            ZCOPYULONG(sv, scan);
+            ZCOPYULONG(mv, match);
 
             xor = sv ^ mv;
 
@@ -489,7 +489,7 @@ static inline unsigned longest_match(deflate_state *const s, IPos cur_match) {
             best_len = len;
             if (len >= nice_match)
                 break;
-            memcpy(&scan_end, scan+best_len-1, sizeof(scan_end));
+            ZCOPY16(scan_end, scan+best_len-1);
         } else {
             /*
              * The probability of finding a match later if we here

--- a/zutil.h
+++ b/zutil.h
@@ -213,6 +213,17 @@ void ZLIB_INTERNAL   zng_cfree(void *opaque, void *ptr);
           ((q & 0x00000000000000FFu) << 56u)
 #endif
 
+/* Copy into data type aligned or unaligned */
+#if defined(UNALIGNED_OK)
+#   define ZCOPY16(val, ptr)    val = *(uint16_t *)(ptr)
+#   define ZCOPY32(val, ptr)    val = *(uint32_t *)(ptr)
+#   define ZCOPYULONG(val, ptr) val = *(unsigned long *)(ptr)
+#else 
+#   define ZCOPY16(val, ptr)    memcpy(&val, ptr, sizeof(val))
+#   define ZCOPY32(val, ptr)    memcpy(&val, ptr, sizeof(val))
+#   define ZCOPYULONG(val, ptr) memcpy(&val, ptr, sizeof(val))
+#endif
+
 /* Only enable likely/unlikely if the compiler is known to support it */
 #if (defined(__GNUC__) && (__GNUC__ >= 3)) || defined(__INTEL_COMPILER) || defined(__Clang__)
 #    define LIKELY_NULL(x)      __builtin_expect((x) != 0, 0)


### PR DESCRIPTION
See #496. At some point `longest_match` variants will still need to be cleaned up, but this should add back unaligned reads to `longest_match` for the short term.

This commit adds new macros that can be used for other areas where we have unaligned read supported, however I have not touched those due to pending pull requests.