### PR TITLE
Clean up windows defines, use _WIN32

### DIFF
--- a/gzguts.h
+++ b/gzguts.h
@@ -34,7 +34,7 @@
 #  include "zlib-ng.h"
 #endif
 
-#ifdef WIN32
+#ifdef _WIN32
 #  include <stddef.h>
 #endif
 
@@ -42,11 +42,8 @@
 #  include <unistd.h>       /* for lseek(), read(), close(), write(), unlink() */
 #endif
 
-#if defined(_MSC_VER) || defined(WIN32)
+#if defined(_WIN32)
 #  include <io.h>
-#endif
-
-#if defined(_WIN32) || defined(__MINGW__)
 #  define WIDECHAR
 #endif
 
@@ -58,7 +55,7 @@
 #endif
 
 /* In Win32, vsnprintf is available as the "non-ANSI" _vsnprintf. */
-#if !defined(STDC99) && !defined(__CYGWIN__) && !defined(__MINGW__) && defined(WIN32)
+#if !defined(STDC99) && !defined(__CYGWIN__) && !defined(__MINGW__) && defined(_WIN32)
 #  if !defined(vsnprintf)
 #    if !defined(_MSC_VER) || ( defined(_MSC_VER) && _MSC_VER < 1500 )
 #       define vsnprintf _vsnprintf

--- a/gzlib.c
+++ b/gzlib.c
@@ -6,7 +6,7 @@
 #include "zbuild.h"
 #include "gzguts.h"
 
-#if defined(WIN32) && !defined(__BORLANDC__)
+#if defined(_WIN32) && !defined(__BORLANDC__)
 #  define LSEEK _lseeki64
 #else
 #if defined(_LARGEFILE64_SOURCE) && _LFS64_LARGEFILE-0
