### PR TITLE
Remove current directory library include path in configure not in cmake

### DIFF
--- a/configure
+++ b/configure
@@ -68,7 +68,7 @@ fi
 
 # set defaults before processing command line options
 LDCONFIG=${LDCONFIG-"ldconfig"}
-LDFLAGS=${LDFLAGS-"-L."}
+LDFLAGS=${LDFLAGS}
 LDSHAREDLIBC="${LDSHAREDLIBC--lc}"
 DEFFILE=
 RC=


### PR DESCRIPTION
Notice this when comparing command line switches during compilations for both configure and cmake. Previous discussion part of #659.