### PR TITLE
Fixed multi-line assembly macro in UPDATE_HASH for MSVC

### DIFF
--- a/arch/x86/insert_string_sse.c
+++ b/arch/x86/insert_string_sse.c
@@ -23,12 +23,10 @@
 #else
 #  ifdef _MSC_VER
 #    define UPDATE_HASH(s, h, val) {\
-        __asm {\
-            mov edx, h\
-            mov eax, val\
-            crc32 eax, edx\
-            mov val, eax\
-        };\
+        __asm mov edx, h\
+        __asm mov eax, val\
+        __asm crc32 eax, edx\
+        __asm mov val, eax\
     }
 #  else
 #    define UPDATE_HASH(s, h, val) \


### PR DESCRIPTION
https://docs.microsoft.com/en-us/cpp/assembler/inline/defining-asm-blocks-as-c-macros
```
insert_string_tpl.h(44,5): error : cannot use more than one symbol in memory operand
insert_string_sse.c(28,13): message : expanded from macro 'UPDATE_HASH'
```