### PR TITLE
Add CIFuzz

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,23 @@
+name: CIFuzz
+on: [pull_request]
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'zlib-ng'
+        dry-run: false
+    - name: Run Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'zlib-ng'
+        fuzz-seconds: 600
+        dry-run: false
+    - name: Upload Crash
+      uses: actions/upload-artifact@v1
+      if: failure()
+      with:
+        name: artifacts
+        path: ./out/artifacts


### PR DESCRIPTION
OSS-Fuzz was wondering if zlib-ng would use CIFuzz, a new feature being rolled out
in OSS-Fuzz. It allows for pull requests to be fuzzed in CI using fuzz targets enabled
in OSS-Fuzz. Documentation for this feature can be found at https://google.github.io/oss-fuzz/getting-started/continuous-integration/
Let us know if you have any questions!