### PR TITLE
Remove support for DYNAMIC_CRC_TABLE

### DIFF
--- a/functable.c
+++ b/functable.c
@@ -43,11 +43,6 @@ extern uint32_t adler32_neon(uint32_t adler, const unsigned char *buf, size_t le
 /* CRC32 */
 ZLIB_INTERNAL uint32_t crc32_generic(uint32_t, const unsigned char *, uint64_t);
 
-#ifdef DYNAMIC_CRC_TABLE
-extern volatile int crc_table_empty;
-extern void make_crc_table(void);
-#endif
-
 #ifdef __ARM_FEATURE_CRC32
 extern uint32_t crc32_acle(uint32_t, const unsigned char *, uint64_t);
 #endif
@@ -165,10 +160,6 @@ ZLIB_INTERNAL uint32_t crc32_stub(uint32_t crc, const unsigned char *buf, uint64
            "crc32_z takes size_t but internally we have a uint64_t len");
     /* return a function pointer for optimized arches here after a capability test */
 
-#ifdef DYNAMIC_CRC_TABLE
-    if (crc_table_empty)
-        make_crc_table();
-#endif /* DYNAMIC_CRC_TABLE */
     cpu_check_features();
 
     if (sizeof(void *) == sizeof(ptrdiff_t)) {

--- a/zutil.c
+++ b/zutil.c
@@ -69,9 +69,7 @@ unsigned long ZEXPORT PREFIX(zlibCompileFlags)(void) {
 #ifdef ZLIB_WINAPI
     flags += 1 << 10;
 #endif
-#ifdef DYNAMIC_CRC_TABLE
-    flags += 1 << 13;
-#endif
+    /* Bit 13 reserved for DYNAMIC_CRC_TABLE */
 #ifdef NO_GZCOMPRESS
     flags += 1L << 16;
 #endif


### PR DESCRIPTION
See #576 for previous discussion. In `zlibCompileFlags` I have commented that bit 13 is reserved, for compatibility, however I can remove that if it is decided otherwise.