### PR TITLE
Enable NEON-optimized slide_hash on aarch64

### DIFF
--- a/configure
+++ b/configure
@@ -1363,10 +1363,10 @@ case "${ARCH}" in
                 if test $native -eq 0; then
                     ARCH="${ARCH}+simd"
                 fi
-                CFLAGS="${CFLAGS} -DARM_NEON_ADLER32"
-                SFLAGS="${SFLAGS} -DARM_NEON_ADLER32"
-                ARCH_STATIC_OBJS="${ARCH_STATIC_OBJS} adler32_neon.o"
-                ARCH_SHARED_OBJS="${ARCH_SHARED_OBJS} adler32_neon.lo"
+                CFLAGS="${CFLAGS} -DARM_NEON_ADLER32 -DARM_NEON_SLIDEHASH"
+                SFLAGS="${SFLAGS} -DARM_NEON_ADLER32 -DARM_NEON_SLIDEHASH"
+                ARCH_STATIC_OBJS="${ARCH_STATIC_OBJS} adler32_neon.o slide_neon.o"
+                ARCH_SHARED_OBJS="${ARCH_SHARED_OBJS} adler32_neon.lo slide_neon.lo"
             fi
         fi
 


### PR DESCRIPTION
 * NEON-optimized slide_hash wasn't built on aarch64 even if NEON-optimizations were enabled.

See https://github.com/zlib-ng/zlib-ng/pull/560#issuecomment-647063133