### PR TITLE
Fixed bad shift operation warning in deflatePrime.

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -586,14 +586,17 @@ int32_t ZEXPORT PREFIX(deflatePrime)(PREFIX3(stream) *strm, int32_t bits, int32_
     if (deflateStateCheck(strm))
         return Z_STREAM_ERROR;
     s = strm->state;
-    if (bits < 0 || bits > BIT_BUF_SIZE ||
+    if (bits < 0 || bits > BIT_BUF_SIZE || bits > (sizeof(value) << 3) ||
         s->sym_buf < s->pending_out + ((BIT_BUF_SIZE + 7) >> 3))
         return Z_BUF_ERROR;
     do {
         put = BIT_BUF_SIZE - s->bi_valid;
         if (put > bits)
             put = bits;
-        s->bi_buf |= (((uint64_t)value & ((UINT64_C(1) << put) - 1)) << s->bi_valid);
+        if (s->bi_valid == 0)
+            s->bi_buf = (uint64_t)value;
+        else
+            s->bi_buf |= (((uint64_t)value & ((UINT64_C(1) << put) - 1)) << s->bi_valid);
         s->bi_valid += put;
         zng_tr_flush_bits(s);
         value >>= put;

--- a/test/example.c
+++ b/test/example.c
@@ -805,50 +805,96 @@ void test_deflate_pending(unsigned char *compr, size_t comprLen) {
 }
 
 /* ===========================================================================
- * Test deflatePrime() with small buffers
+ * Test deflatePrime() wrapping gzip around deflate stream
  */
-void test_deflate_prime(unsigned char *compr, size_t comprLen) {
+void test_deflate_prime(unsigned char *compr, size_t comprLen, unsigned char *uncompr, size_t uncomprLen) {
     PREFIX3(stream) c_stream; /* compression stream */
+    PREFIX3(stream) d_stream; /* decompression stream */
     int err;
-    int bits = 0;
-    int values = 0;
     size_t len = strlen(hello)+1;
+    uint32_t crc = 0;
 
 
     c_stream.zalloc = zalloc;
     c_stream.zfree = zfree;
     c_stream.opaque = (voidpf)0;
 
-    // windowBits can also be -8..-15 for raw deflate,The default value is 15
+    /* Raw deflate windowBits is -15 */
     err = PREFIX(deflateInit2)(&c_stream, Z_DEFAULT_COMPRESSION, Z_DEFLATED, -MAX_WBITS, 8, Z_DEFAULT_STRATEGY);
     CHECK_ERR(err, "deflateInit2");
 
-    err = PREFIX(deflatePrime)(&c_stream, bits,values);
+    /* Gzip magic number */
+    err = PREFIX(deflatePrime)(&c_stream, 16, 0x8b1f);
     CHECK_ERR(err, "deflatePrime");
+    /* Gzip compression method (deflate) */
+    err = PREFIX(deflatePrime)(&c_stream, 8, 0x08);
+    CHECK_ERR(err, "deflatePrime");
+    /* Gzip flags (one byte, using two odd bit calls) */
+    err = PREFIX(deflatePrime)(&c_stream, 3, 0x0);
+    CHECK_ERR(err, "deflatePrime");
+    err = PREFIX(deflatePrime)(&c_stream, 5, 0x0);
+    CHECK_ERR(err, "deflatePrime");
+    /* Gzip modified time */
+    err = PREFIX(deflatePrime)(&c_stream, 32, 0x0);
+    CHECK_ERR(err, "deflatePrime");
+    /* Gzip extra flags */
+    err = PREFIX(deflatePrime)(&c_stream, 8, 0x0);
+    CHECK_ERR(err, "deflatePrime");
+    /* Gzip operating system */
+    err = PREFIX(deflatePrime)(&c_stream, 8, 255);
+    CHECK_ERR(err, "deflatePrime");
+
+    c_stream.next_in = (const unsigned char *)hello;
+    c_stream.avail_in = (uint32_t)len;
+    c_stream.next_out = compr;
+    c_stream.avail_out = (uint32_t)comprLen;
+
+    err = PREFIX(deflate)(&c_stream, Z_FINISH);
+    if (err != Z_STREAM_END)
+        CHECK_ERR(err, "deflate");
+
+    /* Gzip uncompressed data crc32 */
+    crc = PREFIX(crc32)(0, hello, (uint32_t)len);
+    err = PREFIX(deflatePrime)(&c_stream, 32, crc);
+    CHECK_ERR(err, "deflatePrime");
+    /* Gzip uncompressed data length */
+    err = PREFIX(deflatePrime)(&c_stream, 32, (uint32_t)len);
+    CHECK_ERR(err, "deflatePrime");
+
+    err = PREFIX(deflateEnd)(&c_stream);
+    CHECK_ERR(err, "deflateEnd");
+
+    d_stream.zalloc = zalloc;
+    d_stream.zfree = zfree;
+    d_stream.opaque = (void *)0;
+
+    d_stream.next_in  = (const uint8_t *)compr;
+    d_stream.avail_in = (uint32_t)c_stream.total_out;
+    d_stream.next_out = uncompr;
+    d_stream.avail_out = (uint32_t)uncomprLen;
+    d_stream.total_in = 0;
+    d_stream.total_out = 0;
+
+    /* Inflate with gzip header */
+    err = PREFIX(inflateInit2)(&d_stream, MAX_WBITS + 32);
+    CHECK_ERR(err, "inflateInit");
+
+    err = PREFIX(inflate)(&d_stream, Z_FINISH);
+    if (err != Z_BUF_ERROR) {
+        CHECK_ERR(err, "inflate");
+    }
+
+    err = PREFIX(inflateEnd)(&d_stream);
+    CHECK_ERR(err, "inflateEnd");
+
+    if (strcmp((const char *)uncompr, hello) != 0) {
+        fprintf(stderr, "bad deflatePrime\n");
+        exit(1);
+    }
 
     if (err == Z_OK) {
         printf("deflatePrime(): OK\n");
     }
-
-    c_stream.next_in = (const unsigned char *)hello;
-    c_stream.next_out = compr;
-
-    while (c_stream.total_in != len && c_stream.total_out < comprLen) {
-        c_stream.avail_in = c_stream.avail_out = 1; /* force small buffers */
-        err = PREFIX(deflate)(&c_stream, Z_NO_FLUSH);
-        CHECK_ERR(err, "deflate");
-    }
-
-    /* Finish the stream, still forcing small buffers: */
-    for (;;) {
-        c_stream.avail_out = 1;
-        err = PREFIX(deflate)(&c_stream, Z_FINISH);
-        if (err == Z_STREAM_END) break;
-        CHECK_ERR(err, "deflate");
-    }
-
-    err = PREFIX(deflateEnd)(&c_stream);
-    CHECK_ERR(err, "deflateEnd");
 }
 
 /* ===========================================================================
@@ -1005,7 +1051,7 @@ int main(int argc, char *argv[]) {
     test_deflate_set_header(compr, comprLen);
     test_deflate_tune(compr, comprLen);
     test_deflate_pending(compr, comprLen);
-    test_deflate_prime(compr, comprLen);
+    test_deflate_prime(compr, comprLen, uncompr, uncomprLen);
 
     free(compr);
     free(uncompr);

--- a/test/example.c
+++ b/test/example.c
@@ -81,11 +81,12 @@ void test_gzio(const char *fname, unsigned char *uncompr, z_size_t uncomprLen) {
 #ifdef NO_GZCOMPRESS
     fprintf(stderr, "NO_GZCOMPRESS -- gz* functions cannot compress\n");
 #else
-    int err, read;
+    int err;
+    size_t read;
     size_t len = strlen(hello)+1;
-    z_off64_t comprLen;
     gzFile file;
     z_off64_t pos;
+    z_off64_t comprLen;
 
     /* Write gz file with test data */
     file = PREFIX(gzopen)(fname, "wb");
@@ -203,7 +204,7 @@ void test_gzio(const char *fname, unsigned char *uncompr, z_size_t uncomprLen) {
         printf("gzgets(): %s\n", (char*)uncompr);
     }
     pos = PREFIX(gzoffset)(file);
-    if (pos < 0 || (size_t)pos != (comprLen + 10)) {
+    if (pos < 0 || pos != (comprLen + 10)) {
         fprintf(stderr, "gzoffset err: wrong offset at end\n");
         exit(1);
     }


### PR DESCRIPTION
```
  CID 293475 (#2-4 of 4): Bad bit shift operation (BAD_SHIFT)
  In expression 1UL << put, left shifting by more than 63 bits has undefined behavior.
```