### PR TITLE
deflate_medium speedup and some cleanup

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -1552,7 +1552,7 @@ static block_state deflate_stored(deflate_state *s, int flush) {
  * deflate switches away from Z_RLE.)
  */
 static block_state deflate_rle(deflate_state *s, int flush) {
-    int bflush;                     /* set if current block must be flushed */
+    int bflush = 0;                 /* set if current block must be flushed */
     unsigned int prev;              /* byte at distance one to match */
     unsigned char *scan, *strend;   /* scan goes up to strend for length of run */
 
@@ -1624,7 +1624,7 @@ static block_state deflate_rle(deflate_state *s, int flush) {
  * (It will be regenerated if this run of deflate switches away from Huffman.)
  */
 static block_state deflate_huff(deflate_state *s, int flush) {
-    int bflush;             /* set if current block must be flushed */
+    int bflush = 0;         /* set if current block must be flushed */
 
     for (;;) {
         /* Make sure that we have a literal to write. */

--- a/deflate_fast.c
+++ b/deflate_fast.c
@@ -19,7 +19,7 @@
  */
 ZLIB_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
     IPos hash_head;       /* head of the hash chain */
-    int bflush;           /* set if current block must be flushed */
+    int bflush = 0;       /* set if current block must be flushed */
 
     for (;;) {
         /* Make sure that we always have enough lookahead, except

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -21,25 +21,25 @@ struct match {
 };
 
 static int emit_match(deflate_state *s, struct match match) {
-    int flush = 0;
+    int bflush = 0;
 
     /* matches that are not long enough we need to emit as literals */
     if (match.match_length < MIN_MATCH) {
         while (match.match_length) {
-            flush += zng_tr_tally_lit(s, s->window[match.strstart]);
+            bflush += zng_tr_tally_lit(s, s->window[match.strstart]);
             s->lookahead--;
             match.strstart++;
             match.match_length--;
         }
-        return flush;
+        return bflush;
     }
 
     check_match(s, match.strstart, match.match_start, match.match_length);
 
-    flush += zng_tr_tally_dist(s, match.strstart - match.match_start, match.match_length - MIN_MATCH);
+    bflush += zng_tr_tally_dist(s, match.strstart - match.match_start, match.match_length - MIN_MATCH);
 
     s->lookahead -= match.match_length;
-    return flush;
+    return bflush;
 }
 
 static void insert_match(deflate_state *s, struct match match) {
@@ -196,7 +196,7 @@ ZLIB_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
 
     for (;;) {
         IPos hash_head = 0;   /* head of the hash chain */
-        int bflush;           /* set if current block must be flushed */
+        int bflush = 0;       /* set if current block must be flushed */
 
         /* Make sure that we always have enough lookahead, except
          * at the end of the input file. We need MAX_MATCH bytes

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -292,6 +292,7 @@ ZLIB_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
             }
 
             /* short matches with a very long distance are rarely a good idea encoding wise */
+            /* distances 8193–16384 take 12 extra bits, distances 16385–32768 take 13 extra bits */
             if (next_match.match_length == 3 && (next_match.strstart - next_match.match_start) > 12000)
                     next_match.match_length = 1;
             s->strstart = current_match.strstart;

--- a/deflate_slow.c
+++ b/deflate_slow.c
@@ -26,7 +26,7 @@
  */
 ZLIB_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
     IPos hash_head;          /* head of hash chain */
-    int bflush;              /* set if current block must be flushed */
+    int bflush = 0;          /* set if current block must be flushed */
 
     /* Process the input block. */
     for (;;) {
@@ -122,7 +122,8 @@ ZLIB_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
             }
 #endif /*NOT_TWEAK_COMPILER*/
 
-            if (bflush) FLUSH_BLOCK(s, 0);
+            if (bflush)
+                FLUSH_BLOCK(s, 0);
 
         } else if (s->match_available) {
             /* If there was no match at the previous position, output a
@@ -131,9 +132,8 @@ ZLIB_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
              */
             Tracevv((stderr, "%c", s->window[s->strstart-1]));
             bflush = zng_tr_tally_lit(s, s->window[s->strstart-1]);
-            if (bflush) {
+            if (bflush)
                 FLUSH_BLOCK_ONLY(s, 0);
-            }
             s->strstart++;
             s->lookahead--;
             if (s->strm->avail_out == 0)


### PR DESCRIPTION
This is basically the leftovers after my recent experiments with tr_tally in deflate_medium.

First we have a cleanup of bflush usage, and making sure we always initialize that value before we use it.
Second is a minor optimization of deflate_medium by reducing the size of a struct by half.
Third commit is just adding a comment.