### PR TITLE
Move match start offset calculation outside of hot path in longest_match.

### DIFF
--- a/match_tpl.h
+++ b/match_tpl.h
@@ -39,6 +39,7 @@ int32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
     Pos limit;
     unsigned int best_len, nice_match;
     bestcmp_t scan_end, scan_start;
+    uint32_t offset;
 
     /*
      * The code is optimized for HASH_BITS >= 8 and MAX_MATCH-2 multiple
@@ -68,8 +69,9 @@ int32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
      */
     limit = strstart > MAX_DIST(s) ? strstart - MAX_DIST(s) : 0;
 
+    offset = best_len-1;
     scan_start = *(bestcmp_t *)(scan);
-    scan_end = *(bestcmp_t *)(scan+best_len-1);
+    scan_end = *(bestcmp_t *)(scan+offset);
 
     Assert((unsigned long)strstart <= s->window_size - MIN_LOOKAHEAD, "need lookahead");
     do {
@@ -92,7 +94,7 @@ int32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
         cont = 1;
         do {
             match = window + cur_match;
-            if (LIKELY(*(bestcmp_t *)(match+best_len-1) != scan_end ||
+            if (LIKELY(*(bestcmp_t *)(match+offset) != scan_end ||
                        *(bestcmp_t *)(match) != scan_start)) {
                 if ((cur_match = prev[cur_match & wmask]) > limit && --chain_length != 0) {
                     continue;
@@ -118,7 +120,8 @@ int32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
             best_len = len;
             if (len >= nice_match)
                 break;
-            scan_end = *(bestcmp_t *)(scan+best_len-1);
+            offset = best_len-1;
+            scan_end = *(bestcmp_t *)(scan+offset);
         } else {
             /*
              * The probability of finding a match later if we here


### PR DESCRIPTION
This is something I had back while ago, I was testing various changes to `longest_match` using Google Benchmark. Here are my recent results with 100 repetitions.

https://gist.github.com/nmoinvaz/d53fe7a8ac2c891cf63e7124ec0bd435

* longest_match_1_bench - original way
* longest_match_2_bench - modified offset way (this PR)

```
2020-07-02T19:22:36-07:00
Running C:\Users\Nathan\Source\zlib-gtest\Release\longest_match_benchmark.exe
Run on (12 X 3192 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x6)
  L1 Instruction 32 KiB (x6)
  L2 Unified 256 KiB (x6)
  L3 Unified 12288 KiB (x1)
-----------------------------------------------------------------------
Benchmark                             Time             CPU   Iterations
-----------------------------------------------------------------------
longest_match_1_bench             42835 ns        42481 ns        15448
longest_match_1_bench             44524 ns        44504 ns        15448
longest_match_1_bench             45314 ns        45516 ns        15448
longest_match_1_bench             44852 ns        44504 ns        15448
longest_match_1_bench             45998 ns        46527 ns        15448
longest_match_1_bench             44538 ns        44504 ns        15448
longest_match_1_bench             42942 ns        42481 ns        15448
longest_match_1_bench             44248 ns        44504 ns        15448
longest_match_1_bench             46903 ns        46527 ns        15448
longest_match_1_bench             42413 ns        42481 ns        15448
longest_match_1_bench             45056 ns        45516 ns        15448
longest_match_1_bench             43655 ns        43493 ns        15448
longest_match_1_bench             45612 ns        45516 ns        15448
longest_match_1_bench             44406 ns        44504 ns        15448
longest_match_1_bench             45064 ns        45516 ns        15448
longest_match_1_bench             44525 ns        44504 ns        15448
longest_match_1_bench             44180 ns        43493 ns        15448
longest_match_1_bench             43918 ns        44504 ns        15448
longest_match_1_bench             44327 ns        44504 ns        15448
longest_match_1_bench             42469 ns        42481 ns        15448
longest_match_1_bench             44106 ns        43493 ns        15448
longest_match_1_bench             43077 ns        43493 ns        15448
longest_match_1_bench             44173 ns        43493 ns        15448
longest_match_1_bench             43623 ns        44504 ns        15448
longest_match_1_bench             44082 ns        43493 ns        15448
longest_match_1_bench             42226 ns        42481 ns        15448
longest_match_1_bench             44870 ns        44504 ns        15448
longest_match_1_bench             42473 ns        42481 ns        15448
longest_match_1_bench             44211 ns        44504 ns        15448
longest_match_1_bench             46585 ns        46527 ns        15448
longest_match_1_bench             47988 ns        47539 ns        15448
longest_match_1_bench             45803 ns        46527 ns        15448
longest_match_1_bench             47387 ns        47539 ns        15448
longest_match_1_bench             46155 ns        45516 ns        15448
longest_match_1_bench             46739 ns        46527 ns        15448
longest_match_1_bench             43430 ns        43493 ns        15448
longest_match_1_bench             43162 ns        43493 ns        15448
longest_match_1_bench             43681 ns        43493 ns        15448
longest_match_1_bench             43288 ns        43493 ns        15448
longest_match_1_bench             45122 ns        45516 ns        15448
longest_match_1_bench             43467 ns        43493 ns        15448
longest_match_1_bench             43796 ns        43493 ns        15448
longest_match_1_bench             43425 ns        43493 ns        15448
longest_match_1_bench             42800 ns        42481 ns        15448
longest_match_1_bench             41797 ns        42481 ns        15448
longest_match_1_bench             43350 ns        42481 ns        15448
longest_match_1_bench             46650 ns        46527 ns        15448
longest_match_1_bench             43758 ns        43493 ns        15448
longest_match_1_bench             42183 ns        41470 ns        15448
longest_match_1_bench             43867 ns        44504 ns        15448
longest_match_1_bench             42384 ns        42481 ns        15448
longest_match_1_bench             43707 ns        43493 ns        15448
longest_match_1_bench             42357 ns        42481 ns        15448
longest_match_1_bench             42614 ns        42481 ns        15448
longest_match_1_bench             43124 ns        43493 ns        15448
longest_match_1_bench             42683 ns        42481 ns        15448
longest_match_1_bench             44254 ns        44504 ns        15448
longest_match_1_bench             43172 ns        42481 ns        15448
longest_match_1_bench             44607 ns        44504 ns        15448
longest_match_1_bench             43173 ns        43493 ns        15448
longest_match_1_bench             43235 ns        43493 ns        15448
longest_match_1_bench             44092 ns        43493 ns        15448
longest_match_1_bench             43658 ns        44504 ns        15448
longest_match_1_bench             42970 ns        42481 ns        15448
longest_match_1_bench             42528 ns        42481 ns        15448
longest_match_1_bench             42280 ns        42481 ns        15448
longest_match_1_bench             43691 ns        43493 ns        15448
longest_match_1_bench             42294 ns        42481 ns        15448
longest_match_1_bench             42886 ns        42481 ns        15448
longest_match_1_bench             43515 ns        43493 ns        15448
longest_match_1_bench             43514 ns        43493 ns        15448
longest_match_1_bench             42316 ns        42481 ns        15448
longest_match_1_bench             43600 ns        43493 ns        15448
longest_match_1_bench             43540 ns        43493 ns        15448
longest_match_1_bench             43603 ns        43493 ns        15448
longest_match_1_bench             42578 ns        43493 ns        15448
longest_match_1_bench             45357 ns        43493 ns        15448
longest_match_1_bench             43364 ns        43493 ns        15448
longest_match_1_bench             44277 ns        44504 ns        15448
longest_match_1_bench             41712 ns        41470 ns        15448
longest_match_1_bench             45966 ns        46527 ns        15448
longest_match_1_bench             42814 ns        42481 ns        15448
longest_match_1_bench             52816 ns        52596 ns        15448
longest_match_1_bench             44921 ns        45516 ns        15448
longest_match_1_bench             45120 ns        44504 ns        15448
longest_match_1_bench             45044 ns        45516 ns        15448
longest_match_1_bench             46912 ns        46527 ns        15448
longest_match_1_bench             44631 ns        44504 ns        15448
longest_match_1_bench             47785 ns        48550 ns        15448
longest_match_1_bench             44774 ns        44504 ns        15448
longest_match_1_bench             47822 ns        46527 ns        15448
longest_match_1_bench             46088 ns        45516 ns        15448
longest_match_1_bench             45344 ns        45516 ns        15448
longest_match_1_bench             48500 ns        47539 ns        15448
longest_match_1_bench             49849 ns        50573 ns        15448
longest_match_1_bench             46107 ns        44504 ns        15448
longest_match_1_bench             45908 ns        46527 ns        15448
longest_match_1_bench             46455 ns        46527 ns        15448
longest_match_1_bench             45278 ns        44504 ns        15448
longest_match_1_bench             45140 ns        45516 ns        15448
longest_match_1_bench_mean        44394 ns        44342 ns          100
longest_match_1_bench_median      44087 ns        43493 ns          100
longest_match_1_bench_stddev       1822 ns         1834 ns          100
longest_match_2_bench             73064 ns        59464 ns        14452
longest_match_2_bench             55770 ns        50815 ns        14452
longest_match_2_bench             38425 ns        38922 ns        14452
longest_match_2_bench             34709 ns        34597 ns        14452
longest_match_2_bench             38795 ns        38922 ns        14452
longest_match_2_bench             34077 ns        33516 ns        14452
longest_match_2_bench             36423 ns        36760 ns        14452
longest_match_2_bench             33987 ns        33516 ns        14452
longest_match_2_bench             33965 ns        34597 ns        14452
longest_match_2_bench             32374 ns        32435 ns        14452
longest_match_2_bench             39860 ns        40003 ns        14452
longest_match_2_bench             33801 ns        33516 ns        14452
longest_match_2_bench             34460 ns        34597 ns        14452
longest_match_2_bench             32427 ns        32435 ns        14452
longest_match_2_bench             32476 ns        32435 ns        14452
longest_match_2_bench             32656 ns        32435 ns        14452
longest_match_2_bench             31619 ns        31354 ns        14452
longest_match_2_bench             31384 ns        31354 ns        14452
longest_match_2_bench             38278 ns        38922 ns        14452
longest_match_2_bench             32841 ns        32435 ns        14452
longest_match_2_bench             34716 ns        34597 ns        14452
longest_match_2_bench             34790 ns        34597 ns        14452
longest_match_2_bench             33565 ns        33516 ns        14452
longest_match_2_bench             36940 ns        37841 ns        14452
longest_match_2_bench             34031 ns        33516 ns        14452
longest_match_2_bench             32260 ns        32435 ns        14452
longest_match_2_bench             33773 ns        33516 ns        14452
longest_match_2_bench             37384 ns        37841 ns        14452
longest_match_2_bench             41445 ns        41084 ns        14452
longest_match_2_bench             33596 ns        33516 ns        14452
longest_match_2_bench             36796 ns        36760 ns        14452
longest_match_2_bench             34819 ns        34597 ns        14452
longest_match_2_bench             40116 ns        40003 ns        14452
longest_match_2_bench             33952 ns        34597 ns        14452
longest_match_2_bench             33487 ns        33516 ns        14452
longest_match_2_bench             34384 ns        34597 ns        14452
longest_match_2_bench             34684 ns        34597 ns        14452
longest_match_2_bench             35182 ns        34597 ns        14452
longest_match_2_bench             32686 ns        33516 ns        14452
longest_match_2_bench             36315 ns        35678 ns        14452
longest_match_2_bench             35180 ns        35678 ns        14452
longest_match_2_bench             36168 ns        35678 ns        14452
longest_match_2_bench             34599 ns        34597 ns        14452
longest_match_2_bench             34541 ns        34597 ns        14452
longest_match_2_bench             33132 ns        33516 ns        14452
longest_match_2_bench             31537 ns        31354 ns        14452
longest_match_2_bench             32173 ns        32435 ns        14452
longest_match_2_bench             32404 ns        32435 ns        14452
longest_match_2_bench             31728 ns        31354 ns        14452
longest_match_2_bench             32089 ns        32435 ns        14452
longest_match_2_bench             32049 ns        31354 ns        14452
longest_match_2_bench             32823 ns        33516 ns        14452
longest_match_2_bench             32128 ns        31354 ns        14452
longest_match_2_bench             32844 ns        33516 ns        14452
longest_match_2_bench             31907 ns        31354 ns        14452
longest_match_2_bench             32328 ns        32435 ns        14452
longest_match_2_bench             32845 ns        33516 ns        14452
longest_match_2_bench             34210 ns        32435 ns        14452
longest_match_2_bench             33607 ns        33516 ns        14452
longest_match_2_bench             33871 ns        34597 ns        14452
longest_match_2_bench             34685 ns        34597 ns        14452
longest_match_2_bench             37031 ns        36760 ns        14452
longest_match_2_bench             38266 ns        37841 ns        14452
longest_match_2_bench             36921 ns        36760 ns        14452
longest_match_2_bench             35024 ns        35678 ns        14452
longest_match_2_bench             32469 ns        31354 ns        14452
longest_match_2_bench             32812 ns        32435 ns        14452
longest_match_2_bench             33750 ns        33516 ns        14452
longest_match_2_bench             31984 ns        32435 ns        14452
longest_match_2_bench             34681 ns        34597 ns        14452
longest_match_2_bench             32529 ns        32435 ns        14452
longest_match_2_bench             36056 ns        36760 ns        14452
longest_match_2_bench             31984 ns        31354 ns        14452
longest_match_2_bench             31749 ns        32435 ns        14452
longest_match_2_bench             32413 ns        31354 ns        14452
longest_match_2_bench             35352 ns        35678 ns        14452
longest_match_2_bench             33831 ns        34597 ns        14452
longest_match_2_bench             36718 ns        35678 ns        14452
longest_match_2_bench             33565 ns        34597 ns        14452
longest_match_2_bench             33139 ns        32435 ns        14452
longest_match_2_bench             37352 ns        37841 ns        14452
longest_match_2_bench             34996 ns        34597 ns        14452
longest_match_2_bench             34669 ns        34597 ns        14452
longest_match_2_bench             36059 ns        36760 ns        14452
longest_match_2_bench             32850 ns        30273 ns        14452
longest_match_2_bench             31871 ns        31354 ns        14452
longest_match_2_bench             32055 ns        32435 ns        14452
longest_match_2_bench             31804 ns        31354 ns        14452
longest_match_2_bench             31971 ns        32435 ns        14452
longest_match_2_bench             31582 ns        31354 ns        14452
longest_match_2_bench             31476 ns        31354 ns        14452
longest_match_2_bench             33498 ns        33516 ns        14452
longest_match_2_bench             34548 ns        34597 ns        14452
longest_match_2_bench             32325 ns        32435 ns        14452
longest_match_2_bench             32705 ns        32435 ns        14452
longest_match_2_bench             31245 ns        31354 ns        14452
longest_match_2_bench             31856 ns        32435 ns        14452
longest_match_2_bench             32125 ns        32435 ns        14452
longest_match_2_bench             31808 ns        31354 ns        14452
longest_match_2_bench             33212 ns        33516 ns        14452
longest_match_2_bench_mean        34634 ns        34413 ns          100
longest_match_2_bench_median      33678 ns        33516 ns          100
longest_match_2_bench_stddev       4939 ns         3789 ns          100
```