### PR TITLE
Avoid unnecessary include of windows.h from zbuild.h

### DIFF
--- a/zbuild.h
+++ b/zbuild.h
@@ -3,8 +3,11 @@
 
 /* This has to be first include that defines any types */
 #if defined(_MSC_VER)
-#  include <windows.h>
-   typedef SSIZE_T ssize_t;
+#  if defined(_WIN64)
+    typedef __int64 ssize_t;
+#  else
+    typedef long ssize_t;
+#  endif
 #  define __thread __declspec(thread)
 #endif
 


### PR DESCRIPTION
zbuild.h is included from every .c file of zlib-ng, which forces every translation unit to parse all windows system includes only to be able to typedef ssize_t. This change removes windows.h include from zbuild.h and ssize_t is instead defined in-line with equivalent defines from windows.h