### PR TITLE
Fixed unsigned integer overflow in adler32_avx and adler32_ssse3 when len is zero.

### DIFF
--- a/arch/x86/adler32_avx.c
+++ b/arch/x86/adler32_avx.c
@@ -105,7 +105,8 @@ uint32_t adler32_avx2(uint32_t adler, const unsigned char *buf, size_t len) {
        s2[7] = sum2;
     }
 
-    while (len--) {
+    while (len) {
+       len--;
        adler += *buf++;
        sum2 += adler;
     }

--- a/arch/x86/adler32_avx.c
+++ b/arch/x86/adler32_avx.c
@@ -42,18 +42,18 @@ uint32_t adler32_avx2(uint32_t adler, const unsigned char *buf, size_t len) {
     memset(s2, 0, sizeof(s2)); s2[7] = sum2;
 
     char ALIGNED_(32) dot1[32] = \
-        {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
+        {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
          1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
     __m256i dot1v = _mm256_load_si256((__m256i*)dot1);
     char ALIGNED_(32) dot2[32] = \
-        {32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 
+        {32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17,
          16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1};
     __m256i dot2v = _mm256_load_si256((__m256i*)dot2);
     short ALIGNED_(32) dot3[16] = \
         {1, 1, 1, 1, 1, 1, 1, 1,  1, 1, 1, 1, 1, 1, 1, 1};
     __m256i dot3v = _mm256_load_si256((__m256i*)dot3);
 
-    // We will need to multiply by 
+    // We will need to multiply by
     char ALIGNED_(32) shift[16] = {5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     __m128i shiftv = _mm_load_si128((__m128i*)shift);
 
@@ -94,21 +94,21 @@ uint32_t adler32_avx2(uint32_t adler, const unsigned char *buf, size_t len) {
        _mm256_store_si256((__m256i*)s1_unpack, vs1);
        _mm256_store_si256((__m256i*)s2_unpack, vs2);
 
-       adler = (s1_unpack[0] % BASE) + (s1_unpack[1] % BASE) + (s1_unpack[2] % BASE) + (s1_unpack[3] % BASE) + 
+       adler = (s1_unpack[0] % BASE) + (s1_unpack[1] % BASE) + (s1_unpack[2] % BASE) + (s1_unpack[3] % BASE) +
                (s1_unpack[4] % BASE) + (s1_unpack[5] % BASE) + (s1_unpack[6] % BASE) + (s1_unpack[7] % BASE);
        MOD(adler);
        s1[7] = adler;
 
-       sum2 = (s2_unpack[0] % BASE) + (s2_unpack[1] % BASE) + (s2_unpack[2] % BASE) + (s2_unpack[3] % BASE) + 
+       sum2 = (s2_unpack[0] % BASE) + (s2_unpack[1] % BASE) + (s2_unpack[2] % BASE) + (s2_unpack[3] % BASE) +
               (s2_unpack[4] % BASE) + (s2_unpack[5] % BASE) + (s2_unpack[6] % BASE) + (s2_unpack[7] % BASE);
        MOD(sum2);
        s2[7] = sum2;
     }
 
     while (len) {
-       len--;
-       adler += *buf++;
-       sum2 += adler;
+        len--;
+        adler += *buf++;
+        sum2 += adler;
     }
     MOD(adler);
     MOD(sum2);

--- a/arch/x86/adler32_ssse3.c
+++ b/arch/x86/adler32_ssse3.c
@@ -106,7 +106,8 @@ uint32_t adler32_ssse3(uint32_t adler, const unsigned char *buf, size_t len) {
        s2[3] = sum2;
     }
 
-    while (len--) {
+    while (len) {
+       len--;
        adler += *buf++;
        sum2 += adler;
     }

--- a/arch/x86/adler32_ssse3.c
+++ b/arch/x86/adler32_ssse3.c
@@ -48,7 +48,7 @@ uint32_t adler32_ssse3(uint32_t adler, const unsigned char *buf, size_t len) {
     short ALIGNED_(16) dot3[8] = {1, 1, 1, 1, 1, 1, 1, 1};
     __m128i dot3v = _mm_load_si128((__m128i*)dot3);
 
-    // We will need to multiply by 
+    // We will need to multiply by
     //char ALIGNED_(16) shift[4] = {0, 0, 0, 4}; //{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4};
 
     char ALIGNED_(16) shift[16] = {4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
@@ -107,9 +107,9 @@ uint32_t adler32_ssse3(uint32_t adler, const unsigned char *buf, size_t len) {
     }
 
     while (len) {
-       len--;
-       adler += *buf++;
-       sum2 += adler;
+        len--;
+        adler += *buf++;
+        sum2 += adler;
     }
     MOD(adler);
     MOD(sum2);


### PR DESCRIPTION
This is an ASAN error reported by oss-fuzz.
```
adler32_avx.c:108:15: runtime error: unsigned integer overflow: 0 - 1 cannot be represented in type 'size_t' (aka 'unsigned long')
```
What is strange is that oss-fuzz reported "early exit" as the error, but when I ran the test case they provided it reported this.