### PR TITLE
Use 3 byte hash mask for slower compression levels > 6

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -186,6 +186,8 @@ static const config configuration_table[10] = {
     memset((unsigned char *)s->head, 0, (unsigned)(s->hash_size - 1) * sizeof(*s->head)); \
   } while (0)
 
+#define HASH_TRIGGER_LEVEL 6
+
 /* ===========================================================================
  * Slide the hash table when sliding the window down (could be avoided with 32
  * bit values at the expense of memory usage). We slide even when level == 0 to
@@ -402,6 +404,7 @@ int32_t ZEXPORT PREFIX(deflateInit2_)(PREFIX3(stream) *strm, int32_t level, int3
     s->level = level;
     s->strategy = strategy;
     s->method = (unsigned char)method;
+    s->hash_mask_val = (s->level > HASH_TRIGGER_LEVEL) ? 0x00ffffff : 0xffffffff;
     s->block_open = 0;
     s->reproducible = 0;
 
@@ -642,6 +645,7 @@ int32_t ZEXPORT PREFIX(deflateParams)(PREFIX3(stream) *strm, int32_t level, int3
             s->matches = 0;
         }
         s->level = level;
+        s->hash_mask_val    = (s->level > HASH_TRIGGER_LEVEL) ? 0x00ffffff : 0xffffffff;
         s->max_lazy_match   = configuration_table[level].max_lazy;
         s->good_match       = configuration_table[level].good_length;
         s->nice_match       = configuration_table[level].nice_length;

--- a/deflate.h
+++ b/deflate.h
@@ -97,7 +97,7 @@ typedef struct tree_desc_s {
 typedef uint16_t Pos;
 
 /* A Pos is an index in the character window. We use short instead of int to
- * save space in the various tables. 
+ * save space in the various tables.
  */
 
 typedef struct internal_state {
@@ -149,6 +149,7 @@ typedef struct internal_state {
     unsigned int  hash_size;         /* number of elements in hash table */
     unsigned int  hash_bits;         /* log2(hash_size) */
     unsigned int  hash_mask;         /* hash_size-1 */
+    unsigned int  hash_mask_val;     /* mask for hash input */
 
     long block_start;
     /* Window position at the beginning of the current output block. Gets

--- a/insert_string_tpl.h
+++ b/insert_string_tpl.h
@@ -22,6 +22,8 @@
  *
  */
 
+#define HASH_TRIGGER_LEVEL 6
+
 /* ===========================================================================
  * Quick insert string str in the dictionary and set match_head to the previous head
  * of the hash chain (the most recent string with same hash key). Return
@@ -40,6 +42,8 @@ ZLIB_INTERNAL Pos QUICK_INSERT_STRING(deflate_state *const s, const Pos str) {
     val |= ((uint32_t)(strstart[2]) << 16);
     val |= ((uint32_t)(strstart[3]) << 24);
 #endif
+    if (s->level > HASH_TRIGGER_LEVEL)
+        val &= 0x00ffffff;
 
     UPDATE_HASH(s, h, val);
     hm = h & s->hash_mask;
@@ -63,6 +67,7 @@ ZLIB_INTERNAL Pos QUICK_INSERT_STRING(deflate_state *const s, const Pos str) {
 ZLIB_INTERNAL Pos INSERT_STRING(deflate_state *const s, const Pos str, unsigned int count) {
     Pos idx, ret;
     uint8_t *strstart, *strend;
+    uint32_t hash_mask;
 
     if (UNLIKELY(count == 0)) {
         return s->prev[str & s->w_mask];
@@ -70,6 +75,8 @@ ZLIB_INTERNAL Pos INSERT_STRING(deflate_state *const s, const Pos str, unsigned 
 
     strstart = s->window + str;
     strend = strstart + count - 1; /* last position */
+
+    hash_mask = (s->level > HASH_TRIGGER_LEVEL) ? 0x00ffffff : 0xffffffff;
 
     for (ret = 0, idx = str; strstart <= strend; idx++, strstart++) {
         uint32_t val, hm, h = 0;
@@ -82,7 +89,7 @@ ZLIB_INTERNAL Pos INSERT_STRING(deflate_state *const s, const Pos str, unsigned 
         val |= ((uint32_t)(strstart[2]) << 16);
         val |= ((uint32_t)(strstart[3]) << 24);
 #endif
-
+        val &= hash_mask;
         UPDATE_HASH(s, h, val);
         hm = h & s->hash_mask;
 

--- a/insert_string_tpl.h
+++ b/insert_string_tpl.h
@@ -22,8 +22,6 @@
  *
  */
 
-#define HASH_TRIGGER_LEVEL 6
-
 /* ===========================================================================
  * Quick insert string str in the dictionary and set match_head to the previous head
  * of the hash chain (the most recent string with same hash key). Return
@@ -42,9 +40,8 @@ ZLIB_INTERNAL Pos QUICK_INSERT_STRING(deflate_state *const s, const Pos str) {
     val |= ((uint32_t)(strstart[2]) << 16);
     val |= ((uint32_t)(strstart[3]) << 24);
 #endif
-    if (s->level > HASH_TRIGGER_LEVEL)
-        val &= 0x00ffffff;
 
+    val &= s->hash_mask_val;
     UPDATE_HASH(s, h, val);
     hm = h & s->hash_mask;
 
@@ -67,7 +64,7 @@ ZLIB_INTERNAL Pos QUICK_INSERT_STRING(deflate_state *const s, const Pos str) {
 ZLIB_INTERNAL Pos INSERT_STRING(deflate_state *const s, const Pos str, unsigned int count) {
     Pos idx, ret;
     uint8_t *strstart, *strend;
-    uint32_t hash_mask;
+    uint32_t hash_mask, hash_mask_val;
 
     if (UNLIKELY(count == 0)) {
         return s->prev[str & s->w_mask];
@@ -75,8 +72,8 @@ ZLIB_INTERNAL Pos INSERT_STRING(deflate_state *const s, const Pos str, unsigned 
 
     strstart = s->window + str;
     strend = strstart + count - 1; /* last position */
-
-    hash_mask = (s->level > HASH_TRIGGER_LEVEL) ? 0x00ffffff : 0xffffffff;
+    hash_mask = s->hash_mask;
+    hash_mask_val = s->hash_mask_val;
 
     for (ret = 0, idx = str; strstart <= strend; idx++, strstart++) {
         uint32_t val, hm, h = 0;
@@ -89,9 +86,9 @@ ZLIB_INTERNAL Pos INSERT_STRING(deflate_state *const s, const Pos str, unsigned 
         val |= ((uint32_t)(strstart[2]) << 16);
         val |= ((uint32_t)(strstart[3]) << 24);
 #endif
-        val &= hash_mask;
+        val &= hash_mask_val;
         UPDATE_HASH(s, h, val);
-        hm = h & s->hash_mask;
+        hm = h & hash_mask;
 
         Pos head = s->head[hm];
         if (head != idx) {


### PR DESCRIPTION
And use 4 byte hash mask for faster compression levels. Previously we used `TIGGER_LEVEL` which is 5 for this. I am thinking we can do better if it is only for levels 7-9. Also the `s->level` if statement used to be inside of the loop for `INSERT_STRING`. Now I have moved it to the top of the function.