### PR TITLE
Fixed compiler warning when using BITS macro.

### DIFF
--- a/inflate_p.h
+++ b/inflate_p.h
@@ -75,7 +75,7 @@
 
 /* Return the low n bits of the bit accumulator (n < 16) */
 #define BITS(n) \
-    (hold & ((1U << (n)) - 1))
+    (hold & ((1U << (unsigned)(n)) - 1))
 
 /* Remove n bits from the bit accumulator */
 #define DROPBITS(n) \


### PR DESCRIPTION
This is the same cast that occurs in `NEEDBITS` and `DROPBITS`. I have seen warnings related to this.