### PR TITLE
Added CMake and CI configuration for inflate compilation options

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -37,6 +37,8 @@ jobs:
           Ubuntu 18.04 GCC SPARC64 Compat,
           Ubuntu 18.04 GCC S390X Compat,
           Ubuntu 18.04 Clang,
+          Ubuntu 18.04 Clang Inflate Strict,
+          Ubuntu 18.04 Clang Inflate Allow Invalid Dist,
           Ubuntu 18.04 Clang Debug,
           Ubuntu 18.04 Clang MSAN,
           Windows 2019 MSVC Win32,
@@ -250,6 +252,22 @@ jobs:
             packages: llvm-6.0
             gcov-exec: llvm-cov-6.0 gcov
             codecov: ubuntu_clang
+
+          - name: Ubuntu 18.04 Clang Inflate Strict
+            os: ubuntu-18.04
+            compiler: clang
+            cmake-args: -DWITH_INFLATE_STRICT=ON
+            packages: llvm-6.0
+            gcov-exec: llvm-cov-6.0 gcov
+            codecov: ubuntu_clang_inflate_strict
+
+          - name: Ubuntu 18.04 Clang Inflate Allow Invalid Dist
+            os: ubuntu-18.04
+            compiler: clang
+            cmake-args: -DWITH_INFLATE_ALLOW_INVALID_DIST=ON
+            packages: llvm-6.0
+            gcov-exec: llvm-cov-6.0 gcov
+            codecov: ubuntu_clang_inflate_allow_invalid_dist
 
           - name: Ubuntu 18.04 Clang Debug
             os: ubuntu-18.04

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,8 @@ option(WITH_NATIVE_INSTRUCTIONS
     "Instruct the compiler to use the full instruction set on this host (gcc/clang -march=native)" OFF)
 option(WITH_MAINTAINER_WARNINGS "Build with project maintainer warnings" OFF)
 option(WITH_CODE_COVERAGE "Enable code coverage reporting" OFF)
+option(WITH_INFLATE_STRICT "Build with strict inflate distance checking" OFF)
+option(WITH_INFLATE_ALLOW_INVALID_DIST "Build with zero fill for inflate invalid distances" OFF)
 
 if(BASEARCH_ARM_FOUND)
     option(WITH_ACLE "Build with ACLE" ON)
@@ -105,7 +107,7 @@ elseif(BASEARCH_X86_FOUND)
 endif()
 
 mark_as_advanced(FORCE WITH_ACLE WITH_NEON WITH_DFLTCC_DEFLATE WITH_DFLTCC_INFLATE
-    WITH_AVX2 WITH_SSE2 WITH_SSE4 WITH_PCLMULQDQ)
+    WITH_AVX2 WITH_SSE2 WITH_SSE4 WITH_PCLMULQDQ WITH_INFLATE_STRICT WITH_INFLATE_ALLOW_INVALID_DIST)
 
 add_feature_info(ZLIB_COMPAT ZLIB_COMPAT "Provide a zlib-compatible API")
 add_feature_info(WITH_GZFILEOP WITH_GZFILEOP "Compile with support for gzFile-related functions")
@@ -585,6 +587,17 @@ endif()
 #
 if(NOT WITH_NEW_STRATEGIES)
     add_definitions(-DNO_MEDIUM_STRATEGY)
+endif()
+#
+# Enable inflate compilation options
+#
+if(WITH_INFLATE_STRICT)
+    add_definitions(-DINFLATE_STRICT)
+    message(STATUS "Inflate strict distance checking enabled")
+endif()
+if(WITH_INFLATE_ALLOW_INVALID_DIST)
+    add_definitions(-DINFLATE_ALLOW_INVALID_DISTANCE_TOOFAR_ARRR)
+    message(STATUS "Inflate zero data for invalid distances enabled")
 endif()
 
 #

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ make test
 
 Build Options
 -------------
+
 | CMake                    | configure                | Description                                                                                  | Default |
 |:-------------------------|:-------------------------|:---------------------------------------------------------------------------------------------|---------|
 | ZLIB_COMPAT              | --zlib-compat            | Compile with zlib compatible API                                                             | OFF     |
@@ -164,18 +165,21 @@ and Mark Adler (decompression).
 
 Advanced Build Options
 ----------------------
-| CMake               | configure             | Description                                                         | Default                |
-|:--------------------|:----------------------|:--------------------------------------------------------------------|------------------------|
-| UNALIGNED_OK        |                       | Allow unaligned reads                                               | ON (x86, arm)          |
-|                     | --force-sse2          | Assume SSE2 instructions are always available                       | ON (x86), OFF (x86_64) |
-| WITH_AVX2           |                       | Build with AVX2 intrinsics                                          | ON                     |
-| WITH_SSE2           |                       | Build with SSE2 intrinsics                                          | ON                     |
-| WITH_SSE4           |                       | Build with SSE4 intrinsics                                          | ON                     |
-| WITH_PCLMULQDQ      |                       | Build with PCLMULQDQ intrinsics                                     | ON                     |
-| WITH_ACLE           | --without-acle        | Build with ACLE intrinsics                                          | ON                     |
-| WITH_NEON           | --without-neon        | Build with NEON intrinsics                                          | ON                     |
-| WITH_DFLTCC_DEFLATE | --with-dfltcc-deflate | Use DEFLATE COMPRESSION CALL instruction for compression on IBM Z   | OFF                    |
-| WITH_DFLTCC_INFLATE | --with-dfltcc-inflate | Use DEFLATE COMPRESSION CALL instruction for decompression on IBM Z | OFF                    |
+
+| CMake                           | configure             | Description                                                         | Default                |
+|:--------------------------------|:----------------------|:--------------------------------------------------------------------|------------------------|
+| UNALIGNED_OK                    |                       | Allow unaligned reads                                               | ON (x86, arm)          |
+|                                 | --force-sse2          | Assume SSE2 instructions are always available                       | ON (x86), OFF (x86_64) |
+| WITH_AVX2                       |                       | Build with AVX2 intrinsics                                          | ON                     |
+| WITH_SSE2                       |                       | Build with SSE2 intrinsics                                          | ON                     |
+| WITH_SSE4                       |                       | Build with SSE4 intrinsics                                          | ON                     |
+| WITH_PCLMULQDQ                  |                       | Build with PCLMULQDQ intrinsics                                     | ON                     |
+| WITH_ACLE                       | --without-acle        | Build with ACLE intrinsics                                          | ON                     |
+| WITH_NEON                       | --without-neon        | Build with NEON intrinsics                                          | ON                     |
+| WITH_DFLTCC_DEFLATE             | --with-dfltcc-deflate | Use DEFLATE COMPRESSION CALL instruction for compression on IBM Z   | OFF                    |
+| WITH_DFLTCC_INFLATE             | --with-dfltcc-inflate | Use DEFLATE COMPRESSION CALL instruction for decompression on IBM Z | OFF                    |
+| WITH_INFLATE_STRICT             |                       | Build with strict inflate distance checking                         | OFF                    |
+| WITH_INFLATE_ALLOW_INVALID_DIST |                       | Build with zero fill for inflate invalid distances                  | OFF                    |
 
 Contents
 --------


### PR DESCRIPTION
This PR adds CMake and CI configuration for `INFLATE_STRICT` and `INFLATE_ALLOW_INVALID_DISTANCE_TOOFAR_ARRR`.