### PR TITLE
Simplify generic hash function using knuth's multiplicative hash

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -330,9 +330,6 @@ int ZEXPORT PREFIX(deflateInit2_)(PREFIX3(stream) *strm, int level, int method, 
 
     s->hash_size = 1 << s->hash_bits;
     s->hash_mask = s->hash_size - 1;
-#if !defined(__x86_64__) && !defined(_M_X64) && !defined(__i386) && !defined(_M_IX86)
-    s->hash_shift =  ((s->hash_bits+MIN_MATCH-1)/MIN_MATCH);
-#endif
 
 #ifdef X86_PCLMULQDQ_CRC
     window_padding = 8;
@@ -1205,7 +1202,6 @@ static void lm_init(deflate_state *s) {
     s->match_length = s->prev_length = MIN_MATCH-1;
     s->match_available = 0;
     s->match_start = 0;
-    s->ins_h = 0;
 }
 
 #ifdef ZLIB_DEBUG
@@ -1291,7 +1287,6 @@ void ZLIB_INTERNAL fill_window(deflate_state *s) {
         /* Initialize the hash value now that we have some input: */
         if (s->lookahead + s->insert >= MIN_MATCH) {
             unsigned int str = s->strstart - s->insert;
-            s->ins_h = s->window[str];
             if (str >= 1)
                 functable.quick_insert_string(s, str + 2 - MIN_MATCH);
 #if MIN_MATCH != 3

--- a/deflate.h
+++ b/deflate.h
@@ -147,19 +147,9 @@ typedef struct internal_state {
 
     Pos *head; /* Heads of the hash chains or NIL. */
 
-    unsigned int  ins_h;             /* hash index of string to be inserted */
     unsigned int  hash_size;         /* number of elements in hash table */
     unsigned int  hash_bits;         /* log2(hash_size) */
     unsigned int  hash_mask;         /* hash_size-1 */
-
-#if !defined(__x86_64__) && !defined(_M_X64) && !defined(__i386) && !defined(_M_IX86)
-    unsigned int  hash_shift;
-#endif
-    /* Number of bits by which ins_h must be shifted at each input
-     * step. It must be such that after MIN_MATCH steps, the oldest
-     * byte no longer takes part in the hash key, that is:
-     *   hash_shift * MIN_MATCH >= hash_bits
-     */
 
     long block_start;
     /* Window position at the beginning of the current output block. Gets

--- a/deflate_fast.c
+++ b/deflate_fast.c
@@ -75,7 +75,6 @@ ZLIB_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
             } else {
                 s->strstart += s->match_length;
                 s->match_length = 0;
-                s->ins_h = s->window[s->strstart];
 #if MIN_MATCH != 3
                 functable.insert_string(s, s->strstart + 2 - MIN_MATCH, MIN_MATCH - 2);
 #else

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -86,7 +86,6 @@ static void insert_match(deflate_state *s, struct match match) {
     } else {
         match.strstart += match.match_length;
         match.match_length = 0;
-        s->ins_h = s->window[match.strstart];
         if (match.strstart >= (MIN_MATCH - 2))
 #if MIN_MATCH != 3
             functable.insert_string(s, match.strstart + 2 - MIN_MATCH, MIN_MATCH - 2);

--- a/insert_string.c
+++ b/insert_string.c
@@ -15,16 +15,8 @@
  *    previous key instead of complete recalculation each time.
  */
 
-#if defined(__x86_64__) || defined(_M_X64) || defined(__i386) || defined(_M_IX86)
-#  define UPDATE_HASH(s, h, val) \
-    h = (3483  * ((val) & 0xff) +\
-         23081 * (((val) >> 8) & 0xff) +\
-         6954  * (((val) >> 16) & 0xff) +\
-         20947 * (((val) >> 24) & 0xff));
-#else
-#  define UPDATE_HASH(s, h, val)\
-    h = (s->ins_h = ((s->ins_h << s->hash_shift) ^ ((val) >> ((MIN_MATCH - 1) * 8))) & s->hash_mask)
-#endif
+#define UPDATE_HASH(s, h, val) \
+    h = ((val * 2654435761U) >> (32 - s->hash_bits));
 
 #define INSERT_STRING       insert_string_c
 #define QUICK_INSERT_STRING quick_insert_string_c


### PR DESCRIPTION
This PR changes the `UPDATE_HASH` function which is used as a fallback when architecture specific version is not available to use knuth's multiplicative hash.

Some background AFAIK: 

* Original zlib uses a hash function that relies on a simple xor hash involving an initial byte `s->ins_h`
* Zlib-ng uses the fallback function we currently have which I can only find reference to in d306c75d3bb36cba73aec9b3b3ca378e31d1799e. But I can't find any reference to it in Intel zlib where a similar commit [exists](https://github.com/jtkukunas/zlib/commit/43a5e7618b18f2bd502025121afb1c3510464447). But we also have a fallback for this which is the original zlib hash.
* LZ4 & others uses knuth multiplicative hash function (same as this PR)

Because of recent changes, we now pass in a `uint32_t` to the hash functions, which means doing shift and multiply on each byte is extra work. 

I did some testing to see which hash function results in more collisions. I check 100,000 random integers and counted the number of collisions per hash. Then I graphed the number of collisions by how many hashes collided by that number.

![Figure_2](https://user-images.githubusercontent.com/1364432/80782614-c3059900-8b2b-11ea-9377-4bea888d67a9.png)

[This](https://gist.github.com/nmoinvaz/26daed85a714e7c55cb29e61a3ee82fe) is my python script I used to test with. Assuming my script is correct, what it would indicate is that both hash functions perform about the same.

The benefit to this PR would be the knuth hash is simpler and requires fewer instructions and we can get rid of the original zlib hash.
