### PR TITLE
Fixed ubsan error in deflatePrime when bits is 32.

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -587,7 +587,7 @@ int32_t ZEXPORT PREFIX(deflatePrime)(PREFIX3(stream) *strm, int32_t bits, int32_
     if (deflateStateCheck(strm))
         return Z_STREAM_ERROR;
     s = strm->state;
-    if (bits < 0 || bits > BIT_BUF_SIZE || bits > (sizeof(value) << 3) ||
+    if (bits < 0 || bits > BIT_BUF_SIZE || bits > (int32_t)(sizeof(value) << 3) ||
         s->sym_buf < s->pending_out + ((BIT_BUF_SIZE + 7) >> 3))
         return Z_BUF_ERROR;
     do {

--- a/deflate.c
+++ b/deflate.c
@@ -581,6 +581,7 @@ int32_t ZEXPORT PREFIX(deflatePending)(PREFIX3(stream) *strm, uint32_t *pending,
 /* ========================================================================= */
 int32_t ZEXPORT PREFIX(deflatePrime)(PREFIX3(stream) *strm, int32_t bits, int32_t value) {
     deflate_state *s;
+    uint64_t value64 = (uint64_t)value;
     int32_t put;
 
     if (deflateStateCheck(strm))
@@ -594,12 +595,12 @@ int32_t ZEXPORT PREFIX(deflatePrime)(PREFIX3(stream) *strm, int32_t bits, int32_
         if (put > bits)
             put = bits;
         if (s->bi_valid == 0)
-            s->bi_buf = (uint64_t)value;
+            s->bi_buf = value64;
         else
-            s->bi_buf |= (((uint64_t)value & ((UINT64_C(1) << put) - 1)) << s->bi_valid);
+            s->bi_buf |= (value64 & ((UINT64_C(1) << put) - 1)) << s->bi_valid;
         s->bi_valid += put;
         zng_tr_flush_bits(s);
-        value >>= put;
+        value64 >>= put;
         bits -= put;
     } while (bits);
     return Z_OK;

--- a/test/example.c
+++ b/test/example.c
@@ -855,7 +855,7 @@ void test_deflate_prime(unsigned char *compr, size_t comprLen, unsigned char *un
         CHECK_ERR(err, "deflate");
 
     /* Gzip uncompressed data crc32 */
-    crc = PREFIX(crc32)(0, hello, (uint32_t)len);
+    crc = PREFIX(crc32)(0, (const uint8_t *)hello, (uint32_t)len);
     err = PREFIX(deflatePrime)(&c_stream, 32, crc);
     CHECK_ERR(err, "deflatePrime");
     /* Gzip uncompressed data length */


### PR DESCRIPTION
```
    SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /src/zlib-ng/deflate.c:602:15
    deflate.c:602:15: runtime error: shift exponent 32 is too large for 32-bit type 'int32_t' (aka 'int')
```