### PR TITLE
Added GitHub Actions workflow to test against libpng.

### DIFF
--- a/.github/workflows/libpng.yml
+++ b/.github/workflows/libpng.yml
@@ -1,0 +1,46 @@
+name: CI Libpng
+on: [pull_request]
+jobs:
+  pngtest:
+    name: Ubuntu Clang
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository (zlib-ng)
+      uses: actions/checkout@v1
+
+    - name: Generate project files (zlib-ng)
+      run: |
+        cmake . -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DWITH_GZFILEOP=ON -DZLIB_COMPAT=ON -DZLIB_ENABLE_TESTS=OFF
+      env:
+        CC: clang
+        CFLAGS: -fPIC
+        CI: true
+
+    - name: Compile source code (zlib-ng)
+      run: |
+        cmake --build . --config Release
+
+    - name: Checkout repository (libpng)
+      uses: actions/checkout@v2
+      with:
+        repository: glennrp/libpng
+        path: libpng
+
+    - name: Generate project files (libpng)
+      run: |
+        cd libpng
+        cmake . -DCMAKE_BUILD_TYPE=Release -DPNG_TESTS=ON -DPNG_STATIC=OFF -DZLIB_INCLUDE_DIR=.. -DZLIB_LIBRARY=$PWD/../libz.a
+      env:
+        CC: clang
+        CI: true
+
+    - name: Compile source code (libpng)
+      run: |
+        cd libpng
+        cmake --build . --config Release
+
+    - name: Run test cases (libpng)
+      run: |
+        cd libpng
+        ctest -C Release --output-on-failure --max-width 120


### PR DESCRIPTION
See #103. All tests pass. I have only enabled this for pull requests.

Here is an example of what the actions look like:
https://github.com/zlib-ng/zlib-ng/runs/745572645?check_suite_focus=true