### PR TITLE
Remove IPos typedef.

### DIFF
--- a/arch/x86/deflate_quick.c
+++ b/arch/x86/deflate_quick.c
@@ -32,7 +32,7 @@ extern const ct_data static_ltree[L_CODES+2];
 extern const ct_data static_dtree[D_CODES];
 
 ZLIB_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
-    IPos hash_head;
+    Pos hash_head;
     unsigned dist, match_len, last;
 
     if (s->block_open == 0) {

--- a/deflate.c
+++ b/deflate.c
@@ -1210,7 +1210,7 @@ static void lm_init(deflate_state *s) {
 /* ===========================================================================
  * Check that the match at match_start is indeed a match.
  */
-void check_match(deflate_state *s, IPos start, IPos match, int length) {
+void check_match(deflate_state *s, Pos start, Pos match, int length) {
     /* check that the match is indeed a match */
     if (memcmp(s->window + match, s->window + start, length) != EQUAL) {
         fprintf(stderr, " start %u, match %u, length %d\n", start, match, length);

--- a/deflate.h
+++ b/deflate.h
@@ -95,10 +95,9 @@ typedef struct tree_desc_s {
 } tree_desc;
 
 typedef uint16_t Pos;
-typedef unsigned IPos;
 
 /* A Pos is an index in the character window. We use short instead of int to
- * save space in the various tables. IPos is used only for parameter passing.
+ * save space in the various tables. 
  */
 
 typedef struct internal_state {
@@ -157,7 +156,7 @@ typedef struct internal_state {
      */
 
     unsigned int match_length;       /* length of best match */
-    IPos         prev_match;         /* previous match */
+    Pos          prev_match;         /* previous match */
     int          match_available;    /* set if previous match exists */
     unsigned int strstart;           /* start of string to insert */
     unsigned int match_start;        /* start of matching string */

--- a/deflate_fast.c
+++ b/deflate_fast.c
@@ -17,7 +17,7 @@
  * matches. It is used only for the fast compression options.
  */
 ZLIB_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
-    IPos hash_head;       /* head of the hash chain */
+    Pos hash_head;        /* head of the hash chain */
     int bflush = 0;       /* set if current block must be flushed */
 
     for (;;) {

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -98,7 +98,7 @@ static void insert_match(deflate_state *s, struct match match) {
 }
 
 static void fizzle_matches(deflate_state *s, struct match *current, struct match *next) {
-    IPos limit;
+    Pos limit;
     unsigned char *match, *orig;
     int changed = 0;
     struct match c, n;
@@ -169,7 +169,7 @@ ZLIB_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
     memset(&next_match, 0, sizeof(struct match));
 
     for (;;) {
-        IPos hash_head = 0;   /* head of the hash chain */
+        Pos hash_head = 0;    /* head of the hash chain */
         int bflush = 0;       /* set if current block must be flushed */
 
         /* Make sure that we always have enough lookahead, except

--- a/deflate_p.h
+++ b/deflate_p.h
@@ -12,7 +12,7 @@
 /* Forward declare common non-inlined functions declared in deflate.c */
 
 #ifdef ZLIB_DEBUG
-void check_match(deflate_state *s, IPos start, IPos match, int length);
+void check_match(deflate_state *s, Pos start, Pos match, int length);
 #else
 #define check_match(s, start, match, length)
 #endif

--- a/deflate_slow.c
+++ b/deflate_slow.c
@@ -24,7 +24,7 @@
  * no better match at the next window position.
  */
 ZLIB_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
-    IPos hash_head;          /* head of hash chain */
+    Pos hash_head;           /* head of hash chain */
     int bflush = 0;          /* set if current block must be flushed */
 
     /* Process the input block. */

--- a/functable.c
+++ b/functable.c
@@ -73,16 +73,16 @@ extern int32_t compare258_unaligned_avx2(const unsigned char *src0, const unsign
 #endif
 
 /* longest_match */
-extern int32_t longest_match_c(deflate_state *const s, IPos cur_match);
+extern int32_t longest_match_c(deflate_state *const s, Pos cur_match);
 #ifdef UNALIGNED_OK
-extern int32_t longest_match_unaligned_16(deflate_state *const s, IPos cur_match);
-extern int32_t longest_match_unaligned_32(deflate_state *const s, IPos cur_match);
-extern int32_t longest_match_unaligned_64(deflate_state *const s, IPos cur_match);
+extern int32_t longest_match_unaligned_16(deflate_state *const s, Pos cur_match);
+extern int32_t longest_match_unaligned_32(deflate_state *const s, Pos cur_match);
+extern int32_t longest_match_unaligned_64(deflate_state *const s, Pos cur_match);
 #ifdef X86_SSE42_CMP_STR
-extern int32_t longest_match_unaligned_sse4(deflate_state *const s, IPos cur_match);
+extern int32_t longest_match_unaligned_sse4(deflate_state *const s, Pos cur_match);
 #endif
 #if defined(X86_AVX2) && defined(HAVE_BUILTIN_CTZ)
-extern int32_t longest_match_unaligned_avx2(deflate_state *const s, IPos cur_match);
+extern int32_t longest_match_unaligned_avx2(deflate_state *const s, Pos cur_match);
 #endif
 #endif
 
@@ -93,7 +93,7 @@ ZLIB_INTERNAL uint32_t adler32_stub(uint32_t adler, const unsigned char *buf, si
 ZLIB_INTERNAL uint32_t crc32_stub(uint32_t crc, const unsigned char *buf, uint64_t len);
 ZLIB_INTERNAL void slide_hash_stub(deflate_state *s);
 ZLIB_INTERNAL int32_t compare258_stub(const unsigned char *src0, const unsigned char *src1);
-ZLIB_INTERNAL int32_t longest_match_stub(deflate_state *const s, IPos cur_match);
+ZLIB_INTERNAL int32_t longest_match_stub(deflate_state *const s, Pos cur_match);
 
 /* functable init */
 ZLIB_INTERNAL __thread struct functable_s functable = {
@@ -242,7 +242,7 @@ ZLIB_INTERNAL int32_t compare258_stub(const unsigned char *src0, const unsigned 
     return functable.compare258(src0, src1);
 }
 
-ZLIB_INTERNAL int32_t longest_match_stub(deflate_state *const s, IPos cur_match) {
+ZLIB_INTERNAL int32_t longest_match_stub(deflate_state *const s, Pos cur_match) {
 
     functable.longest_match = &longest_match_c;
 
@@ -266,4 +266,3 @@ ZLIB_INTERNAL int32_t longest_match_stub(deflate_state *const s, IPos cur_match)
 
     return functable.longest_match(s, cur_match);
 }
-

--- a/functable.h
+++ b/functable.h
@@ -15,7 +15,7 @@ struct functable_s {
     uint32_t (* crc32)              (uint32_t crc, const unsigned char *buf, uint64_t len);
     void     (* slide_hash)         (deflate_state *s);
     int32_t  (* compare258)         (const unsigned char *src0, const unsigned char *src1);
-    int32_t  (* longest_match)      (deflate_state *const s, IPos cur_match);
+    int32_t  (* longest_match)      (deflate_state *const s, Pos cur_match);
 };
 
 ZLIB_INTERNAL extern __thread struct functable_s functable;

--- a/match_tpl.h
+++ b/match_tpl.h
@@ -16,7 +16,7 @@ typedef uint8_t         bestcmp_t;
 #endif
 #else
 typedef uint8_t         bestcmp_t;
-#endif 
+#endif
 
 #endif
 
@@ -29,14 +29,14 @@ typedef uint8_t         bestcmp_t;
  * string (strstart) and its distance is <= MAX_DIST, and prev_length >=1
  * OUT assertion: the match length is not greater than s->lookahead
  */
-int32_t LONGEST_MATCH(deflate_state *const s, IPos cur_match) {
+int32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
     unsigned int strstart = s->strstart;
     const unsigned wmask = s->w_mask;
     unsigned char *window = s->window;
     unsigned char *scan = window + strstart;
     const Pos *prev = s->prev;
     unsigned chain_length;
-    IPos limit;
+    Pos limit;
     unsigned int len, best_len, nice_match;
     bestcmp_t scan_end, scan_start;
 


### PR DESCRIPTION
This typedef seems like legacy compiler optimization from K&R days and leads to more casting warnings.