### PR TITLE
Default to optimization level 2 in cmake for release mode.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,6 +268,12 @@ else()
     endif()
 endif()
 
+# Replace optimization level 3 added by default with level 2
+if(NOT MSVC AND NOT CMAKE_C_FLAGS MATCHES "([\\/\\-]O)3")
+    string(REGEX REPLACE "([\\/\\-]O)3" "\\12"
+        CMAKE_C_FLAGS_RELEASE ${CMAKE_C_FLAGS_RELEASE})
+endif()
+
 # Set architecture alignment requirements
 if(BASEARCH_ARM_FOUND OR (BASEARCH_PPC_FOUND AND "${ARCH}" MATCHES "powerpc64le") OR BASEARCH_X86_FOUND)
     if(NOT DEFINED UNALIGNED_OK)


### PR DESCRIPTION
This will sync up configure and cmake settings in preparation for #659.