### PR TITLE
Move trace statements to emitting functions

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -1216,6 +1216,11 @@ static void lm_init(deflate_state *s) {
  * Check that the match at match_start is indeed a match.
  */
 void check_match(deflate_state *s, Pos start, Pos match, int length) {
+    /* check that the match length is valid*/
+    if (length < MIN_MATCH || length > MAX_MATCH) {
+        fprintf(stderr, " start %u, match %u, length %d\n", start, match, length);
+        z_error("invalid match length");
+    }
     /* check that the match is indeed a match */
     if (memcmp(s->window + match, s->window + start, length) != EQUAL) {
         fprintf(stderr, " start %u, match %u, length %d\n", start, match, length);

--- a/deflate.c
+++ b/deflate.c
@@ -754,6 +754,7 @@ ZLIB_INTERNAL void flush_pending(PREFIX3(stream) *strm) {
     if (len == 0)
         return;
 
+    Tracev((stderr, "[FLUSH]"));
     memcpy(strm->next_out, s->pending_out, len);
     strm->next_out  += len;
     s->pending_out  += len;

--- a/deflate.c
+++ b/deflate.c
@@ -1602,7 +1602,6 @@ static block_state deflate_rle(deflate_state *s, int flush) {
             s->match_length = 0;
         } else {
             /* No match, output a literal byte */
-            Tracevv((stderr, "%c", s->window[s->strstart]));
             bflush = zng_tr_tally_lit(s, s->window[s->strstart]);
             s->lookahead--;
             s->strstart++;
@@ -1640,7 +1639,6 @@ static block_state deflate_huff(deflate_state *s, int flush) {
 
         /* Output a literal byte */
         s->match_length = 0;
-        Tracevv((stderr, "%c", s->window[s->strstart]));
         bflush = zng_tr_tally_lit(s, s->window[s->strstart]);
         s->lookahead--;
         s->strstart++;

--- a/deflate_fast.c
+++ b/deflate_fast.c
@@ -85,7 +85,6 @@ ZLIB_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
             }
         } else {
             /* No match, output a literal byte */
-            Tracevv((stderr, "%c", s->window[s->strstart]));
             bflush = zng_tr_tally_lit(s, s->window[s->strstart]);
             s->lookahead--;
             s->strstart++;

--- a/deflate_p.h
+++ b/deflate_p.h
@@ -32,6 +32,7 @@ static inline int zng_tr_tally_lit(deflate_state *s, unsigned char c) {
     s->sym_buf[s->sym_next++] = 0;
     s->sym_buf[s->sym_next++] = c;
     s->dyn_ltree[c].Freq++;
+    Tracevv((stderr, "%c", c));
     Assert(c <= (MAX_MATCH-MIN_MATCH), "zng_tr_tally: bad literal");
     return (s->sym_next == s->sym_end);
 }

--- a/deflate_p.h
+++ b/deflate_p.h
@@ -65,7 +65,6 @@ static inline int zng_tr_tally_dist(deflate_state *s, unsigned dist, unsigned ch
                    (last)); \
     s->block_start = s->strstart; \
     flush_pending(s->strm); \
-    Tracev((stderr, "[FLUSH]")); \
 }
 
 /* Same but force premature exit if necessary. */

--- a/deflate_quick.c
+++ b/deflate_quick.c
@@ -68,9 +68,6 @@ ZLIB_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
                     if (match_len > s->lookahead)
                         match_len = s->lookahead;
 
-                    if (match_len > MAX_MATCH)
-                        match_len = MAX_MATCH;
-
                     check_match(s, s->strstart, hash_head, match_len);
 
                     zng_tr_emit_dist(s, static_ltree, static_dtree, match_len - MIN_MATCH, dist);

--- a/deflate_slow.c
+++ b/deflate_slow.c
@@ -101,7 +101,6 @@ ZLIB_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
              * single literal. If there was a match but the current match
              * is longer, truncate the previous match to a single literal.
              */
-            Tracevv((stderr, "%c", s->window[s->strstart-1]));
             bflush = zng_tr_tally_lit(s, s->window[s->strstart-1]);
             if (bflush)
                 FLUSH_BLOCK_ONLY(s, 0);
@@ -120,7 +119,6 @@ ZLIB_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
     }
     Assert(flush != Z_NO_FLUSH, "no flush?");
     if (s->match_available) {
-        Tracevv((stderr, "%c", s->window[s->strstart-1]));
         bflush = zng_tr_tally_lit(s, s->window[s->strstart-1]);
         s->match_available = 0;
     }

--- a/trees.c
+++ b/trees.c
@@ -787,8 +787,7 @@ static void bi_flush(deflate_state *s) {
         put_uint64(s, s->bi_buf);
         s->bi_buf = 0;
         s->bi_valid = 0;
-    }
-    else {
+    } else {
         if (s->bi_valid >= 32) {
             put_uint32(s, (uint32_t)s->bi_buf);
             s->bi_buf >>= 32;


### PR DESCRIPTION
This also moves match length check into `check_match`. Also none of the `compare256` functions should be able to return more than 258..