### PR TITLE
Use mainline codecov repository

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -333,10 +333,8 @@ jobs:
 
     - name: Install codecov.io tools
       if: matrix.codecov
-      # Need to use special fork of codecov-python for Windows
-      # https://github.com/codecov/codecov-python/pull/169
       run: |
-        python -u -m pip install git+https://github.com/nmoinvaz/codecov-python.git@master
+        python -u -m pip install git+https://github.com/codecov/codecov-python.git
 
     - name: Generate project files
       # Shared libaries turned off for qemu ppc* and sparc & reduce code coverage sources


### PR DESCRIPTION
It is no longer necessary to use my fork since codecov has brought their repository up to speed with the necessary changes including retry.