### PR TITLE
Add back unaligned access support to longest_match variants

### DIFF
--- a/arch/arm/insert_string_acle.c
+++ b/arch/arm/insert_string_acle.c
@@ -29,8 +29,10 @@ Pos insert_string_acle(deflate_state *const s, const Pos str, unsigned int count
     lp = str + count - 1; /* last position */
 
     for (p = str; p <= lp; p++) {
-        uint32_t val, h, hm;
-        memcpy(&val, &s->window[p], sizeof(val));
+        unsigned *ip, val, h, hm;
+
+        ip = (unsigned *)&s->window[p];
+        val = *ip;
 
         if (s->level >= TRIGGER_LEVEL)
             val &= 0xFFFFFF;

--- a/arch/x86/insert_string_sse.c
+++ b/arch/x86/insert_string_sse.c
@@ -24,11 +24,11 @@
 ZLIB_INTERNAL Pos insert_string_sse(deflate_state *const s, const Pos str, unsigned int count) {
     Pos ret = 0;
     unsigned int idx;
-    unsigned int *ip, val, h;
+    unsigned *ip, val, h;
 
     for (idx = 0; idx < count; idx++) {
         ip = (unsigned *)&s->window[str+idx];
-        memcpy(&val, ip, sizeof(val));
+        val = *ip;
         h = 0;
 
         if (s->level >= TRIGGER_LEVEL)

--- a/match_p.h
+++ b/match_p.h
@@ -203,8 +203,8 @@ static inline unsigned longest_match(deflate_state *const s, IPos cur_match) {
 
     scan = s->window + s->strstart;
     strend = s->window + s->strstart + MAX_MATCH - 1;
-    memcpy(&scan_start, scan, sizeof(scan_start));
-    memcpy(&scan_end, scan + best_len - 1, sizeof(scan_end));
+    scan_start = *(uint16_t *)scan;
+    scan_end = *(uint16_t *)(scan + best_len-1);
 
     Assert((unsigned long)s->strstart <= s->window_size - MIN_LOOKAHEAD, "need lookahead");
     do {
@@ -224,13 +224,9 @@ static inline unsigned longest_match(deflate_state *const s, IPos cur_match) {
          * is limited to the lookahead, so the output of deflate is not
          * affected by the uninitialized values.
          */
-        uint16_t val;
-        memcpy(&val, match + best_len - 1, sizeof(val));
-        if (LIKELY(val != scan_end))
+        if (LIKELY(*(uint16_t *)(match + best_len - 1) != scan_end))
             continue;
-
-        memcpy(&val, match, sizeof(val));
-        if (val != scan_start)
+        if (*(uint16_t *)match != scan_start)
             continue;
 
         /* It is not necessary to compare scan[2] and match[2] since
@@ -248,36 +244,11 @@ static inline unsigned longest_match(deflate_state *const s, IPos cur_match) {
         match++;
 
         do {
-            uint16_t mval, sval;
-
-            memcpy(&mval, match, sizeof(mval));
-            memcpy(&sval, scan, sizeof(sval));
-            if (mval != sval)
-                break;
-            match += sizeof(mval);
-            scan += sizeof(sval);
-
-            memcpy(&mval, match, sizeof(mval));
-            memcpy(&sval, scan, sizeof(sval));
-            if (mval != sval)
-                break;
-            match += sizeof(mval);
-            scan += sizeof(sval);
-
-            memcpy(&mval, match, sizeof(mval));
-            memcpy(&sval, scan, sizeof(sval));
-            if (mval != sval)
-                break;
-            match += sizeof(mval);
-            scan += sizeof(sval);
-
-            memcpy(&mval, match, sizeof(mval));
-            memcpy(&sval, scan, sizeof(sval));
-            if (mval != sval)
-                break;
-            match += sizeof(mval);
-            scan += sizeof(sval);
-        } while (scan < strend);
+        } while (*(uint16_t *)(scan += 2) == *(uint16_t *)(match += 2) &&
+                 *(uint16_t *)(scan += 2) == *(uint16_t *)(match += 2) &&
+                 *(uint16_t *)(scan += 2) == *(uint16_t *)(match += 2) &&
+                 *(uint16_t *)(scan += 2) == *(uint16_t *)(match += 2) &&
+                 scan < strend);
 
         /*
          * Here, scan <= window + strstart + 257
@@ -294,7 +265,7 @@ static inline unsigned longest_match(deflate_state *const s, IPos cur_match) {
             best_len = len;
             if (len >= nice_match)
                 break;
-            memcpy(&scan_end, scan + best_len - 1, sizeof(scan_end));
+            scan_end = *(uint16_t *)(scan + best_len - 1);
         } else {
             /*
              * The probability of finding a match later if we here


### PR DESCRIPTION
For previous discussion see #508.

Changed `longest_match` and `insert_string` to use unaligned access instead of `memcmp` or `memcpy` for architectures where unaligned access is supported - these variants are intended for architectures where unaligned access is acceptable. If an architecture does not support unaligned access, then `UNALIGNED_OK` should not be defined. Added some comments to indicate that unaligned access is expected in certain places. These changes may have been made to fix sanitizers, however the alignment sanitizer should not be run on architectures that support unaligned access or when `UNALIGNED_OK` is defined.

Revert "Prefer memcpy and memcmp over direct memory read/comparisons. (#135)"
This reverts commit 72214719ca8db882ab49d31872528b8b456362aa.

Revert "fix all ASan errors on arm/aarch64"
This reverts commit bee695a6415bbf37087be132a3c40e2e761658c0.