### PR TITLE
Added cmake unit tests to verify gzip compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1024,6 +1024,7 @@ if (ZLIB_ENABLE_TESTS)
         endforeach()
         string(REPLACE ";" "" GZ_ARGS "${ARGN}")
         string(REPLACE "-" "" GZ_ARGS "${GZ_ARGS}")
+        # Test minigzip can decompress minigzip compressed
         add_test(NAME ${target}-${name}-${GZ_ARGS}-compr
             COMMAND ${CMAKE_COMMAND}
             "-DCOMMAND=${GZ_COMMAND}"
@@ -1040,9 +1041,49 @@ if (ZLIB_ENABLE_TESTS)
             "-DSUCCESS_EXIT=0;1"
             -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/run-and-redirect.cmake)
         add_test(NAME ${target}-${name}-${GZ_ARGS}-cmp
-            COMMAND ${CMAKE_COMMAND} -E compare_files
-                ${CMAKE_CURRENT_SOURCE_DIR}/${path}
-                ${CMAKE_CURRENT_SOURCE_DIR}/${path}.out)
+        COMMAND ${CMAKE_COMMAND} -E compare_files
+            ${CMAKE_CURRENT_SOURCE_DIR}/${path}
+            ${CMAKE_CURRENT_SOURCE_DIR}/${path}.out)
+        if(NOT "${ARGN}" MATCHES "-T")
+            # Transparent writing does not use gzip format
+            find_program(GZIP gzip)
+            if(GZIP)
+                # Test gzip can decompress minigzip compressed
+                set(GZ_COMMAND ${GZIP} --decompress)
+                add_test(NAME ${target}-${name}-${GZ_ARGS}-gzip-uncompr
+                    COMMAND ${CMAKE_COMMAND}
+                    "-DCOMMAND=${GZ_COMMAND}"
+                    -DINPUT=${CMAKE_CURRENT_SOURCE_DIR}/${path}.gz
+                    -DOUTPUT=${CMAKE_CURRENT_SOURCE_DIR}/${path}.gzip.out
+                    "-DSUCCESS_EXIT=0;1"
+                    -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/run-and-redirect.cmake)
+                add_test(NAME ${target}-${name}-${GZ_ARGS}-gzip-uncompr-cmp
+                    COMMAND ${CMAKE_COMMAND} -E compare_files
+                        ${CMAKE_CURRENT_SOURCE_DIR}/${path}
+                        ${CMAKE_CURRENT_SOURCE_DIR}/${path}.gzip.out)
+                # Test minigzip can decompress gzip compressed
+                set(GZ_COMMAND ${GZIP} --stdout)
+                add_test(NAME ${target}-${name}-${GZ_ARGS}-gzip-compr
+                    COMMAND ${CMAKE_COMMAND}
+                    "-DCOMMAND=${GZ_COMMAND}"
+                    -DINPUT=${CMAKE_CURRENT_SOURCE_DIR}/${path}
+                    -DOUTPUT=${CMAKE_CURRENT_SOURCE_DIR}/${path}.gzip.gz
+                    "-DSUCCESS_EXIT=0;1"
+                    -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/run-and-redirect.cmake)
+                set(GZ_COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:${target}> -d)
+                add_test(NAME ${target}-${name}-${GZ_ARGS}-minigzip-uncompr
+                    COMMAND ${CMAKE_COMMAND}
+                    "-DCOMMAND=${GZ_COMMAND}"
+                    -DINPUT=${CMAKE_CURRENT_SOURCE_DIR}/${path}.gzip.gz
+                    -DOUTPUT=${CMAKE_CURRENT_SOURCE_DIR}/${path}.gzip.out
+                    "-DSUCCESS_EXIT=0;1"
+                    -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/run-and-redirect.cmake)
+                add_test(NAME ${target}-${name}-${GZ_ARGS}-minigzip-cmp
+                    COMMAND ${CMAKE_COMMAND} -E compare_files
+                        ${CMAKE_CURRENT_SOURCE_DIR}/${path}
+                        ${CMAKE_CURRENT_SOURCE_DIR}/${path}.gzip.out)
+            endif()
+        endif()
     endmacro()
 
     set(OPEN_MODES -f -h -R -F -T)


### PR DESCRIPTION
This PR confirms that gzip utility on Linux and Mac can decompress minigzip compressed data. Currently we only check to see that minigzip can decompress minigzip compressed data.

Buildkite seems to fail. I don't have access to that CI.