### PR TITLE
Remove ARM crc instruction set from NEONFLAG. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,7 +232,7 @@ else()
                 endif()
                 # NEON
                 if("${ARCH}" MATCHES "aarch64")
-                    set(NEONFLAG "-march=armv8-a+crc+simd")
+                    set(NEONFLAG "-march=armv8-a+simd")
                 else()
                     # Check whether -mfpu=neon is available
                     set(CMAKE_REQUIRED_FLAGS "-mfpu=neon")


### PR DESCRIPTION
The crc instruction set is not used for neon source files. It may have been necessary back when the NEONFLAG was applied to all source files in CMake. Configure script does not apply crc instruction set when setting neon flags.