### PR TITLE
Clean up longest_match variants and abstract match comparisons to compare258

### DIFF
--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -136,12 +136,21 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
+    - name: Install packages (Ubuntu)
+      if: runner.os == 'Linux' && matrix.packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y ${{ matrix.packages }}
+
     - name: Generate project files
       run: |
         mkdir ${{ matrix.build-dir || '.not-used' }}
         cd ${{ matrix.build-dir || '.' }}
         ${{ matrix.build-src-dir || '.' }}/configure ${{ matrix.configure-args }}
       env:
+        CC: ${{ matrix.compiler }}
+        CFLAGS: ${{ matrix.cflags }}
+        LDFLAGS: ${{ matrix.ldflags }}
         CI: true
 
     - name: Compile source code

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -402,20 +402,37 @@ if(HAVE_ATTRIBUTE_VISIBILITY_INTERNAL)
 endif()
 
 #
-# check for __builtin_ctzl() support in the compiler
+# check for __builtin_ctz() support in the compiler
 #
 check_c_source_compiles(
     "int main(void)
     {
         unsigned int zero = 0;
-        long test = __builtin_ctzl(zero);
+        long test = __builtin_ctz(zero);
         (void)test;
         return 0;
     }"
-    HAVE_BUILTIN_CTZL
+    HAVE_BUILTIN_CTZ
 )
-if(HAVE_BUILTIN_CTZL)
-    add_definitions(-DHAVE_BUILTIN_CTZL)
+if(HAVE_BUILTIN_CTZ)
+    add_definitions(-DHAVE_BUILTIN_CTZ)
+endif()
+
+#
+# check for __builtin_ctzll() support in the compiler
+#
+check_c_source_compiles(
+    "int main(void)
+    {
+        unsigned int zero = 0;
+        long test = __builtin_ctzll(zero);
+        (void)test;
+        return 0;
+    }"
+    HAVE_BUILTIN_CTZLL
+)
+if(HAVE_BUILTIN_CTZLL)
+    add_definitions(-DHAVE_BUILTIN_CTZLL)
 endif()
 
 #
@@ -513,6 +530,22 @@ if(BASEARCH_X86_FOUND)
             return 0;
         }"
         HAVE_SSE42CRC_INTRIN
+    )
+    set(CMAKE_REQUIRED_FLAGS)
+
+    # Check whether compiler supports SSE4.2 compare string instrinics
+    check_c_source_compile_or_run(
+        "#include <immintrin.h>
+        int main(void)
+        {
+            unsigned char a[64] = { 0 };
+            unsigned char b[64] = { 0 };
+            __m128i xmm_src0, xmm_src1;
+            xmm_src0 = _mm_loadu_si128((__m128i *)(char *)a);
+            xmm_src1 = _mm_loadu_si128((__m128i *)(char *)b);
+            return _mm_cmpestri(xmm_src0, 16, xmm_src1, 16, 0);
+        }"
+        HAVE_SSE42CMPSTR_INTRIN
     )
     set(CMAKE_REQUIRED_FLAGS)
 
@@ -628,7 +661,7 @@ if(WITH_OPTIM)
             if("${ARCH}" MATCHES "arm" OR NOT WITH_NEON)
                 add_intrinsics_option("${ACLEFLAG}")
             endif()
-            add_feature_info(ACLE_CRC 1 "Support CRC hash generation using the ACLE instruction set, using \"${ACLEFLAG}\"")
+            add_feature_info(ACLE_CRC 1 "Support ACLE optimized CRC hash generation, using \"${ACLEFLAG}\"")
         endif()
     elseif(BASEARCH_X86_FOUND)
         add_definitions(-DX86_CPUID)
@@ -639,13 +672,16 @@ if(WITH_OPTIM)
         if(HAVE_AVX2_INTRIN)
             add_definitions(-DX86_AVX2)
             list(APPEND ZLIB_ARCH_SRCS ${ARCHDIR}/slide_avx.c)
-            add_feature_info(AVX2_SLIDEHASH 1 "Support AVX2-optimized slide_hash, using \"${AVX2FLAG}\"")
+            add_feature_info(AVX2_SLIDEHASH 1 "Support AVX2 optimized slide_hash, using \"${AVX2FLAG}\"")
+            list(APPEND ZLIB_ARCH_HDRS ${ARCHDIR}/compare258_avx.h)
+            list(APPEND ZLIB_ARCH_SRCS ${ARCHDIR}/compare258_avx.c)
+            add_feature_info(AVX2_COMPARE258 1 "Support AVX2 optimized compare258, using \"${AVX2FLAG}\"")
             add_intrinsics_option("${AVX2FLAG}")
         endif()
         if(HAVE_SSE42CRC_INLINE_ASM OR HAVE_SSE42CRC_INTRIN)
             add_definitions(-DX86_SSE42_CRC_HASH)
             list(APPEND ZLIB_ARCH_SRCS ${ARCHDIR}/insert_string_sse.c)
-            add_feature_info(SSE42_CRC 1 "Support CRC hash generation using the SSE4.2 instruction set, using \"${SSE4FLAG}\"")
+            add_feature_info(SSE42_CRC 1 "Support SSE4.2 optimized CRC hash generation, using \"${SSE4FLAG}\"")
             add_intrinsics_option("${SSE4FLAG}")
             if(HAVE_SSE42CRC_INTRIN)
                 add_definitions(-DX86_SSE42_CRC_INTRIN)
@@ -653,8 +689,14 @@ if(WITH_OPTIM)
             if(WITH_NEW_STRATEGIES)
                 add_definitions(-DX86_QUICK_STRATEGY)
                 list(APPEND ZLIB_ARCH_SRCS ${ARCHDIR}/deflate_quick.c)
-                add_feature_info(SSE42_DEFLATE_QUICK 1 "Support SSE4.2-accelerated quick compression")
+                add_feature_info(SSE42_DEFLATE_QUICK 1 "Support SSE4.2 accelerated quick compression")
             endif()
+        endif()
+        if(HAVE_SSE42CMPSTR_INTRIN)
+            add_definitions(-DX86_SSE42_CMP_STR)
+            list(APPEND ZLIB_ARCH_HDRS ${ARCHDIR}/compare258_sse.h)
+            list(APPEND ZLIB_ARCH_SRCS ${ARCHDIR}/compare258_sse.c)
+            add_feature_info(SSE42_COMPARE258 1 "Support SSE4.2 optimized compare258, using \"${SSE4FLAG}\"")
         endif()
         if(HAVE_SSE2_INTRIN)
             add_definitions(-DX86_SSE2)
