### PR TITLE
Fixed compiler warning about inline already being defined

### DIFF
--- a/zutil.h
+++ b/zutil.h
@@ -121,7 +121,7 @@ extern const char * const zng_errmsg[10]; /* indexed by 2-zlib_error */
 
 /* MS Visual Studio does not allow inline in C, only C++.
    But it provides __inline instead, so use that. */
-#if defined(_MSC_VER) && !defined(inline)
+#if defined(_MSC_VER) && !defined(inline) && !defined(__cplusplus) 
 #  define inline __inline
 #endif
 


### PR DESCRIPTION
For some of my Google benchmark test apps I include zutil.h and it complains about inline already being defined. In these instances, I am just throwing the test app inside our CMakeLists.txt and putting the source files inside zlib-ng because I am testing zlib-ng functions.