### PR TITLE
Reintroduce support for ZLIB_CONST in compat mode.

### DIFF
--- a/compress.c
+++ b/compress.c
@@ -42,7 +42,7 @@ int ZEXPORT PREFIX(compress2)(unsigned char *dest, z_size_t *destLen, const unsi
 
     stream.next_out = dest;
     stream.avail_out = 0;
-    stream.next_in = (const unsigned char *)source;
+    stream.next_in = C_CONST_UCP(source);
     stream.avail_in = 0;
 
     do {

--- a/compress.c
+++ b/compress.c
@@ -42,7 +42,7 @@ int ZEXPORT PREFIX(compress2)(unsigned char *dest, z_size_t *destLen, const unsi
 
     stream.next_out = dest;
     stream.avail_out = 0;
-    stream.next_in = C_CONST_UCP(source);
+    stream.next_in = (z_const unsigned char *)source;
     stream.avail_in = 0;
 
     do {

--- a/deflate.c
+++ b/deflate.c
@@ -468,7 +468,7 @@ int32_t ZEXPORT PREFIX(deflateSetDictionary)(PREFIX3(stream) *strm, const uint8_
     avail = strm->avail_in;
     next = strm->next_in;
     strm->avail_in = dictLength;
-    strm->next_in = C_CONST_UCP(dictionary);
+    strm->next_in = (z_const unsigned char *)dictionary;
     fill_window(s);
     while (s->lookahead >= MIN_MATCH) {
         str = s->strstart;
@@ -484,7 +484,7 @@ int32_t ZEXPORT PREFIX(deflateSetDictionary)(PREFIX3(stream) *strm, const uint8_
     s->lookahead = 0;
     s->prev_length = MIN_MATCH-1;
     s->match_available = 0;
-    strm->next_in = C_CONST_UCP(next);
+    strm->next_in = (z_const unsigned char *)next;
     strm->avail_in = avail;
     s->wrap = wrap;
     return Z_OK;

--- a/deflate.c
+++ b/deflate.c
@@ -468,7 +468,7 @@ int32_t ZEXPORT PREFIX(deflateSetDictionary)(PREFIX3(stream) *strm, const uint8_
     avail = strm->avail_in;
     next = strm->next_in;
     strm->avail_in = dictLength;
-    strm->next_in = (const unsigned char *)dictionary;
+    strm->next_in = C_CONST_UCP(dictionary);
     fill_window(s);
     while (s->lookahead >= MIN_MATCH) {
         str = s->strstart;
@@ -484,7 +484,7 @@ int32_t ZEXPORT PREFIX(deflateSetDictionary)(PREFIX3(stream) *strm, const uint8_
     s->lookahead = 0;
     s->prev_length = MIN_MATCH-1;
     s->match_available = 0;
-    strm->next_in = next;
+    strm->next_in = C_CONST_UCP(next);
     strm->avail_in = avail;
     s->wrap = wrap;
     return Z_OK;

--- a/gzwrite.c
+++ b/gzwrite.c
@@ -212,7 +212,7 @@ static size_t gz_write(gz_state *state, void const *buf, size_t len) {
             return 0;
 
         /* directly compress user buffer to file */
-        state->strm.next_in = (const unsigned char *)buf;
+        state->strm.next_in = C_CONST_UCP(buf);
         do {
             unsigned n = (unsigned)-1;
             if (n > len)

--- a/gzwrite.c
+++ b/gzwrite.c
@@ -212,7 +212,7 @@ static size_t gz_write(gz_state *state, void const *buf, size_t len) {
             return 0;
 
         /* directly compress user buffer to file */
-        state->strm.next_in = C_CONST_UCP(buf);
+        state->strm.next_in = (z_const unsigned char *) buf;
         do {
             unsigned n = (unsigned)-1;
             if (n > len)

--- a/infback.c
+++ b/infback.c
@@ -129,17 +129,17 @@ int32_t ZEXPORT PREFIX(inflateBackInit_)(PREFIX3(stream) *strm, int32_t windowBi
  */
 int32_t ZEXPORT PREFIX(inflateBack)(PREFIX3(stream) *strm, in_func in, void *in_desc, out_func out, void *out_desc) {
     struct inflate_state *state;
-    T_CONST_UCP(next);          /* next input */
-    unsigned char *put;         /* next output */
-    unsigned have, left;        /* available input and output */
-    uint32_t hold;              /* bit buffer */
-    unsigned bits;              /* bits in bit buffer */
-    unsigned copy;              /* number of stored or match bytes to copy */
-    unsigned char *from;        /* where to copy match bytes from */
-    code here;                  /* current decoding table entry */
-    code last;                  /* parent table entry */
-    unsigned len;               /* length to copy for repeats, bits to drop */
-    int32_t ret;                /* return code */
+    z_const unsigned char *next; /* next input */
+    unsigned char *put;          /* next output */
+    unsigned have, left;         /* available input and output */
+    uint32_t hold;               /* bit buffer */
+    unsigned bits;               /* bits in bit buffer */
+    unsigned copy;               /* number of stored or match bytes to copy */
+    unsigned char *from;         /* where to copy match bytes from */
+    code here;                   /* current decoding table entry */
+    code last;                   /* parent table entry */
+    unsigned len;                /* length to copy for repeats, bits to drop */
+    int32_t ret;                 /* return code */
     static const uint16_t order[19] = /* permutation of code lengths */
         {16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15};
 

--- a/infback.c
+++ b/infback.c
@@ -129,7 +129,7 @@ int32_t ZEXPORT PREFIX(inflateBackInit_)(PREFIX3(stream) *strm, int32_t windowBi
  */
 int32_t ZEXPORT PREFIX(inflateBack)(PREFIX3(stream) *strm, in_func in, void *in_desc, out_func out, void *out_desc) {
     struct inflate_state *state;
-    const unsigned char *next;  /* next input */
+    T_CONST_UCP(next);          /* next input */
     unsigned char *put;         /* next output */
     unsigned have, left;        /* available input and output */
     uint32_t hold;              /* bit buffer */

--- a/inffast.c
+++ b/inffast.c
@@ -65,7 +65,7 @@ static inline uint64_t load_64_bits(const unsigned char *in, unsigned bits) {
 void ZLIB_INTERNAL zng_inflate_fast(PREFIX3(stream) *strm, unsigned long start) {
     /* start: inflate()'s starting value for strm->avail_out */
     struct inflate_state *state;
-    T_CONST_UCP(in);            /* local strm->next_in */
+    z_const unsigned char *in;  /* local strm->next_in */
     const unsigned char *last;  /* have enough input while in < last */
     unsigned char *out;         /* local strm->next_out */
     unsigned char *beg;         /* inflate()'s initial strm->next_out */

--- a/inffast.c
+++ b/inffast.c
@@ -65,7 +65,7 @@ static inline uint64_t load_64_bits(const unsigned char *in, unsigned bits) {
 void ZLIB_INTERNAL zng_inflate_fast(PREFIX3(stream) *strm, unsigned long start) {
     /* start: inflate()'s starting value for strm->avail_out */
     struct inflate_state *state;
-    const unsigned char *in;    /* local strm->next_in */
+    T_CONST_UCP(in);            /* local strm->next_in */
     const unsigned char *last;  /* have enough input while in < last */
     unsigned char *out;         /* local strm->next_out */
     unsigned char *beg;         /* inflate()'s initial strm->next_out */

--- a/inflate_p.h
+++ b/inflate_p.h
@@ -52,7 +52,7 @@
     do { \
         strm->next_out = put; \
         strm->avail_out = left; \
-        strm->next_in = next; \
+        strm->next_in = C_CONST_UCP(next); \
         strm->avail_in = have; \
         state->hold = hold; \
         state->bits = bits; \

--- a/inflate_p.h
+++ b/inflate_p.h
@@ -52,7 +52,7 @@
     do { \
         strm->next_out = put; \
         strm->avail_out = left; \
-        strm->next_in = C_CONST_UCP(next); \
+        strm->next_in = (z_const unsigned char *)next; \
         strm->avail_in = have; \
         state->hold = hold; \
         state->bits = bits; \

--- a/test/example.c
+++ b/test/example.c
@@ -249,7 +249,7 @@ void test_deflate(unsigned char *compr, size_t comprLen) {
     err = PREFIX(deflateInit)(&c_stream, Z_DEFAULT_COMPRESSION);
     CHECK_ERR(err, "deflateInit");
 
-    c_stream.next_in  = C_CONST_UCP(hello);
+    c_stream.next_in  = (z_const unsigned char *)hello;
     c_stream.next_out = compr;
 
     while (c_stream.total_in != len && c_stream.total_out < comprLen) {
@@ -282,7 +282,7 @@ void test_inflate(unsigned char *compr, size_t comprLen, unsigned char *uncompr,
     d_stream.zfree = zfree;
     d_stream.opaque = (void *)0;
 
-    d_stream.next_in  = C_CONST_UCP(compr);
+    d_stream.next_in  = compr;
     d_stream.avail_in = 0;
     d_stream.next_out = uncompr;
     d_stream.total_in = 0;
@@ -344,7 +344,7 @@ void test_large_deflate(unsigned char *compr, size_t comprLen, unsigned char *un
     /* At this point, uncompr is still mostly zeroes, so it should compress
      * very well:
      */
-    c_stream.next_in = C_CONST_UCP(uncompr);
+    c_stream.next_in = uncompr;
     c_stream.avail_in = (unsigned int)uncomprLen;
     err = PREFIX(deflate)(&c_stream, Z_NO_FLUSH);
     CHECK_ERR(err, "deflate");
@@ -375,7 +375,7 @@ void test_large_deflate(unsigned char *compr, size_t comprLen, unsigned char *un
     } else {
         PREFIX(deflateParams)(&c_stream, Z_NO_COMPRESSION, Z_DEFAULT_STRATEGY);
     }
-    c_stream.next_in = C_CONST_UCP(compr);
+    c_stream.next_in = compr;
     diff = (unsigned int)(c_stream.next_out - compr);
     c_stream.avail_in = diff;
     err = PREFIX(deflate)(&c_stream, Z_NO_FLUSH);
@@ -405,7 +405,7 @@ void test_large_deflate(unsigned char *compr, size_t comprLen, unsigned char *un
     } else {
         PREFIX(deflateParams)(&c_stream, Z_BEST_COMPRESSION, Z_FILTERED);
     }
-    c_stream.next_in = C_CONST_UCP(uncompr);
+    c_stream.next_in = uncompr;
     c_stream.avail_in = (unsigned int)uncomprLen;
     err = PREFIX(deflate)(&c_stream, Z_NO_FLUSH);
     CHECK_ERR(err, "deflate");
@@ -432,7 +432,7 @@ void test_large_inflate(unsigned char *compr, size_t comprLen, unsigned char *un
     d_stream.zfree = zfree;
     d_stream.opaque = (void *)0;
 
-    d_stream.next_in  = C_CONST_UCP(compr);
+    d_stream.next_in  = compr;
     d_stream.avail_in = (unsigned int)comprLen;
     d_stream.total_in = 0;
     d_stream.total_out = 0;
@@ -474,7 +474,7 @@ void test_flush(unsigned char *compr, z_size_t *comprLen) {
     err = PREFIX(deflateInit)(&c_stream, Z_DEFAULT_COMPRESSION);
     CHECK_ERR(err, "deflateInit");
 
-    c_stream.next_in  = C_CONST_UCP(hello);
+    c_stream.next_in  = (z_const unsigned char *)hello;
     c_stream.next_out = compr;
     c_stream.avail_in = 3;
     c_stream.avail_out = (unsigned int)*comprLen;
@@ -507,7 +507,7 @@ void test_sync(unsigned char *compr, size_t comprLen, unsigned char *uncompr, si
     d_stream.zfree = zfree;
     d_stream.opaque = (void *)0;
 
-    d_stream.next_in  = C_CONST_UCP(compr);
+    d_stream.next_in  = compr;
     d_stream.avail_in = 2; /* just read the zlib header */
 
     err = PREFIX(inflateInit)(&d_stream);
@@ -557,7 +557,7 @@ void test_dict_deflate(unsigned char *compr, size_t comprLen) {
     c_stream.next_out = compr;
     c_stream.avail_out = (unsigned int)comprLen;
 
-    c_stream.next_in = C_CONST_UCP(hello);
+    c_stream.next_in = (z_const unsigned char *)hello;
     c_stream.avail_in = (unsigned int)strlen(hello)+1;
 
     err = PREFIX(deflate)(&c_stream, Z_FINISH);
@@ -582,7 +582,7 @@ void test_dict_inflate(unsigned char *compr, size_t comprLen, unsigned char *unc
     d_stream.zfree = zfree;
     d_stream.opaque = (void *)0;
     d_stream.adler = 0;
-    d_stream.next_in  = C_CONST_UCP(compr);
+    d_stream.next_in  = compr;
     d_stream.avail_in = (unsigned int)comprLen;
 
     err = PREFIX(inflateInit)(&d_stream);
@@ -630,7 +630,7 @@ void test_deflate_bound(void) {
     c_stream.zfree = zfree;
     c_stream.opaque = (voidpf)0;
     c_stream.avail_in = len;
-    c_stream.next_in = C_CONST_UCP(hello);
+    c_stream.next_in = (z_const unsigned char *)hello;
     c_stream.avail_out = 0;
     c_stream.next_out = outBuf;
 
@@ -678,7 +678,7 @@ void test_deflate_copy(unsigned char *compr, size_t comprLen) {
     err = PREFIX(deflateInit)(&c_stream, Z_DEFAULT_COMPRESSION);
     CHECK_ERR(err, "deflateInit");
 
-    c_stream.next_in = C_CONST_UCP(hello);
+    c_stream.next_in = (z_const unsigned char *)hello;
     c_stream.next_out = compr;
 
     while (c_stream.total_in != len && c_stream.total_out < comprLen) {
@@ -728,7 +728,7 @@ void test_deflate_get_dict(unsigned char *compr, size_t comprLen) {
     c_stream.next_out = compr;
     c_stream.avail_out = (uInt)comprLen;
 
-    c_stream.next_in = C_CONST_UCP(hello);
+    c_stream.next_in = (z_const unsigned char *)hello;
     c_stream.avail_in = (unsigned int)strlen(hello)+1;
 
     err = PREFIX(deflate)(&c_stream, Z_FINISH);
@@ -772,7 +772,7 @@ void test_deflate_pending(unsigned char *compr, size_t comprLen) {
     err = PREFIX(deflateInit)(&c_stream, Z_DEFAULT_COMPRESSION);
     CHECK_ERR(err, "deflateInit");
 
-    c_stream.next_in = C_CONST_UCP(hello);
+    c_stream.next_in = (z_const unsigned char *)hello;
     c_stream.next_out = compr;
 
     while (c_stream.total_in != len && c_stream.total_out < comprLen) {
@@ -845,7 +845,7 @@ void test_deflate_prime(unsigned char *compr, size_t comprLen, unsigned char *un
     err = PREFIX(deflatePrime)(&c_stream, 8, 255);
     CHECK_ERR(err, "deflatePrime");
 
-    c_stream.next_in = C_CONST_UCP(hello);
+    c_stream.next_in = (z_const unsigned char *)hello;
     c_stream.avail_in = (uint32_t)len;
     c_stream.next_out = compr;
     c_stream.avail_out = (uint32_t)comprLen;
@@ -869,7 +869,7 @@ void test_deflate_prime(unsigned char *compr, size_t comprLen, unsigned char *un
     d_stream.zfree = zfree;
     d_stream.opaque = (void *)0;
 
-    d_stream.next_in  = C_CONST_UCP(compr);
+    d_stream.next_in  = compr;
     d_stream.avail_in = (uint32_t)c_stream.total_out;
     d_stream.next_out = uncompr;
     d_stream.avail_out = (uint32_t)uncomprLen;
@@ -972,7 +972,7 @@ void test_deflate_tune(unsigned char *compr, size_t comprLen) {
         printf("deflateTune(): OK\n");
     }
 
-    c_stream.next_in = C_CONST_UCP(hello);
+    c_stream.next_in = (z_const unsigned char *)hello;
     c_stream.next_out = compr;
 
     while (c_stream.total_in != len && c_stream.total_out < comprLen) {

--- a/test/example.c
+++ b/test/example.c
@@ -249,7 +249,7 @@ void test_deflate(unsigned char *compr, size_t comprLen) {
     err = PREFIX(deflateInit)(&c_stream, Z_DEFAULT_COMPRESSION);
     CHECK_ERR(err, "deflateInit");
 
-    c_stream.next_in  = (const unsigned char *)hello;
+    c_stream.next_in  = C_CONST_UCP(hello);
     c_stream.next_out = compr;
 
     while (c_stream.total_in != len && c_stream.total_out < comprLen) {
@@ -282,7 +282,7 @@ void test_inflate(unsigned char *compr, size_t comprLen, unsigned char *uncompr,
     d_stream.zfree = zfree;
     d_stream.opaque = (void *)0;
 
-    d_stream.next_in  = (const unsigned char *)compr;
+    d_stream.next_in  = C_CONST_UCP(compr);
     d_stream.avail_in = 0;
     d_stream.next_out = uncompr;
     d_stream.total_in = 0;
@@ -344,7 +344,7 @@ void test_large_deflate(unsigned char *compr, size_t comprLen, unsigned char *un
     /* At this point, uncompr is still mostly zeroes, so it should compress
      * very well:
      */
-    c_stream.next_in = (const unsigned char *)uncompr;
+    c_stream.next_in = C_CONST_UCP(uncompr);
     c_stream.avail_in = (unsigned int)uncomprLen;
     err = PREFIX(deflate)(&c_stream, Z_NO_FLUSH);
     CHECK_ERR(err, "deflate");
@@ -375,7 +375,7 @@ void test_large_deflate(unsigned char *compr, size_t comprLen, unsigned char *un
     } else {
         PREFIX(deflateParams)(&c_stream, Z_NO_COMPRESSION, Z_DEFAULT_STRATEGY);
     }
-    c_stream.next_in = (const unsigned char *)compr;
+    c_stream.next_in = C_CONST_UCP(compr);
     diff = (unsigned int)(c_stream.next_out - compr);
     c_stream.avail_in = diff;
     err = PREFIX(deflate)(&c_stream, Z_NO_FLUSH);
@@ -405,7 +405,7 @@ void test_large_deflate(unsigned char *compr, size_t comprLen, unsigned char *un
     } else {
         PREFIX(deflateParams)(&c_stream, Z_BEST_COMPRESSION, Z_FILTERED);
     }
-    c_stream.next_in = (const unsigned char *)uncompr;
+    c_stream.next_in = C_CONST_UCP(uncompr);
     c_stream.avail_in = (unsigned int)uncomprLen;
     err = PREFIX(deflate)(&c_stream, Z_NO_FLUSH);
     CHECK_ERR(err, "deflate");
@@ -432,7 +432,7 @@ void test_large_inflate(unsigned char *compr, size_t comprLen, unsigned char *un
     d_stream.zfree = zfree;
     d_stream.opaque = (void *)0;
 
-    d_stream.next_in  = (const unsigned char *)compr;
+    d_stream.next_in  = C_CONST_UCP(compr);
     d_stream.avail_in = (unsigned int)comprLen;
     d_stream.total_in = 0;
     d_stream.total_out = 0;
@@ -474,7 +474,7 @@ void test_flush(unsigned char *compr, z_size_t *comprLen) {
     err = PREFIX(deflateInit)(&c_stream, Z_DEFAULT_COMPRESSION);
     CHECK_ERR(err, "deflateInit");
 
-    c_stream.next_in  = (const unsigned char *)hello;
+    c_stream.next_in  = C_CONST_UCP(hello);
     c_stream.next_out = compr;
     c_stream.avail_in = 3;
     c_stream.avail_out = (unsigned int)*comprLen;
@@ -507,7 +507,7 @@ void test_sync(unsigned char *compr, size_t comprLen, unsigned char *uncompr, si
     d_stream.zfree = zfree;
     d_stream.opaque = (void *)0;
 
-    d_stream.next_in  = (const unsigned char *)compr;
+    d_stream.next_in  = C_CONST_UCP(compr);
     d_stream.avail_in = 2; /* just read the zlib header */
 
     err = PREFIX(inflateInit)(&d_stream);
@@ -557,7 +557,7 @@ void test_dict_deflate(unsigned char *compr, size_t comprLen) {
     c_stream.next_out = compr;
     c_stream.avail_out = (unsigned int)comprLen;
 
-    c_stream.next_in = (const unsigned char *)hello;
+    c_stream.next_in = C_CONST_UCP(hello);
     c_stream.avail_in = (unsigned int)strlen(hello)+1;
 
     err = PREFIX(deflate)(&c_stream, Z_FINISH);
@@ -582,7 +582,7 @@ void test_dict_inflate(unsigned char *compr, size_t comprLen, unsigned char *unc
     d_stream.zfree = zfree;
     d_stream.opaque = (void *)0;
     d_stream.adler = 0;
-    d_stream.next_in  = (const unsigned char *)compr;
+    d_stream.next_in  = C_CONST_UCP(compr);
     d_stream.avail_in = (unsigned int)comprLen;
 
     err = PREFIX(inflateInit)(&d_stream);
@@ -630,7 +630,7 @@ void test_deflate_bound(void) {
     c_stream.zfree = zfree;
     c_stream.opaque = (voidpf)0;
     c_stream.avail_in = len;
-    c_stream.next_in = (const unsigned char *)hello;
+    c_stream.next_in = C_CONST_UCP(hello);
     c_stream.avail_out = 0;
     c_stream.next_out = outBuf;
 
@@ -678,7 +678,7 @@ void test_deflate_copy(unsigned char *compr, size_t comprLen) {
     err = PREFIX(deflateInit)(&c_stream, Z_DEFAULT_COMPRESSION);
     CHECK_ERR(err, "deflateInit");
 
-    c_stream.next_in = (const unsigned char *)hello;
+    c_stream.next_in = C_CONST_UCP(hello);
     c_stream.next_out = compr;
 
     while (c_stream.total_in != len && c_stream.total_out < comprLen) {
@@ -728,7 +728,7 @@ void test_deflate_get_dict(unsigned char *compr, size_t comprLen) {
     c_stream.next_out = compr;
     c_stream.avail_out = (uInt)comprLen;
 
-    c_stream.next_in = (const unsigned char *)hello;
+    c_stream.next_in = C_CONST_UCP(hello);
     c_stream.avail_in = (unsigned int)strlen(hello)+1;
 
     err = PREFIX(deflate)(&c_stream, Z_FINISH);
@@ -772,7 +772,7 @@ void test_deflate_pending(unsigned char *compr, size_t comprLen) {
     err = PREFIX(deflateInit)(&c_stream, Z_DEFAULT_COMPRESSION);
     CHECK_ERR(err, "deflateInit");
 
-    c_stream.next_in = (const unsigned char *)hello;
+    c_stream.next_in = C_CONST_UCP(hello);
     c_stream.next_out = compr;
 
     while (c_stream.total_in != len && c_stream.total_out < comprLen) {
@@ -845,7 +845,7 @@ void test_deflate_prime(unsigned char *compr, size_t comprLen, unsigned char *un
     err = PREFIX(deflatePrime)(&c_stream, 8, 255);
     CHECK_ERR(err, "deflatePrime");
 
-    c_stream.next_in = (const unsigned char *)hello;
+    c_stream.next_in = C_CONST_UCP(hello);
     c_stream.avail_in = (uint32_t)len;
     c_stream.next_out = compr;
     c_stream.avail_out = (uint32_t)comprLen;
@@ -869,7 +869,7 @@ void test_deflate_prime(unsigned char *compr, size_t comprLen, unsigned char *un
     d_stream.zfree = zfree;
     d_stream.opaque = (void *)0;
 
-    d_stream.next_in  = (const uint8_t *)compr;
+    d_stream.next_in  = C_CONST_UCP(compr);
     d_stream.avail_in = (uint32_t)c_stream.total_out;
     d_stream.next_out = uncompr;
     d_stream.avail_out = (uint32_t)uncomprLen;
@@ -972,7 +972,7 @@ void test_deflate_tune(unsigned char *compr, size_t comprLen) {
         printf("deflateTune(): OK\n");
     }
 
-    c_stream.next_in = (const unsigned char *)hello;
+    c_stream.next_in = C_CONST_UCP(hello);
     c_stream.next_out = compr;
 
     while (c_stream.total_in != len && c_stream.total_out < comprLen) {

--- a/test/infcover.c
+++ b/test/infcover.c
@@ -451,7 +451,7 @@ static void cover_wrap(void) {
 }
 
 /* input and output functions for inflateBack() */
-static unsigned pull(void *desc, const unsigned char **buf) {
+static unsigned pull(void *desc, z_const unsigned char **buf) {
     static unsigned int next = 0;
     static unsigned char dat[] = {0x63, 0, 2, 0};
     struct inflate_state *state;

--- a/test/minideflate.c
+++ b/test/minideflate.c
@@ -78,7 +78,7 @@ void deflate_params(FILE *fin, FILE *fout, int32_t read_buf_size, int32_t write_
         if (read <= 0)
             break;
 
-        c_stream.next_in  = (const uint8_t *)read_buf;
+        c_stream.next_in  = (z_const uint8_t *)read_buf;
         c_stream.next_out = write_buf;
         c_stream.avail_in = read;
 
@@ -163,7 +163,7 @@ void inflate_params(FILE *fin, FILE *fout, int32_t read_buf_size, int32_t write_
         if (read <= 0)
             break;
 
-        d_stream.next_in  = (const uint8_t *)read_buf;
+        d_stream.next_in  = (z_const uint8_t *)read_buf;
         d_stream.next_out = write_buf;
         d_stream.avail_in = read;
 

--- a/uncompr.c
+++ b/uncompr.c
@@ -43,7 +43,7 @@ int ZEXPORT PREFIX(uncompress2)(unsigned char *dest, z_size_t *destLen, const un
         dest = buf;
     }
 
-    stream.next_in = C_CONST_UCP(source);
+    stream.next_in = (z_const unsigned char *)source;
     stream.avail_in = 0;
     stream.zalloc = NULL;
     stream.zfree = NULL;

--- a/uncompr.c
+++ b/uncompr.c
@@ -43,7 +43,7 @@ int ZEXPORT PREFIX(uncompress2)(unsigned char *dest, z_size_t *destLen, const un
         dest = buf;
     }
 
-    stream.next_in = (const unsigned char *)source;
+    stream.next_in = C_CONST_UCP(source);
     stream.avail_in = 0;
     stream.zalloc = NULL;
     stream.zfree = NULL;

--- a/zbuild.h
+++ b/zbuild.h
@@ -18,15 +18,6 @@
 #  define PREFIX4(x) x ## 64
 #  define zVersion zlibVersion
 #  define z_size_t unsigned long
-#  if ZLIB_CONST
-#    define C_CONST_CP(x)  (const char *) x
-#    define C_CONST_UCP(x) (const unsigned char *) x
-#    define T_CONST_UCP(x) const unsigned char * x
-#  else
-#    define C_CONST_CP(x)  (char *) x
-#    define C_CONST_UCP(x) (unsigned char *) x
-#    define T_CONST_UCP(x) unsigned char * x
-#  endif
 #else
 #  define PREFIX(x) zng_ ## x
 #  define PREFIX2(x) ZLIBNG_ ## x
@@ -34,9 +25,6 @@
 #  define PREFIX4(x) zng_ ## x
 #  define zVersion zlibng_version
 #  define z_size_t size_t
-#  define C_CONST_CP(x)  (const char *) x
-#  define C_CONST_UCP(x) (const unsigned char *) x
-#  define T_CONST_UCP(x) const unsigned char * x
 #endif
 
 #endif

--- a/zbuild.h
+++ b/zbuild.h
@@ -18,6 +18,15 @@
 #  define PREFIX4(x) x ## 64
 #  define zVersion zlibVersion
 #  define z_size_t unsigned long
+#  if ZLIB_CONST
+#    define C_CONST_CP(x)  (const char *) x
+#    define C_CONST_UCP(x) (const unsigned char *) x
+#    define T_CONST_UCP(x) const unsigned char * x
+#  else
+#    define C_CONST_CP(x)  (char *) x
+#    define C_CONST_UCP(x) (unsigned char *) x
+#    define T_CONST_UCP(x) unsigned char * x
+#  endif
 #else
 #  define PREFIX(x) zng_ ## x
 #  define PREFIX2(x) ZLIBNG_ ## x
@@ -25,6 +34,9 @@
 #  define PREFIX4(x) zng_ ## x
 #  define zVersion zlibng_version
 #  define z_size_t size_t
+#  define C_CONST_CP(x)  (const char *) x
+#  define C_CONST_UCP(x) (const unsigned char *) x
+#  define T_CONST_UCP(x) const unsigned char * x
 #endif
 
 #endif

--- a/zconf-ng.h.in
+++ b/zconf-ng.h.in
@@ -25,6 +25,9 @@
 #  define __has_declspec_attribute(x) 0
 #endif
 
+/* Always define z_const as const */
+#define z_const const
+
 /* Maximum value for memLevel in deflateInit2 */
 #ifndef MAX_MEM_LEVEL
 #  define MAX_MEM_LEVEL 9

--- a/zconf.h.in
+++ b/zconf.h.in
@@ -25,6 +25,12 @@
 #  define __has_declspec_attribute(x) 0
 #endif
 
+#if defined(ZLIB_CONST) && !defined(z_const)
+#  define z_const const
+#else
+#  define z_const
+#endif
+
 /* Maximum value for memLevel in deflateInit2 */
 #ifndef MAX_MEM_LEVEL
 #  define MAX_MEM_LEVEL 9

--- a/zlib.h
+++ b/zlib.h
@@ -92,7 +92,7 @@ typedef void  (*free_func)  (void *opaque, void *address);
 struct internal_state;
 
 typedef struct z_stream_s {
-    const unsigned char   *next_in;   /* next input byte */
+    z_const unsigned char *next_in;   /* next input byte */
     uint32_t              avail_in;   /* number of bytes available at next_in */
     size_t                total_in;   /* total number of input bytes read so far */
 
@@ -100,7 +100,7 @@ typedef struct z_stream_s {
     uint32_t              avail_out;  /* remaining free space at next_out */
     size_t                total_out;  /* total number of bytes output so far */
 
-    const char            *msg;       /* last error message, NULL if no error */
+    z_const char          *msg;       /* last error message, NULL if no error */
     struct internal_state *state;     /* not visible by applications */
 
     alloc_func            zalloc;     /* used to allocate the internal state */
@@ -1063,7 +1063,7 @@ ZEXTERN int ZEXPORT inflateBackInit (z_stream *strm, int windowBits, unsigned ch
    the version of the header file.
 */
 
-typedef uint32_t (*in_func) (void *, const unsigned char * *);
+typedef uint32_t (*in_func) (void *, z_const unsigned char * *);
 typedef int (*out_func) (void *, unsigned char *, uint32_t);
 
 ZEXTERN int ZEXPORT inflateBack(z_stream *strm, in_func in, void *in_desc, out_func out, void *out_desc);

--- a/zutil.c
+++ b/zutil.c
@@ -9,17 +9,17 @@
 #  include "gzguts.h"
 #endif
 
-const char * const PREFIX(z_errmsg)[10] = {
-    (const char *)"need dictionary",     /* Z_NEED_DICT       2  */
-    (const char *)"stream end",          /* Z_STREAM_END      1  */
-    (const char *)"",                    /* Z_OK              0  */
-    (const char *)"file error",          /* Z_ERRNO         (-1) */
-    (const char *)"stream error",        /* Z_STREAM_ERROR  (-2) */
-    (const char *)"data error",          /* Z_DATA_ERROR    (-3) */
-    (const char *)"insufficient memory", /* Z_MEM_ERROR     (-4) */
-    (const char *)"buffer error",        /* Z_BUF_ERROR     (-5) */
-    (const char *)"incompatible version",/* Z_VERSION_ERROR (-6) */
-    (const char *)""
+z_const char * const PREFIX(z_errmsg)[10] = {
+    (z_const char *)"need dictionary",     /* Z_NEED_DICT       2  */
+    (z_const char *)"stream end",          /* Z_STREAM_END      1  */
+    (z_const char *)"",                    /* Z_OK              0  */
+    (z_const char *)"file error",          /* Z_ERRNO         (-1) */
+    (z_const char *)"stream error",        /* Z_STREAM_ERROR  (-2) */
+    (z_const char *)"data error",          /* Z_DATA_ERROR    (-3) */
+    (z_const char *)"insufficient memory", /* Z_MEM_ERROR     (-4) */
+    (z_const char *)"buffer error",        /* Z_BUF_ERROR     (-5) */
+    (z_const char *)"incompatible version",/* Z_VERSION_ERROR (-6) */
+    (z_const char *)""
 };
 
 const char zlibng_string[] =

--- a/zutil.h
+++ b/zutil.h
@@ -39,10 +39,10 @@ typedef unsigned char uch; /* Included for compatibility with external code only
 typedef uint16_t ush;      /* Included for compatibility with external code only */
 typedef unsigned long ulg;
 
-extern const char * const PREFIX(z_errmsg)[10]; /* indexed by 2-zlib_error */
+extern z_const char * const PREFIX(z_errmsg)[10]; /* indexed by 2-zlib_error */
 /* (size given to avoid silly warnings with Visual C++) */
 
-#define ERR_MSG(err) C_CONST_CP(PREFIX(z_errmsg)[Z_NEED_DICT-(err)])
+#define ERR_MSG(err) PREFIX(z_errmsg)[Z_NEED_DICT-(err)]
 
 #define ERR_RETURN(strm, err) return (strm->msg = ERR_MSG(err), (err))
 /* To be used only when the state is known to be valid */

--- a/zutil.h
+++ b/zutil.h
@@ -42,7 +42,7 @@ typedef unsigned long ulg;
 extern const char * const PREFIX(z_errmsg)[10]; /* indexed by 2-zlib_error */
 /* (size given to avoid silly warnings with Visual C++) */
 
-#define ERR_MSG(err) PREFIX(z_errmsg)[Z_NEED_DICT-(err)]
+#define ERR_MSG(err) C_CONST_CP(PREFIX(z_errmsg)[Z_NEED_DICT-(err)])
 
 #define ERR_RETURN(strm, err) return (strm->msg = ERR_MSG(err), (err))
 /* To be used only when the state is known to be valid */


### PR DESCRIPTION
* In compat mode, the default should be next_in and msg without const qualified in zstream.

Fixes #703.