### PR TITLE
Fixed deflate_quick algorithm not being used due to old check.

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -1003,9 +1003,6 @@ int ZEXPORT PREFIX(deflate)(PREFIX3(stream) *strm, int flush) {
                  s->level == 0 ? deflate_stored(s, flush) :
                  s->strategy == Z_HUFFMAN_ONLY ? deflate_huff(s, flush) :
                  s->strategy == Z_RLE ? deflate_rle(s, flush) :
-#ifndef NO_QUICK_STRATEGY
-                 s->level == 1 ? deflate_fast(s, flush) :
-#endif
                  (*(configuration_table[s->level].func))(s, flush);
 
         if (bstate == finish_started || bstate == finish_done) {


### PR DESCRIPTION
Configuration table should be used now for all levels.