@@ -754,6 +796,7 @@ set(ZLIB_PUBLIC_HDRS
 )
 set(ZLIB_PRIVATE_HDRS
     adler32_p.h
+    compare258.h
     crc32.h
     crc32_p.h
     deflate.h
@@ -766,6 +809,7 @@ set(ZLIB_PRIVATE_HDRS
     inflate_p.h
     inftrees.h
     match_p.h
+    match.h
     memcopy.h
     trees.h
     trees_p.h
@@ -775,6 +819,7 @@ set(ZLIB_PRIVATE_HDRS
 )
 set(ZLIB_SRCS
     adler32.c
+    compare258.c
     compress.c
     crc32.c
     deflate.c

--- a/Makefile.in
+++ b/Makefile.in
@@ -71,11 +71,11 @@ mandir = ${prefix}/share/man
 man3dir = ${mandir}/man3
 pkgconfigdir = ${libdir}/pkgconfig
 
-OBJZ = adler32.o compress.o crc32.o deflate.o deflate_fast.o deflate_medium.o deflate_slow.o functable.o infback.o inffast.o inflate.o inftrees.o trees.o uncompr.o zutil.o $(ARCH_STATIC_OBJS)
+OBJZ = adler32.o compare258.o compress.o crc32.o deflate.o deflate_fast.o deflate_medium.o deflate_slow.o functable.o infback.o inffast.o inflate.o inftrees.o trees.o uncompr.o zutil.o $(ARCH_STATIC_OBJS)
 OBJG = gzclose.o gzlib.o gzread.o gzwrite.o
 OBJC = $(OBJZ) $(OBJG)
 
-PIC_OBJZ = adler32.lo compress.lo crc32.lo deflate.lo deflate_fast.lo deflate_medium.lo deflate_slow.lo functable.lo infback.lo inffast.lo inflate.lo inftrees.lo trees.lo uncompr.lo zutil.lo $(ARCH_SHARED_OBJS)
+PIC_OBJZ = adler32.lo compare258.lo compress.lo crc32.lo deflate.lo deflate_fast.lo deflate_medium.lo deflate_slow.lo functable.lo infback.lo inffast.lo inflate.lo inftrees.lo trees.lo uncompr.lo zutil.lo $(ARCH_SHARED_OBJS)
 PIC_OBJG = gzclose.lo gzlib.lo gzread.lo gzwrite.lo
 PIC_OBJC = $(PIC_OBJZ) $(PIC_OBJG)
 

--- a/arch/x86/Makefile.in
+++ b/arch/x86/Makefile.in
@@ -17,13 +17,25 @@ SRCDIR=.
 SRCTOP=../..
 TOPDIR=$(SRCTOP)
 
-all: x86.o x86.lo fill_window_sse.o fill_window_sse.lo deflate_quick.o deflate_quick.lo insert_string_sse.o insert_string_sse.lo crc_folding.o crc_folding.lo slide_avx.o slide_avx.lo slide_sse.o slide_sse.lo
+all: x86.o x86.lo compare258_avx.o compare258_avx.lo compare258_sse.o compare258_sse.lo fill_window_sse.o fill_window_sse.lo deflate_quick.o deflate_quick.lo insert_string_sse.o insert_string_sse.lo crc_folding.o crc_folding.lo slide_avx.o slide_avx.lo slide_sse.o slide_sse.lo
 
 x86.o:
 	$(CC) $(CFLAGS) $(INCLUDES) -c -o $@ $(SRCDIR)/x86.c
 
 x86.lo:
 	$(CC) $(SFLAGS) $(INCLUDES) -c -o $@ $(SRCDIR)/x86.c
+
+compare258_avx.o:
+	$(CC) $(CFLAGS) $(AVX2FLAG) $(INCLUDES) -c -o $@ $(SRCDIR)/compare258_avx.c
+
+compare258_avx.lo:
+	$(CC) $(SFLAGS) $(AVX2FLAG) -DPIC $(INCLUDES) -c -o $@ $(SRCDIR)/compare258_avx.c
+
+compare258_sse.o:
+	$(CC) $(CFLAGS) $(SSE4FLAG) $(INCLUDES) -c -o $@ $(SRCDIR)/compare258_sse.c
+
+compare258_sse.lo:
+	$(CC) $(SFLAGS) $(SSE4FLAG) -DPIC $(INCLUDES) -c -o $@ $(SRCDIR)/compare258_sse.c
 
 fill_window_sse.o:
 	$(CC) $(CFLAGS) $(SSE2FLAG) $(INCLUDES) -c -o $@ $(SRCDIR)/fill_window_sse.c

--- a/arch/x86/compare258_avx.c
+++ b/arch/x86/compare258_avx.c
@@ -1,0 +1,16 @@
+/* compare258_avx.c -- AVX version of extern compare258
+ * Copyright (C) 2020 Nathan Moinvaziri
+ * For conditions of distribution and use, see copyright notice in zlib.h
+ */
+
+#include "../../zbuild.h"
+#include "../../zutil.h"
+
+#include "compare258_avx.h"
+
+#ifdef X86_AVX2
+// UNALIGNED_OK, AVX2 instrinic comparison
+int32_t compare258_unaligned_avx(const unsigned char *src0, const unsigned char *src1) {
+    return compare258_unaligned_avx_static(src0, src1);
+}
+#endif

--- a/arch/x86/compare258_avx.h
+++ b/arch/x86/compare258_avx.h
@@ -1,0 +1,55 @@
+#ifndef COMPARE258_AVX_H_
+#define COMPARE258_AVX_H_
+
+/* compare258_avx.c -- AVX2 static version of compare258
+ * Copyright Mika T. Lindqvist  <postmaster@raasu.org>
+ * For conditions of distribution and use, see copyright notice in zlib.h
+ */
+
+#include "../../zbuild.h"
+#include "../../zutil.h"
+
+#include "fallback_builtins.h"
+
+#if defined(X86_AVX2) && defined(HAVE_BUILTIN_CTZ)
+
+#include <immintrin.h>
+#ifdef _MSC_VER
+#  include <nmmintrin.h>
+#endif
+
+// UNALIGNED_OK, AVX2 instrinic comparison
+static inline int32_t compare258_unaligned_avx_static(const unsigned char *src0, const unsigned char *src1) {
+    register const unsigned char *src0start = src0;
+    register const unsigned char *src0end = src0 + 258;
+    __m256i ymm_zero = _mm256_set1_epi8(0);
+
+    if (*(uint16_t *)src0 != *(uint16_t *)src1)
+        return (*src0 == *src1);
+
+    src0 += 2, src1 += 2;
+    if (*src0 != *src1)
+        return 2;
+    if (src0[1] != src1[1])
+        return 3;
+
+    do {
+        __m256i ymm_src0, ymm_src1, ymm_xor;
+        ymm_src0 = _mm256_loadu_si256((__m256i*)src0);
+        ymm_src1 = _mm256_loadu_si256((__m256i*)src1);
+        ymm_xor = _mm256_xor_si256(ymm_src0, ymm_src1); // identical bytes = 00
+        ymm_xor = _mm256_cmpeq_epi8(ymm_xor, ymm_zero); // non-identical bytes = 00, identical bytes = FF
+        uint32_t mask = _mm256_movemask_epi8(ymm_xor); 
+        if (mask != 0xFFFFFFFF) {
+            int match_byte = __builtin_ctz(~mask); // Invert bits so identical = 0
+            return (int32_t)(src0 - src0start + match_byte);
+        }
+
+        src0 += 32, src1 += 32;
+    } while (src0 < src0end);
+
+    return (int32_t)(src0 - src0start);
+}
+#endif
+
+#endif

--- a/arch/x86/compare258_sse.c
+++ b/arch/x86/compare258_sse.c
@@ -1,0 +1,16 @@
+/* compare258_sse.c -- SSE4.2 version of extern compare258
+ * Copyright (C) 2020 Nathan Moinvaziri
+ * For conditions of distribution and use, see copyright notice in zlib.h
+ */
+
+#include "../../zbuild.h"
+#include "../../zutil.h"
+
+#include "compare258_sse.h"
+
+#ifdef X86_SSE42_CMP_STR
+// UNALIGNED_OK, SSE4.2 instrinic comparison
+int32_t compare258_unaligned_sse(const unsigned char *src0, const unsigned char *src1) {
+    return compare258_unaligned_sse_static(src0, src1);
+}
+#endif

--- a/arch/x86/compare258_sse.h
+++ b/arch/x86/compare258_sse.h
@@ -1,0 +1,125 @@
+#ifndef COMPARE258_SSE_H_
+#define COMPARE258_SSE_H_
+
+/* compare258_sse.c -- SSE4.2 static version of compare258
+ *
+ * Copyright (C) 2013 Intel Corporation. All rights reserved.
+ * Authors:
+ *  Wajdi Feghali   <wajdi.k.feghali@intel.com>
+ *  Jim Guilford    <james.guilford@intel.com>
+ *  Vinodh Gopal    <vinodh.gopal@intel.com>
+ *     Erdinc Ozturk   <erdinc.ozturk@intel.com>
+ *  Jim Kukunas     <james.t.kukunas@linux.intel.com>
+ *
+ * Portions are Copyright (C) 2016 12Sided Technology, LLC.
+ * Author:
+ *  Phil Vachon     <pvachon@12sidedtech.com>
+ *
+ * For conditions of distribution and use, see copyright notice in zlib.h
+ */
+
+#include "../../zbuild.h"
+#include "../../zutil.h"
+
+#ifdef X86_SSE42_CMP_STR
+
+#include <immintrin.h>
+#ifdef _MSC_VER
+#  include <nmmintrin.h>
+#endif
+
+// UNALIGNED_OK, SSE4.2 instrinic comparison
+static inline int32_t compare258_unaligned_sse_static(const unsigned char *src0, const unsigned char *src1) {
+#ifdef _MSC_VER
+    register const unsigned char *src0start = src0;
+    register const unsigned char *src0end = src0 + 258; // (258 - 2) % 16 = 0
+
+    if (*(uint16_t *)src0 != *(uint16_t *)src1)
+        return (*src0 == *src1);
+
+    src0 += 2, src1 += 2;
+
+    if (*src0 != *src1)
+        return 2;
+    if (src0[1] != src1[1])
+        return 3;
+
+    do {
+        #define mode _SIDD_UBYTE_OPS | _SIDD_CMP_EQUAL_EACH | _SIDD_NEGATIVE_POLARITY
+        __m128i xmm_src0, xmm_src1;
+        int ret;
+
+        xmm_src0 = _mm_loadu_si128((__m128i *)src0);
+        xmm_src1 = _mm_loadu_si128((__m128i *)src1);
+        ret = _mm_cmpestri(xmm_src0, 16, xmm_src1, 16, mode);
+        if (_mm_cmpestrc(xmm_src0, 16, xmm_src1, 16, mode)) {
+            return (int32_t)(src0 - src0start + ret);
+        }
+        src0 += 16, src1 += 16;
+
+        xmm_src0 = _mm_loadu_si128((__m128i *)src0);
+        xmm_src1 = _mm_loadu_si128((__m128i *)src1);
+        ret = _mm_cmpestri(xmm_src0, 16, xmm_src1, 16, mode);
+        if (_mm_cmpestrc(xmm_src0, 16, xmm_src1, 16, mode)) {
+            return (int32_t)(src0 - src0start + ret);
+        }
+        src0 += 16, src1 += 16;
+    } while (src0 < src0end);
+
+    return (int32_t)(src0 - src0start);
+#else
+    uintptr_t ax, dx, cx;
+    __m128i xmm_src0;
+
+    ax = 16;
+    dx = 16;
+    /* Set cx to something, otherwise gcc thinks it's used
+       uninitalised */
+    cx = 0;
+
+    __asm__ __volatile__ (
+    "1:"
+        "movdqu     -16(%[src0], %[ax]), %[xmm_src0]\n\t"
+        "pcmpestri  $0x18, -16(%[src1], %[ax]), %[xmm_src0]\n\t"
+        "jc         2f\n\t"
+        "add        $16, %[ax]\n\t"
+
+        "movdqu     -16(%[src0], %[ax]), %[xmm_src0]\n\t"
+        "pcmpestri  $0x18, -16(%[src1], %[ax]), %[xmm_src0]\n\t"
+        "jc         2f\n\t"
+        "add        $16, %[ax]\n\t"
+
+        "cmp        $256 + 16, %[ax]\n\t"
+        "jb         1b\n\t"
+
+#  if !defined(__x86_64__)
+        "movzwl     -16(%[src0], %[ax]), %[dx]\n\t"
+#  else
+        "movzwq     -16(%[src0], %[ax]), %[dx]\n\t"
+#  endif
+        "xorw       -16(%[src1], %[ax]), %%dx\n\t"
+        "jnz        3f\n\t"
+
+        "add        $2, %[ax]\n\t"
+        "jmp        4f\n\t"
+    "3:\n\t"
+        "rep; bsf   %[dx], %[cx]\n\t"
+        "shr        $3, %[cx]\n\t"
+    "2:"
+        "add        %[cx], %[ax]\n\t"
+    "4:"
+    : [ax] "+a" (ax),
+      [cx] "+c" (cx),
+      [dx] "+d" (dx),
+      [xmm_src0] "=x" (xmm_src0)
+    : [src0] "r" (src0),
+      [src1] "r" (src1)
+    : "cc"
+    );
+    return (int32_t)(ax - 16);
+#endif
+}
+
+#endif
+
+#endif

--- a/arch/x86/deflate_quick.c
+++ b/arch/x86/deflate_quick.c
@@ -23,6 +23,7 @@
 #  include <nmmintrin.h>
 #endif
 #include "../../deflate.h"
+#include "../../functable.h"
 #include "../../memcopy.h"
 
 #ifdef ZLIB_DEBUG
@@ -31,95 +32,6 @@
 
 extern void fill_window_sse(deflate_state *s);
 extern void flush_pending(PREFIX3(stream) *strm);
-
-static inline long compare258(const unsigned char *const src0, const unsigned char *const src1) {
-#ifdef _MSC_VER
-    long cnt;
-
-    cnt = 0;
-    do {
-#define mode  _SIDD_UBYTE_OPS | _SIDD_CMP_EQUAL_EACH | _SIDD_NEGATIVE_POLARITY
-
-        int ret;
-        __m128i xmm_src0, xmm_src1;
-
-        xmm_src0 = _mm_loadu_si128((__m128i *)(src0 + cnt));
-        xmm_src1 = _mm_loadu_si128((__m128i *)(src1 + cnt));
-        ret = _mm_cmpestri(xmm_src0, 16, xmm_src1, 16, mode);
-        if (_mm_cmpestrc(xmm_src0, 16, xmm_src1, 16, mode)) {
-            cnt += ret;
-            break;
-        }
-        cnt += 16;
-
-        xmm_src0 = _mm_loadu_si128((__m128i *)(src0 + cnt));
-        xmm_src1 = _mm_loadu_si128((__m128i *)(src1 + cnt));
-        ret = _mm_cmpestri(xmm_src0, 16, xmm_src1, 16, mode);
-        if (_mm_cmpestrc(xmm_src0, 16, xmm_src1, 16, mode)) {
-            cnt += ret;
-            break;
-        }
-        cnt += 16;
-    } while (cnt < 256);
-
-    if (memcmp(src0 + cnt, src1 + cnt, sizeof(uint16_t)) == 0) {
-        cnt += 2;
-    } else if (*(src0 + cnt) == *(src1 + cnt)) {
-        cnt++;
-    }
-    return cnt;
-#else
-    uintptr_t ax, dx, cx;
-    __m128i xmm_src0;
-
-    ax = 16;
-    dx = 16;
-    /* set cx to something, otherwise gcc thinks it's used
-       uninitalised */
-    cx = 0;
-
-    __asm__ __volatile__ (
-    "1:"
-        "movdqu     -16(%[src0], %[ax]), %[xmm_src0]\n\t"
-        "pcmpestri  $0x18, -16(%[src1], %[ax]), %[xmm_src0]\n\t"
-        "jc         2f\n\t"
-        "add        $16, %[ax]\n\t"
-
-        "movdqu     -16(%[src0], %[ax]), %[xmm_src0]\n\t"
-        "pcmpestri  $0x18, -16(%[src1], %[ax]), %[xmm_src0]\n\t"
-        "jc         2f\n\t"
-        "add        $16, %[ax]\n\t"
-
-        "cmp        $256 + 16, %[ax]\n\t"
-        "jb         1b\n\t"
-
-#  if !defined(__x86_64__)
-        "movzwl     -16(%[src0], %[ax]), %[dx]\n\t"
-#  else
-        "movzwq     -16(%[src0], %[ax]), %[dx]\n\t"
-#  endif
-        "xorw       -16(%[src1], %[ax]), %%dx\n\t"
-        "jnz        3f\n\t"
-
-        "add        $2, %[ax]\n\t"
-        "jmp        4f\n\t"
-    "3:\n\t"
-        "rep; bsf   %[dx], %[cx]\n\t"
-        "shr        $3, %[cx]\n\t"
-    "2:"
-        "add        %[cx], %[ax]\n\t"
-    "4:"
-    : [ax] "+a" (ax),
-      [cx] "+c" (cx),
-      [dx] "+d" (dx),
-      [xmm_src0] "=x" (xmm_src0)
-    : [src0] "r" (src0),
-      [src1] "r" (src1)
-    : "cc"
-    );
-    return ax - 16;
-#endif
-}
 
 static const unsigned quick_len_codes[MAX_MATCH-MIN_MATCH+1];
 static const unsigned quick_dist_codes[8192];
@@ -238,7 +150,7 @@ ZLIB_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
             dist = s->strstart - hash_head;
 
             if (dist > 0 && (dist-1) < (s->w_size - 1)) {
-                match_len = compare258(s->window + s->strstart, s->window + s->strstart - dist);
+                match_len = functable.longest_match(s, hash_head);
 
                 if (match_len >= MIN_MATCH) {
                     if (match_len > s->lookahead)

--- a/compare258.c
+++ b/compare258.c
@@ -1,0 +1,33 @@
+/* compare258.c -- architecture specific versions of extern compare258
+ * Copyright (C) 2020 Nathan Moinvaziri
+ * For conditions of distribution and use, see copyright notice in zlib.h
+ */
+
+#include "zbuild.h"
+#include "zutil.h"
+
+#include "compare258.h"
+
+// ALIGNED, byte comparison
+int32_t compare258(const unsigned char *src0, const unsigned char *src1) {
+    return compare258_static(src0, src1);
+}
+
+// UNALIGNED_OK, 16-bit integer comparison
+int32_t compare258_unaligned_16(const unsigned char *src0, const unsigned char *src1) {
+    return compare258_unaligned_16_static(src0, src1);
+}
+
+#ifdef HAVE_BUILTIN_CTZ
+// UNALIGNED_OK, 32-bit integer comparison
+int32_t compare258_unaligned_32(const unsigned char *src0, const unsigned char *src1) {
+    return compare258_unaligned_32_static(src0, src1);
+}
+#endif
+
+#ifdef HAVE_BUILTIN_CTZLL
+// UNALIGNED_OK, 64-bit integer comparison
+int32_t compare258_unaligned_64(const unsigned char *src0, const unsigned char *src1) {
+    return compare258_unaligned_64_static(src0, src1);
+}
+#endif

--- a/compare258.h
+++ b/compare258.h
@@ -1,0 +1,134 @@
+#ifndef COMPARE258_H_
+#define COMPARE258_H_
+
+/* compare258.h -- architecture specific versions of static compare258
+ * Copyright (C) 2020 Nathan Moinvaziri
+ * For conditions of distribution and use, see copyright notice in zlib.h
+ */
+
+#include "zbuild.h"
+#include "zutil.h"
+
+#ifdef X86_CPUID
+#  include "fallback_builtins.h"
+#  include "arch/x86/compare258_sse.h"
+#  include "arch/x86/compare258_avx.h"
+#endif
+
+// ALIGNED, byte comparison
+static inline int32_t compare258_static(const unsigned char *src0, const unsigned char *src1) {
+    register const unsigned char *src0start = src0;
+    register const unsigned char *src0end = src0 + 258; // 258 % 6 = 0
+
+    do {
+        if (*src0 != *src1)
+            break;
+        src0 += 1, src1 += 1;
+        if (*src0 != *src1)
+            break;
+        src0 += 1, src1 += 1;
+        if (*src0 != *src1)
+            break;
+        src0 += 1, src1 += 1;
+        if (*src0 != *src1)
+            break;
+        src0 += 1, src1 += 1;
+        if (*src0 != *src1)
+            break;
+        src0 += 1, src1 += 1;
+        if (*src0 != *src1)
+            break;
+        src0 += 1, src1 += 1;
+    } while (src0 < src0end);
+ 
+    return (int32_t)(src0 - src0start);
+}
+
+// UNALIGNED_OK, 16-bit integer comparison
+static inline int32_t compare258_unaligned_16_static(const unsigned char *src0, const unsigned char *src1) {
+    register const unsigned char *src0start = src0;
+    register const unsigned char *src0end = src0 + 258; // 258 % 6 = 0
+
+    do {
+        if (*(uint16_t *)src0 != *(uint16_t *)src1)
+            break;
+        src0 += 2, src1 += 2;
+        if (*(uint16_t *)src0 != *(uint16_t *)src1)
+            break;
+        src0 += 2, src1 += 2;
+        if (*(uint16_t *)src0 != *(uint16_t *)src1)
+            break;
+        src0 += 2, src1 += 2;
+    } while (src0 < src0end);
+
+    if (*src0 == *src1)
+        src0 += 1;
+
+    return (int32_t)(src0 - src0start);
+}
+
+#ifdef HAVE_BUILTIN_CTZ
+// UNALIGNED_OK, 32-bit integer comparison
+static inline int32_t compare258_unaligned_32_static(const unsigned char *src0, const unsigned char *src1) {
+    register const unsigned char *src0start = src0;
+    register const unsigned char *src0end = src0 + 258; // (258 - 2) % 4 = 0
+
+    if (*(uint16_t *)src0 != *(uint16_t *)src1)
+        return (*src0 == *src1);
+
+    src0 += 2, src1 += 2;
+    if (*src0 != *src1)
+        return 2;
+    if (src0[1] != src1[1])
+        return 3;
+
+    do {
+        uint32_t *sv = (uint32_t *)src0;
+        uint32_t *mv = (uint32_t *)src1;
+        uint32_t xor = *sv ^ *mv;
+
+        if (xor) {
+            uint32_t match_byte = __builtin_ctz(xor) / 8;
+            return (int32_t)(src0 - src0start + match_byte);
+        }
+
+        src0 += 4, src1 += 4;
+    } while (src0 < src0end);
+
+    return (int32_t)(src0 - src0start);
+}
+#endif
+
+#ifdef HAVE_BUILTIN_CTZLL
+// UNALIGNED_OK, 64-bit integer comparison
+static inline int32_t compare258_unaligned_64_static(const unsigned char *src0, const unsigned char *src1) {
+    register const unsigned char *src0start = src0;
+    register const unsigned char *src0end = src0 + 258; // (258 - 2) % 8 = 0
+
+    if (*(uint16_t *)src0 != *(uint16_t *)src1)
+        return (*src0 == *src1);
+
+    src0 += 2, src1 += 2;
+    if (*src0 != *src1)
+        return 2;
+    if (src0[1] != src1[1])
+        return 3;
+
+    do {
+        uint64_t *sv = (uint64_t *)src0;
+        uint64_t *mv = (uint64_t *)src1;
+        uint64_t xor = *sv ^ *mv;
+
+        if (xor) {
+            uint64_t match_byte = __builtin_ctzll(xor) / 8;
+            return (int32_t)(src0 - src0start + match_byte);
+        }
+
+        src0 += 8, src1 += 8;
+    } while (src0 < src0end);
+
+    return (int32_t)(src0 - src0start);
+}
+#endif
+
+#endif

--- a/configure
+++ b/configure
@@ -1046,14 +1046,14 @@ case "${ARCH}" in
             if test ${HAVE_AVX2_INTRIN} -eq 1; then
                 CFLAGS="${CFLAGS} -DX86_AVX2"
                 SFLAGS="${SFLAGS} -DX86_AVX2"
-                ARCH_STATIC_OBJS="${ARCH_STATIC_OBJS} slide_avx.o"
-                ARCH_SHARED_OBJS="${ARCH_SHARED_OBJS} slide_avx.lo"
+                ARCH_STATIC_OBJS="${ARCH_STATIC_OBJS} slide_avx.o compare258_avx.o"
+                ARCH_SHARED_OBJS="${ARCH_SHARED_OBJS} slide_avx.lo compare258_avx.lo"
             fi
 
             CFLAGS="${CFLAGS} -DX86_SSE42_CRC_HASH"
             SFLAGS="${SFLAGS} -DX86_SSE42_CRC_HASH"
-            ARCH_STATIC_OBJS="${ARCH_STATIC_OBJS} insert_string_sse.o"
-            ARCH_SHARED_OBJS="${ARCH_SHARED_OBJS} insert_string_sse.lo"
+            ARCH_STATIC_OBJS="${ARCH_STATIC_OBJS} insert_string_sse.o compare258_sse.o"
+            ARCH_SHARED_OBJS="${ARCH_SHARED_OBJS} insert_string_sse.lo compare258_sse.lo"
 
             if test ${HAVE_PCLMULQDQ_INTRIN} -eq 1; then
                 CFLAGS="${CFLAGS} -DX86_PCLMULQDQ_CRC"

--- a/deflate.c
+++ b/deflate.c
@@ -52,7 +52,7 @@
 #include "zbuild.h"
 #include "deflate.h"
 #include "deflate_p.h"
-#include "match_p.h"
+#include "match.h"
 #include "functable.h"
 
 const char zng_deflate_copyright[] = " deflate 1.2.11.f Copyright 1995-2016 Jean-loup Gailly and Mark Adler ";

--- a/deflate_fast.c
+++ b/deflate_fast.c
@@ -7,7 +7,6 @@
 #include "zbuild.h"
 #include "deflate.h"
 #include "deflate_p.h"
-#include "match_p.h"
 #include "functable.h"
 
 /* ===========================================================================
@@ -52,7 +51,7 @@ ZLIB_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
              * of window index 0 (in particular we have to avoid a match
              * of the string with itself at the start of the input file).
              */
-            s->match_length = longest_match(s, hash_head);
+            s->match_length = functable.longest_match(s, hash_head);
             /* longest_match() sets match_start */
         }
         if (s->match_length >= MIN_MATCH) {

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -10,7 +10,6 @@
 #include "zbuild.h"
 #include "deflate.h"
 #include "deflate_p.h"
-#include "match_p.h"
 #include "functable.h"
 
 struct match {
@@ -252,7 +251,7 @@ ZLIB_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
                  * of window index 0 (in particular we have to avoid a match
                  * of the string with itself at the start of the input file).
                  */
-                current_match.match_length = longest_match(s, hash_head);
+                current_match.match_length = functable.longest_match(s, hash_head);
                 current_match.match_start = s->match_start;
                 if (current_match.match_length < MIN_MATCH)
                     current_match.match_length = 1;
@@ -284,7 +283,7 @@ ZLIB_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
                  * of window index 0 (in particular we have to avoid a match
                  * of the string with itself at the start of the input file).
                  */
-                next_match.match_length = longest_match(s, hash_head);
+                next_match.match_length = functable.longest_match(s, hash_head);
                 next_match.match_start = s->match_start;
                 if (next_match.match_start >= next_match.strstart) {
                     /* this can happen due to some restarts */

--- a/deflate_slow.c
+++ b/deflate_slow.c
@@ -7,7 +7,6 @@
 #include "zbuild.h"
 #include "deflate.h"
 #include "deflate_p.h"
-#include "match_p.h"
 #include "functable.h"
 
 /* ===========================================================================
@@ -62,7 +61,7 @@ ZLIB_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
              * of window index 0 (in particular we have to avoid a match
              * of the string with itself at the start of the input file).
              */
-            s->match_length = longest_match(s, hash_head);
+            s->match_length = functable.longest_match(s, hash_head);
             /* longest_match() sets match_start */
 
             if (s->match_length <= 5 && (s->strategy == Z_FILTERED

--- a/fallback_builtins.h
+++ b/fallback_builtins.h
@@ -1,16 +1,18 @@
-#ifndef X86_CTZL_H
-#define X86_CTZL_H
+#ifndef X86_BUILTIN_CTZ_H
+#define X86_BUILTIN_CTZ_H
+
+#if defined(_MSC_VER) && !defined(__clang__)
+#if defined(_M_IX86) || defined(_M_AMD64) || defined(_M_IA64) ||  defined(_M_ARM) || defined(_M_ARM64)
 
 #include <intrin.h>
 #ifdef X86_CPUID
 #  include "arch/x86/x86.h"
 #endif
 
-#if defined(_MSC_VER) && !defined(__clang__)
-/* This is not a general purpose replacement for __builtin_ctzl. The function expects that value is != 0
+/* This is not a general purpose replacement for __builtin_ctz. The function expects that value is != 0
  * Because of that assumption trailing_zero is not initialized and the return value of _BitScanForward is not checked
  */
-static __forceinline unsigned long __builtin_ctzl(unsigned long value) {
+static __forceinline unsigned long __builtin_ctz(uint32_t value) {
 #ifdef X86_CPUID
     if (x86_cpu_has_tzcnt)
         return _tzcnt_u32(value);
@@ -19,6 +21,24 @@ static __forceinline unsigned long __builtin_ctzl(unsigned long value) {
     _BitScanForward(&trailing_zero, value);
     return trailing_zero;
 }
+#define HAVE_BUILTIN_CTZ
+
+#ifdef _M_AMD64
+/* This is not a general purpose replacement for __builtin_ctzll. The function expects that value is != 0
+ * Because of that assumption trailing_zero is not initialized and the return value of _BitScanForward64 is not checked
+ */
+static __forceinline unsigned long long __builtin_ctzll(uint64_t value) {
+#ifdef X86_CPUID
+    if (x86_cpu_has_tzcnt)
+        return _tzcnt_u64(value);
+#endif
+    unsigned long trailing_zero;
+    _BitScanForward64(&trailing_zero, value);
+    return trailing_zero;
+}
+#define HAVE_BUILTIN_CTZLL
 #endif
 
+#endif
+#endif
 #endif

--- a/functable.h
+++ b/functable.h
@@ -14,6 +14,7 @@ struct functable_s {
     uint32_t (* adler32)        (uint32_t adler, const unsigned char *buf, size_t len);
     uint32_t (* crc32)          (uint32_t crc, const unsigned char *buf, uint64_t len);
     void     (* slide_hash)     (deflate_state *s);
+    unsigned (* longest_match)  (deflate_state *const s, IPos cur_match);
 };
 
 ZLIB_INTERNAL extern __thread struct functable_s functable;

--- a/match.h
+++ b/match.h
@@ -1,0 +1,62 @@
+/* match.h -- inline versions of longest_match 
+ * Copyright (C) 2020 Nathan Moinvaziri
+ * For conditions of distribution and use, see copyright notice in zlib.h
+ */
+
+#include "zbuild.h"
+#include "deflate.h"
+#include "compare258.h"
+
+#ifdef UNALIGNED_OK
+#if MIN_MATCH >= 4
+typedef uint32_t        bestcmp_t;
+#elif MIN_MATCH > 1
+typedef uint16_t        bestcmp_t;
+#else
+typedef uint8_t         bestcmp_t;
+#endif
+
+#define LONGEST_MATCH   longest_match_unaligned_16
+#undef  COMPARE258
+#define COMPARE258      compare258_unaligned_16_static
+#include "match_p.h"
+
+#ifdef HAVE_BUILTIN_CTZ
+#undef  LONGEST_MATCH
+#define LONGEST_MATCH   longest_match_unaligned_32
+#undef  COMPARE258
+#define COMPARE258      compare258_unaligned_32_static
+#include "match_p.h"
+#endif
+
+#ifdef HAVE_BUILTIN_CTZLL
+#undef  LONGEST_MATCH
+#define LONGEST_MATCH   longest_match_unaligned_64
+#undef  COMPARE258
+#define COMPARE258      compare258_unaligned_64_static
+#include "match_p.h"
+#endif
+
+#ifdef X86_AVX2
+#undef  LONGEST_MATCH
+#define LONGEST_MATCH   longest_match_unaligned_avx
+#undef  COMPARE258
+#define COMPARE258      compare258_unaligned_avx_static
+#include "match_p.h"
+#endif
+
+#ifdef X86_SSE42_CMP_STR
+#undef  LONGEST_MATCH
+#define LONGEST_MATCH   longest_match_unaligned_sse
+#undef  COMPARE258
+#define COMPARE258      compare258_unaligned_sse_static
+#include "match_p.h"
+#endif
+
+#else
+typedef uint8_t         bestcmp_t;
+#define LONGEST_MATCH   longest_match
+#define COMPARE258      compare258_static
+
+#include "match_p.h"
+#endif

--- a/match_p.h
+++ b/match_p.h
@@ -1,3 +1,7 @@
+
+#include "zbuild.h"
+#include "deflate.h"
+
 /*
  * Set match_start to the longest match starting at the given string and
  * return its length. Matches shorter or equal to prev_length are discarded,
@@ -7,173 +11,17 @@
  * string (strstart) and its distance is <= MAX_DIST, and prev_length >=1
  * OUT assertion: the match length is not greater than s->lookahead
  */
-
-#include "zbuild.h"
-#include "deflate.h"
-
-#if (defined(UNALIGNED_OK) && MAX_MATCH == 258)
-
-   /* ARM 32-bit clang/gcc builds perform better, on average, with std2. Both gcc and clang and define __GNUC__. */
-#  if defined(__GNUC__) && defined(__arm__) && !defined(__aarch64__)
-#    define std2_longest_match
-   /* Only use std3_longest_match for little_endian systems, also avoid using it with
-      non-gcc compilers since the __builtin_ctzl() function might not be optimized. */
-#  elif(defined(__GNUC__) && defined(HAVE_BUILTIN_CTZL) && ((__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) \
-        || defined(__LITTLE_ENDIAN__)))
-#    define std3_longest_match
-#  elif(defined(_MSC_VER) && defined(_WIN32))
-#    define std3_longest_match
-#  else
-#    define std2_longest_match
-#  endif
-
-#else
-#  define std1_longest_match
-#endif
-
-
-#if defined(_MSC_VER) && !defined(__clang__)
-#  if defined(_M_IX86) || defined(_M_AMD64) || defined(_M_IA64) ||  defined(_M_ARM) || defined(_M_ARM64)
-#    include "fallback_builtins.h"
-#  endif
-#endif
-
-
-
-#ifdef std1_longest_match
-
-/*
- * Standard longest_match
- *
- */
-static inline unsigned longest_match(deflate_state *const s, IPos cur_match) {
+unsigned LONGEST_MATCH(deflate_state *const s, IPos cur_match) {
+    unsigned int strstart = s->strstart;
     const unsigned wmask = s->w_mask;
+    unsigned char *window = s->window;
+    register unsigned char *match;                    /* match string */
+    register unsigned char *scan = window + strstart; /* current string */
     const Pos *prev = s->prev;
-
     unsigned chain_length;
     IPos limit;
     unsigned int len, best_len, nice_match;
-    unsigned char *scan, *match, *strend, scan_end, scan_end1;
-
-    /*
-     * The code is optimized for HASH_BITS >= 8 and MAX_MATCH-2 multiple
-     * of 16. It is easy to get rid of this optimization if necessary.
-     */
-    Assert(s->hash_bits >= 8 && MAX_MATCH == 258, "Code too clever");
-
-    /*
-     * Do not waste too much time if we already have a good match
-     */
-    best_len = s->prev_length ? s->prev_length : 1;
-    chain_length = s->max_chain_length;
-    if (best_len >= s->good_match)
-        chain_length >>= 2;
-
-    /*
-     * Do not looks for matches beyond the end of the input. This is
-     * necessary to make deflate deterministic
-     */
-    nice_match = (unsigned int)s->nice_match > s->lookahead ? s->lookahead : (unsigned int)s->nice_match;
-
-    /*
-     * Stop when cur_match becomes <= limit. To simplify the code,
-     * we prevent matches with the string of window index 0
-     */
-    limit = s->strstart > MAX_DIST(s) ? s->strstart - MAX_DIST(s) : 0;
-
-    scan = s->window + s->strstart;
-    strend = s->window + s->strstart + MAX_MATCH;
-    scan_end1 = scan[best_len-1];
-    scan_end = scan[best_len];
-
-    Assert((unsigned long)s->strstart <= s->window_size - MIN_LOOKAHEAD, "need lookahead");
-    do {
-        if (cur_match >= s->strstart) {
-            break;
-        }
-        match = s->window + cur_match;
-
-        /*
-         * Skip to next match if the match length cannot increase
-         * or if the match length is less than 2. Note that the checks
-         * below for insufficient lookahead only occur occasionally
-         * for performance reasons. Therefore uninitialized memory
-         * will be accessed and conditional jumps will be made that
-         * depend on those values. However the length of the match
-         * is limited to the lookahead, so the output of deflate is not
-         * affected by the uninitialized values.
-         */
-        if (match[best_len] != scan_end ||
-            match[best_len-1] != scan_end1 ||
-            *match != *scan ||
-            *++match != scan[1])
-            continue;
-
-        /*
-         * The check at best_len-1 can be removed because it will
-         * be made again later. (This heuristic is not always a win.)
-         * It is not necessary to compare scan[2] and match[2] since
-         * they are always equal when the other bytes match, given
-         * that the hash keys are equal and that HASH_BITS >= 8.
-         */
-        scan += 2;
-        match++;
-        Assert(*scan == *match, "match[2]?");
-
-        /*
-         * We check for insufficient lookahead only every 8th
-         * comparision; the 256th check will be made at strstart + 258.
-         */
-        do {
-        } while (*++scan == *++match && *++scan == *++match &&
-             *++scan == *++match && *++scan == *++match &&
-             *++scan == *++match && *++scan == *++match &&
-             *++scan == *++match && *++scan == *++match &&
-             scan < strend);
-
-        Assert(scan <= s->window+(unsigned int)(s->window_size-1), "wild scan");
-
-        len = MAX_MATCH - (int)(strend - scan);
-        scan = strend - MAX_MATCH;
-
-        if (len > best_len) {
-            s->match_start = cur_match;
-            best_len = len;
-            if (len >= nice_match)
-                break;
-            scan_end1 = scan[best_len-1];
-            scan_end = scan[best_len];
-        } else {
-            /*
-             * The probability of finding a match later if we here
-             * is pretty low, so for performance it's best to
-             * outright stop here for the lower compression levels
-             */
-            if (s->level < TRIGGER_LEVEL)
-                break;
-        }
-    } while ((cur_match = prev[cur_match & wmask]) > limit && --chain_length);
-
-    if ((unsigned int)best_len <= s->lookahead)
-        return best_len;
-    return s->lookahead;
-}
-#endif
-
-#ifdef std2_longest_match
-/*
- * UNALIGNED_OK longest_match
- *
- */
-static inline unsigned longest_match(deflate_state *const s, IPos cur_match) {
-    const unsigned wmask = s->w_mask;
-    const Pos *prev = s->prev;
-
-    uint16_t scan_start, scan_end;
-    unsigned chain_length;
-    IPos limit;
-    unsigned int len, best_len, nice_match;
-    unsigned char *scan, *strend;
+    bestcmp_t scan_end, scan_start;
 
     /*
      * The code is optimized for HASH_BITS >= 8 and MAX_MATCH-2 multiple
@@ -199,20 +47,16 @@ static inline unsigned longest_match(deflate_state *const s, IPos cur_match) {
      * Stop when cur_match becomes <= limit. To simplify the code,
      * we prevent matches with the string of window index 0
      */
-    limit = s->strstart > MAX_DIST(s) ? s->strstart - MAX_DIST(s) : 0;
+    limit = strstart > MAX_DIST(s) ? strstart - MAX_DIST(s) : 0;
 
-    scan = s->window + s->strstart;
-    strend = s->window + s->strstart + MAX_MATCH - 1;
-    memcpy(&scan_start, scan, sizeof(scan_start));
-    memcpy(&scan_end, scan + best_len - 1, sizeof(scan_end));
+    scan_start = *(bestcmp_t *)(scan);
+    scan_end = *(bestcmp_t *)(scan+best_len-1);
 
-    Assert((unsigned long)s->strstart <= s->window_size - MIN_LOOKAHEAD, "need lookahead");
+    Assert((unsigned long)strstart <= s->window_size - MIN_LOOKAHEAD, "need lookahead");
     do {
-        unsigned char *match;
-        if (cur_match >= s->strstart) {
+        if (cur_match >= strstart) {
             break;
         }
-        match = s->window + cur_match;
 
         /*
          * Skip to next match if the match length cannot increase
@@ -224,77 +68,31 @@ static inline unsigned longest_match(deflate_state *const s, IPos cur_match) {
          * is limited to the lookahead, so the output of deflate is not
          * affected by the uninitialized values.
          */
-        uint16_t val;
-        memcpy(&val, match + best_len - 1, sizeof(val));
-        if (LIKELY(val != scan_end))
-            continue;
-
-        memcpy(&val, match, sizeof(val));
-        if (val != scan_start)
-            continue;
-
-        /* It is not necessary to compare scan[2] and match[2] since
-         * they are always equal when the other bytes match, given that
-         * the hash keys are equal and that HASH_BITS >= 8. Compare 2
-         * bytes at a time at strstart+3, +5, ... up to strstart+257.
-         * We check for insufficient lookahead only every 4th
-         * comparison; the 128th check will be made at strstart+257.
-         * If MAX_MATCH-2 is not a multiple of 8, it is necessary to
-         * put more guard bytes at the end of the window, or to check
-         * more often for insufficient lookahead.
-         */
-        Assert(scan[2] == match[2], "scan[2]?");
-        scan++;
-        match++;
-
+        int cont = 1;
         do {
-            uint16_t mval, sval;
+            match = window + cur_match;
+            if (LIKELY(*(bestcmp_t *)(match+best_len-1) != scan_end) ||
+                       *(bestcmp_t *)(match) != scan_start) {
+                if ((cur_match = prev[cur_match & wmask]) > limit && --chain_length) {
+                    continue;
+                }
+                cont = 0;
+            }
+            break;
+        } while (1);
 
-            memcpy(&mval, match, sizeof(mval));
-            memcpy(&sval, scan, sizeof(sval));
-            if (mval != sval)
-                break;
-            match += sizeof(mval);
-            scan += sizeof(sval);
+        if (!cont)
+            break;
 
-            memcpy(&mval, match, sizeof(mval));
-            memcpy(&sval, scan, sizeof(sval));
-            if (mval != sval)
-                break;
-            match += sizeof(mval);
-            scan += sizeof(sval);
-
-            memcpy(&mval, match, sizeof(mval));
-            memcpy(&sval, scan, sizeof(sval));
-            if (mval != sval)
-                break;
-            match += sizeof(mval);
-            scan += sizeof(sval);
-
-            memcpy(&mval, match, sizeof(mval));
-            memcpy(&sval, scan, sizeof(sval));
-            if (mval != sval)
-                break;
-            match += sizeof(mval);
-            scan += sizeof(sval);
-        } while (scan < strend);
-
-        /*
-         * Here, scan <= window + strstart + 257
-         */
-        Assert(scan <= s->window+(unsigned)(s->window_size-1), "wild scan");
-        if (*scan == *match)
-            scan++;
-
-        len = (MAX_MATCH -1) - (int)(strend-scan);
-        scan = strend - (MAX_MATCH-1);
+        len = COMPARE258(match, scan);
+        Assert(scan+len <= window+(unsigned)(s->window_size-1), "wild scan");
 
         if (len > best_len) {
             s->match_start = cur_match;
             best_len = len;
             if (len >= nice_match)
                 break;
-            memcpy(&scan_end, scan + best_len - 1, sizeof(scan_end));
+            scan_end = *(bestcmp_t *)(scan+best_len-1);
         } else {
             /*
              * The probability of finding a match later if we here
@@ -310,199 +108,3 @@ static inline unsigned longest_match(deflate_state *const s, IPos cur_match) {
         return best_len;
     return s->lookahead;
 }
-#endif
-
-#ifdef std3_longest_match
-/* longest_match() with minor change to improve performance (in terms of
- * execution time).
- *
- * The pristine longest_match() function is sketched below (strip the
- * then-clause of the "#ifdef UNALIGNED_OK"-directive)
- *
- * ------------------------------------------------------------
- * unsigned int longest_match(...) {
- *    ...
- *    do {
- *        match = s->window + cur_match;                //s0
- *        if (*(ushf*)(match+best_len-1) != scan_end || //s1
- *            *(ushf*)match != scan_start) continue;    //s2
- *        ...
- *
- *        do {
- *        } while (*(ushf*)(scan+=2) == *(ushf*)(match+=2) &&
- *                 *(ushf*)(scan+=2) == *(ushf*)(match+=2) &&
- *                 *(ushf*)(scan+=2) == *(ushf*)(match+=2) &&
- *                 *(ushf*)(scan+=2) == *(ushf*)(match+=2) &&
- *                 scan < strend); //s3
- *
- *        ...
- *    } while(cond); //s4
- *
- * -------------------------------------------------------------
- *
- * The change include:
- *
- *  1) The hottest statements of the function is: s0, s1 and s4. Pull them
- *     together to form a new loop. The benefit is two-fold:
- *
- *    o. Ease the compiler to yield good code layout: the conditional-branch
- *       corresponding to s1 and its biased target s4 become very close (likely,
- *       fit in the same cache-line), hence improving instruction-fetching
- *       efficiency.
- *
- *    o. Ease the compiler to promote "s->window" into register. "s->window"
- *       is loop-invariant; it is supposed to be promoted into register and keep
- *       the value throughout the entire loop. However, there are many such
- *       loop-invariant, and x86-family has small register file; "s->window" is
- *       likely to be chosen as register-allocation victim such that its value
- *       is reloaded from memory in every single iteration. By forming a new loop,
- *       "s->window" is loop-invariant of that newly created tight loop. It is
- *       lot easier for compiler to promote this quantity to register and keep
- *       its value throughout the entire small loop.
- *
- * 2) Transfrom s3 such that it examines sizeof(long)-byte-match at a time.
- *    This is done by:
- *        ------------------------------------------------
- *        v1 = load from "scan" by sizeof(long) bytes
- *        v2 = load from "match" by sizeof(lnog) bytes
- *        v3 = v1 xor v2
- *        match-bit = little-endian-machine(yes-for-x86) ?
- *                     count-trailing-zero(v3) :
- *                     count-leading-zero(v3);
- *
- *        match-byte = match-bit/8
- *
- *        "scan" and "match" advance if necessary
- *       -------------------------------------------------
- */
-
-static inline unsigned longest_match(deflate_state *const s, IPos cur_match) {
-    unsigned int strstart = s->strstart;
-    unsigned chain_length = s->max_chain_length;/* max hash chain length */
-    unsigned char *window = s->window;
-    register unsigned char *scan = window + strstart; /* current string */
-    register unsigned char *match;                       /* matched string */
-    register unsigned int len;                  /* length of current match */
-    unsigned int best_len = s->prev_length ? s->prev_length : 1;     /* best match length so far */
-    unsigned int nice_match = s->nice_match;    /* stop if match long enough */
-    IPos limit = strstart > (IPos)MAX_DIST(s) ?
-        strstart - (IPos)MAX_DIST(s) : NIL;
-    /* Stop when cur_match becomes <= limit. To simplify the code,
-     * we prevent matches with the string of window index 0.
-     */
-    Pos *prev = s->prev;
-    unsigned int wmask = s->w_mask;
-
-    register unsigned char *strend = window + strstart + MAX_MATCH;
-
-    uint16_t scan_start, scan_end;
-
-    memcpy(&scan_start, scan, sizeof(scan_start));
-    memcpy(&scan_end, scan+best_len-1, sizeof(scan_end));
-
-    /* The code is optimized for HASH_BITS >= 8 and MAX_MATCH-2 multiple of 16.
-     * It is easy to get rid of this optimization if necessary.
-     */
-    Assert(s->hash_bits >= 8 && MAX_MATCH == 258, "Code too clever");
-
-    /* Do not waste too much time if we already have a good match: */
-    if (s->prev_length >= s->good_match) {
-        chain_length >>= 2;
-    }
-    /* Do not look for matches beyond the end of the input. This is necessary
-     * to make deflate deterministic.
-     */
-    if ((unsigned int)nice_match > s->lookahead) nice_match = s->lookahead;
-
-    Assert((unsigned long)strstart <= s->window_size-MIN_LOOKAHEAD, "need lookahead");
-
-    do {
-        if (cur_match >= strstart) {
-            break;
-        }
-
-        /* Skip to next match if the match length cannot increase
-         * or if the match length is less than 2.  Note that the checks below
-         * for insufficient lookahead only occur occasionally for performance
-         * reasons.  Therefore uninitialized memory will be accessed, and
-         * conditional jumps will be made that depend on those values.
-         * However the length of the match is limited to the lookahead, so
-         * the output of deflate is not affected by the uninitialized values.
-         */
-        int cont = 1;
-        do {
-            match = window + cur_match;
-            if (LIKELY(memcmp(match+best_len-1, &scan_end, sizeof(scan_end)) != 0
-                || memcmp(match, &scan_start, sizeof(scan_start)) != 0)) {
-                if ((cur_match = prev[cur_match & wmask]) > limit
-                    && --chain_length != 0) {
-                    continue;
-                } else {
-                    cont = 0;
-                }
-            }
-            break;
-        } while (1);
-
-        if (!cont)
-            break;
-
-        /* It is not necessary to compare scan[2] and match[2] since they are
-         * always equal when the other bytes match, given that the hash keys
-         * are equal and that HASH_BITS >= 8. Compare 2 bytes at a time at
-         * strstart+3, +5, ... up to strstart+257. We check for insufficient
-         * lookahead only every 4th comparison; the 128th check will be made
-         * at strstart+257. If MAX_MATCH-2 is not a multiple of 8, it is
-         * necessary to put more guard bytes at the end of the window, or
-         * to check more often for insufficient lookahead.
-         */
-        scan += 2, match+=2;
-        Assert(*scan == *match, "match[2]?");
-        do {
-            unsigned long sv, mv, xor;
-
-            memcpy(&sv, scan, sizeof(sv));
-            memcpy(&mv, match, sizeof(mv));
-
-            xor = sv ^ mv;
-
-            if (xor) {
-                int match_byte = __builtin_ctzl(xor) / 8;
-                scan += match_byte;
-                break;
-            } else {
-                scan += sizeof(unsigned long);
-                match += sizeof(unsigned long);
-            }
-        } while (scan < strend);
-
-        if (scan > strend)
-            scan = strend;
-
-        Assert(scan <= window + (unsigned)(s->window_size-1), "wild scan");
-
-        len = MAX_MATCH - (int)(strend - scan);
-        scan = strend - MAX_MATCH;
-
-        if (len > best_len) {
-            s->match_start = cur_match;
-            best_len = len;
-            if (len >= nice_match)
-                break;
-            memcpy(&scan_end, scan+best_len-1, sizeof(scan_end));
-        } else {
-            /*
-             * The probability of finding a match later if we here
-             * is pretty low, so for performance it's best to
-             * outright stop here for the lower compression levels
-             */
-            if (s->level < TRIGGER_LEVEL)
-                break;
-        }
-    } while ((cur_match = prev[cur_match & wmask]) > limit && --chain_length != 0);
-
-    if ((unsigned int)best_len <= s->lookahead)
-        return (unsigned int)best_len;
-    return s->lookahead;
-}
-#endif


### PR DESCRIPTION
This is a preliminary PR to see if we want to go this route. Performance testing will need to be done to see impact. Once we decide then I will try to fix the configure script and other makefiles, etc.

There are static versions of `compare258` which are used for inlining in `longest_match`. And there are non-static versions of `compare258` which are used for `functable` and used by `deflate_quick` - doing this will allow `deflate_quick` to be used for more than just X86 in a future check-in.

`longest_match` now can use `compare258` for SSE 4.2 while before only `deflate_quick` used it.

This change also supports `compare258` using 64-bit integers, before the max was 32-bit.

For background see #496.