### PR TITLE
Fixes to deflate_quick algorithm when compiling with USE_MMAP

### DIFF
--- a/deflate_quick.c
+++ b/deflate_quick.c
@@ -37,6 +37,7 @@ extern const ct_data static_dtree[D_CODES];
         zng_tr_emit_end_block(s, static_ltree, last); \
         s->block_open = 0; \
         s->block_start = s->strstart; \
+        flush_pending(s->strm); \
     } \
 } 
 
@@ -108,15 +109,14 @@ ZLIB_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
 
     s->insert = s->strstart < MIN_MATCH-1 ? s->strstart : MIN_MATCH-1;
 
-    QUICK_END_BLOCK(s, last);
-    flush_pending(s->strm);
-
     if (last) {
         if (s->strm->avail_out == 0)
             return s->strm->avail_in == 0 ? finish_started : need_more;
-        else
-            return finish_done;
+
+        QUICK_END_BLOCK(s, 1);
+        return finish_done;
     }
 
+    QUICK_END_BLOCK(s, 0);
     return block_done;
 }


### PR DESCRIPTION
This fixes the bug reported in #654 with deflate_quick when compiling with `USE_MMAP`

* Fixed avail_out == 0 conditional not returning `need_more` in deflate_quick.
* Fixed ending block when returning `need_more` caused problems with inflate.

So instead of ending the block each time the function returns, we check upon start to see if it is Z_FINISH, and if it is, and the last block not yet started it will end the previous  block and start the last block.

I have tested this against pigz-bench-python and with USE_MMAP and the x-ray file from silesia corpus.