### PR TITLE
Fixed extra symbols added to ABI when zlib-compat specified.

### DIFF
--- a/adler32.c
+++ b/adler32.c
@@ -8,11 +8,8 @@
 #include "functable.h"
 #include "adler32_p.h"
 
-uint32_t adler32_c(uint32_t adler, const unsigned char *buf, size_t len);
-static uint32_t adler32_combine_(uint32_t adler1, uint32_t adler2, z_off64_t len2);
-
 /* ========================================================================= */
-uint32_t adler32_c(uint32_t adler, const unsigned char *buf, size_t len) {
+ZLIB_INTERNAL uint32_t adler32_c(uint32_t adler, const unsigned char *buf, size_t len) {
     uint32_t sum2;
     unsigned n;
 

--- a/arch/power/power.c
+++ b/arch/power/power.c
@@ -4,7 +4,7 @@
  */
 
 #include <sys/auxv.h>
-#include "zutil.h"
+#include "../../zutil.h"
 
 ZLIB_INTERNAL int power_cpu_has_arch_2_07;
 

--- a/arch/x86/adler32_avx.c
+++ b/arch/x86/adler32_avx.c
@@ -17,7 +17,7 @@
 
 #ifdef X86_AVX2_ADLER32
 
-uint32_t adler32_avx2(uint32_t adler, const unsigned char *buf, size_t len) {
+ZLIB_INTERNAL uint32_t adler32_avx2(uint32_t adler, const unsigned char *buf, size_t len) {
     uint32_t sum2;
 
      /* split Adler-32 into component sums */

--- a/arch/x86/adler32_ssse3.c
+++ b/arch/x86/adler32_ssse3.c
@@ -17,7 +17,7 @@
 
 #include <immintrin.h>
 
-uint32_t adler32_ssse3(uint32_t adler, const unsigned char *buf, size_t len) {
+ZLIB_INTERNAL uint32_t adler32_ssse3(uint32_t adler, const unsigned char *buf, size_t len) {
     uint32_t sum2;
 
      /* split Adler-32 into component sums */

--- a/arch/x86/compare258_avx.c
+++ b/arch/x86/compare258_avx.c
@@ -54,7 +54,7 @@ static inline int32_t compare258_unaligned_avx2_static(const unsigned char *src0
     return compare256_unaligned_avx2_static(src0+2, src1+2) + 2;
 }
 
-int32_t compare258_unaligned_avx2(const unsigned char *src0, const unsigned char *src1) {
+ZLIB_INTERNAL int32_t compare258_unaligned_avx2(const unsigned char *src0, const unsigned char *src1) {
     return compare258_unaligned_avx2_static(src0, src1);
 }
 

--- a/arch/x86/compare258_sse.c
+++ b/arch/x86/compare258_sse.c
@@ -61,7 +61,7 @@ static inline int32_t compare258_unaligned_sse4_static(const unsigned char *src0
     return compare256_unaligned_sse4_static(src0+2, src1+2) + 2;
 }
 
-int32_t compare258_unaligned_sse4(const unsigned char *src0, const unsigned char *src1) {
+ZLIB_INTERNAL int32_t compare258_unaligned_sse4(const unsigned char *src0, const unsigned char *src1) {
     return compare258_unaligned_sse4_static(src0, src1);
 }
 

--- a/chunkset_tpl.h
+++ b/chunkset_tpl.h
@@ -3,7 +3,7 @@
  */
 
 /* Returns the chunk size */
-uint32_t CHUNKSIZE(void) {
+ZLIB_INTERNAL uint32_t CHUNKSIZE(void) {
     return sizeof(chunk_t);
 }
 
@@ -17,7 +17,7 @@ uint32_t CHUNKSIZE(void) {
    (chunk_t bytes or fewer) will fall straight through the loop
    without iteration, which will hopefully make the branch prediction more
    reliable. */
-uint8_t* CHUNKCOPY(uint8_t *out, uint8_t const *from, unsigned len) {
+ZLIB_INTERNAL uint8_t* CHUNKCOPY(uint8_t *out, uint8_t const *from, unsigned len) {
     chunk_t chunk;
     --len;
     loadchunk(from, &chunk);
@@ -36,7 +36,7 @@ uint8_t* CHUNKCOPY(uint8_t *out, uint8_t const *from, unsigned len) {
 }
 
 /* Behave like chunkcopy, but avoid writing beyond of legal output. */
-uint8_t* CHUNKCOPY_SAFE(uint8_t *out, uint8_t const *from, unsigned len, uint8_t *safe) {
+ZLIB_INTERNAL uint8_t* CHUNKCOPY_SAFE(uint8_t *out, uint8_t const *from, unsigned len, uint8_t *safe) {
     if ((safe - out) < (ptrdiff_t)sizeof(chunk_t)) {
         if (len & 8) {
             memcpy(out, from, 8);
@@ -69,7 +69,7 @@ uint8_t* CHUNKCOPY_SAFE(uint8_t *out, uint8_t const *from, unsigned len, uint8_t
    This assumption holds because inflate_fast() starts every iteration with at
    least 258 bytes of output space available (258 being the maximum length
    output from a single token; see inflate_fast()'s assumptions below). */
-uint8_t* CHUNKUNROLL(uint8_t *out, unsigned *dist, unsigned *len) {
+ZLIB_INTERNAL uint8_t* CHUNKUNROLL(uint8_t *out, unsigned *dist, unsigned *len) {
     unsigned char const *from = out - *dist;
     chunk_t chunk;
     while (*dist < *len && *dist < sizeof(chunk_t)) {
@@ -84,7 +84,7 @@ uint8_t* CHUNKUNROLL(uint8_t *out, unsigned *dist, unsigned *len) {
 
 /* Copy DIST bytes from OUT - DIST into OUT + DIST * k, for 0 <= k < LEN/DIST.
    Return OUT + LEN. */
-uint8_t* CHUNKMEMSET(uint8_t *out, unsigned dist, unsigned len) {
+ZLIB_INTERNAL uint8_t* CHUNKMEMSET(uint8_t *out, unsigned dist, unsigned len) {
     /* Debug performance related issues when len < sizeof(uint64_t):
        Assert(len >= sizeof(uint64_t), "chunkmemset should be called on larger chunks"); */
     Assert(dist > 0, "cannot have a distance 0");
@@ -153,7 +153,7 @@ uint8_t* CHUNKMEMSET(uint8_t *out, unsigned dist, unsigned len) {
     return out;
 }
 
-uint8_t* CHUNKMEMSET_SAFE(uint8_t *out, unsigned dist, unsigned len, unsigned left) {
+ZLIB_INTERNAL uint8_t* CHUNKMEMSET_SAFE(uint8_t *out, unsigned dist, unsigned len, unsigned left) {
     if (left < (unsigned)(3 * sizeof(chunk_t))) {
         while (len > 0) {
             *out = *(out - dist);

--- a/compare258.c
+++ b/compare258.c
@@ -53,7 +53,7 @@ static inline int32_t compare258_c_static(const unsigned char *src0, const unsig
     return compare256_c_static(src0, src1) + 2;
 }
 
-int32_t compare258_c(const unsigned char *src0, const unsigned char *src1) {
+ZLIB_INTERNAL int32_t compare258_c(const unsigned char *src0, const unsigned char *src1) {
     return compare258_c_static(src0, src1);
 }
 
@@ -93,7 +93,7 @@ static inline int32_t compare258_unaligned_16_static(const unsigned char *src0, 
     return compare256_unaligned_16_static(src0+2, src1+2) + 2;
 }
 
-int32_t compare258_unaligned_16(const unsigned char *src0, const unsigned char *src1) {
+ZLIB_INTERNAL int32_t compare258_unaligned_16(const unsigned char *src0, const unsigned char *src1) {
     return compare258_unaligned_16_static(src0, src1);
 }
 
@@ -131,7 +131,7 @@ static inline int32_t compare258_unaligned_32_static(const unsigned char *src0, 
     return compare256_unaligned_32_static(src0+2, src1+2) + 2;
 }
 
-int32_t compare258_unaligned_32(const unsigned char *src0, const unsigned char *src1) {
+ZLIB_INTERNAL int32_t compare258_unaligned_32(const unsigned char *src0, const unsigned char *src1) {
     return compare258_unaligned_32_static(src0, src1);
 }
 
@@ -171,7 +171,7 @@ static inline int32_t compare258_unaligned_64_static(const unsigned char *src0, 
     return compare256_unaligned_64_static(src0+2, src1+2) + 2;
 }
 
-int32_t compare258_unaligned_64(const unsigned char *src0, const unsigned char *src1) {
+ZLIB_INTERNAL int32_t compare258_unaligned_64(const unsigned char *src0, const unsigned char *src1) {
     return compare258_unaligned_64_static(src0, src1);
 }
 

--- a/deflate.c
+++ b/deflate.c
@@ -52,7 +52,7 @@
 #include "deflate_p.h"
 #include "functable.h"
 
-const char zng_deflate_copyright[] = " deflate 1.2.11.f Copyright 1995-2016 Jean-loup Gailly and Mark Adler ";
+const char PREFIX(deflate_copyright)[] = " deflate 1.2.12.f Copyright 1995-2016 Jean-loup Gailly and Mark Adler ";
 /*
   If you use the zlib library in a product, an acknowledgment is welcome
   in the documentation of your product. If for some reason you cannot

--- a/inftrees.c
+++ b/inftrees.c
@@ -9,7 +9,7 @@
 
 #define MAXBITS 15
 
-const char zng_inflate_copyright[] = " inflate 1.2.11.f Copyright 1995-2016 Mark Adler ";
+const char PREFIX(inflate_copyright)[] = " inflate 1.2.12.f Copyright 1995-2016 Mark Adler ";
 /*
   If you use the zlib library in a product, an acknowledgment is welcome
   in the documentation of your product. If for some reason you cannot

--- a/match_tpl.h
+++ b/match_tpl.h
@@ -29,7 +29,7 @@ typedef uint8_t         bestcmp_t;
  * string (strstart) and its distance is <= MAX_DIST, and prev_length >=1
  * OUT assertion: the match length is not greater than s->lookahead
  */
-int32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
+ZLIB_INTERNAL int32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
     unsigned int strstart = s->strstart;
     const unsigned wmask = s->w_mask;
     ZLIB_REGISTER unsigned char *window = s->window;

--- a/zlib.map
+++ b/zlib.map
@@ -91,6 +91,10 @@ ZLIB_1.2.9 {
     deflateGetDictionary;
     adler32_z;
     crc32_z;
-    crc32_combine_gen;
-    crc32_combine_op;
 } ZLIB_1.2.7.1;
+
+ZLIB_1.2.12 {
+    crc32_combine_gen;
+    crc32_combine_gen64;
+    crc32_combine_op;
+} ZLIB_1.2.9;

--- a/zutil.c
+++ b/zutil.c
@@ -9,7 +9,7 @@
 #  include "gzguts.h"
 #endif
 
-const char * const zng_errmsg[10] = {
+const char * const PREFIX(z_errmsg)[10] = {
     (const char *)"need dictionary",     /* Z_NEED_DICT       2  */
     (const char *)"stream end",          /* Z_STREAM_END      1  */
     (const char *)"",                    /* Z_OK              0  */
@@ -23,7 +23,7 @@ const char * const zng_errmsg[10] = {
 };
 
 const char zlibng_string[] =
-    " zlib-ng 1.9.9 forked from zlib 1.2.11 ";
+    " zlib-ng 1.9.9 forked from zlib 1.2.12.f ";
 
 #ifdef ZLIB_COMPAT
 const char * ZEXPORT zlibVersion(void) {

--- a/zutil.h
+++ b/zutil.h
@@ -33,15 +33,16 @@
 #else
 #  include "zlib-ng.h"
 #endif
+#include "zbuild.h"
 
 typedef unsigned char uch; /* Included for compatibility with external code only */
 typedef uint16_t ush;      /* Included for compatibility with external code only */
 typedef unsigned long ulg;
 
-extern const char * const zng_errmsg[10]; /* indexed by 2-zlib_error */
+extern const char * const PREFIX(z_errmsg)[10]; /* indexed by 2-zlib_error */
 /* (size given to avoid silly warnings with Visual C++) */
 
-#define ERR_MSG(err) zng_errmsg[Z_NEED_DICT-(err)]
+#define ERR_MSG(err) PREFIX(z_errmsg)[Z_NEED_DICT-(err)]
 
 #define ERR_RETURN(strm, err) return (strm->msg = ERR_MSG(err), (err))
 /* To be used only when the state is known to be valid */
@@ -122,7 +123,7 @@ extern const char * const zng_errmsg[10]; /* indexed by 2-zlib_error */
 
 /* MS Visual Studio does not allow inline in C, only C++.
    But it provides __inline instead, so use that. */
-#if defined(_MSC_VER) && !defined(inline) && !defined(__cplusplus) 
+#if defined(_MSC_VER) && !defined(inline) && !defined(__cplusplus)
 #  define inline __inline
 #endif
 
@@ -200,7 +201,7 @@ void ZLIB_INTERNAL   zng_cfree(void *opaque, void *ptr);
 #else
 #  define ZSWAP16(q) ((((q) & 0xff) << 8) | (((q) & 0xff00) >> 8))
 #  define ZSWAP32(q) ((((q) >> 24) & 0xff) + (((q) >> 8) & 0xff00) + \
-                    (((q) & 0xff00) << 8) + (((q) & 0xff) << 24))
+                     (((q) & 0xff00) << 8) + (((q) & 0xff) << 24))
 #  define ZSWAP64(q)                           \
           ((q & 0xFF00000000000000u) >> 56u) | \
           ((q & 0x00FF000000000000u) >> 40u) | \


### PR DESCRIPTION
See #658 for background.

Abi diff before:
```
31 Added function symbols not referenced by debug info:

  adler32_avx2
  adler32_c
  adler32_ssse3
  chunkcopy_c
  chunkcopy_safe_c
  chunkcopy_safe_sse2
  chunkcopy_sse2
  chunkmemset_c
  chunkmemset_safe_c
  chunkmemset_safe_sse2
  chunkmemset_sse2
  chunksize_c
  chunksize_sse2
  chunkunroll_c
  chunkunroll_sse2
  compare258_c
  compare258_unaligned_16
  compare258_unaligned_32
  compare258_unaligned_64
  compare258_unaligned_avx2
  compare258_unaligned_sse4
  crc32_combine_gen64
  crc32_combine_gen@@ZLIB_1.2.9
  crc32_combine_op@@ZLIB_1.2.9
  longest_match_c
  longest_match_unaligned_16
  longest_match_unaligned_32
  longest_match_unaligned_64
  longest_match_unaligned_avx2
  longest_match_unaligned_sse4
  zlibng_version

4 Added variable symbols not referenced by debug info:

  zlibng_string
  zng_deflate_copyright
  zng_errmsg
  zng_inflate_copyright
```

After:

```
Functions changes summary: 0 Removed, 0 Changed, 0 Added function
Variables changes summary: 0 Removed, 0 Changed, 0 Added variable
Function symbols changes summary: 0 Removed, 3 Added function symbols not referenced by debug info
Variable symbols changes summary: 0 Removed, 0 Added variable symbol not referenced by debug info
3 Added function symbols not referenced by debug info:

  crc32_combine_gen64@@ZLIB_1.2.12
  crc32_combine_gen@@ZLIB_1.2.12
  crc32_combine_op@@ZLIB_1.2.12
```