### PR TITLE
Change deflate_state's bi_buf to 32-bit

### DIFF
--- a/arch/x86/deflate_quick.c
+++ b/arch/x86/deflate_quick.c
@@ -135,6 +135,9 @@ static inline void static_emit_ptr(deflate_state *const s, const int lc, const u
 
     send_bits(s, code1, len1, bi_buf, bi_valid);
     send_bits(s, code2, len2, bi_buf, bi_valid);
+#ifdef ZLIB_DEBUG
+    s->compressed_len += len1 + len2;
+#endif
 
     s->bi_valid = bi_valid;
     s->bi_buf = bi_buf;
@@ -147,6 +150,9 @@ static inline void static_emit_lit(deflate_state *const s, const int lit) {
     uint32_t bi_buf = s->bi_buf;
 
     send_bits(s, static_ltree[lit].Code, static_ltree[lit].Len, bi_buf, bi_valid);
+#ifdef ZLIB_DEBUG
+    s->compressed_len += static_ltree[lit].Len;
+#endif
 
     s->bi_valid = bi_valid;
     s->bi_buf = bi_buf;

--- a/arch/x86/deflate_quick.c
+++ b/arch/x86/deflate_quick.c
@@ -130,26 +130,26 @@ static inline void static_emit_ptr(deflate_state *const s, const int lc, const u
     unsigned code2 = quick_dist_codes[dist-1] >> 8;
     unsigned len2  = quick_dist_codes[dist-1] & 0xFF;
 
-    int filled = s->bi_valid;
-    uint32_t bit_buf = s->bi_buf;
+    uint32_t bi_valid = s->bi_valid;
+    uint32_t bi_buf = s->bi_buf;
 
-    send_bits(s, code1, len1, bit_buf, filled);
-    send_bits(s, code2, len2, bit_buf, filled);
+    send_bits(s, code1, len1, bi_buf, bi_valid);
+    send_bits(s, code2, len2, bi_buf, bi_valid);
 
-    s->bi_valid = filled;
-    s->bi_buf = bit_buf;
+    s->bi_valid = bi_valid;
+    s->bi_buf = bi_buf;
 }
 
 const ct_data static_ltree[L_CODES+2];
 
 static inline void static_emit_lit(deflate_state *const s, const int lit) {
-    int filled = s->bi_valid;
-    uint32_t bit_buf = s->bi_buf;
+    uint32_t bi_valid = s->bi_valid;
+    uint32_t bi_buf = s->bi_buf;
 
-    send_bits(s, static_ltree[lit].Code, static_ltree[lit].Len, s->bi_buf, s->bi_valid);
+    send_bits(s, static_ltree[lit].Code, static_ltree[lit].Len, bi_buf, bi_valid);
 
-    s->bi_valid = filled;
-    s->bi_buf = bit_buf;
+    s->bi_valid = bi_valid;
+    s->bi_buf = bi_buf;
 
     Tracecv(isgraph(lit), (stderr, " '%c' ", lit));
 }

--- a/arch/x86/deflate_quick.c
+++ b/arch/x86/deflate_quick.c
@@ -124,51 +124,33 @@ static inline long compare258(const unsigned char *const src0, const unsigned ch
 static const unsigned quick_len_codes[MAX_MATCH-MIN_MATCH+1];
 static const unsigned quick_dist_codes[8192];
 
-static inline void quick_send_bits(deflate_state *const s,
-                                   const int value1, const int length1,
-                                   const int value2, const int length2) {
-    unsigned offset2 = s->bi_valid + length1;
-    unsigned width = s->bi_valid + length1 + length2;
-    unsigned bytes_out = width / 8;
-
-    /* Concatenate the new bits with the bits currently in the buffer */
-    unsigned out = s->bi_buf | (value1 << s->bi_valid);
-    if (width < 32) {
-        out |= (value2 << offset2);
-        /* Shift out the valid LSBs written out. */
-        s->bi_buf = out >> (bytes_out * 8);
-    } else { /* width => 32 */
-        unsigned bits_that_fit = 32 - offset2;
-        unsigned mask = (1 << bits_that_fit) - 1;
-        /* Zero out the high bits of value2 such that the shift by offset2 will
-           not cause undefined behavior. */
-        out |= ((value2 & mask) << offset2);
-
-        /* Save in s->bi_buf the bits of value2 that do not fit: they will be
-           written in a next full byte. */
-        s->bi_buf = (width == 32) ? 0 : value2 >> bits_that_fit;
-    }
-
-    s->bi_valid = width - (bytes_out * 8);
-
-    /* Taking advantage of the fact that LSB comes first, write to output buffer */
-    memcpy(s->pending_buf + s->pending, &out, sizeof(out));
-
-    s->pending += bytes_out;
-}
-
 static inline void static_emit_ptr(deflate_state *const s, const int lc, const unsigned dist) {
     unsigned code1 = quick_len_codes[lc] >> 8;
     unsigned len1 =  quick_len_codes[lc] & 0xFF;
     unsigned code2 = quick_dist_codes[dist-1] >> 8;
     unsigned len2  = quick_dist_codes[dist-1] & 0xFF;
-    quick_send_bits(s, code1, len1, code2, len2);
+
+    int filled = s->bi_valid;
+    uint32_t bit_buf = s->bi_buf;
+
+    send_bits(s, code1, len1, bit_buf, filled);
+    send_bits(s, code2, len2, bit_buf, filled);
+
+    s->bi_valid = filled;
+    s->bi_buf = bit_buf;
 }
 
 const ct_data static_ltree[L_CODES+2];
 
 static inline void static_emit_lit(deflate_state *const s, const int lit) {
-    quick_send_bits(s, static_ltree[lit].Code, static_ltree[lit].Len, 0, 0);
+    int filled = s->bi_valid;
+    uint32_t bit_buf = s->bi_buf;
+
+    send_bits(s, static_ltree[lit].Code, static_ltree[lit].Len, s->bi_buf, s->bi_valid);
+
+    s->bi_valid = filled;
+    s->bi_buf = bit_buf;
+
     Tracecv(isgraph(lit), (stderr, " '%c' ", lit));
 }
 

--- a/deflate.c
+++ b/deflate.c
@@ -592,14 +592,14 @@ int ZEXPORT PREFIX(deflatePrime)(PREFIX3(stream) *strm, int bits, int value) {
     if (deflateStateCheck(strm))
         return Z_STREAM_ERROR;
     s = strm->state;
-    if (bits < 0 || bits > 16 ||
-        s->sym_buf < s->pending_out + ((Buf_size + 7) >> 3))
+    if (bits < 0 || bits > BIT_BUF_SIZE ||
+        s->sym_buf < s->pending_out + ((BIT_BUF_SIZE + 7) >> 3))
         return Z_BUF_ERROR;
     do {
-        put = Buf_size - s->bi_valid;
+        put = BIT_BUF_SIZE - s->bi_valid;
         if (put > bits)
             put = bits;
-        s->bi_buf |= (uint16_t)((value & ((1 << put) - 1)) << s->bi_valid);
+        s->bi_buf |= (uint32_t)((value & ((1 << put) - 1)) << s->bi_valid);
         s->bi_valid += put;
         zng_tr_flush_bits(s);
         value >>= put;

--- a/deflate.h
+++ b/deflate.h
@@ -473,7 +473,7 @@ extern const unsigned char ZLIB_INTERNAL zng_dist_code[];
 #ifdef ZLIB_DEBUG
 #  define send_debug_trace(s, value, length) {\
         Tracevv((stderr, " l %2d v %4x ", length, value));\
-        Assert(length > 0 && length <= BIT_BUF_SIZE - 1, "invalid length");\
+        Assert(length > 0 && length <= BIT_BUF_SIZE, "invalid length");\
         s->bits_sent += (unsigned long)length;\
     }
 #else
@@ -488,19 +488,18 @@ extern const unsigned char ZLIB_INTERNAL zng_dist_code[];
     uint32_t val = (uint32_t)t_val;\
     uint32_t len = (uint32_t)t_len;\
     send_debug_trace(s, val, len);\
-    if (bits_valid == BIT_BUF_SIZE) {\
+    if (bits_valid + len < BIT_BUF_SIZE) {\
+        bit_buf |= val << bits_valid;\
+        bits_valid += len;\
+    } else if (bits_valid == BIT_BUF_SIZE) {\
         put_uint32(s, bit_buf);\
         bit_buf = val;\
         bits_valid = len;\
-    } else if (bits_valid + len >= BIT_BUF_SIZE) {\
+    } else {\
         bit_buf |= val << bits_valid;\
         put_uint32(s, bit_buf);\
         bit_buf = val >> (BIT_BUF_SIZE - bits_valid);\
         bits_valid += len - BIT_BUF_SIZE;\
-    } else {\
-        bit_buf |= val << bits_valid;\
-        bits_valid += len;\
     }\
 }
-
 #endif /* DEFLATE_H_ */

--- a/test/fuzz/compress_fuzzer.c
+++ b/test/fuzz/compress_fuzzer.c
@@ -38,8 +38,8 @@ static void write_zlib_header(uint8_t *s) {
     header += 31 - (header % 31);
 
     /* s is guaranteed to be longer than 2 bytes. */
-    put_byte(s, 0, (unsigned char)(header >> 8));
-    put_byte(s, 1, (unsigned char)(header & 0xff));
+    put_byte(s, 0, (header >> 8));
+    put_byte(s, 1, (header & 0xff));
 }
 
 static void check_decompress(uint8_t *compr, size_t comprLen) {


### PR DESCRIPTION
This PR requires #496 and #504 which are the first two commits. In the third commit I changed `deflate_state`'s `bi_buf` to 32-bit and then in the fourth commit I replaced `quick_send_bits` with `send_bits` which is 32-bit now. All the code can benefit from 32-bit bit buffer now and the code path for all the deflate methods is the same.