### PR TITLE
Remove several NOT_TWEAK_COMPILER checks.

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -223,8 +223,8 @@ ZLIB_INTERNAL void slide_hash_c(deflate_state *s) {
             *q++ = (Pos)(m >= t ? m-t: NIL);
         }
     }
-
 #endif /* NOT_TWEAK_COMPILER */
+
     n = wsize;
     p = &s->prev[n];
 #ifdef NOT_TWEAK_COMPILER

--- a/deflate.h
+++ b/deflate.h
@@ -391,11 +391,7 @@ void ZLIB_INTERNAL flush_pending(PREFIX3(streamp) strm);
  * used.
  */
 
-#ifdef NOT_TWEAK_COMPILER
-#  define TRIGGER_LEVEL 6
-#else
-#  define TRIGGER_LEVEL 5
-#endif
+#define TRIGGER_LEVEL 5
 
 #ifdef ZLIB_DEBUG
 #  define send_code(s, c, tree, bit_buf, bits_valid) { \

--- a/deflate_fast.c
+++ b/deflate_fast.c
@@ -68,21 +68,10 @@ ZLIB_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
             if (s->match_length <= s->max_insert_length && s->lookahead >= MIN_MATCH) {
                 s->match_length--; /* string at strstart already in table */
                 s->strstart++;
-#ifdef NOT_TWEAK_COMPILER
-                do {
-                    functable.quick_insert_string(s, s->strstart);
-                    s->strstart++;
-                    /* strstart never exceeds WSIZE-MAX_MATCH, so there are
-                     * always MIN_MATCH bytes ahead.
-                     */
-                } while (--s->match_length != 0);
-#else
-                {
-                    functable.insert_string(s, s->strstart, s->match_length);
-                    s->strstart += s->match_length;
-                    s->match_length = 0;
-                }
-#endif
+
+                functable.insert_string(s, s->strstart, s->match_length);
+                s->strstart += s->match_length;
+                s->match_length = 0;
             } else {
                 s->strstart += s->match_length;
                 s->match_length = 0;

--- a/deflate_fast.c
+++ b/deflate_fast.c
@@ -76,13 +76,10 @@ ZLIB_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
                 s->strstart += s->match_length;
                 s->match_length = 0;
                 s->ins_h = s->window[s->strstart];
-#ifndef NOT_TWEAK_COMPILER
+#if MIN_MATCH != 3
                 functable.insert_string(s, s->strstart + 2 - MIN_MATCH, MIN_MATCH - 2);
 #else
                 functable.quick_insert_string(s, s->strstart + 2 - MIN_MATCH);
-#if MIN_MATCH != 3
-#warning        Call insert_string() MIN_MATCH-3 more times
-#endif
 #endif
                 /* If lookahead < MIN_MATCH, ins_h is garbage, but it does not
                  * matter since it will be recomputed at next deflate call.

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -88,13 +88,10 @@ static void insert_match(deflate_state *s, struct match match) {
         match.match_length = 0;
         s->ins_h = s->window[match.strstart];
         if (match.strstart >= (MIN_MATCH - 2))
-#ifndef NOT_TWEAK_COMPILER
+#if MIN_MATCH != 3
             functable.insert_string(s, match.strstart + 2 - MIN_MATCH, MIN_MATCH - 2);
 #else
             functable.quick_insert_string(s, match.strstart + 2 - MIN_MATCH);
-#if MIN_MATCH != 3
-#warning    Call insert_string() MIN_MATCH-3 more times
-#endif
 #endif
         /* If lookahead < MIN_MATCH, ins_h is garbage, but it does not
          * matter since it will be recomputed at next deflate call.

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -49,18 +49,6 @@ static void insert_match(deflate_state *s, struct match match) {
 
     /* matches that are not long enough we need to emit as literals */
     if (match.match_length < MIN_MATCH) {
-#ifdef NOT_TWEAK_COMPILER
-        while (match.match_length) {
-            match.strstart++;
-            match.match_length--;
-
-            if (match.match_length) {
-                if (match.strstart >= match.orgstart) {
-                    functable.quick_insert_string(s, match.strstart);
-                }
-            }
-        }
-#else
         match.strstart++;
         match.match_length--;
         if (match.match_length > 0) {
@@ -74,7 +62,6 @@ static void insert_match(deflate_state *s, struct match match) {
                 match.match_length = 0;
             }
         }
-#endif
         return;
     }
 
@@ -84,17 +71,7 @@ static void insert_match(deflate_state *s, struct match match) {
     if (match.match_length <= 16* s->max_insert_length && s->lookahead >= MIN_MATCH) {
         match.match_length--; /* string at strstart already in table */
         match.strstart++;
-#ifdef NOT_TWEAK_COMPILER
-        do {
-            if (LIKELY(match.strstart >= match.orgstart)) {
-                functable.quick_insert_string(s, match.strstart);
-            }
-            match.strstart++;
-            /* strstart never exceeds WSIZE-MAX_MATCH, so there are
-             * always MIN_MATCH bytes ahead.
-             */
-        } while (--match.match_length != 0);
-#else
+
         if (LIKELY(match.strstart >= match.orgstart)) {
             if (LIKELY(match.strstart + match.match_length - 1 >= match.orgstart)) {
                 functable.insert_string(s, match.strstart, match.match_length);
@@ -106,7 +83,6 @@ static void insert_match(deflate_state *s, struct match match) {
         }
         match.strstart += match.match_length;
         match.match_length = 0;
-#endif
     } else {
         match.strstart += match.match_length;
         match.match_length = 0;


### PR DESCRIPTION
Gets rid of several instances of legacy code that is likely to bit-rot.

The compiled code (without the define set) should be identical, except for two cases where the code is no longer in local scope code blocks. As far as I can see, there is no reason to have those in such blocks. One of them has local variables, and that used to be a valid reason, but C99 that we target removed the requirement that variables have to be defined before code (not that many modern compilers cared, except for printing warnings about standards compliance).

Benchmarks show that these changes does not change performance.
To be precise, my benchmarks show an overall 0.0538% speedup, and that could potentially be because the compiler can optimize those blocks of code (and the before and after code) better, but that is well within the margin of error of my measurements, so it is hard to tell without analyzing the generated assembly code.

The text-size of the library remains the same as before.