### PR TITLE
Remove Borland C++ compiler references

### DIFF
--- a/gzlib.c
+++ b/gzlib.c
@@ -6,7 +6,7 @@
 #include "zbuild.h"
 #include "gzguts.h"
 
-#if defined(_WIN32) && !defined(__BORLANDC__)
+#if defined(_WIN32)
 #  define LSEEK _lseeki64
 #else
 #if defined(_LARGEFILE64_SOURCE) && _LFS64_LARGEFILE-0

--- a/zconf-ng.h.in
+++ b/zconf-ng.h.in
@@ -52,7 +52,7 @@
    /* If building or using zlib as a DLL, define ZLIB_DLL.
     * This is not mandatory, but it offers a little performance increase.
     */
-#  if defined(ZLIB_DLL) && (!defined(__BORLANDC__) || (__BORLANDC__ >= 0x500))
+#  if defined(ZLIB_DLL)
 #    ifdef ZLIB_INTERNAL
 #      define ZEXTERN extern __declspec(dllexport)
 #    else

--- a/zconf.h.in
+++ b/zconf.h.in
@@ -56,7 +56,7 @@
    /* If building or using zlib as a DLL, define ZLIB_DLL.
     * This is not mandatory, but it offers a little performance increase.
     */
-#  if defined(ZLIB_DLL) && (!defined(__BORLANDC__) || (__BORLANDC__ >= 0x500))
+#  if defined(ZLIB_DLL)
 #    ifdef ZLIB_INTERNAL
 #      define ZEXTERN extern __declspec(dllexport)
 #    else


### PR DESCRIPTION
There are a few guards checking for Borland C++ 5.0 or greater which was released
in 1996. While there is still a descendent of this compiler in Embarcadero C++ Builder
its value for __BORLANDC__ is greater than 0x500 so it is safe to remove these guards.