@@ -181,7 +181,7 @@ static gzFile gz_open(const void *path, int fd, const char *mode) {
 
     /* open the file with the appropriate flags (or just use fd) */
     state->fd = fd > -1 ? fd : (
-#if defined(WIN32) || defined(__MINGW__)
+#if defined(_WIN32)
         fd == -2 ? _wopen(path, oflag, 0666) :
 #elif __CYGWIN__
         fd == -2 ? open(state->path, oflag, 0666) :

--- a/test/fuzz/minigzip_fuzzer.c
+++ b/test/fuzz/minigzip_fuzzer.c
@@ -33,7 +33,7 @@
 #  include <malloc.h>
 #endif
 
-#if defined(WIN32) || defined(__CYGWIN__)
+#if defined(_WIN32) || defined(__CYGWIN__)
 #  include <fcntl.h>
 #  include <io.h>
 #  define SET_BINARY_MODE(file) setmode(fileno(file), O_BINARY)
@@ -46,7 +46,7 @@
 #endif
 
 #if !defined(Z_HAVE_UNISTD_H) && !defined(_LARGEFILE64_SOURCE)
-#ifndef WIN32 /* unlink already in stdio.h for WIN32 */
+#ifndef _WIN32 /* unlink already in stdio.h for Win32 */
 extern int unlink (const char *);
 #endif
 #endif

--- a/test/minigzip.c
+++ b/test/minigzip.c
@@ -36,7 +36,7 @@
 #  include <malloc.h>
 #endif
 
-#if defined(WIN32) || defined(__CYGWIN__)
+#if defined(_WIN32) || defined(__CYGWIN__)
 #  include <fcntl.h>
 #  include <io.h>
 #  define SET_BINARY_MODE(file) setmode(fileno(file), O_BINARY)
@@ -49,7 +49,7 @@
 #endif
 
 #if !defined(Z_HAVE_UNISTD_H) && !defined(_LARGEFILE64_SOURCE)
-#ifndef WIN32 /* unlink already in stdio.h for WIN32 */
+#ifndef _WIN32 /* unlink already in stdio.h for Win32 */
 extern int unlink (const char *);
 #endif
 #endif

--- a/zconf-ng.h.in
+++ b/zconf-ng.h.in
@@ -6,13 +6,8 @@
 #ifndef ZCONFNG_H
 #define ZCONFNG_H
 
-#if defined(_WINDOWS) && !defined(WINDOWS)
-#  define WINDOWS
-#endif
-#if defined(_WIN32) || defined(__WIN32__)
-#  ifndef WIN32
-#    define WIN32
-#  endif
+#if !defined(_WIN32) && defined(__WIN32__)
+#  define _WIN32
 #endif
 
 #ifdef __STDC_VERSION__
@@ -50,20 +45,18 @@
  for small objects.
 */
 
-                        /* Type declarations */
+/* Type declarations */
 
 
-#if defined(WINDOWS) || defined(WIN32)
+#if defined(_WIN32)
    /* If building or using zlib as a DLL, define ZLIB_DLL.
     * This is not mandatory, but it offers a little performance increase.
     */
-#  ifdef ZLIB_DLL
-#    if defined(WIN32) && (!defined(__BORLANDC__) || (__BORLANDC__ >= 0x500))
-#      ifdef ZLIB_INTERNAL
-#        define ZEXTERN extern __declspec(dllexport)
-#      else
-#        define ZEXTERN extern __declspec(dllimport)
-#      endif
+#  if defined(ZLIB_DLL) && (!defined(__BORLANDC__) || (__BORLANDC__ >= 0x500))
+#    ifdef ZLIB_INTERNAL
+#      define ZEXTERN extern __declspec(dllexport)
+#    else
+#      define ZEXTERN extern __declspec(dllimport)
 #    endif
 #  endif  /* ZLIB_DLL */
    /* If building or using zlib with the WINAPI/WINAPIV calling convention,
@@ -157,12 +150,12 @@ typedef PTRDIFF_TYPE ptrdiff_t;
 #  define z_off_t long
 #endif
 
-#if !defined(WIN32) && defined(Z_LARGE64)
+#if !defined(_WIN32) && defined(Z_LARGE64)
 #  define z_off64_t off64_t
 #else
 #  if defined(__MSYS__)
 #    define z_off64_t _off64_t
-#  elif defined(WIN32) && !defined(__GNUC__)
+#  elif defined(_WIN32) && !defined(__GNUC__)
 #    define z_off64_t __int64
 #  else
 #    define z_off64_t z_off_t

--- a/zconf.h.in
+++ b/zconf.h.in
@@ -6,13 +6,8 @@
 #ifndef ZCONF_H
 #define ZCONF_H
 
-#if defined(_WINDOWS) && !defined(WINDOWS)
-#  define WINDOWS
-#endif
-#if defined(_WIN32) || defined(__WIN32__)
-#  ifndef WIN32
-#    define WIN32
-#  endif
+#if !defined(_WIN32) && defined(__WIN32__)
+#  define _WIN32
 #endif
 
 #ifdef __STDC_VERSION__
@@ -50,24 +45,22 @@
  for small objects.
 */
 
-                        /* Type declarations */
+/* Type declarations */
 
 
 #ifndef OF /* function prototypes */
 #  define OF(args)  args
 #endif
 
-#if defined(WINDOWS) || defined(WIN32)
+#if defined(_WIN32)
    /* If building or using zlib as a DLL, define ZLIB_DLL.
     * This is not mandatory, but it offers a little performance increase.
     */
-#  ifdef ZLIB_DLL
-#    if defined(WIN32) && (!defined(__BORLANDC__) || (__BORLANDC__ >= 0x500))
-#      ifdef ZLIB_INTERNAL
-#        define ZEXTERN extern __declspec(dllexport)
-#      else
-#        define ZEXTERN extern __declspec(dllimport)
-#      endif
+#  if defined(ZLIB_DLL) && (!defined(__BORLANDC__) || (__BORLANDC__ >= 0x500))
+#    ifdef ZLIB_INTERNAL
+#      define ZEXTERN extern __declspec(dllexport)
+#    else
+#      define ZEXTERN extern __declspec(dllimport)
 #    endif
 #  endif  /* ZLIB_DLL */
    /* If building or using zlib with the WINAPI/WINAPIV calling convention,
@@ -161,12 +154,12 @@ typedef PTRDIFF_TYPE ptrdiff_t;
 #  define z_off_t long
 #endif
 
-#if !defined(WIN32) && defined(Z_LARGE64)
+#if !defined(_WIN32) && defined(Z_LARGE64)
 #  define z_off64_t off64_t
 #else
 #  if defined(__MSYS__)
 #    define z_off64_t _off64_t
-#  elif defined(WIN32) && !defined(__GNUC__)
+#  elif defined(_WIN32) && !defined(__GNUC__)
 #    define z_off64_t __int64
 #  else
 #    define z_off64_t z_off_t

--- a/zendian.h
+++ b/zendian.h
@@ -24,7 +24,7 @@
 #  endif
 #elif defined(__MINGW32__)
 #  include <sys/param.h>
-#elif defined(WIN32) || defined(_WIN32)
+#elif defined(_WIN32)
 #  define LITTLE_ENDIAN 1234
 #  define BIG_ENDIAN 4321
 #  if defined(_M_IX86) || defined(_M_AMD64) || defined(_M_IA64) || defined (_M_ARM) || defined (_M_ARM64)

--- a/zlib-ng.h
+++ b/zlib-ng.h
@@ -1939,7 +1939,7 @@ ZEXTERN ZEXPORT int              zng_inflateResetKeep (zng_stream *);
 ZEXTERN ZEXPORT int              zng_deflateResetKeep (zng_stream *);
 
 #ifdef WITH_GZFILEOP
-#  if (defined(WIN32) || defined(__MINGW__))
+#  if defined(_WIN32)
      ZEXTERN ZEXPORT gzFile zng_gzopen_w(const wchar_t *path, const char *mode);
 #  endif
 ZEXTERN ZEXPORTVA int zng_gzvprintf(gzFile file, const char *format, va_list va);

--- a/zlib.h
+++ b/zlib.h
@@ -1836,7 +1836,7 @@ ZEXTERN unsigned long    ZEXPORT inflateCodesUsed (z_stream *);
 ZEXTERN int              ZEXPORT inflateResetKeep (z_stream *);
 ZEXTERN int              ZEXPORT deflateResetKeep (z_stream *);
 
-#if (defined(WIN32) || defined(__MINGW__))
+#if defined(_WIN32)
     ZEXTERN gzFile ZEXPORT gzopen_w(const wchar_t *path, const char *mode);
 #endif
 ZEXTERN int ZEXPORTVA gzvprintf(gzFile file, const char *format, va_list va);

--- a/zutil.h
+++ b/zutil.h
@@ -100,7 +100,7 @@ extern const char * const zng_errmsg[10]; /* indexed by 2-zlib_error */
 #  define OS_CODE 13
 #endif
 
-#if defined(WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__)
 #  define OS_CODE  10
 #endif
 
@@ -113,7 +113,7 @@ extern const char * const zng_errmsg[10]; /* indexed by 2-zlib_error */
 #endif
 
 /* provide prototypes for these when building zlib without LFS */
-#if !defined(WIN32) && !defined(__MSYS__) && (!defined(_LARGEFILE64_SOURCE) || _LFS64_LARGEFILE-0 == 0)
+#if !defined(_WIN32) && !defined(__MSYS__) && (!defined(_LARGEFILE64_SOURCE) || _LFS64_LARGEFILE-0 == 0)
 #  include "zbuild.h"  /* For PREFIX() */
     ZEXTERN uint32_t ZEXPORT PREFIX(adler32_combine64)(uint32_t, uint32_t, z_off_t);
     ZEXTERN uint32_t ZEXPORT PREFIX(crc32_combine64)(uint32_t, uint32_t, z_off_t);
@@ -166,7 +166,7 @@ void ZLIB_INTERNAL   zng_cfree(void *opaque, void *ptr);
 
 /* Reverse the bytes in a value. Use compiler intrinsics when
    possible to take advantage of hardware implementations. */
-#if defined(WIN32) && (_MSC_VER >= 1300)
+#if defined(_MSC_VER) && (_MSC_VER >= 1300)
 #  pragma intrinsic(_byteswap_ulong)
 #  define ZSWAP16(q) _byteswap_ushort(q)
 #  define ZSWAP32(q) _byteswap_ulong(q)


### PR DESCRIPTION
 + replaced `WIN32` with `_WIN32`
 + removed unused `WINDOWS`/`_WINDOWS` defines
 + no need to test for `__MINGW__`, as `_WIN32` is also defined