### PR TITLE
Disable codecov for out of source builds

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -62,7 +62,6 @@ jobs:
             cmake-args: -DWITH_SANITIZERS=ON
             build-dir: ../build
             build-src-dir: ../zlib-ng
-            codecov: ubuntu_gcc_osb
             cflags: -O1 -g3
 
           - name: Ubuntu 18.04 GCC No AVX2


### PR DESCRIPTION
@Dead2. I know you said this was configurable via codecov, but I put this PR here in case you change your mind. If not you can close it.