### PR TITLE
Quick fixes to make POWER code more consistent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -705,6 +705,7 @@ if(WITH_OPTIM)
             add_definitions(-DPOWER8)
             add_definitions(-DPOWER_FEATURES)
             add_definitions(-DPOWER8_VSX_ADLER32)
+            add_definitions(-DPOWER8_VSX_SLIDEHASH)
             set(ZLIB_POWER8_SRCS
                 ${ARCHDIR}/adler32_power8.c
                 ${ARCHDIR}/slide_hash_power8.c)

--- a/arch/power/slide_hash_power8.c
+++ b/arch/power/slide_hash_power8.c
@@ -1,7 +1,10 @@
 /* Optimized slide_hash for POWER processors
- * Copyright (C) 2019-2020 Matheus Castanho <msc@linux.ibm.com>, IBM
+ * Copyright (C) 2019-2020 IBM Corporation
+ * Author: Matheus Castanho <msc@linux.ibm.com>
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
+
+#ifdef POWER8_VSX_SLIDEHASH
 
 #include <altivec.h>
 #include "zbuild.h"
@@ -53,3 +56,5 @@ void ZLIB_INTERNAL slide_hash_power8(deflate_state *s) {
     p = &s->prev[n];
     slide_hash_power8_loop(s,n,p);
 }
+
+#endif /* POWER8_VSX_SLIDEHASH */

--- a/cmake/detect-arch.c
+++ b/cmake/detect-arch.c
@@ -35,12 +35,12 @@
 #elif defined(__powerpc__) || defined(_ppc__) || defined(__PPC__)
     #if defined(__64BIT__) || defined(__powerpc64__) || defined(__ppc64__)
         #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-            #error archfound ppc64le
+            #error archfound powerpc64le
         #else 
-            #error archfound ppc64
+            #error archfound powerpc64
         #endif
     #else
-        #error archfound ppc
+        #error archfound powerpc
     #endif
 
 // --------------- Less common architectures alphabetically below ---------------

--- a/configure
+++ b/configure
@@ -1394,7 +1394,7 @@ case "${ARCH}" in
             if test $HAVE_POWER8 -eq 1; then
                 ARCH_STATIC_OBJS="${ARCH_STATIC_OBJS} adler32_power8.o power.o slide_hash_power8.o"
                 ARCH_SHARED_OBJS="${ARCH_SHARED_OBJS} adler32_power8.lo power.lo slide_hash_power8.lo"
-                POWERFLAGS="-DPOWER8 -DPOWER_FEATURES -DPOWER8_VSX_ADLER32"
+                POWERFLAGS="-DPOWER8 -DPOWER_FEATURES -DPOWER8_VSX_ADLER32 -DPOWER8_VSX_SLIDEHASH"
             fi
         fi
 

--- a/functable.c
+++ b/functable.c
@@ -35,7 +35,7 @@ extern Pos quick_insert_string_acle(deflate_state *const s, const Pos str);
 void slide_hash_sse2(deflate_state *s);
 #elif defined(ARM_NEON_SLIDEHASH)
 void slide_hash_neon(deflate_state *s);
-#elif defined(POWER8)
+#elif defined(POWER8_VSX_SLIDEHASH)
 void slide_hash_power8(deflate_state *s);
 #endif
 #ifdef X86_AVX2
@@ -189,7 +189,7 @@ ZLIB_INTERNAL void slide_hash_stub(deflate_state *s) {
     if (x86_cpu_has_avx2)
         functable.slide_hash = &slide_hash_avx2;
 #endif
-#ifdef POWER8
+#ifdef POWER8_VSX_SLIDEHASH
     if (power_cpu_has_arch_2_07)
         functable.slide_hash = &slide_hash_power8;
 #endif


### PR DESCRIPTION
Currently unaligned reads are not being properly enabled on native powerpc64le machines when using cmake (configure is fine). In such cases `cmake/detect-arch.c` is returning an abbreviated CPU string:
https://github.com/zlib-ng/zlib-ng/blob/738a6e5b07c0495b8652c77b4879145c083ea49f/cmake/detect-arch.c#L35-L44

While the check to enable the feature is expecting a full form:
https://github.com/zlib-ng/zlib-ng/blob/738a6e5b07c0495b8652c77b4879145c083ea49f/CMakeLists.txt#L272
https://github.com/zlib-ng/zlib-ng/blob/738a6e5b07c0495b8652c77b4879145c083ea49f/CMakeLists.txt#L290

To make it consistent with `configure`, switch to using the longer form everywhere.

Also, as discussed previously with @nmoinvaz (https://github.com/zlib-ng/zlib-ng/pull/647#discussion_r442969611), I'm also adding a new `POWER8_VSX_SLIDEHASH` macro to keep the naming scheme consistent. This is just a code organization improvement and does not add any functional changes.