### PR TITLE
Allow deflate_quick() to continue processing input data after flushing pending buffer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1175,6 +1175,13 @@ if (ZLIB_ENABLE_TESTS)
             "-DCOMMAND=${GH_536_COMMAND}"
             -DINPUT=${CMAKE_CURRENT_SOURCE_DIR}/test/data/lcet10.txt
             -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/run-and-redirect.cmake)
+
+    set(GH_536_COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:switchlevels> 6 88933 1 195840 2 45761)
+    add_test(NAME GH-536-incomplete-read
+            COMMAND ${CMAKE_COMMAND}
+            "-DCOMMAND=${GH_536_COMMAND}"
+            -DINPUT=${CMAKE_CURRENT_SOURCE_DIR}/test/data/lcet10.txt
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/run-and-redirect.cmake)
 endif()
 
 FEATURE_SUMMARY(WHAT ALL INCLUDE_QUIET_PACKAGES)

--- a/arch/x86/deflate_quick.c
+++ b/arch/x86/deflate_quick.c
@@ -222,7 +222,7 @@ ZLIB_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
     do {
         if (s->pending + 4 >= s->pending_buf_size) {
             flush_pending(s->strm);
-            if (flush != Z_FINISH) {
+            if (s->strm->avail_in == 0 && flush != Z_FINISH) {
                 return need_more;
             }
         }


### PR DESCRIPTION
This is related to discussion on #536.

This merge request relies on #541 and should be rebased after it is merged in.

I have added a unit test which covers this change. Before the change in https://github.com/nmoinvaz/zlib-ng/runs/467259498 it errors out with `deflate() did not consume 55397 bytes of input`. And after the change there is no such error https://github.com/nmoinvaz/zlib-ng/runs/467278325.

Background:

Switch levels and `pigz` check to see that all of the input buffer was consumed. `deflate_quick` was not processing all available input after flushing the pending buffer but instead was exiting early.

The relevant change is the check for `avail_in == 0` in:

```
if (s->pending + 4 >= s->pending_buf_size) {
    flush_pending(s->strm);
    if (s->strm->avail_in == 0 && flush != Z_FINISH) {
        return need_more;
    }
}
```
