### PR TITLE
Fixed invalid deflate quick output when flush_pending didn't flush

### DIFF
--- a/arch/x86/deflate_quick.c
+++ b/arch/x86/deflate_quick.c
@@ -44,7 +44,7 @@ ZLIB_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
     do {
         if (s->pending + ((BIT_BUF_SIZE + 7) >> 3) >= s->pending_buf_size) {
             flush_pending(s->strm);
-            if (s->strm->avail_in == 0 && flush != Z_FINISH) {
+            if ((s->strm->avail_in == 0 || s->strm->avail_out == 0) && (flush != Z_FINISH)) {
                 return need_more;
             }
         }


### PR DESCRIPTION
See #605 for background.

> Fixed invalid deflate quick output when flush_pending didn't flush due to s->strm->avail_out == 0. We check that there is input data available to process and output space to write to, which allows us to continue processing as long as we can keep flushing successfully.