### PR TITLE
Fixed GitHub Actions warning about old version of macOS being used

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -38,8 +38,8 @@ jobs:
           Windows 2019 GCC,
           Windows 2019 GCC Compat,
           Windows 2019 GCC Compat No Opt,
-          macOS 10.14 Clang,
-          macOS 10.14 GCC
+          macOS Clang,
+          macOS GCC
         ]
         include:
           - name: Ubuntu 18.04 GCC
@@ -251,14 +251,14 @@ jobs:
             cmake-args: -G Ninja -DZLIB_COMPAT=ON -DWITH_NEW_STRATEGIES=NO -DWITH_OPTIM=NO
             codecov: win64_gcc
 
-          - name: macOS 10.14 Clang
-            os: macOS-10.14
+          - name: macOS Clang
+            os: macOS-latest
             compiler: clang
             cmake-args: -DWITH_SANITIZERS=ON
             codecov: macos_clang
 
-          - name: macOS 10.14 GCC
-            os: macOS-10.14
+          - name: macOS GCC
+            os: macOS-latest
             compiler: gcc
             cmake-args: -DWITH_SANITIZERS=ON
             codecov: macos_gcc

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -25,7 +25,7 @@ jobs:
           Ubuntu 18.04 GCC ARM HF Compat No Neon,
           Ubuntu 18.04 GCC AARCH64 Compat No Opt,
           Ubuntu 18.04 GCC AARCH64 Compat,
-          macOS 10.14 GCC
+          macOS GCC
         ]
         include:
           - name: Ubuntu 18.04 GCC
@@ -128,8 +128,8 @@ jobs:
             asan-options: detect_leaks=0
             packages: qemu gcc-aarch64-linux-gnu libc-dev-arm64-cross
 
-          - name: macOS 10.14 GCC
-            os: macOS-10.14
+          - name: macOS GCC
+            os: macOS-latest
             compiler: gcc
             configure-args: --warn
 


### PR DESCRIPTION
GitHub Actions has stopped supporting macOS-10.14 image for a while now and has automatically switched over everybody to macOS-latest. This check-in just renames the CI configurations and uses the new image to get rid of the warning.