### PR TITLE
Add optimized adler32 for POWER and new adler32 tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@
 *.gcno
 *.gcov
 
+/adler32_test
+/adler32_testsh
 /example
 /example64
 /examplesh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1040,6 +1040,13 @@ if(ZLIB_ENABLE_TESTS)
         endif()
     endmacro()
 
+    add_executable(adler32_test test/adler32_test.c)
+    configure_test_executable(adler32_test)
+    target_link_libraries(adler32_test zlib)
+
+    set(ADLER32TEST_COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:adler32_test>)
+    add_test(NAME adler32_test COMMAND ${ADLER32TEST_COMMAND})
+
     add_executable(example test/example.c)
     configure_test_executable(example)
     target_link_libraries(example zlib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -692,9 +692,11 @@ if(WITH_OPTIM)
         endif()
     elseif(BASEARCH_PPC_FOUND)
         if(WITH_POWER8 AND HAVE_POWER8)
-            add_definitions(-DPOWER_FEATURES)
             add_definitions(-DPOWER8)
+            add_definitions(-DPOWER_FEATURES)
+            add_definitions(-DPOWER8_VSX_ADLER32)
             set(ZLIB_POWER8_SRCS
+                ${ARCHDIR}/adler32_power8.c
                 ${ARCHDIR}/slide_hash_power8.c)
             set_source_files_properties(
                 ${ZLIB_POWER8_SRCS}

--- a/Makefile.in
+++ b/Makefile.in
@@ -135,9 +135,9 @@ PIC_OBJS = $(PIC_OBJC)
 
 all: static shared
 
-static: example$(EXE) minigzip$(EXE) fuzzers makefixed$(EXE) maketrees$(EXE) makecrct$(EXE)
+static: adler32_test$(EXE) example$(EXE) minigzip$(EXE) fuzzers makefixed$(EXE) maketrees$(EXE) makecrct$(EXE)
 
-shared: examplesh$(EXE) minigzipsh$(EXE)
+shared: adler32_testsh$(EXE) examplesh$(EXE) minigzipsh$(EXE)
 
 check: test
 
@@ -229,6 +229,9 @@ $(STATICLIB): $(OBJS)
 	$(AR) $(ARFLAGS) $@ $(OBJS)
 	-@ ($(RANLIB) $@ || true) >/dev/null 2>&1
 
+adler32_test.o:
+	$(CC) $(CFLAGS) $(INCLUDES) -c -o $@ $(SRCDIR)/test/adler32_test.c
+
 example.o:
 	$(CC) $(CFLAGS) -DWITH_GZFILEOP $(INCLUDES) -c -o $@ $(SRCDIR)/test/example.c
 
@@ -271,6 +274,12 @@ ifneq ($(SHAREDLIB),$(SHAREDTARGET))
 endif
 endif
 
+adler32_test$(EXE): adler32_test.o $(OBJG) $(STATICLIB)
+	$(CC) $(LDFLAGS) -o $@ adler32_test.o $(OBJG) $(TEST_LIBS) $(LDSHAREDLIBC)
+ifneq ($(STRIP),)
+	$(STRIP) $@
+endif
+
 example$(EXE): example.o $(OBJG) $(STATICLIB)
 	$(CC) $(LDFLAGS) -o $@ example.o $(OBJG) $(TEST_LIBS) $(LDSHAREDLIBC)
 ifneq ($(STRIP),)
@@ -279,6 +288,12 @@ endif
 
 minigzip$(EXE): minigzip.o $(OBJG) $(STATICLIB)
 	$(CC) $(LDFLAGS) -o $@ minigzip.o $(OBJG) $(TEST_LIBS) $(LDSHAREDLIBC)
+ifneq ($(STRIP),)
+	$(STRIP) $@
+endif
+
+adler32_testsh$(EXE): adler32_test.o $(OBJG) $(SHAREDTARGET)
+	$(CC) $(LDFLAGS) -o $@ adler32_test.o $(OBJG) $(SHAREDTARGET) $(LDSHAREDLIBC)
 ifneq ($(STRIP),)
 	$(STRIP) $@
 endif
@@ -383,7 +398,8 @@ clean:
 	@if [ -f $(ARCHDIR)/Makefile ]; then $(MAKE) -C $(ARCHDIR) clean; fi
 	@if [ -f test/Makefile ]; then $(MAKE) -C test clean; fi
 	rm -f *.o *.lo *~ \
-	   example$(EXE) minigzip$(EXE) examplesh$(EXE) minigzipsh$(EXE) \
+	   adler32_test$(EXE) example$(EXE) minigzip$(EXE) \
+	   adler32_testsh$(EXE) examplesh$(EXE) minigzipsh$(EXE) \
 	   checksum_fuzzer$(EXE) compress_fuzzer$(EXE) example_small_fuzzer$(EXE) example_large_fuzzer$(EXE) \
 	   example_flush_fuzzer$(EXE) example_dict_fuzzer$(EXE) minigzip_fuzzer$(EXE) \
 	   infcover makefixed$(EXE) maketrees$(EXE) makecrct$(EXE) \

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Features
 * Modernized native API based on zlib API for ease of porting
 * Intel deflate medium and quick algorithms
 * Support for CPU intrinsics when available
-  * Adler32 implementation using SSSE3, AVX2, & Neon
+  * Adler32 implementation using SSSE3, AVX2, Neon, & VSX
   * Intel CRC32-B implementation using PCLMULQDQ
   * Intel CRC32-C intrinics for hash tables
   * ARM CRC32-B implementation using ACLE

--- a/adler32.c
+++ b/adler32.c
@@ -11,12 +11,6 @@
 uint32_t adler32_c(uint32_t adler, const unsigned char *buf, size_t len);
 static uint32_t adler32_combine_(uint32_t adler1, uint32_t adler2, z_off64_t len2);
 
-#define DO1(buf, i)  {adler += (buf)[i]; sum2 += adler;}
-#define DO2(buf, i)  DO1(buf, i); DO1(buf, i+1);
-#define DO4(buf, i)  DO2(buf, i); DO2(buf, i+2);
-#define DO8(buf, i)  DO4(buf, i); DO4(buf, i+4);
-#define DO16(buf)    DO8(buf, 0); DO8(buf, 8);
-
 /* ========================================================================= */
 uint32_t adler32_c(uint32_t adler, const unsigned char *buf, size_t len) {
     uint32_t sum2;
@@ -48,10 +42,10 @@ uint32_t adler32_c(uint32_t adler, const unsigned char *buf, size_t len) {
 #endif
         do {
 #ifdef UNROLL_MORE
-            DO16(buf);          /* 16 sums unrolled */
+            DO16(adler, sum2, buf);          /* 16 sums unrolled */
             buf += 16;
 #else
-            DO8(buf, 0);         /* 8 sums unrolled */
+            DO8(adler, sum2, buf, 0);         /* 8 sums unrolled */
             buf += 8;
 #endif
         } while (--n);
@@ -64,12 +58,12 @@ uint32_t adler32_c(uint32_t adler, const unsigned char *buf, size_t len) {
 #ifdef UNROLL_MORE
         while (len >= 16) {
             len -= 16;
-            DO16(buf);
+            DO16(adler, sum2, buf);
             buf += 16;
 #else
         while (len >= 8) {
             len -= 8;
-            DO8(buf, 0);
+            DO8(adler, sum2, buf, 0);
             buf += 8;
 #endif
         }

--- a/adler32_p.h
+++ b/adler32_p.h
@@ -80,4 +80,14 @@ static inline uint32_t adler32_len_16(uint32_t adler, const unsigned char *buf, 
     return adler | (sum2 << 16);
 }
 
+static inline uint32_t adler32_len_64(uint32_t adler, const unsigned char *buf, size_t len, uint32_t sum2) {
+    while (len >= 16) {
+        len -= 16;
+        DO16(adler, sum2, buf);
+        buf += 16;
+    }
+    /* Process tail (len < 16).  */
+    return adler32_len_16(adler, buf, len, sum2);
+}
+
 #endif /* ADLER32_P_H */

--- a/adler32_p.h
+++ b/adler32_p.h
@@ -12,6 +12,12 @@
 #define NMAX 5552
 /* NMAX is the largest n such that 255n(n+1)/2 + (n+1)(BASE-1) <= 2^32-1 */
 
+#define DO1(sum1, sum2, buf, i)  {(sum1) += buf[(i)]; (sum2) += (sum1);}
+#define DO2(sum1, sum2, buf, i)  {DO1(sum1, sum2, buf, i); DO1(sum1, sum2, buf, i+1);}
+#define DO4(sum1, sum2, buf, i)  {DO2(sum1, sum2, buf, i); DO2(sum1, sum2, buf, i+2);}
+#define DO8(sum1, sum2, buf, i)  {DO4(sum1, sum2, buf, i); DO4(sum1, sum2, buf, i+4);}
+#define DO16(sum1, sum2, buf)    {DO8(sum1, sum2, buf, 0); DO8(sum1, sum2, buf, 8);}
+
 /* use NO_DIVIDE if your processor does not do division in hardware --
    try it both ways to see which is faster */
 #ifdef NO_DIVIDE

--- a/arch/power/Makefile.in
+++ b/arch/power/Makefile.in
@@ -16,6 +16,8 @@ P8FLAGS=-mcpu=power8
 
 all: power.o \
      power.lo \
+     adler32_power8.o \
+     adler32_power8.lo \
      slide_hash_power8.o \
      slide_hash_power8.lo
 
@@ -24,6 +26,12 @@ power.o:
 
 power.lo:
 	$(CC) $(SFLAGS) $(INCLUDES) -c -o $@ $(SRCDIR)/power.c
+
+adler32_power8.o:
+	$(CC) $(CFLAGS) $(P8FLAGS) $(INCLUDES) -c -o $@ $(SRCDIR)/adler32_power8.c
+
+adler32_power8.lo:
+	$(CC) $(SFLAGS) $(P8FLAGS) $(INCLUDES) -c -o $@ $(SRCDIR)/adler32_power8.c
 
 slide_hash_power8.o:
 	$(CC) $(CFLAGS) $(P8FLAGS) $(INCLUDES) -c -o $@ $(SRCDIR)/slide_hash_power8.c

--- a/arch/power/adler32_power8.c
+++ b/arch/power/adler32_power8.c
@@ -1,0 +1,165 @@
+/* Adler32 for POWER8 using VSX instructions.
+ * Copyright (C) 2020 IBM Corporation
+ * Author: Rogerio Alves <rcardoso@linux.ibm.com>
+ * For conditions of distribution and use, see copyright notice in zlib.h
+ *
+ * Calculate adler32 checksum for 16 bytes at once using POWER8+ VSX (vector)
+ * instructions.
+ *
+ * If adler32 do 1 byte at time on the first iteration s1 is s1_0 (_n means
+ * iteration n) is the initial value of adler - at start  _0 is 1 unless
+ * adler initial value is different than 1. So s1_1 = s1_0 + c[0] after
+ * the first calculation. For the iteration s1_2 = s1_1 + c[1] and so on.
+ * Hence, for iteration N, s1_N = s1_(N-1) + c[N] is the value of s1 on
+ * after iteration N.
+ *
+ * Therefore, for s2 and iteration N, s2_N = s2_0 + N*s1_N + N*c[0] +
+ * N-1*c[1] + ... + c[N]
+ *
+ * In a more general way:
+ *
+ * s1_N = s1_0 + sum(i=1 to N)c[i]
+ * s2_N = s2_0 + N*s1 + sum (i=1 to N)(N-i+1)*c[i]
+ *
+ * Where s1_N, s2_N are the values for s1, s2 after N iterations. So if we
+ * can process N-bit at time we can do this at once.
+ *
+ * Since VSX can support 16-bit vector instructions, we can process
+ * 16-bit at time using N = 16 we have:
+ *
+ * s1 = s1_16 = s1_(16-1) + c[16] = s1_0 + sum(i=1 to 16)c[i]
+ * s2 = s2_16 = s2_0 + 16*s1 + sum(i=1 to 16)(16-i+1)*c[i]
+ *
+ * After the first iteration we calculate the adler32 checksum for 16 bytes.
+ *
+ * For more background about adler32 please check the RFC:
+ * https://www.ietf.org/rfc/rfc1950.txt
+ */
+
+#ifdef POWER8_VSX_ADLER32
+
+#include <altivec.h>
+#include "zbuild.h"
+#include "zutil.h"
+#include "adler32_p.h"
+
+#define DO1(s1,s2,buf,i)  {(s1) += buf[(i)]; (s2) += (s1);}
+#define DO2(s1,s2,buf,i)  {DO1(s1,s2,buf,i); DO1(s1,s2,buf,i+1);}
+#define DO4(s1,s2,buf,i)  {DO2(s1,s2,buf,i); DO2(s1,s2,buf,i+2);}
+#define DO8(s1,s2,buf,i)  {DO4(s1,s2,buf,i); DO4(s1,s2,buf,i+4);}
+#define DO16(s1,s2,buf)   {DO8(s1,s2,buf,0); DO8(s1,s2,buf,8);}
+
+/* Vector across sum unsigned int (saturate).  */
+inline vector unsigned int vec_sumsu(vector unsigned int __a, vector unsigned int __b) {
+    __b = vec_sld(__a, __a, 8);
+    __b = vec_add(__b, __a);
+    __a = vec_sld(__b, __b, 4);
+    __a = vec_add(__a, __b);
+
+    return __a;
+}
+
+uint32_t adler32_power8(uint32_t adler, const unsigned char* buf, size_t len) {
+    uint32_t s1 = adler & 0xffff;
+    uint32_t s2 = (adler >> 16) & 0xffff;
+
+    /* in case user likes doing a byte at a time, keep it fast */
+    if (UNLIKELY(len == 1))
+        return adler32_len_1(s1, buf, s2);
+
+    /* If buffer is empty or len=0 we need to return adler initial value.  */
+    if (UNLIKELY(buf == NULL))
+        return 1;
+
+    /* This is faster than VSX code for len < 64.  */
+    if (len < 64) {
+        while (len >= 16) {
+            len -= 16;
+            DO16(s1,s2,buf);
+            buf += 16;
+        }
+    } else {
+        /* Use POWER VSX instructions for len >= 64. */
+        const vector unsigned int v_zeros = { 0 };
+        const vector unsigned char v_mul = {16, 15, 14, 13, 12, 11, 10, 9, 8, 7,
+             6, 5, 4, 3, 2, 1};
+        const vector unsigned char vsh = vec_splat_u8(4);
+        const vector unsigned int vmask = {0xffffffff, 0x0, 0x0, 0x0};
+        vector unsigned int vs1 = { 0 };
+        vector unsigned int vs2 = { 0 };
+        vector unsigned int vs1_save = { 0 };
+        vector unsigned int vsum1, vsum2;
+        vector unsigned char vbuf;
+        int n;
+
+        vs1[0] = s1;
+        vs2[0] = s2;
+
+        /* Do length bigger than NMAX in blocks of NMAX size.  */
+        while (len >= NMAX) {
+            len -= NMAX;
+            n = NMAX / 16;
+            do {
+                vbuf = vec_xl(0, (unsigned char *) buf);
+                vsum1 = vec_sum4s(vbuf, v_zeros); /* sum(i=1 to 16) buf[i].  */
+                /* sum(i=1 to 16) buf[i]*(16-i+1).  */
+                vsum2 = vec_msum(vbuf, v_mul, v_zeros);
+                /* Save vs1.  */
+                vs1_save = vec_add(vs1_save, vs1);
+                /* Accumulate the sums.  */
+                vs1 = vec_add(vsum1, vs1);
+                vs2 = vec_add(vsum2, vs2);
+
+                buf += 16;
+            } while (--n);
+            /* Once each block of NMAX size.  */
+            vs1 = vec_sumsu(vs1, vsum1);
+            vs1_save = vec_sll(vs1_save, vsh); /* 16*vs1_save.  */
+            vs2 = vec_add(vs1_save, vs2);
+            vs2 = vec_sumsu(vs2, vsum2);
+
+            /* vs1[0] = (s1_i + sum(i=1 to 16)buf[i]) mod 65521.  */
+            vs1[0] = vs1[0] % BASE;
+            /* vs2[0] = s2_i + 16*s1_save +
+               sum(i=1 to 16)(16-i+1)*buf[i] mod 65521.  */
+            vs2[0] = vs2[0] % BASE;
+
+            vs1 = vec_and(vs1, vmask);
+            vs2 = vec_and(vs2, vmask);
+            vs1_save = v_zeros;
+        }
+
+        /* len is less than NMAX one modulo is needed.  */
+        if (len >= 16) {
+            while (len >= 16) {
+                len -= 16;
+
+                vbuf = vec_xl(0, (unsigned char *) buf);
+
+                vsum1 = vec_sum4s(vbuf, v_zeros); /* sum(i=1 to 16) buf[i].  */
+                /* sum(i=1 to 16) buf[i]*(16-i+1).  */
+                vsum2 = vec_msum(vbuf, v_mul, v_zeros);
+                /* Save vs1.  */
+                vs1_save = vec_add(vs1_save, vs1);
+                /* Accumulate the sums.  */
+                vs1 = vec_add(vsum1, vs1);
+                vs2 = vec_add(vsum2, vs2);
+
+                buf += 16;
+            }
+            /* Since the size will be always less than NMAX we do this once.  */
+            vs1 = vec_sumsu(vs1, vsum1);
+            vs1_save = vec_sll(vs1_save, vsh); /* 16*vs1_save.  */
+            vs2 = vec_add(vs1_save, vs2);
+            vs2 = vec_sumsu(vs2, vsum2);
+        }
+        /* Copy result back to s1, s2 (mod 65521).  */
+        s1 = vs1[0] % BASE;
+        s2 = vs2[0] % BASE;
+    }
+
+    /* Process tail (len < 16).and return  */
+    return adler32_len_16(s1, buf, len, s2);
+}
+
+#endif /* POWER8_VSX_ADLER32 */

--- a/arch/power/adler32_power8.c
+++ b/arch/power/adler32_power8.c
@@ -43,12 +43,6 @@
 #include "zutil.h"
 #include "adler32_p.h"
 
-#define DO1(s1,s2,buf,i)  {(s1) += buf[(i)]; (s2) += (s1);}
-#define DO2(s1,s2,buf,i)  {DO1(s1,s2,buf,i); DO1(s1,s2,buf,i+1);}
-#define DO4(s1,s2,buf,i)  {DO2(s1,s2,buf,i); DO2(s1,s2,buf,i+2);}
-#define DO8(s1,s2,buf,i)  {DO4(s1,s2,buf,i); DO4(s1,s2,buf,i+4);}
-#define DO16(s1,s2,buf)   {DO8(s1,s2,buf,0); DO8(s1,s2,buf,8);}
-
 /* Vector across sum unsigned int (saturate).  */
 inline vector unsigned int vec_sumsu(vector unsigned int __a, vector unsigned int __b) {
     __b = vec_sld(__a, __a, 8);

--- a/configure
+++ b/configure
@@ -1392,9 +1392,9 @@ case "${ARCH}" in
 
         if test $without_optimizations -eq 0; then
             if test $HAVE_POWER8 -eq 1; then
-                ARCH_STATIC_OBJS="${ARCH_STATIC_OBJS} power.o slide_hash_power8.o"
-                ARCH_SHARED_OBJS="${ARCH_SHARED_OBJS} power.lo slide_hash_power8.lo"
-                POWERFLAGS="-DPOWER_FEATURES -DPOWER8"
+                ARCH_STATIC_OBJS="${ARCH_STATIC_OBJS} adler32_power8.o power.o slide_hash_power8.o"
+                ARCH_SHARED_OBJS="${ARCH_SHARED_OBJS} adler32_power8.lo power.lo slide_hash_power8.lo"
+                POWERFLAGS="-DPOWER8 -DPOWER_FEATURES -DPOWER8_VSX_ADLER32"
             fi
         fi
 

--- a/functable.c
+++ b/functable.c
@@ -53,6 +53,9 @@ extern uint32_t adler32_ssse3(uint32_t adler, const unsigned char *buf, size_t l
 #ifdef X86_AVX2_ADLER32
 extern uint32_t adler32_avx2(uint32_t adler, const unsigned char *buf, size_t len);
 #endif
+#ifdef POWER8_VSX_ADLER32
+extern uint32_t adler32_power8(uint32_t adler, const unsigned char* buf, size_t len);
+#endif
 
 /* CRC32 */
 ZLIB_INTERNAL uint32_t crc32_generic(uint32_t, const unsigned char *, uint64_t);
@@ -212,6 +215,10 @@ ZLIB_INTERNAL uint32_t adler32_stub(uint32_t adler, const unsigned char *buf, si
 #ifdef X86_AVX2_ADLER32
     if (x86_cpu_has_avx2)
         functable.adler32 = &adler32_avx2;
+#endif
+#ifdef POWER8_VSX_ADLER32
+    if (power_cpu_has_arch_2_07)
+        functable.adler32 = &adler32_power8;
 #endif
 
     return functable.adler32(adler, buf, len);

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -48,7 +48,7 @@ endif
 teststatic: check_cross_dep
 	@TMPST=tmpst_$$$$; \
 	HELLOST=tmphellost_$$$$; \
-	if echo hello world | ${QEMU_RUN} ../minigzip$(EXE) > $$HELLOST && ${QEMU_RUN} ../minigzip$(EXE) -d < $$HELLOST && ${QEMU_RUN} ../example$(EXE) $$TMPST ; then \
+	if echo hello world | ${QEMU_RUN} ../minigzip$(EXE) > $$HELLOST && ${QEMU_RUN} ../minigzip$(EXE) -d < $$HELLOST && ${QEMU_RUN} ../example$(EXE) $$TMPST && ${QEMU_RUN} ../adler32_test$(EXE); then \
 	  echo '		*** zlib test OK ***'; \
 	else \
 	  echo '		*** zlib test FAILED ***'; exit 1; \
@@ -62,7 +62,7 @@ testshared: check_cross_dep
 	SHLIB_PATH=`pwd`/..:$(SHLIB_PATH) ; export SHLIB_PATH; \
 	TMPSH=tmpsh_$$$$; \
 	HELLOSH=tmphellosh_$$$$; \
-	if echo hello world | ${QEMU_RUN} ../minigzipsh$(EXE) > $$HELLOSH && ${QEMU_RUN} ../minigzipsh$(EXE) -d < $$HELLOSH && ${QEMU_RUN} ../examplesh$(EXE) $$TMPSH; then \
+	if echo hello world | ${QEMU_RUN} ../minigzipsh$(EXE) > $$HELLOSH && ${QEMU_RUN} ../minigzipsh$(EXE) -d < $$HELLOSH && ${QEMU_RUN} ../examplesh$(EXE) $$TMPSH && ${QEMU_RUN} ../adler32_testsh$(EXE); then \
 	  echo '		*** zlib shared test OK ***'; \
 	else \
 	  echo '		*** zlib shared test FAILED ***'; exit 1; \

--- a/test/adler32_test.c
+++ b/test/adler32_test.c
@@ -1,0 +1,333 @@
+/* adler32_test.c -- unit test for adler32 in the zlib compression library
+ * Copyright (C) 2020 IBM Corporation
+ * Author: Rogerio Alves <rcardoso@linux.ibm.com>
+ * For conditions of distribution and use, see copyright notice in zlib.h
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "zbuild.h"
+#ifdef ZLIB_COMPAT
+#  include "zlib.h"
+#else
+#  include "zlib-ng.h"
+#endif
+
+typedef struct {
+    uint32_t line;
+    uint32_t adler;
+    const uint8_t *buf;
+    uint32_t len;
+    uint32_t expect;
+} adler32_test;
+
+void test_adler32(uint32_t adler, const uint8_t *buf, uint32_t len, uint32_t chk, uint32_t line) {
+    uint32_t res = PREFIX(adler32)(adler, buf, len);
+    if (res != chk) {
+        fprintf(stderr, "FAIL [%d]: adler32 returned 0x%08X expected 0x%08X\n",
+                line, res, chk);
+        exit(1);
+    }
+}
+
+static const adler32_test tests[] = {
+   {__LINE__, 0x1, (const uint8_t *)0x0, 0, 0x1},
+   {__LINE__, 0x1, (const uint8_t *)"", 1, 0x10001},
+   {__LINE__, 0x1, (const uint8_t *)"a", 1, 0x620062},
+   {__LINE__, 0x1, (const uint8_t *)"abacus", 6, 0x8400270},
+   {__LINE__, 0x1, (const uint8_t *)"backlog", 7, 0xb1f02d4},
+   {__LINE__, 0x1, (const uint8_t *)"campfire", 8, 0xea10348},
+   {__LINE__, 0x1, (const uint8_t *)"delta", 5, 0x61a020b},
+   {__LINE__, 0x1, (const uint8_t *)"executable", 10, 0x16fa0423},
+   {__LINE__, 0x1, (const uint8_t *)"file", 4, 0x41401a1},
+   {__LINE__, 0x1, (const uint8_t *)"greatest", 8, 0xefa0360},
+   {__LINE__, 0x1, (const uint8_t *)"inverter", 8, 0xf6f0370},
+   {__LINE__, 0x1, (const uint8_t *)"jigsaw", 6, 0x8bd0286},
+   {__LINE__, 0x1, (const uint8_t *)"karate", 6, 0x8a50279},
+   {__LINE__, 0x1, (const uint8_t *)"landscape", 9, 0x126a03ac},
+   {__LINE__, 0x1, (const uint8_t *)"machine", 7, 0xb5302d6},
+   {__LINE__, 0x1, (const uint8_t *)"nanometer", 9, 0x12d803ca},
+   {__LINE__, 0x1, (const uint8_t *)"oblivion", 8, 0xf220363},
+   {__LINE__, 0x1, (const uint8_t *)"panama", 6, 0x8a1026f},
+   {__LINE__, 0x1, (const uint8_t *)"quest", 5, 0x6970233},
+   {__LINE__, 0x1, (const uint8_t *)"resource", 8, 0xf8d0369},
+   {__LINE__, 0x1, (const uint8_t *)"secret", 6, 0x8d10287},
+   {__LINE__, 0x1, (const uint8_t *)"ultimate", 8, 0xf8d0366},
+   {__LINE__, 0x1, (const uint8_t *)"vector", 6, 0x8fb0294},
+   {__LINE__, 0x1, (const uint8_t *)"walrus", 6, 0x918029f},
+   {__LINE__, 0x1, (const uint8_t *)"xeno", 4, 0x45e01bb},
+   {__LINE__, 0x1, (const uint8_t *)"yelling", 7, 0xbfe02f5},
+   {__LINE__, 0x1, (const uint8_t *)"zero", 4, 0x46e01c1},
+   {__LINE__, 0x1, (const uint8_t *)"4BJD7PocN1VqX0jXVpWB", 20, 0x3eef064d},
+   {__LINE__, 0x1, (const uint8_t *)"F1rPWI7XvDs6nAIRx41l", 20, 0x425d065f},
+   {__LINE__, 0x1, (const uint8_t *)"ldhKlsVkPFOveXgkGtC2", 20, 0x4f1a073e},
+   {__LINE__, 0x1, (const uint8_t *)"5KKnGOOrs8BvJ35iKTOS", 20, 0x42290650},
+   {__LINE__, 0x1, (const uint8_t *)"0l1tw7GOcem06Ddu7yn4", 20, 0x43fd0690},
+   {__LINE__, 0x1, (const uint8_t *)"MCr47CjPIn9R1IvE1Tm5", 20, 0x3f770609},
+   {__LINE__, 0x1, (const uint8_t *)"UcixbzPKTIv0SvILHVdO", 20, 0x4c7c0703},
+   {__LINE__, 0x1, (const uint8_t *)"dGnAyAhRQDsWw0ESou24", 20, 0x48ac06b7},
+   {__LINE__, 0x1, (const uint8_t *)"di0nvmY9UYMYDh0r45XT", 20, 0x489a0698},
+   {__LINE__, 0x1, (const uint8_t *)"2XKDwHfAhFsV0RhbqtvH", 20, 0x44a906e6},
+   {__LINE__, 0x1, (const uint8_t *)"ZhrANFIiIvRnqClIVyeD", 20, 0x4a29071c},
+   {__LINE__, 0x1, (const uint8_t *)"v7Q9ehzioTOVeDIZioT1", 20, 0x4a7706f9},
+   {__LINE__, 0x1, (const uint8_t *)"Yod5hEeKcYqyhfXbhxj2", 20, 0x4ce60769},
+   {__LINE__, 0x1, (const uint8_t *)"GehSWY2ay4uUKhehXYb0", 20, 0x48ae06e5},
+   {__LINE__, 0x1, (const uint8_t *)"kwytJmq6UqpflV8Y8GoE", 20, 0x51d60750},
+   {__LINE__, 0x1, (const uint8_t *)"70684206568419061514", 20, 0x2b100414},
+   {__LINE__, 0x1, (const uint8_t *)"42015093765128581010", 20, 0x2a550405},
+   {__LINE__, 0x1, (const uint8_t *)"88214814356148806939", 20, 0x2b450423},
+   {__LINE__, 0x1, (const uint8_t *)"43472694284527343838", 20, 0x2b460421},
+   {__LINE__, 0x1, (const uint8_t *)"49769333513942933689", 20, 0x2bc1042b},
+   {__LINE__, 0x1, (const uint8_t *)"54979784887993251199", 20, 0x2ccd043d},
+   {__LINE__, 0x1, (const uint8_t *)"58360544869206793220", 20, 0x2b68041a},
+   {__LINE__, 0x1, (const uint8_t *)"27347953487840714234", 20, 0x2b84041d},
+   {__LINE__, 0x1, (const uint8_t *)"07650690295365319082", 20, 0x2afa0417},
+   {__LINE__, 0x1, (const uint8_t *)"42655507906821911703", 20, 0x2aff0412},
+   {__LINE__, 0x1, (const uint8_t *)"29977409200786225655", 20, 0x2b8d0420},
+   {__LINE__, 0x1, (const uint8_t *)"85181542907229116674", 20, 0x2b140419},
+   {__LINE__, 0x1, (const uint8_t *)"87963594337989416799", 20, 0x2c8e043f},
+   {__LINE__, 0x1, (const uint8_t *)"21395988329504168551", 20, 0x2b68041f},
+   {__LINE__, 0x1, (const uint8_t *)"51991013580943379423", 20, 0x2af10417},
+   {__LINE__, 0x1, (const uint8_t *)"*]+@!);({_$;}[_},?{?;(_?,=-][@", 30, 0x7c9d0841},
+   {__LINE__, 0x1, (const uint8_t *)"_@:_).&(#.[:[{[:)$++-($_;@[)}+", 30, 0x71060751},
+   {__LINE__, 0x1, (const uint8_t *)"&[!,[$_==}+.]@!;*(+},[;:)$;)-@", 30, 0x7095070a},
+   {__LINE__, 0x1, (const uint8_t *)"]{.[.+?+[[=;[?}_#&;[=)__$$:+=_", 30, 0x82530815},
+   {__LINE__, 0x1, (const uint8_t *)"-%.)=/[@].:.(:,()$;=%@-$?]{%+%", 30, 0x61250661},
+   {__LINE__, 0x1, (const uint8_t *)"+]#$(@&.=:,*];/.!]%/{:){:@(;)$", 30, 0x642006a3},
+   {__LINE__, 0x1, (const uint8_t *)")-._.:?[&:.=+}(*$/=!.${;(=$@!}", 30, 0x674206cb},
+   {__LINE__, 0x1, (const uint8_t *)":(_*&%/[[}+,?#$&*+#[([*-/#;%(]", 30, 0x67670680},
+   {__LINE__, 0x1, (const uint8_t *)"{[#-;:$/{)(+[}#]/{&!%(@)%:@-$:", 30, 0x7547070f},
+   {__LINE__, 0x1, (const uint8_t *)"_{$*,}(&,@.)):=!/%(&(,,-?$}}}!", 30, 0x69ea06ee},
+   {__LINE__, 0x1, (const uint8_t *)"e$98KNzqaV)Y:2X?]77].{gKRD4G5{mHZk,Z)SpU%L3FSgv!Wb8MLAFdi{+fp)c,@8m6v)yXg@]HBDFk?.4&}g5_udE*JHCiH=aL", 100, 0x1b01e92},
+   {__LINE__, 0x1, (const uint8_t *)"r*Fd}ef+5RJQ;+W=4jTR9)R*p!B;]Ed7tkrLi;88U7g@3v!5pk2X6D)vt,.@N8c]@yyEcKi[vwUu@.Ppm@C6%Mv*3Nw}Y,58_aH)", 100, 0xfbdb1e96},
+   {__LINE__, 0x1, (const uint8_t *)"h{bcmdC+a;t+Cf{6Y_dFq-{X4Yu&7uNfVDh?q&_u.UWJU],-GiH7ADzb7-V.Q%4=+v!$L9W+T=bP]$_:]Vyg}A.ygD.r;h-D]m%&", 100, 0x47a61ec8},
+   {__LINE__, 0x1, (const uint8_t *)"qjdwq48mBukJVUzVVfMjiqSWL5GnFSPQQDi6mE9ZaAPh9drb5tXUULwqekEH6W7kAxNQRkdV5ynU"
+    "NWQYiW59RpDCxpuhCamrznzAdJ6uNerx7Q3vVhHSHSfKfeET9JfKwtxJ2y7BxXXpGbTg3kU6EZMtJ"
+    "qvnST6x5x4PzpMFVbdmfGnJmwzK8aqEDeb3hBVgy3PL58rzXbQgH7LcZB3C4ytukzhvCYpp8Hv5Xw"
+    "4LRVV4UC84TEaNZS7UuzfHpPJuYZhT6evzVFhuyHbkJMf36gyLEWtBBdd9uMZkFGfhqk5kfrM7cM7"
+    "ynu8bd7QfEmFKxWfB2F85qzy3RiUmXkhNJyBChux4fkJ56XTWh8J4mKpN3gCgAEeZxAP2E4tQ5XYj"
+    "6mbhGav6tv6CMGPuBCAVb29d2c5abXwVG6a7c8G6KUQmwPV5NxbvxENCANtvNBzXBRqUniAQdmaD7"
+    "Yf3J8YmwZbwrHqEjcuEiiSbnGPaFjcRDDGFviaiM7BewmLEF2Y447YCtyq72VGmmEeVumLpRXWzVK"
+    "EkpVrJdN3tiuSVw2wUQ3Fq4hqkB7RXBFQZbb4EKvTBwkVCxdKgNSukp9zwcyUMVE2YPFh9Tyhwb9P"
+    "wGcWWkjJQNBUG69UbvaN9NCGnxR69QChejPUhURi4TBW5wmJpe7r9tc9ZjprFCeUPxTAN76aiyewF"
+    "CXHYGCqqmAt7zuDSLUCf7etGVFucx5M7NiM6h2nHShKMdTzXdxx4qzdDa2XrprRmUUySHcaFeZaUP"
+    "9VJeqjYMxevK7MPN2b6fPhH4UXknfQM99aJNewyfFPpaFYaMLWiTMB3UvXvGp7afu4SyX9ggbBGci"
+    "MUnma7qf9nQ2VL6eTR249d6QBYq249GQEbY5u2TQGL5n4Y2yGFjc8MGLe3aNvAAWtRS2iDR8jdQ36"
+    "CVMewjUZwM4bm8JPQLPRcrbVC3N8K4dWDNUAA2JpbDdpjNCkAjBacuvLXUB4UXWeCbCudAvUzPtDe"
+    "5yYcxK47jeeDM5KBQ6dpTTRjMEEMrN687qxFSxEU4dB65WCemJe5jwVJwvd7vfKum8hWTeQjM8RYd"
+    "BR2rFj7dEqVkejP93XRpRbAv74AM2krE7X37k5cB7W5uJBQR2V7hQh9gGyccxMz7G2Jwvj59EbkzW"
+    "TCb4KRXTkVSG2jd6yE4PHKwamFZx9ji2dXua4aMz8ppzgtH5YLQcRFmEnGXdf7x8jgJzDSaShy5hY"
+    "NpwYWhENv8QDWZkferZD7RDT2HXzGXfvEzPvUHe4RWUxtt4wprzK9fghPrfvkhce58aLFJMGRaNqS"
+    "gWe7RKRABz6vSpwnexkErjfYx89zeT6EGv9fDANvyU7DM2E5WG6b9qgYFfkqQExYCRG6Rh4JdUDb9"
+    "b8rfVdgb2zZdmXvjYdwK8GrvjNychu5zgJHaZbzGCrPfyP6FPh79w7yR3nEhGD4mYEqkafaRBqtWE"
+    "TpH7kX2dX6WnHmwMiYMEF5RppycbqR9YtT7wuKMQznP7gx6R4xNvwM6jKv7aY4aM6nz3E2VN4iEfu"
+    "WJWe83QeaFPc3PkizdqmqMad8D3FMedEjzVedzHDJ8XgEiuc7AwSJ2Ae8rqCm99ag2yyPMe83Trm8"
+    "jvrpMZYga92dHBm946aZVuSHg3XhiN3BSEk9k29RAi3LXMBS4SFFFwudMT9KB7RUR8D8T5UtERxnx"
+    "hvkBNkEUTtpruZhtE4iPzfzqMpfAK2DtjfcYENMxkg7TU2cdVg2zLijYqbTAyvatN5tZ5nDayGnPx"
+    "VkM8tJZGg59RhPPJNXpGJp2yAvdGUz3VMyqUNMYpBZUhjqzqxw7dJQuFq3m9cQWd67bVM7Pjrk9hR"
+    "zmbiBuEL9kvhhW2KeMUQpAQYJGETULfqG4zKKyaUWKDPcNDVSY6TpRyyJaTJWQ9pFPXyk9zz4Gdaz"
+    "Xnh4JPWVDrUma8abXFJXL4SX5WpWhyxBfdCXw7rgVTHai4Nvcwn23AiAJ9Ncz7nn3nhniRibEhkUc"
+    "cU6fxqNyHMeJBUBrga8VaGVyuccvCHWygzQ24kSmfeGHvQ3PefSVPcUe3Pxdc7cfgDw2tqyg2QV4K"
+    "aQgBbLx9maK4ixgQM9WN2wpv2kBy9kAcfZDRASdvwffqtK3jxDGPnurvUkA2dRNTG4Bgkth7JkFAC"
+    "gWgJFzSQcvMbDeHQSjvGERkfiPEFN6ypbtMcQB7gwJ73dVEmz66PPdirJHDHJrbnvzWeugBuZ2mD5"
+    "hFXB2r6wuY4NXKavV3jBrrCcwRgS8VbF2NMcK8YEENKXKVBxnQpaqfktzYEPZynacBVaxbdXrd8PH"
+    "FvrV5gJw6ihddpJccYSqWmU5GbHNzEZKEyMcGidwZDNNwStgyaYbHeMNfYY7a9bMUkaVkCnakUHAM"
+    "ivktadi3Fd52ApUcJURhGdAYvqXcwrx4j34bFdaLNJ3Zg6WQRuPtMA3F6yKYG2tvupwbGSK5p4dEw"
+    "6gtV4b2nbZ33fmd2camjXUED66FwH97ZYdXCKigpFYn2bF4RuVkfdJiabXH7vKaQiWMjMiainFhrq"
+    "4wxm4qyF8wi4DBALBUuKvKnaQiekvQU5wQcrA6MwygnevK7Wu2yfQueryawVpfQzCuii9SPqLrCHS"
+    "3Ep8SmQSKrVbJRmwcnQNQ4MufXSfUZxU4jK4GzX7QjRhiGmqcVTxUaEbQqEiFK7KiRJ5YFVB7R8Mi"
+    "fjZwjbBupNYrSrfhEJTBPRDVKAZARjzfBiYLFGVYwRCPGm97C5eywNKNaQjaW32fGwnM6FuK8g8MG"
+    "re9Zzy2GUkG6mAD4nb8aqSmS65R5D5SBgXT8QVdAngy8ah7K9HDJFwG4wTJFfi8XeBJKH7VyX7E8S"
+    "AdbwS8YaJdjEVJTEUR57VMEvD3z5rkzvemA7P8jXEfQq8Dgy8jAeBccMzk2cqvvyQyhgpvMmmCGDk"
+    "8uTnQHGHfbJj5Xci77qbR8bbzffhYQ7uBXeijMqCTMvtJJwbFvJme2ue8LVGqAjm7mgm5irppUyF6"
+    "fbu6qLMEtVWCtepwanwyXh8eGCHqrXG9ch7k8MGbamYQw8JzaFr4WMjPqazUyu3bZfY57gNMhMa3C"
+    "K66fapifqkTizwfZcHLXg6mgrwYuK8Lp8PRARAbZVaxVcGAHtY6PTLWNzgzkdEvCtZMZK4w95DWfU"
+    "85u6b5B8gyCEQze9pNSPDDfxkZ4RvXVkpbntcFRex9CDJ26fZDwJRjj9bwNNpRfZzjFrQeFxftVVA"
+    "yJGWZHrD5MuHVLNUVXzj9rvedRcuVxrc6kLhqwUWQgGFCtEaDhx95PRZEM5f42tA6frXGXYB8GEnB"
+    "vxfMRfBzY32qzGtPC66rzJrcnd6hewDDhVLuib5KdSy9NpErDkBzuvdQpK5mJrbYZ7pMJFEqxfEKU"
+    "U4fa6g5aqDU8FyRaP55xz6VTPDmy7U5CA7Qhwr6xgQibKFpBXQhiErCzvxWQ6p6bMKVxukdRSkQpn"
+    "hdQYxnx5Kt5wA5pkFzWpjUyVxGmyLAXHGAaJ5EPqEU7p6A9ndGDgihtWbcE2PdyJMu4gPSXJvw3vD"
+    "qUiUTqEY52tbjP2jD9yiB5Y3XLwmVXzXrZdHLAHkRX5iLmq3paGPjghRPYUzM5RMAEQVcwr4MSkND"
+    "iRRxtqTiuNKRxZKagGy9cjJS93HTfFq6DWFKheppbqNkACmyuBJvqDejeb2wRtJNjFTA8LmXiTgjc"
+    "V4Vh2hRp29kccGDhztihtWRnYi8u6G9TP99JPYRhXKzhLWrCU2LTk2m6WLPTZztiH5GwtEvzkbHbb"
+    "WWubihCQnHNu5uKXrMWU3YkP2kxfxCwzzbG8yWejv2vrtqzpYdw6ZDJL9FzGU4a8H6Uaq7yQJvmDP"
+    "Sjqvtntgj3t8fKK7bWdFiNKaRVVVvmAQ2yjctfkj7XyjbUFwW396ASJpq2Z7Lpb7b5iprrhPMhjcy"
+    "euhBd99ufdgupwu9ScLUgAyVFV6DDXiVmuYPJvLTAFMQHZ6v8pALPzCVaChXjW8GzjdM4uxwHgVqK"
+    "zbg23DNyGXFTvTLyvL9gcCR8LA7YNtnR6bnm9ihtTFaVNJJ3JqpW7bTGrMka7DHvyTACUPuqLRY4q"
+    "hyfFJxK7NBv3aZMtUx89VEtjKruYYAuwY2yQzSnJB2tXxKzg6dni7ZNFQ6wNrbkdWXStcUm642ew6"
+    "xZaQA74hHzreJqjw4qciR4xnrjrPgE7tkbZrAbdgiGVDEULbJUq2SKmAULkQ4NpkGC6RZByBBjyxL"
+    "dhLG6xHzT5dY42mqQyH6cNumUviYZ74LKFbv2Yhx8aRwqxEaTymC2QUTDQvuM9D8r8bmpE7CT9BAG"
+    "kbGzZGLNkh3kJefdxF8WK7T6hHVChPuHevwzPKrDGXZBXfHQ4eDyWZ64KAeaFSNhxSWJcEPgjawTm"
+    "ZXEPYRM2R2XNFXYWxzpJgnD4ip6Nr9GkEhThUhxBQ9H7wUPQdG6qpjjvCaXJNGYwfHCxFkz39rh87"
+    "5ViVCRqxN22iWFU7THfzEanuQtUYGt3Amr6dfenezFuUN8mhpRNSH66VMStqPEiuyg8LQYYGeWWCG"
+    "ybytuPRP5mNKBZwftkx3LbqdwSGEhRF4qe56F2nqTRyfnYh2FuxMiihwGCZviCaXUCY8dhRxVnvGi"
+    "DaUpUaebFwPdXnKh9Hrbg2fmXkmq6n5bGHdR9DUcrZYWSZxptxy4kjFUtCieibpe4Czh335QPnGiA"
+    "8cQzBaV42B2zuu3iLwygKHky2Bbe5e4eU4znPzacEfuMGCgzj4E7RtDKctpgWHCHJQJcF54WK7jhA"
+    "TKztSffjCc8n7cTURQE7AWZzK5j2HkajggWw4TA9JUeSNPKdkLQGZeWiHujCz4E2v5Lu9Za9AbCMG"
+    "XBC2YZeUnE5YnyFhHp9jYFVwYr8QfCJ4TtzQNMe743yEMmbSchwaXEdEzth9kpAkKHxqKZBua93UU"
+    "u8EDvykWYXkrRDXnQVdeDgxEVYwkmKrHDt26NUg3tB9tuMDzYKzKrV5iepMdtw6affWkLigMVMYbx"
+    "e4hhYgwZmee6RWMxGyVn6egAgKaN7pauE46MtXhgbjp5xxBP3JM7jZPyeQZetj3tFVxmbbByJLL93"
+    "Ra5jSVte26mHwrwr6Q3xzmAdxtEHcZxcPjruUWk6gXgnfn7HMBtv6vxgMfe2wmydHSqcKUH2XhdpQ"
+    "7JXiXfazVAF28zvhChe4gzwzhqp6Bnm8hWU7zhT6Jf4ZnQWz2N4tg7u4X2CFLnJnmj3P3YeJRAHeR"
+    "Dz7uXYyDwJmGUPH5SdaFFYcMf33LvVBUCAdNHQh784rpGvMDH7eEriKQiBDMZpcRGucHaNkEf9R7x"
+    "635ux3hvp6qrjufWTqPnYLB6UwP2TWRg233eNVajbe4TuJuuFBDGHxxk5Ge34BmLSbitTpMDZAAir"
+    "Jp4HUAGydQ5URF8qaSHn5z9g3uRHmGmbpcLZYumiKAQRTXGtb8776wMNfRGrLmqn75kX8guK7YwKq"
+    "UeWAriZapqL5PuntyGxCNXqPrUvArrqefczM7N6azZatfp4vJYjhMDtkABpQAyxX7pS8mMyKBA527"
+    "byRKqAu3J", 5552, 0x8b81718f},
+   {__LINE__, 0x7a30360d, (const uint8_t *)0x0, 0, 0x1},
+   {__LINE__, 0x6fd767ee, (const uint8_t *)"", 1, 0xd7c567ee},
+   {__LINE__, 0xefeb7589, (const uint8_t *)"a", 1, 0x65e475ea},
+   {__LINE__, 0x61cf7e6b, (const uint8_t *)"abacus", 6, 0x60b880da},
+   {__LINE__, 0xdc712e2,  (const uint8_t *)"backlog", 7, 0x9d0d15b5},
+   {__LINE__, 0xad23c7fd, (const uint8_t *)"campfire", 8, 0xfbfecb44},
+   {__LINE__, 0x85cb2317, (const uint8_t *)"delta", 5, 0x3b622521},
+   {__LINE__, 0x9eed31b0, (const uint8_t *)"executable", 10, 0xa6db35d2},
+   {__LINE__, 0xb94f34ca, (const uint8_t *)"file", 4, 0x9096366a},
+   {__LINE__, 0xab058a2,  (const uint8_t *)"greatest", 8, 0xded05c01},
+   {__LINE__, 0x5bff2b7a, (const uint8_t *)"inverter", 8, 0xc7452ee9},
+   {__LINE__, 0x605c9a5f, (const uint8_t *)"jigsaw", 6, 0x7899ce4},
+   {__LINE__, 0x51bdeea5, (const uint8_t *)"karate", 6, 0xf285f11d},
+   {__LINE__, 0x85c21c79, (const uint8_t *)"landscape", 9, 0x98732024},
+   {__LINE__, 0x97216f56, (const uint8_t *)"machine", 7, 0xadf4722b},
+   {__LINE__, 0x18444af2, (const uint8_t *)"nanometer", 9, 0xcdb34ebb},
+   {__LINE__, 0xbe6ce359, (const uint8_t *)"oblivion", 8, 0xe8b7e6bb},
+   {__LINE__, 0x843071f1, (const uint8_t *)"panama", 6, 0x389e745f},
+   {__LINE__, 0xf2480c60, (const uint8_t *)"quest", 5, 0x36c90e92},
+   {__LINE__, 0x2d2feb3d, (const uint8_t *)"resource", 8, 0x9705eea5},
+   {__LINE__, 0x7490310a, (const uint8_t *)"secret", 6, 0xa3a63390},
+   {__LINE__, 0x97d247d4, (const uint8_t *)"ultimate", 8, 0xe6154b39},
+   {__LINE__, 0x93cf7599, (const uint8_t *)"vector", 6, 0x5e87782c},
+   {__LINE__, 0x73c84278, (const uint8_t *)"walrus", 6, 0xbc84516},
+   {__LINE__, 0x228a87d1, (const uint8_t *)"xeno", 4, 0x4646898b},
+   {__LINE__, 0xa7a048d0, (const uint8_t *)"yelling", 7, 0xb1654bc4},
+   {__LINE__, 0x1f0ded40, (const uint8_t *)"zero", 4, 0xd8a4ef00},
+   {__LINE__, 0xa804a62f, (const uint8_t *)"4BJD7PocN1VqX0jXVpWB", 20, 0xe34eac7b},
+   {__LINE__, 0x508fae6a, (const uint8_t *)"F1rPWI7XvDs6nAIRx41l", 20, 0x33f2b4c8},
+   {__LINE__, 0xe5adaf4f, (const uint8_t *)"ldhKlsVkPFOveXgkGtC2", 20, 0xe7b1b68c},
+   {__LINE__, 0x67136a40, (const uint8_t *)"5KKnGOOrs8BvJ35iKTOS", 20, 0xf6a0708f},
+   {__LINE__, 0xb00c4a10, (const uint8_t *)"0l1tw7GOcem06Ddu7yn4", 20, 0xbd8f509f},
+   {__LINE__, 0x2e0c84b5, (const uint8_t *)"MCr47CjPIn9R1IvE1Tm5", 20, 0xcc298abd},
+   {__LINE__, 0x81238d44, (const uint8_t *)"UcixbzPKTIv0SvILHVdO", 20, 0xd7809446},
+   {__LINE__, 0xf853aa92, (const uint8_t *)"dGnAyAhRQDsWw0ESou24", 20, 0x9525b148},
+   {__LINE__, 0x5a692325, (const uint8_t *)"di0nvmY9UYMYDh0r45XT", 20, 0x620029bc},
+   {__LINE__, 0x3275b9f,  (const uint8_t *)"2XKDwHfAhFsV0RhbqtvH", 20, 0x70916284},
+   {__LINE__, 0x38371feb, (const uint8_t *)"ZhrANFIiIvRnqClIVyeD", 20, 0xd52706},
+   {__LINE__, 0xafc8bf62, (const uint8_t *)"v7Q9ehzioTOVeDIZioT1", 20, 0xeeb4c65a},
+   {__LINE__, 0x9b07db73, (const uint8_t *)"Yod5hEeKcYqyhfXbhxj2", 20, 0xde3e2db},
+   {__LINE__, 0xe75b214,  (const uint8_t *)"GehSWY2ay4uUKhehXYb0", 20, 0x4171b8f8},
+   {__LINE__, 0x72d0fe6f, (const uint8_t *)"kwytJmq6UqpflV8Y8GoE", 20, 0xa66a05cd},
+   {__LINE__, 0xf857a4b1, (const uint8_t *)"70684206568419061514", 20, 0x1f9a8c4},
+   {__LINE__, 0x54b8e14,  (const uint8_t *)"42015093765128581010", 20, 0x49c19218},
+   {__LINE__, 0xd6aa5616, (const uint8_t *)"88214814356148806939", 20, 0xbbfc5a38},
+   {__LINE__, 0x11e63098, (const uint8_t *)"43472694284527343838", 20, 0x93434b8},
+   {__LINE__, 0xbe92385,  (const uint8_t *)"49769333513942933689", 20, 0xfe1827af},
+   {__LINE__, 0x49511de0, (const uint8_t *)"54979784887993251199", 20, 0xcba8221c},
+   {__LINE__, 0x3db13bc1, (const uint8_t *)"58360544869206793220", 20, 0x14643fda},
+   {__LINE__, 0xbb899bea, (const uint8_t *)"27347953487840714234", 20, 0x1604a006},
+   {__LINE__, 0xf6cd9436, (const uint8_t *)"07650690295365319082", 20, 0xb69f984c},
+   {__LINE__, 0x9109e6c3, (const uint8_t *)"42655507906821911703", 20, 0xc43eead4},
+   {__LINE__, 0x75770fc,  (const uint8_t *)"29977409200786225655", 20, 0x707751b},
+   {__LINE__, 0x69b1d19b, (const uint8_t *)"85181542907229116674", 20, 0xf5bdd5b3},
+   {__LINE__, 0xc6132975, (const uint8_t *)"87963594337989416799", 20, 0x2fed2db3},
+   {__LINE__, 0xd58cb00c, (const uint8_t *)"21395988329504168551", 20, 0xc2a2b42a},
+   {__LINE__, 0xb63b8caa, (const uint8_t *)"51991013580943379423", 20, 0xdf0590c0},
+   {__LINE__, 0x8a45a2b8, (const uint8_t *)"*]+@!);({_$;}[_},?{?;(_?,=-][@", 30, 0x1980aaf8},
+   {__LINE__, 0xcbe95b78, (const uint8_t *)"_@:_).&(#.[:[{[:)$++-($_;@[)}+", 30, 0xf58662c8},
+   {__LINE__, 0x4ef8a54b, (const uint8_t *)"&[!,[$_==}+.]@!;*(+},[;:)$;)-@", 30, 0x1f65ac54},
+   {__LINE__, 0x76ad267a, (const uint8_t *)"]{.[.+?+[[=;[?}_#&;[=)__$$:+=_", 30, 0x7b792e8e},
+   {__LINE__, 0x569e613c, (const uint8_t *)"-%.)=/[@].:.(:,()$;=%@-$?]{%+%", 30, 0x1d61679c},
+   {__LINE__, 0x36aa61da, (const uint8_t *)"+]#$(@&.=:,*];/.!]%/{:){:@(;)$", 30, 0x12ec687c},
+   {__LINE__, 0xf67222df, (const uint8_t *)")-._.:?[&:.=+}(*$/=!.${;(=$@!}", 30, 0x740329a9},
+   {__LINE__, 0x74b34fd3, (const uint8_t *)":(_*&%/[[}+,?#$&*+#[([*-/#;%(]", 30, 0x374c5652},
+   {__LINE__, 0x351fd770, (const uint8_t *)"{[#-;:$/{)(+[}#]/{&!%(@)%:@-$:", 30, 0xeadfde7e},
+   {__LINE__, 0xc45aef77, (const uint8_t *)"_{$*,}(&,@.)):=!/%(&(,,-?$}}}!", 30, 0x3fcbf664},
+   {__LINE__, 0xd034ea71, (const uint8_t *)"e$98KNzqaV)Y:2X?]77].{gKRD4G5{mHZk,Z)SpU%L3FSgv!Wb8MLAFdi{+fp)c,@8m6v)yXg@]HBDFk?.4&}g5_udE*JHCiH=aL", 100, 0x6b080911},
+   {__LINE__, 0xdeadc0de, (const uint8_t *)"r*Fd}ef+5RJQ;+W=4jTR9)R*p!B;]Ed7tkrLi;88U7g@3v!5pk2X6D)vt,.@N8c]@yyEcKi[vwUu@.Ppm@C6%Mv*3Nw}Y,58_aH)", 100, 0x355fdf73},
+   {__LINE__, 0xba5eba11, (const uint8_t *)"h{bcmdC+a;t+Cf{6Y_dFq-{X4Yu&7uNfVDh?q&_u.UWJU],-GiH7ADzb7-V.Q%4=+v!$L9W+T=bP]$_:]Vyg}A.ygD.r;h-D]m%&", 100, 0xb48bd8d8},
+   {__LINE__, 0x7712aa45, (const uint8_t *)"qjdwq48mBukJVUzVVfMjiqSWL5GnFSPQQDi6mE9ZaAPh9drb5tXUULwqekEH6W7kAxNQRkdV5ynU"
+    "NWQYiW59RpDCxpuhCamrznzAdJ6uNerx7Q3vVhHSHSfKfeET9JfKwtxJ2y7BxXXpGbTg3kU6EZMtJ"
+    "qvnST6x5x4PzpMFVbdmfGnJmwzK8aqEDeb3hBVgy3PL58rzXbQgH7LcZB3C4ytukzhvCYpp8Hv5Xw"
+    "4LRVV4UC84TEaNZS7UuzfHpPJuYZhT6evzVFhuyHbkJMf36gyLEWtBBdd9uMZkFGfhqk5kfrM7cM7"
+    "ynu8bd7QfEmFKxWfB2F85qzy3RiUmXkhNJyBChux4fkJ56XTWh8J4mKpN3gCgAEeZxAP2E4tQ5XYj"
+    "6mbhGav6tv6CMGPuBCAVb29d2c5abXwVG6a7c8G6KUQmwPV5NxbvxENCANtvNBzXBRqUniAQdmaD7"
+    "Yf3J8YmwZbwrHqEjcuEiiSbnGPaFjcRDDGFviaiM7BewmLEF2Y447YCtyq72VGmmEeVumLpRXWzVK"
+    "EkpVrJdN3tiuSVw2wUQ3Fq4hqkB7RXBFQZbb4EKvTBwkVCxdKgNSukp9zwcyUMVE2YPFh9Tyhwb9P"
+    "wGcWWkjJQNBUG69UbvaN9NCGnxR69QChejPUhURi4TBW5wmJpe7r9tc9ZjprFCeUPxTAN76aiyewF"
+    "CXHYGCqqmAt7zuDSLUCf7etGVFucx5M7NiM6h2nHShKMdTzXdxx4qzdDa2XrprRmUUySHcaFeZaUP"
+    "9VJeqjYMxevK7MPN2b6fPhH4UXknfQM99aJNewyfFPpaFYaMLWiTMB3UvXvGp7afu4SyX9ggbBGci"
+    "MUnma7qf9nQ2VL6eTR249d6QBYq249GQEbY5u2TQGL5n4Y2yGFjc8MGLe3aNvAAWtRS2iDR8jdQ36"
+    "CVMewjUZwM4bm8JPQLPRcrbVC3N8K4dWDNUAA2JpbDdpjNCkAjBacuvLXUB4UXWeCbCudAvUzPtDe"
+    "5yYcxK47jeeDM5KBQ6dpTTRjMEEMrN687qxFSxEU4dB65WCemJe5jwVJwvd7vfKum8hWTeQjM8RYd"
+    "BR2rFj7dEqVkejP93XRpRbAv74AM2krE7X37k5cB7W5uJBQR2V7hQh9gGyccxMz7G2Jwvj59EbkzW"
+    "TCb4KRXTkVSG2jd6yE4PHKwamFZx9ji2dXua4aMz8ppzgtH5YLQcRFmEnGXdf7x8jgJzDSaShy5hY"
+    "NpwYWhENv8QDWZkferZD7RDT2HXzGXfvEzPvUHe4RWUxtt4wprzK9fghPrfvkhce58aLFJMGRaNqS"
+    "gWe7RKRABz6vSpwnexkErjfYx89zeT6EGv9fDANvyU7DM2E5WG6b9qgYFfkqQExYCRG6Rh4JdUDb9"
+    "b8rfVdgb2zZdmXvjYdwK8GrvjNychu5zgJHaZbzGCrPfyP6FPh79w7yR3nEhGD4mYEqkafaRBqtWE"
+    "TpH7kX2dX6WnHmwMiYMEF5RppycbqR9YtT7wuKMQznP7gx6R4xNvwM6jKv7aY4aM6nz3E2VN4iEfu"
+    "WJWe83QeaFPc3PkizdqmqMad8D3FMedEjzVedzHDJ8XgEiuc7AwSJ2Ae8rqCm99ag2yyPMe83Trm8"
+    "jvrpMZYga92dHBm946aZVuSHg3XhiN3BSEk9k29RAi3LXMBS4SFFFwudMT9KB7RUR8D8T5UtERxnx"
+    "hvkBNkEUTtpruZhtE4iPzfzqMpfAK2DtjfcYENMxkg7TU2cdVg2zLijYqbTAyvatN5tZ5nDayGnPx"
+    "VkM8tJZGg59RhPPJNXpGJp2yAvdGUz3VMyqUNMYpBZUhjqzqxw7dJQuFq3m9cQWd67bVM7Pjrk9hR"
+    "zmbiBuEL9kvhhW2KeMUQpAQYJGETULfqG4zKKyaUWKDPcNDVSY6TpRyyJaTJWQ9pFPXyk9zz4Gdaz"
+    "Xnh4JPWVDrUma8abXFJXL4SX5WpWhyxBfdCXw7rgVTHai4Nvcwn23AiAJ9Ncz7nn3nhniRibEhkUc"
+    "cU6fxqNyHMeJBUBrga8VaGVyuccvCHWygzQ24kSmfeGHvQ3PefSVPcUe3Pxdc7cfgDw2tqyg2QV4K"
+    "aQgBbLx9maK4ixgQM9WN2wpv2kBy9kAcfZDRASdvwffqtK3jxDGPnurvUkA2dRNTG4Bgkth7JkFAC"
+    "gWgJFzSQcvMbDeHQSjvGERkfiPEFN6ypbtMcQB7gwJ73dVEmz66PPdirJHDHJrbnvzWeugBuZ2mD5"
+    "hFXB2r6wuY4NXKavV3jBrrCcwRgS8VbF2NMcK8YEENKXKVBxnQpaqfktzYEPZynacBVaxbdXrd8PH"
+    "FvrV5gJw6ihddpJccYSqWmU5GbHNzEZKEyMcGidwZDNNwStgyaYbHeMNfYY7a9bMUkaVkCnakUHAM"
+    "ivktadi3Fd52ApUcJURhGdAYvqXcwrx4j34bFdaLNJ3Zg6WQRuPtMA3F6yKYG2tvupwbGSK5p4dEw"
+    "6gtV4b2nbZ33fmd2camjXUED66FwH97ZYdXCKigpFYn2bF4RuVkfdJiabXH7vKaQiWMjMiainFhrq"
+    "4wxm4qyF8wi4DBALBUuKvKnaQiekvQU5wQcrA6MwygnevK7Wu2yfQueryawVpfQzCuii9SPqLrCHS"
+    "3Ep8SmQSKrVbJRmwcnQNQ4MufXSfUZxU4jK4GzX7QjRhiGmqcVTxUaEbQqEiFK7KiRJ5YFVB7R8Mi"
+    "fjZwjbBupNYrSrfhEJTBPRDVKAZARjzfBiYLFGVYwRCPGm97C5eywNKNaQjaW32fGwnM6FuK8g8MG"
+    "re9Zzy2GUkG6mAD4nb8aqSmS65R5D5SBgXT8QVdAngy8ah7K9HDJFwG4wTJFfi8XeBJKH7VyX7E8S"
+    "AdbwS8YaJdjEVJTEUR57VMEvD3z5rkzvemA7P8jXEfQq8Dgy8jAeBccMzk2cqvvyQyhgpvMmmCGDk"
+    "8uTnQHGHfbJj5Xci77qbR8bbzffhYQ7uBXeijMqCTMvtJJwbFvJme2ue8LVGqAjm7mgm5irppUyF6"
+    "fbu6qLMEtVWCtepwanwyXh8eGCHqrXG9ch7k8MGbamYQw8JzaFr4WMjPqazUyu3bZfY57gNMhMa3C"
+    "K66fapifqkTizwfZcHLXg6mgrwYuK8Lp8PRARAbZVaxVcGAHtY6PTLWNzgzkdEvCtZMZK4w95DWfU"
+    "85u6b5B8gyCEQze9pNSPDDfxkZ4RvXVkpbntcFRex9CDJ26fZDwJRjj9bwNNpRfZzjFrQeFxftVVA"
+    "yJGWZHrD5MuHVLNUVXzj9rvedRcuVxrc6kLhqwUWQgGFCtEaDhx95PRZEM5f42tA6frXGXYB8GEnB"
+    "vxfMRfBzY32qzGtPC66rzJrcnd6hewDDhVLuib5KdSy9NpErDkBzuvdQpK5mJrbYZ7pMJFEqxfEKU"
+    "U4fa6g5aqDU8FyRaP55xz6VTPDmy7U5CA7Qhwr6xgQibKFpBXQhiErCzvxWQ6p6bMKVxukdRSkQpn"
+    "hdQYxnx5Kt5wA5pkFzWpjUyVxGmyLAXHGAaJ5EPqEU7p6A9ndGDgihtWbcE2PdyJMu4gPSXJvw3vD"
+    "qUiUTqEY52tbjP2jD9yiB5Y3XLwmVXzXrZdHLAHkRX5iLmq3paGPjghRPYUzM5RMAEQVcwr4MSkND"
+    "iRRxtqTiuNKRxZKagGy9cjJS93HTfFq6DWFKheppbqNkACmyuBJvqDejeb2wRtJNjFTA8LmXiTgjc"
+    "V4Vh2hRp29kccGDhztihtWRnYi8u6G9TP99JPYRhXKzhLWrCU2LTk2m6WLPTZztiH5GwtEvzkbHbb"
+    "WWubihCQnHNu5uKXrMWU3YkP2kxfxCwzzbG8yWejv2vrtqzpYdw6ZDJL9FzGU4a8H6Uaq7yQJvmDP"
+    "Sjqvtntgj3t8fKK7bWdFiNKaRVVVvmAQ2yjctfkj7XyjbUFwW396ASJpq2Z7Lpb7b5iprrhPMhjcy"
+    "euhBd99ufdgupwu9ScLUgAyVFV6DDXiVmuYPJvLTAFMQHZ6v8pALPzCVaChXjW8GzjdM4uxwHgVqK"
+    "zbg23DNyGXFTvTLyvL9gcCR8LA7YNtnR6bnm9ihtTFaVNJJ3JqpW7bTGrMka7DHvyTACUPuqLRY4q"
+    "hyfFJxK7NBv3aZMtUx89VEtjKruYYAuwY2yQzSnJB2tXxKzg6dni7ZNFQ6wNrbkdWXStcUm642ew6"
+    "xZaQA74hHzreJqjw4qciR4xnrjrPgE7tkbZrAbdgiGVDEULbJUq2SKmAULkQ4NpkGC6RZByBBjyxL"
+    "dhLG6xHzT5dY42mqQyH6cNumUviYZ74LKFbv2Yhx8aRwqxEaTymC2QUTDQvuM9D8r8bmpE7CT9BAG"
+    "kbGzZGLNkh3kJefdxF8WK7T6hHVChPuHevwzPKrDGXZBXfHQ4eDyWZ64KAeaFSNhxSWJcEPgjawTm"
+    "ZXEPYRM2R2XNFXYWxzpJgnD4ip6Nr9GkEhThUhxBQ9H7wUPQdG6qpjjvCaXJNGYwfHCxFkz39rh87"
+    "5ViVCRqxN22iWFU7THfzEanuQtUYGt3Amr6dfenezFuUN8mhpRNSH66VMStqPEiuyg8LQYYGeWWCG"
+    "ybytuPRP5mNKBZwftkx3LbqdwSGEhRF4qe56F2nqTRyfnYh2FuxMiihwGCZviCaXUCY8dhRxVnvGi"
+    "DaUpUaebFwPdXnKh9Hrbg2fmXkmq6n5bGHdR9DUcrZYWSZxptxy4kjFUtCieibpe4Czh335QPnGiA"
+    "8cQzBaV42B2zuu3iLwygKHky2Bbe5e4eU4znPzacEfuMGCgzj4E7RtDKctpgWHCHJQJcF54WK7jhA"
+    "TKztSffjCc8n7cTURQE7AWZzK5j2HkajggWw4TA9JUeSNPKdkLQGZeWiHujCz4E2v5Lu9Za9AbCMG"
+    "XBC2YZeUnE5YnyFhHp9jYFVwYr8QfCJ4TtzQNMe743yEMmbSchwaXEdEzth9kpAkKHxqKZBua93UU"
+    "u8EDvykWYXkrRDXnQVdeDgxEVYwkmKrHDt26NUg3tB9tuMDzYKzKrV5iepMdtw6affWkLigMVMYbx"
+    "e4hhYgwZmee6RWMxGyVn6egAgKaN7pauE46MtXhgbjp5xxBP3JM7jZPyeQZetj3tFVxmbbByJLL93"
+    "Ra5jSVte26mHwrwr6Q3xzmAdxtEHcZxcPjruUWk6gXgnfn7HMBtv6vxgMfe2wmydHSqcKUH2XhdpQ"
+    "7JXiXfazVAF28zvhChe4gzwzhqp6Bnm8hWU7zhT6Jf4ZnQWz2N4tg7u4X2CFLnJnmj3P3YeJRAHeR"
+    "Dz7uXYyDwJmGUPH5SdaFFYcMf33LvVBUCAdNHQh784rpGvMDH7eEriKQiBDMZpcRGucHaNkEf9R7x"
+    "635ux3hvp6qrjufWTqPnYLB6UwP2TWRg233eNVajbe4TuJuuFBDGHxxk5Ge34BmLSbitTpMDZAAir"
+    "Jp4HUAGydQ5URF8qaSHn5z9g3uRHmGmbpcLZYumiKAQRTXGtb8776wMNfRGrLmqn75kX8guK7YwKq"
+    "UeWAriZapqL5PuntyGxCNXqPrUvArrqefczM7N6azZatfp4vJYjhMDtkABpQAyxX7pS8mMyKBA527"
+    "byRKqAu3J", 5552, 0x7dc51be2},
+};
+
+static const int test_size = sizeof(tests) / sizeof(tests[0]);
+
+int main(void) {
+    int i;
+    for (i = 0; i < test_size; i++) {
+        test_adler32(tests[i].adler, tests[i].buf, tests[i].len, tests[i].expect, tests[i].line);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This PR adds an optimized adler32 implementation for POWER processors. The work was originally developed by @racardoso (madler/zlib#458). In addition, we provide a new set of tests for adler32 that applies to all archs. 

To measure the performance improvement, we used [Chromium's zlib_bench.cc](https://cs.chromium.org/chromium/src/third_party/zlib/contrib/bench/) with input files from [jsnell/zlib-bench](https://github.com/jsnell/zlib-bench/tree/master/corpus).

Benchmark was run on a POWER9 machine and the results below show compression and decompression throughput in MB/s using zlib wrapper, for all compression levels:

```
======== File 'html' ======== 

 Wrapper 'zlib'

          |    compression throughput (MB)     |   decompression throughput (MB)    |
  | level | default | adler32-power |     gain | default | adler32-power |     gain |
  |     1 |    90.2 |          94.8 |   +5.10% |   180.1 |         202.9 |  +12.66% |
  |     2 |    67.4 |          70.9 |   +5.19% |   212.6 |         244.9 |  +15.19% |
  |     3 |    51.2 |          53.0 |   +3.52% |   224.5 |         260.2 |  +15.90% |
  |     4 |    48.1 |          49.9 |   +3.74% |   230.7 |         267.2 |  +15.82% |
  |     5 |    43.4 |          44.8 |   +3.23% |   233.0 |         272.0 |  +16.74% |
  |     6 |    35.7 |          36.7 |   +2.80% |   235.1 |         274.8 |  +16.89% |
  |     7 |    23.3 |          23.7 |   +1.72% |   230.4 |         268.4 |  +16.49% |
  |     8 |    16.2 |          16.4 |   +1.23% |   230.4 |         268.5 |  +16.54% |
  |     9 |    15.9 |          16.1 |   +1.26% |   230.3 |         268.7 |  +16.67% |

======== File 'executable' ======== 

 Wrapper 'zlib'

          |    compression throughput (MB)     |   decompression throughput (MB)    |
  | level | default | adler32-power |     gain | default | adler32-power |     gain |
  |     1 |    99.7 |         106.3 |   +6.62% |   210.7 |         242.3 |  +15.00% |
  |     2 |    65.3 |          68.3 |   +4.59% |   202.0 |         230.6 |  +14.16% |
  |     3 |    54.4 |          56.6 |   +4.04% |   209.0 |         239.7 |  +14.69% |
  |     4 |    48.9 |          50.6 |   +3.48% |   214.7 |         247.3 |  +15.18% |
  |     5 |    44.7 |          46.2 |   +3.36% |   216.8 |         249.0 |  +14.85% |
  |     6 |    37.9 |          39.0 |   +2.90% |   218.2 |         251.7 |  +15.35% |
  |     7 |    22.2 |          22.5 |   +1.35% |   220.4 |         254.6 |  +15.52% |
  |     8 |    14.5 |          14.7 |   +1.38% |   220.9 |         255.2 |  +15.53% |
  |     9 |     9.4 |           9.5 |   +1.06% |   221.2 |         255.7 |  +15.60% |

======== File 'jpeg' ======== 

 Wrapper 'zlib'

          |    compression throughput (MB)     |   decompression throughput (MB)    |
  | level | default | adler32-power |     gain | default | adler32-power |     gain |
  |     1 |    59.5 |          62.3 |   +4.71% |   176.6 |         198.5 |  +12.40% |
  |     2 |    29.1 |          29.8 |   +2.41% |   870.2 |        1953.8 | +124.52% |
  |     3 |    29.1 |          29.8 |   +2.41% |   869.2 |        1954.6 | +124.87% |
  |     4 |    24.7 |          25.1 |   +1.62% |   869.4 |        1952.0 | +124.52% |
  |     5 |    24.7 |          24.8 |   +0.40% |   870.2 |        1949.1 | +123.98% |
  |     6 |    24.7 |          25.1 |   +1.62% |   869.4 |        1951.8 | +124.50% |
  |     7 |    28.7 |          29.4 |   +2.44% |   870.1 |        1954.9 | +124.68% |
  |     8 |    28.7 |          29.4 |   +2.44% |   869.3 |        1955.3 | +124.93% |
  |     9 |    28.7 |          29.4 |   +2.44% |   869.3 |        1954.4 | +124.82% |

======== File 'pngpixels' ======== 

 Wrapper 'zlib'

          |    compression throughput (MB)     |   decompression throughput (MB)    |
  | level | default | adler32-power |     gain | default | adler32-power |     gain |
  |     1 |   144.7 |         160.0 |  +10.57% |   301.6 |         370.5 |  +22.84% |
  |     2 |   122.8 |         134.4 |   +9.45% |   343.0 |         433.6 |  +26.41% |
  |     3 |    87.0 |          92.9 |   +6.78% |   377.8 |         489.3 |  +29.51% |
  |     4 |    76.2 |          80.6 |   +5.77% |   375.3 |         484.1 |  +28.99% |
  |     5 |    57.2 |          59.7 |   +4.37% |   407.4 |         540.1 |  +32.57% |
  |     6 |    30.5 |          31.2 |   +2.30% |   440.8 |         599.4 |  +35.98% |
  |     7 |    16.9 |          17.2 |   +1.78% |   439.7 |         597.5 |  +35.89% |
  |     8 |     5.3 |           5.3 |   +0.00% |   448.8 |         613.7 |  +36.74% |
  |     9 |     2.4 |           2.5 |   +4.17% |   451.0 |         618.9 |  +37.23% |


```