### PR TITLE
deflate_slow: ignore unused return value from final call to zng_tr_tally_lit

### DIFF
--- a/deflate_slow.c
+++ b/deflate_slow.c
@@ -119,7 +119,7 @@ ZLIB_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
     }
     Assert(flush != Z_NO_FLUSH, "no flush?");
     if (s->match_available) {
-        bflush = zng_tr_tally_lit(s, s->window[s->strstart-1]);
+        (void) zng_tr_tally_lit(s, s->window[s->strstart-1]);
         s->match_available = 0;
     }
     s->insert = s->strstart < MIN_MATCH-1 ? s->strstart : MIN_MATCH-1;


### PR DESCRIPTION
The recent refactoring ( https://github.com/zlib-ng/zlib-ng/pull/547 )
turned a macro's call-by-name parameter into a function's
return value, triggering a static analyzer warning.

This should have no effect but to silence the static analyzer warning,
but still needs careful review.

Partly fixes https://github.com/zlib-ng/zlib-ng/issues/593