### PR TITLE
Fixed signed/unsigned mismatch in deflate_medium.

### DIFF
--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -261,7 +261,7 @@ ZLIB_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
         insert_match(s, current_match);
 
         /* now, look ahead one */
-        if (s->lookahead > MIN_LOOKAHEAD && (current_match.strstart + current_match.match_length) < (s->window_size - MIN_LOOKAHEAD)) {
+        if (s->lookahead > MIN_LOOKAHEAD && (uint32_t)(current_match.strstart + current_match.match_length) < (s->window_size - MIN_LOOKAHEAD)) {
             s->strstart = current_match.strstart + current_match.match_length;
             hash_head = functable.insert_string(s, s->strstart, 1);
 


### PR DESCRIPTION
Happens when using MSVC.
```
1>deflate_medium.c(264,99): warning C4018: '<': signed/unsigned mismatch
```

I think this is related to recent changes to `match` struct.