### PR TITLE
Use unaligned 32-bit and 64-bit compare in longest_match

### DIFF
--- a/deflate.h
+++ b/deflate.h
@@ -399,8 +399,6 @@ void ZLIB_INTERNAL flush_pending(PREFIX3(streamp) strm);
  * used.
  */
 
-#define TRIGGER_LEVEL 5
-
 /* Bit buffer and compress bits calculation debugging */
 #ifdef ZLIB_DEBUG
 #  define cmpr_bits_add(s, len)     s->compressed_len += (len)


### PR DESCRIPTION
- Use unaligned 32-bit and 64-bit compare based on best match length when searching for matches.
- Move TRIGGER_LEVEL to match_tpl.h since it is only used in longest match.
- Use early return inside match loops instead of cont variable.
- Added back 2 byte check for platforms that don't supported unaligned access.