### PR TITLE
test: bring back default behavior of minigzip

### DIFF
--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -46,26 +46,28 @@ fuzzer:
 endif
 
 teststatic: check_cross_dep
-	@TMPST=tmpst_$$; \
-	if echo hello world | ${QEMU_RUN} ../minigzip$(EXE) | ${QEMU_RUN} ../minigzip$(EXE) -d && ${QEMU_RUN} ../example$(EXE) $$TMPST ; then \
+	@TMPST=tmpst_$$$$; \
+	HELLOST=tmphellost_$$$$; \
+	if echo hello world | ${QEMU_RUN} ../minigzip$(EXE) > $$HELLOST && ${QEMU_RUN} ../minigzip$(EXE) -d < $$HELLOST && ${QEMU_RUN} ../example$(EXE) $$TMPST ; then \
 	  echo '		*** zlib test OK ***'; \
 	else \
 	  echo '		*** zlib test FAILED ***'; exit 1; \
-	fi
-	@rm -f tmpst_$$
+	fi; \
+	rm -f $$TMPST $$HELLOST
 
 testshared: check_cross_dep
 	@LD_LIBRARY_PATH=`pwd`/..:$(LD_LIBRARY_PATH) ; export LD_LIBRARY_PATH; \
 	LD_LIBRARYN32_PATH=`pwd`/..:$(LD_LIBRARYN32_PATH) ; export LD_LIBRARYN32_PATH; \
 	DYLD_LIBRARY_PATH=`pwd`/..:$(DYLD_LIBRARY_PATH) ; export DYLD_LIBRARY_PATH; \
 	SHLIB_PATH=`pwd`/..:$(SHLIB_PATH) ; export SHLIB_PATH; \
-	TMPSH=tmpsh_$$; \
-	if echo hello world | ${QEMU_RUN} ../minigzipsh$(EXE) | ${QEMU_RUN} ../minigzipsh$(EXE) -d && ${QEMU_RUN} ../examplesh$(EXE) $$TMPSH; then \
+	TMPSH=tmpsh_$$$$; \
+	HELLOSH=tmphellosh_$$$$; \
+	if echo hello world | ${QEMU_RUN} ../minigzipsh$(EXE) > $$HELLOSH && ${QEMU_RUN} ../minigzipsh$(EXE) -d < $$HELLOSH && ${QEMU_RUN} ../examplesh$(EXE) $$TMPSH; then \
 	  echo '		*** zlib shared test OK ***'; \
 	else \
 	  echo '		*** zlib shared test FAILED ***'; exit 1; \
-	fi
-	@rm -f tmpsh_$$
+	fi; \
+	rm -f $$TMPSH $$HELLOSH
 
 cvetests: testCVEinputs
 

--- a/test/minigzip.c
+++ b/test/minigzip.c
@@ -275,11 +275,6 @@ int main(int argc, char *argv[]) {
     char *level = "6";
     char *type = "b";
 
-    if ((argc == 1) || (argc == 2 && strcmp(argv[1], "--help") == 0)) {
-        show_help();
-        return 0;
-    }
-
     prog = argv[i];
     bname = strrchr(argv[i], '/');
     if (bname)
@@ -306,8 +301,15 @@ int main(int argc, char *argv[]) {
             strategy = argv[i] + 1;
         else if (argv[i][0] == '-' && argv[i][1] >= '0' && argv[i][1] <= '9' && argv[i][2] == 0)
             level = argv[i] + 1;
-        else
+        else if (strcmp(argv[i], "--help") == 0) {
+            show_help();
+            return 0;
+        } else if (argv[i][0] == '-') {
+            show_help();
+            return 64;   /* EX_USAGE */
+        } else {
             break;
+        }
     }
 
     snprintf(outmode, sizeof(outmode), "w%s%s%s", type, strategy, level);


### PR DESCRIPTION
Fixes #635 

Also:
- makes sure 'make test' fails if minigzip aborts
- fixes old quoting error that prevented temp file names from being unique as intended
- uses a distinguishable exit code on bad commandline, as minigzip_stdio_cmp treats 1 as expected and ok.  Chose value used by BSD for bad usage.