### PR TITLE
Fixed defined WIN32 in switchlevels should be _WIN32.

### DIFF
--- a/test/switchlevels.c
+++ b/test/switchlevels.c
@@ -13,7 +13,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if defined(WIN32) || defined(__CYGWIN__)
+#if defined(_WIN32) || defined(__CYGWIN__)
 #  include <fcntl.h>
 #  include <io.h>
 #  define SET_BINARY_MODE(file) setmode(fileno(file), O_BINARY)


### PR DESCRIPTION
This should fix the Windows GCC builds that have been failing in CI.