### PR TITLE
Cache chocolatey packages on Windows for CMake workflow.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -341,6 +341,17 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y ${{ matrix.packages }}
 
+    - name: Set environment variables (Windows)
+      run:  echo "::set-env name=temp::$($env:TEMP)"
+
+    - name: Cache packages (Windows)
+      uses: actions/cache@v2
+      if: runner.os == 'Windows'
+      with:
+        key: zlib-ng-win-choco-${{matrix.compiler}}
+        path: |
+          ${{env.temp}}\chocolatey\
+
     - name: Install packages (Windows)
       if: runner.os == 'Windows'
       run: |


### PR DESCRIPTION
This should cache chocolatey packages on Windows.
*  It prevents download errors on Windows GCC builds we have been getting
 * Speed up Windows GCC CI builds because don't have to redownload. 

This is the expected output when loading from cache:

```
Chocolatey v0.10.15
Installing the following packages:
mingw
By installing you accept licenses for the packages.

mingw v7.3.0 (forced) [Approved]
mingw package files install completed. Performing other installation steps.
File appears to be downloaded already. Verifying with package checksum to determine if it needs to be redownloaded.
Hashes match.
Hashes match.
```