### PR TITLE
Fixed zero length stored block left open when using Z_SYNC_FLUSH.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1185,6 +1185,22 @@ if (ZLIB_ENABLE_TESTS)
             "-DCOMMAND=${GH_536_COMMAND}"
             -DINPUT=${CMAKE_CURRENT_SOURCE_DIR}/test/data/lcet10.txt
             -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/run-and-redirect.cmake)
+
+    set(GH_536_COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:switchlevels> 6 15248 1 1050 2 25217)
+    add_test(NAME GH-536-deflate-zero-stored-block
+            COMMAND ${CMAKE_COMMAND}
+            "-DCOMMAND=${GH_536_COMMAND}"
+            -DINPUT=${CMAKE_CURRENT_SOURCE_DIR}/test/data/lcet10.txt
+            -DOUTPUT=${CMAKE_CURRENT_SOURCE_DIR}/test/data/lcet10-zl.txt.gz
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/run-and-redirect.cmake)
+
+    set(GH_536_COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:minigzip> -d)
+    add_test(NAME GH-536-inflate-zero-stored-block
+        COMMAND ${CMAKE_COMMAND}
+        "-DCOMMAND=${GH_536_COMMAND}"
+        -DINPUT=${CMAKE_CURRENT_SOURCE_DIR}/test/data/lcet10-zl.txt.gz
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/run-and-redirect.cmake)
+
 endif()
 
 FEATURE_SUMMARY(WHAT ALL INCLUDE_QUIET_PACKAGES)

--- a/arch/x86/deflate_quick.c
+++ b/arch/x86/deflate_quick.c
@@ -38,6 +38,7 @@ ZLIB_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
     if (s->block_open == 0) {
         last = (flush == Z_FINISH) ? 1 : 0;
         zng_tr_emit_tree(s, STATIC_TREES, last);
+        s->block_open = 1;
     }
 
     do {
@@ -52,6 +53,7 @@ ZLIB_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
             fill_window(s);
             if (s->lookahead < MIN_LOOKAHEAD && flush == Z_NO_FLUSH) {
                 zng_tr_emit_end_block(s, static_ltree, 0);
+                s->block_open = 0;
                 s->block_start = s->strstart;
                 flush_pending(s->strm);
                 return need_more;
@@ -94,6 +96,7 @@ ZLIB_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
 
     last = (flush == Z_FINISH) ? 1 : 0;
     zng_tr_emit_end_block(s, static_ltree, last);
+    s->block_open = 0;
     s->block_start = s->strstart;
     flush_pending(s->strm);
 

--- a/trees.c
+++ b/trees.c
@@ -597,11 +597,12 @@ void ZLIB_INTERNAL zng_tr_stored_block(deflate_state *s, char *buf, unsigned lon
     put_short(s, (uint16_t)~stored_len);
     cmpr_bits_add(s, 32);
     sent_bits_add(s, 32);
-    if (stored_len)
+    if (stored_len) {
         memcpy(s->pending_buf + s->pending, (unsigned char *)buf, stored_len);
-    s->pending += stored_len;
-    cmpr_bits_add(s, stored_len << 3);
-    sent_bits_add(s, stored_len << 3);
+        s->pending += stored_len;
+        cmpr_bits_add(s, stored_len << 3);
+        sent_bits_add(s, stored_len << 3);
+    }
 }
 
 /* ===========================================================================

--- a/trees_emit.h
+++ b/trees_emit.h
@@ -198,7 +198,6 @@ static inline void zng_emit_end_block(deflate_state *s, const ct_data *ltree, co
     send_code(s, END_BLOCK, ltree, bi_buf, bi_valid);
     s->bi_valid = bi_valid;
     s->bi_buf = bi_buf;
-    s->block_open = 0;
     Tracev((stderr, "\n+++ Emit End Block: Last: %u Pending: %u Total Out: %zu\n",
         last, s->pending, s->strm->total_out));
     (void)last;
@@ -229,7 +228,6 @@ static inline void zng_tr_emit_tree(deflate_state *s, int type, const int last) 
     cmpr_bits_add(s, 3);
     s->bi_valid = bi_valid;
     s->bi_buf = bi_buf;
-    s->block_open = 1;
     Tracev((stderr, "\n--- Emit Tree: Last: %u\n", last));
 } 
 


### PR DESCRIPTION
This fixes an issue found from running tests in #536. Inflate would error with `minigzip: lcet10x.txt.gz: invalid stored block lengths`. I have included ctests unit tests using _switchlevels_. This PR uses commits from #583 and #584 which are necessary for proper testing of the initial issue.

Background:

_Z_SYNC_FLUSH_ writes a stored block of zero length to help inflate - with no end of block code. What was previously happening was this zero length block was being written and the _block_open_ was left set to 1 by _zng_tr_emit_tree_ - so when the stream was switched to _deflate_quick_ (when used in switchlevels) it would not emit the beginning of the block when it started.