### PR TITLE
Use a constant to load adler-32 initial hash value.

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -539,7 +539,7 @@ int ZEXPORT PREFIX(deflateResetKeep)(PREFIX3(stream) *strm) {
         crc_reset(s);
     else
 #endif
-        strm->adler = functable.adler32(0L, NULL, 0);
+        strm->adler = ADLER32_INITIAL_VALUE;
     s->last_flush = -2;
 
     zng_tr_init(s);
@@ -848,7 +848,7 @@ int ZEXPORT PREFIX(deflate)(PREFIX3(stream) *strm, int flush) {
         if (s->strstart != 0) {
             put_uint32_msb(s, strm->adler);
         }
-        strm->adler = functable.adler32(0L, NULL, 0);
+        strm->adler = ADLER32_INITIAL_VALUE;
         s->status = BUSY_STATE;
 
         /* Compression must start with an empty pending buffer */

--- a/inflate.c
+++ b/inflate.c
@@ -64,7 +64,7 @@ int ZEXPORT PREFIX(inflateResetKeep)(PREFIX3(stream) *strm) {
     if (state->wrap)        /* to support ill-conceived Java test suite */
         strm->adler = state->wrap & 1;
     state->mode = HEAD;
-    state->check = functable.adler32(0L, NULL, 0);
+    state->check = ADLER32_INITIAL_VALUE;
     state->last = 0;
     state->havedict = 0;
     state->flags = -1;
@@ -448,7 +448,7 @@ int ZEXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int flush) {
             state->dmax = 1U << len;
             state->flags = 0;               /* indicate zlib header */
             Tracev((stderr, "inflate:   zlib header ok\n"));
-            strm->adler = state->check = functable.adler32(0L, NULL, 0);
+            strm->adler = state->check = ADLER32_INITIAL_VALUE;
             state->mode = hold & 0x200 ? DICTID : TYPE;
             INITBITS();
             break;
@@ -604,7 +604,7 @@ int ZEXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int flush) {
                 RESTORE();
                 return Z_NEED_DICT;
             }
-            strm->adler = state->check = functable.adler32(0L, NULL, 0);
+            strm->adler = state->check = ADLER32_INITIAL_VALUE;
             state->mode = TYPE;
 
         case TYPE:
@@ -1143,8 +1143,7 @@ int ZEXPORT PREFIX(inflateSetDictionary)(PREFIX3(stream) *strm, const unsigned c
 
     /* check for correct dictionary identifier */
     if (state->mode == DICT) {
-        dictid = functable.adler32(0L, NULL, 0);
-        dictid = functable.adler32(dictid, dictionary, dictLength);
+        dictid = functable.adler32(ADLER32_INITIAL_VALUE, dictionary, dictLength);
         if (dictid != state->check)
             return Z_DATA_ERROR;
     }

--- a/zutil.h
+++ b/zutil.h
@@ -65,6 +65,8 @@ extern const char * const zng_errmsg[10]; /* indexed by 2-zlib_error */
 
 #define PRESET_DICT 0x20 /* preset dictionary flag in zlib header */
 
+#define ADLER32_INITIAL_VALUE 1 /* initial adler-32 hash value */
+
         /* target dependencies */
 
 #ifdef AMIGA


### PR DESCRIPTION
Sometimes adler32 is not used, but we incur the cost of initialization of stub.