### PR TITLE
Fixed wrong size being used in calloc in test_deflate_set_header.

### DIFF
--- a/test/example.c
+++ b/test/example.c
@@ -855,7 +855,7 @@ void test_deflate_prime(unsigned char *compr, size_t comprLen) {
  * Test deflateSetHeader() with small buffers
  */
 void test_deflate_set_header(unsigned char *compr, size_t comprLen) {
-    PREFIX(gz_header) *head = calloc(256, 1);
+    PREFIX(gz_header) *head = calloc(1, sizeof(PREFIX(gz_header)));
     PREFIX3(stream) c_stream; /* compression stream */
     int err;
     size_t len = strlen(hello)+1;


### PR DESCRIPTION
    CID 293478 (#1 of 1): Wrong size argument (SIZEOF_MISMATCH)
    suspicious_sizeof: Passing argument 1UL to function calloc that returns a pointer of type zng_gz_header * is suspicious because a multiple of sizeof (zng_gz_header) /*80*/ is expected.