### PR TITLE
Fix signature of crc32_combine(), crc32_combine64() and crc32_z() in compat mode.

### DIFF
--- a/crc32.c
+++ b/crc32.c
@@ -33,7 +33,7 @@ const uint32_t * ZEXPORT PREFIX(get_crc_table)(void) {
 unsigned long ZEXPORT PREFIX(crc32_z)(unsigned long crc, const unsigned char *buf, size_t len) {
     if (buf == NULL) return 0;
 
-    return (unsigned long) functable.crc32((uint32_t) crc, buf, len);
+    return (unsigned long)functable.crc32((uint32_t)crc, buf, len);
 }
 #else
 uint32_t ZEXPORT PREFIX(crc32_z)(uint32_t crc, const unsigned char *buf, size_t len) {
@@ -71,7 +71,7 @@ ZLIB_INTERNAL uint32_t crc32_generic(uint32_t crc, const unsigned char *buf, uin
 
 #ifdef ZLIB_COMPAT
 unsigned long ZEXPORT PREFIX(crc32)(unsigned long crc, const unsigned char *buf, unsigned int len) {
-    return (unsigned long) PREFIX(crc32_z)((uint32_t) crc, buf, len);
+    return (unsigned long)PREFIX(crc32_z)((uint32_t)crc, buf, len);
 }
 #else
 uint32_t ZEXPORT PREFIX(crc32)(uint32_t crc, const unsigned char *buf, uint32_t len) {
@@ -191,11 +191,11 @@ static uint32_t crc32_combine_(uint32_t crc1, uint32_t crc2, z_off64_t len2) {
 /* ========================================================================= */
 #ifdef ZLIB_COMPAT
 unsigned long ZEXPORT PREFIX(crc32_combine)(unsigned long crc1, unsigned long crc2, z_off_t len2) {
-    return (unsigned long) crc32_combine_((uint32_t) crc1, (uint32_t) crc2, len2);
+    return (unsigned long)crc32_combine_((uint32_t)crc1, (uint32_t)crc2, len2);
 }
 
 unsigned long ZEXPORT PREFIX4(crc32_combine)(unsigned long crc1, unsigned long crc2, z_off64_t len2) {
-    return (unsigned long) crc32_combine_((uint32_t) crc1, (uint32_t) crc2, len2);
+    return (unsigned long)crc32_combine_((uint32_t)crc1, (uint32_t)crc2, len2);
 }
 #else
 uint32_t ZEXPORT PREFIX4(crc32_combine)(uint32_t crc1, uint32_t crc2, z_off64_t len2) {

--- a/crc32.c
+++ b/crc32.c
@@ -29,11 +29,19 @@ const uint32_t * ZEXPORT PREFIX(get_crc_table)(void) {
     return (const uint32_t *)crc_table;
 }
 
+#ifdef ZLIB_COMPAT
+unsigned long ZEXPORT PREFIX(crc32_z)(unsigned long crc, const unsigned char *buf, size_t len) {
+    if (buf == NULL) return 0;
+
+    return (unsigned long) functable.crc32((uint32_t) crc, buf, len);
+}
+#else
 uint32_t ZEXPORT PREFIX(crc32_z)(uint32_t crc, const unsigned char *buf, size_t len) {
     if (buf == NULL) return 0;
 
     return functable.crc32(crc, buf, len);
 }
+#endif
 /* ========================================================================= */
 #define DO1 crc = crc_table[0][((int)crc ^ (*buf++)) & 0xff] ^ (crc >> 8)
 #define DO8 DO1; DO1; DO1; DO1; DO1; DO1; DO1; DO1
@@ -182,14 +190,18 @@ static uint32_t crc32_combine_(uint32_t crc1, uint32_t crc2, z_off64_t len2) {
 
 /* ========================================================================= */
 #ifdef ZLIB_COMPAT
-uint32_t ZEXPORT PREFIX(crc32_combine)(uint32_t crc1, uint32_t crc2, z_off_t len2) {
-    return crc32_combine_(crc1, crc2, len2);
+unsigned long ZEXPORT PREFIX(crc32_combine)(unsigned long crc1, unsigned long crc2, z_off_t len2) {
+    return (unsigned long) crc32_combine_((uint32_t) crc1, (uint32_t) crc2, len2);
 }
-#endif
 
+unsigned long ZEXPORT PREFIX4(crc32_combine)(unsigned long crc1, unsigned long crc2, z_off64_t len2) {
+    return (unsigned long) crc32_combine_((uint32_t) crc1, (uint32_t) crc2, len2);
+}
+#else
 uint32_t ZEXPORT PREFIX4(crc32_combine)(uint32_t crc1, uint32_t crc2, z_off64_t len2) {
     return crc32_combine_(crc1, crc2, len2);
 }
+#endif
 
 #ifdef X86_PCLMULQDQ_CRC
 #include "arch/x86/x86.h"

--- a/zlib.h
+++ b/zlib.h
@@ -1697,13 +1697,13 @@ ZEXTERN unsigned long ZEXPORT crc32(unsigned long crc, const unsigned char *buf,
      if (crc != original_crc) error();
 */
 
-ZEXTERN uint32_t ZEXPORT crc32_z (uint32_t crc, const unsigned char *buf, size_t len);
+ZEXTERN unsigned long ZEXPORT crc32_z (unsigned long crc, const unsigned char *buf, size_t len);
 /*
      Same as crc32(), but with a size_t length.
 */
 
 /*
-ZEXTERN uint32_t ZEXPORT crc32_combine(uint32_t crc1, uint32_t crc2, z_off64_t len2);
+ZEXTERN unsigned long ZEXPORT crc32_combine(unsigned long crc1, unsigned long crc2, z_off64_t len2);
 
      Combine two CRC-32 check values into one.  For two sequences of bytes,
    seq1 and seq2 with lengths len1 and len2, CRC-32 check values were
@@ -1778,7 +1778,7 @@ ZEXTERN int ZEXPORT gzgetc_(gzFile file);  /* backward compatibility */
    ZEXTERN z_off64_t ZEXPORT gztell64(gzFile);
    ZEXTERN z_off64_t ZEXPORT gzoffset64(gzFile);
    ZEXTERN unsigned long ZEXPORT adler32_combine64(unsigned long, unsigned long, z_off64_t);
-   ZEXTERN uint32_t ZEXPORT crc32_combine64(uint32_t, uint32_t, z_off64_t);
+   ZEXTERN unsigned long ZEXPORT crc32_combine64(unsigned long, unsigned long, z_off64_t);
    ZEXTERN void ZEXPORT crc32_combine_gen64(uint32_t *op, z_off64_t);
 #endif
 
@@ -1796,7 +1796,7 @@ ZEXTERN int ZEXPORT gzgetc_(gzFile file);  /* backward compatibility */
      ZEXTERN z_off_t ZEXPORT gztell64(gzFile);
      ZEXTERN z_off_t ZEXPORT gzoffset64(gzFile);
      ZEXTERN unsigned long ZEXPORT adler32_combine64(unsigned long, unsigned long, z_off_t);
-     ZEXTERN uint32_t ZEXPORT crc32_combine64(uint32_t, uint32_t, z_off_t);
+     ZEXTERN unsigned long ZEXPORT crc32_combine64(unsigned long, unsigned long, z_off_t);
      ZEXTERN void ZEXPORT crc32_combine_gen64(uint32_t *op, z_off64_t);
 #  endif
 #else
@@ -1805,7 +1805,7 @@ ZEXTERN int ZEXPORT gzgetc_(gzFile file);  /* backward compatibility */
    ZEXTERN z_off_t ZEXPORT gztell(gzFile);
    ZEXTERN z_off_t ZEXPORT gzoffset(gzFile);
    ZEXTERN unsigned long ZEXPORT adler32_combine(unsigned long, unsigned long, z_off_t);
-   ZEXTERN uint32_t ZEXPORT crc32_combine(uint32_t, uint32_t, z_off_t);
+   ZEXTERN unsigned long ZEXPORT crc32_combine(unsigned long, unsigned long, z_off_t);
    ZEXTERN void ZEXPORT crc32_combine_gen(uint32_t *op, z_off_t);
 #endif
 

--- a/zlib.h
+++ b/zlib.h
@@ -1697,7 +1697,7 @@ ZEXTERN unsigned long ZEXPORT crc32(unsigned long crc, const unsigned char *buf,
      if (crc != original_crc) error();
 */
 
-ZEXTERN unsigned long ZEXPORT crc32_z (unsigned long crc, const unsigned char *buf, size_t len);
+ZEXTERN unsigned long ZEXPORT crc32_z(unsigned long crc, const unsigned char *buf, size_t len);
 /*
      Same as crc32(), but with a size_t length.
 */


### PR DESCRIPTION
* compat API needs to use "unsigned long" instead of "uint32_t"