### PR TITLE
Remove inflate compilation options from CMake script

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -219,7 +219,7 @@ jobs:
           - name: Ubuntu Clang Inflate Strict
             os: ubuntu-latest
             compiler: clang
-            cmake-args: -DWITH_INFLATE_STRICT=ON
+            cflags: -DINFLATE_STRICT
             packages: llvm-6.0
             gcov-exec: llvm-cov-6.0 gcov
             codecov: ubuntu_clang_inflate_strict
@@ -227,7 +227,7 @@ jobs:
           - name: Ubuntu Clang Inflate Allow Invalid Dist
             os: ubuntu-latest
             compiler: clang
-            cmake-args: -DWITH_INFLATE_ALLOW_INVALID_DIST=ON
+            cflags: -DINFLATE_ALLOW_INVALID_DISTANCE_TOOFAR_ARRR
             packages: llvm-6.0
             gcov-exec: llvm-cov-6.0 gcov
             codecov: ubuntu_clang_inflate_allow_invalid_dist

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,8 +85,6 @@ option(WITH_NATIVE_INSTRUCTIONS
     "Instruct the compiler to use the full instruction set on this host (gcc/clang -march=native)" OFF)
 option(WITH_MAINTAINER_WARNINGS "Build with project maintainer warnings" OFF)
 option(WITH_CODE_COVERAGE "Enable code coverage reporting" OFF)
-option(WITH_INFLATE_STRICT "Build with strict inflate distance checking" OFF)
-option(WITH_INFLATE_ALLOW_INVALID_DIST "Build with zero fill for inflate invalid distances" OFF)
 
 if(BASEARCH_ARM_FOUND)
     option(WITH_ACLE "Build with ACLE" ON)
@@ -114,8 +112,6 @@ mark_as_advanced(FORCE
     WITH_SSSE3 WITH_SSE4
     WITH_PCLMULQDQ
     WITH_POWER8
-    WITH_INFLATE_STRICT
-    WITH_INFLATE_ALLOW_INVALID_DIST
     INSTALL_UTILS
     )
 
@@ -612,18 +608,6 @@ endif()
 if(NOT WITH_NEW_STRATEGIES)
     add_definitions(-DNO_MEDIUM_STRATEGY)
 endif()
-#
-# Enable inflate compilation options
-#
-if(WITH_INFLATE_STRICT)
-    add_definitions(-DINFLATE_STRICT)
-    message(STATUS "Inflate strict distance checking enabled")
-endif()
-if(WITH_INFLATE_ALLOW_INVALID_DIST)
-    add_definitions(-DINFLATE_ALLOW_INVALID_DISTANCE_TOOFAR_ARRR)
-    message(STATUS "Inflate zero data for invalid distances enabled")
-endif()
-
 
 set(ZLIB_ARCH_SRCS)
 set(ZLIB_ARCH_HDRS)

--- a/README.md
+++ b/README.md
@@ -202,6 +202,4 @@ Advanced Build Options
 | WITH_POWER8                     |                       | Build with POWER8 optimisations                                     | ON                     |
 | WITH_DFLTCC_DEFLATE             | --with-dfltcc-deflate | Use DEFLATE COMPRESSION CALL instruction for compression on IBM Z   | OFF                    |
 | WITH_DFLTCC_INFLATE             | --with-dfltcc-inflate | Use DEFLATE COMPRESSION CALL instruction for decompression on IBM Z | OFF                    |
-| WITH_INFLATE_STRICT             |                       | Build with strict inflate distance checking                         | OFF                    |
-| WITH_INFLATE_ALLOW_INVALID_DIST |                       | Build with zero fill for inflate invalid distances                  | OFF                    |
 | INSTALL_UTILS                   |                       | Copy minigzip and minigzip during install                           | OFF                    |


### PR DESCRIPTION
Instead I now just pass them through CMAKE_C_FLAGS in CI yaml. No reason to support two extra options if we don’t have to.