### PR TITLE
Fixed wrong 64-bit casting in deflatePrime causing bits to be lost.

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -581,7 +581,7 @@ int ZEXPORT PREFIX(deflatePending)(PREFIX3(stream) *strm, uint32_t *pending, int
 /* ========================================================================= */
 int ZEXPORT PREFIX(deflatePrime)(PREFIX3(stream) *strm, int bits, int value) {
     deflate_state *s;
-    int put;
+    int32_t put;
 
     if (deflateStateCheck(strm))
         return Z_STREAM_ERROR;
@@ -593,7 +593,7 @@ int ZEXPORT PREFIX(deflatePrime)(PREFIX3(stream) *strm, int bits, int value) {
         put = BIT_BUF_SIZE - s->bi_valid;
         if (put > bits)
             put = bits;
-        s->bi_buf |= (uint64_t)((value & ((1 << put) - 1)) << s->bi_valid);
+        s->bi_buf |= (((uint64_t)value & ((UINT64_C(1) << put) - 1)) << s->bi_valid);
         s->bi_valid += put;
         zng_tr_flush_bits(s);
         value >>= put;


### PR DESCRIPTION
The casting to higher integer type should happen to `value` first so no loss of bits.

Even _madler/zlib_ has the same casting, it looks like since it always used < 32-bit it was ok. Probably should have casted `value` first anyways.

![image](https://user-images.githubusercontent.com/1364432/83335718-8086c780-a263-11ea-9678-eff89c3677d8.png)
