### PR TITLE
Fixed segmentation fault in deflate_quick() when switching levels using deflateParam

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1121,6 +1121,13 @@ if (ZLIB_ENABLE_TESTS)
             "-DCOMMAND=${GH_364_COMMAND}"
             -DINPUT=${CMAKE_CURRENT_SOURCE_DIR}/test/GH-364/test.bin
             -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/run-and-redirect.cmake)
+
+    set(GH_536_COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:switchlevels> 6 9744 1 91207)
+    add_test(NAME GH-536-segfault
+            COMMAND ${CMAKE_COMMAND}
+            "-DCOMMAND=${GH_536_COMMAND}"
+            -DINPUT=${CMAKE_CURRENT_SOURCE_DIR}/test/data/lcet10.txt
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/run-and-redirect.cmake)
 endif()
 
 FEATURE_SUMMARY(WHAT ALL INCLUDE_QUIET_PACKAGES)

--- a/arch/x86/deflate_quick.c
+++ b/arch/x86/deflate_quick.c
@@ -209,6 +209,10 @@ static inline Pos quick_insert_string(deflate_state *const s, const Pos str) {
 ZLIB_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
     IPos hash_head;
     unsigned dist, match_len;
+    unsigned int wsize = s->w_size;
+
+    if (wsize > 8192)
+        wsize = 8192;
 
     if (s->block_open == 0) {
         static_emit_tree(s, flush);
@@ -237,7 +241,7 @@ ZLIB_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
             hash_head = quick_insert_string(s, s->strstart);
             dist = s->strstart - hash_head;
 
-            if (dist > 0 && (dist-1) < (s->w_size - 1)) {
+            if (dist > 0 && (dist-1) < (wsize - 1)) {
                 match_len = compare258(s->window + s->strstart, s->window + hash_head);
 
                 if (match_len >= MIN_MATCH) {


### PR DESCRIPTION
This is related to discussion on #536. 

I have added a unit test case that reproduces the segmentation fault. Here is the initial check-in of just the unit test causing the segmentation fault https://github.com/nmoinvaz/zlib-ng/runs/467173544 and afterwards after the fix is applied https://github.com/nmoinvaz/zlib-ng/runs/467198265.

Background:

- deflateInit would be initialized with a window size greater than 8K
- deflateParams called to switch to level 1 which does not update w_size
- Fault would occur because deflate_quick was not checking w_size bounds on dist when accessing quick_dist_codes