### PR TITLE
Fix signature of adler32(), adler32_combine(), adler32_combine64() and adler32_z() in compat mode.

### DIFF
--- a/adler32.c
+++ b/adler32.c
@@ -82,7 +82,7 @@ uint32_t adler32_c(uint32_t adler, const unsigned char *buf, size_t len) {
 
 #ifdef ZLIB_COMPAT
 unsigned long ZEXPORT PREFIX(adler32_z)(unsigned long adler, const unsigned char *buf, size_t len) {
-    return (unsigned long) functable.adler32((uint32_t) adler, buf, len);
+    return (unsigned long)functable.adler32((uint32_t)adler, buf, len);
 }
 #else
 uint32_t ZEXPORT PREFIX(adler32_z)(uint32_t adler, const unsigned char *buf, size_t len) {
@@ -93,7 +93,7 @@ uint32_t ZEXPORT PREFIX(adler32_z)(uint32_t adler, const unsigned char *buf, siz
 /* ========================================================================= */
 #ifdef ZLIB_COMPAT
 unsigned long ZEXPORT PREFIX(adler32)(unsigned long adler, const unsigned char *buf, unsigned int len) {
-    return (unsigned long) functable.adler32((uint32_t) adler, buf, len);
+    return (unsigned long)functable.adler32((uint32_t)adler, buf, len);
 }
 #else
 uint32_t ZEXPORT PREFIX(adler32)(uint32_t adler, const unsigned char *buf, uint32_t len) {
@@ -129,11 +129,11 @@ static uint32_t adler32_combine_(uint32_t adler1, uint32_t adler2, z_off64_t len
 /* ========================================================================= */
 #ifdef ZLIB_COMPAT
 unsigned long ZEXPORT PREFIX(adler32_combine)(unsigned long adler1, unsigned long adler2, z_off_t len2) {
-    return (unsigned long) adler32_combine_((uint32_t) adler1, (uint32_t) adler2, len2);
+    return (unsigned long)adler32_combine_((uint32_t)adler1, (uint32_t)adler2, len2);
 }
 
 unsigned long ZEXPORT PREFIX4(adler32_combine)(unsigned long adler1, unsigned long adler2, z_off64_t len2) {
-    return (unsigned long) adler32_combine_((uint32_t) adler1, (uint32_t) adler2, len2);
+    return (unsigned long)adler32_combine_((uint32_t)adler1, (uint32_t)adler2, len2);
 }
 #else
 uint32_t ZEXPORT PREFIX4(adler32_combine)(uint32_t adler1, uint32_t adler2, z_off64_t len2) {

--- a/adler32.c
+++ b/adler32.c
@@ -80,14 +80,26 @@ uint32_t adler32_c(uint32_t adler, const unsigned char *buf, size_t len) {
     return adler | (sum2 << 16);
 }
 
+#ifdef ZLIB_COMPAT
+unsigned long ZEXPORT PREFIX(adler32_z)(unsigned long adler, const unsigned char *buf, size_t len) {
+    return (unsigned long) functable.adler32((uint32_t) adler, buf, len);
+}
+#else
 uint32_t ZEXPORT PREFIX(adler32_z)(uint32_t adler, const unsigned char *buf, size_t len) {
     return functable.adler32(adler, buf, len);
 }
+#endif
 
 /* ========================================================================= */
+#ifdef ZLIB_COMPAT
+unsigned long ZEXPORT PREFIX(adler32)(unsigned long adler, const unsigned char *buf, unsigned int len) {
+    return (unsigned long) functable.adler32((uint32_t) adler, buf, len);
+}
+#else
 uint32_t ZEXPORT PREFIX(adler32)(uint32_t adler, const unsigned char *buf, uint32_t len) {
     return functable.adler32(adler, buf, len);
 }
+#endif
 
 /* ========================================================================= */
 static uint32_t adler32_combine_(uint32_t adler1, uint32_t adler2, z_off64_t len2) {
@@ -116,11 +128,15 @@ static uint32_t adler32_combine_(uint32_t adler1, uint32_t adler2, z_off64_t len
 
 /* ========================================================================= */
 #ifdef ZLIB_COMPAT
-uint32_t ZEXPORT PREFIX(adler32_combine)(uint32_t adler1, uint32_t adler2, z_off_t len2) {
-    return adler32_combine_(adler1, adler2, len2);
+unsigned long ZEXPORT PREFIX(adler32_combine)(unsigned long adler1, unsigned long adler2, z_off_t len2) {
+    return (unsigned long) adler32_combine_((uint32_t) adler1, (uint32_t) adler2, len2);
 }
-#endif
 
+unsigned long ZEXPORT PREFIX4(adler32_combine)(unsigned long adler1, unsigned long adler2, z_off64_t len2) {
+    return (unsigned long) adler32_combine_((uint32_t) adler1, (uint32_t) adler2, len2);
+}
+#else
 uint32_t ZEXPORT PREFIX4(adler32_combine)(uint32_t adler1, uint32_t adler2, z_off64_t len2) {
     return adler32_combine_(adler1, adler2, len2);
 }
+#endif

--- a/zlib.h
+++ b/zlib.h
@@ -1664,7 +1664,7 @@ ZEXTERN unsigned long ZEXPORT adler32(unsigned long adler, const unsigned char *
      if (adler != original_adler) error();
 */
 
-ZEXTERN unsigned long ZEXPORT adler32_z (unsigned long adler, const unsigned char *buf, size_t len);
+ZEXTERN unsigned long ZEXPORT adler32_z(unsigned long adler, const unsigned char *buf, size_t len);
 /*
      Same as adler32(), but with a size_t length.
 */

--- a/zlib.h
+++ b/zlib.h
@@ -1645,7 +1645,7 @@ ZEXTERN void ZEXPORT gzclearerr(gzFile file);
    library.
 */
 
-ZEXTERN uint32_t ZEXPORT adler32(uint32_t adler, const unsigned char *buf, uint32_t len);
+ZEXTERN unsigned long ZEXPORT adler32(unsigned long adler, const unsigned char *buf, unsigned int len);
 /*
      Update a running Adler-32 checksum with the bytes buf[0..len-1] and
    return the updated checksum.  If buf is NULL, this function returns the
@@ -1664,13 +1664,13 @@ ZEXTERN uint32_t ZEXPORT adler32(uint32_t adler, const unsigned char *buf, uint3
      if (adler != original_adler) error();
 */
 
-ZEXTERN uint32_t ZEXPORT adler32_z (uint32_t adler, const unsigned char *buf, size_t len);
+ZEXTERN unsigned long ZEXPORT adler32_z (unsigned long adler, const unsigned char *buf, size_t len);
 /*
      Same as adler32(), but with a size_t length.
 */
 
 /*
-ZEXTERN uint32_t ZEXPORT adler32_combine(uint32_t adler1, uint32_t adler2, z_off_t len2);
+ZEXTERN unsigned long ZEXPORT adler32_combine(unsigned long adler1, unsigned long adler2, z_off_t len2);
 
      Combine two Adler-32 checksums into one.  For two sequences of bytes, seq1
    and seq2 with lengths len1 and len2, Adler-32 checksums were calculated for
@@ -1777,7 +1777,7 @@ ZEXTERN int ZEXPORT gzgetc_(gzFile file);  /* backward compatibility */
    ZEXTERN z_off64_t ZEXPORT gzseek64(gzFile, z_off64_t, int);
    ZEXTERN z_off64_t ZEXPORT gztell64(gzFile);
    ZEXTERN z_off64_t ZEXPORT gzoffset64(gzFile);
-   ZEXTERN uint32_t ZEXPORT adler32_combine64(uint32_t, uint32_t, z_off64_t);
+   ZEXTERN unsigned long ZEXPORT adler32_combine64(unsigned long, unsigned long, z_off64_t);
    ZEXTERN uint32_t ZEXPORT crc32_combine64(uint32_t, uint32_t, z_off64_t);
    ZEXTERN void ZEXPORT crc32_combine_gen64(uint32_t *op, z_off64_t);
 #endif
@@ -1795,7 +1795,7 @@ ZEXTERN int ZEXPORT gzgetc_(gzFile file);  /* backward compatibility */
      ZEXTERN z_off_t ZEXPORT gzseek64(gzFile, z_off_t, int);
      ZEXTERN z_off_t ZEXPORT gztell64(gzFile);
      ZEXTERN z_off_t ZEXPORT gzoffset64(gzFile);
-     ZEXTERN uint32_t ZEXPORT adler32_combine64(uint32_t, uint32_t, z_off_t);
+     ZEXTERN unsigned long ZEXPORT adler32_combine64(unsigned long, unsigned long, z_off_t);
      ZEXTERN uint32_t ZEXPORT crc32_combine64(uint32_t, uint32_t, z_off_t);
      ZEXTERN void ZEXPORT crc32_combine_gen64(uint32_t *op, z_off64_t);
 #  endif
@@ -1804,7 +1804,7 @@ ZEXTERN int ZEXPORT gzgetc_(gzFile file);  /* backward compatibility */
    ZEXTERN z_off_t ZEXPORT gzseek(gzFile, z_off_t, int);
    ZEXTERN z_off_t ZEXPORT gztell(gzFile);
    ZEXTERN z_off_t ZEXPORT gzoffset(gzFile);
-   ZEXTERN uint32_t ZEXPORT adler32_combine(uint32_t, uint32_t, z_off_t);
+   ZEXTERN unsigned long ZEXPORT adler32_combine(unsigned long, unsigned long, z_off_t);
    ZEXTERN uint32_t ZEXPORT crc32_combine(uint32_t, uint32_t, z_off_t);
    ZEXTERN void ZEXPORT crc32_combine_gen(uint32_t *op, z_off_t);
 #endif


### PR DESCRIPTION
* See #700, compat API needs to use "unsigned long" instead of "uint32_t"