### PR TITLE
Fixed segmentation fault in deflate_quick() when switching levels using deflateParam

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1097,6 +1097,13 @@ if (ZLIB_ENABLE_TESTS)
             "-DCOMMAND=${GH_364_COMMAND}"
             -DINPUT=${CMAKE_CURRENT_SOURCE_DIR}/test/GH-364/test.bin
             -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/run-and-redirect.cmake)
+
+    set(GH_546_COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:switchlevels> 6 9744 1 91207)
+    add_test(NAME GH-546-segfault
+            COMMAND ${CMAKE_COMMAND}
+            "-DCOMMAND=${GH_546_COMMAND}"
+            -DINPUT=${CMAKE_CURRENT_SOURCE_DIR}/test/data/lcet10.txt
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/run-and-redirect.cmake)
 endif()
 
 FEATURE_SUMMARY(WHAT ALL INCLUDE_QUIET_PACKAGES)


### PR DESCRIPTION
This is related to discussion on #536. 

I have added a unit test case that reproduces the segmentation fault. Here is the initial check-in of just the unit test causing the segmentation fault https://github.com/nmoinvaz/zlib-ng/runs/467173544 and afterwards after the fix is applied https://github.com/nmoinvaz/zlib-ng/runs/467198265.

Background:

- deflateInit would be initialized with a window size greater than 8K
- deflateParams called to switch to level 1 which does not update w_size
- Fault would occur because deflate_quick was not checking w_size bounds on dist when accessing quick_dist_codes