### PR TITLE
Remove toofar checks

### DIFF
--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -261,11 +261,6 @@ ZLIB_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
                 else
                     fizzle_matches(s, &current_match, &next_match);
             }
-
-            /* short matches with a very long distance are rarely a good idea encoding wise */
-            /* distances 8193–16384 take 12 extra bits, distances 16385–32768 take 13 extra bits */
-            if (next_match.match_length == 3 && (next_match.strstart - next_match.match_start) > 12000)
-                    next_match.match_length = 1;
             s->strstart = current_match.strstart;
 
         } else {

--- a/deflate_slow.c
+++ b/deflate_slow.c
@@ -10,15 +10,6 @@
 #include "functable.h"
 
 /* ===========================================================================
- * Local data
- */
-
-#ifndef TOO_FAR
-#  define TOO_FAR 4096
-#endif
-/* Matches of length 3 are discarded if their distance exceeds TOO_FAR */
-
-/* ===========================================================================
  * Same as deflate_medium, but achieves better compression. We use a lazy
  * evaluation for matches: a match is finally adopted only if there is
  * no better match at the next window position.
@@ -64,12 +55,7 @@ ZLIB_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
             s->match_length = functable.longest_match(s, hash_head);
             /* longest_match() sets match_start */
 
-            if (s->match_length <= 5 && (s->strategy == Z_FILTERED
-#if TOO_FAR <= 32767
-                || (s->match_length == MIN_MATCH && s->strstart - s->match_start > TOO_FAR)
-#endif
-                )) {
-
+            if (s->match_length <= 5 && (s->strategy == Z_FILTERED)) {
                 /* If prev_match is also MIN_MATCH, match_start is garbage
                  * but we will ignore the current match anyway.
                  */


### PR DESCRIPTION
Remove toofar checks now that we always hash 4 bytes, and the minimum
match length is thus also 4. (MIN_MATCH is still 3 due to it being used for calculations of other needed numbers, and they fail when set to 4, those still need to get fixed).

If MIN_MATCH was 4, we could instead hide these behind an ifdef.

Thoughts on whether we want to support an actual MIN_MATCH=3 mode in the future? It would need a different UPDATE_HASH algo in that case, and would sacrifice a lot of speed.

Not supporting MIN_MATCH=3 could affect compression of some png files, that is why for example optipng recommends setting TOO_FAR higher than the default.
It would likely not be an issue for just saving a png, but when you try to use optipng/pngcrush for maximum compression we would not be able to reduce size as much as stock zlib.