### PR TITLE
Fix unaligned double word accesses in chunkset_neon on ARMv7

### DIFF
--- a/arch/arm/chunkset_neon.c
+++ b/arch/arm/chunkset_neon.c
@@ -114,12 +114,11 @@ static inline uint8_t *chunkmemset_6(uint8_t *out, uint8_t *from, unsigned dist,
 #endif
 
 static inline void loadchunk(uint8_t const *s, chunk_t *chunk) {
-    *chunk = *(chunk_t *)s;
+    *chunk = vld1q_u8(s);
 }
 
 static inline void storechunk(uint8_t *out, chunk_t *chunk) {
-    /* Cast to chunk_t pointer to avoid compiler error on MSVC ARM */
-    memcpy((chunk_t *)out, chunk, sizeof(chunk_t));
+    vst1q_u8(out, *chunk);
 }
 
 #include "chunkset_tpl.h"


### PR DESCRIPTION
Don't let the compiler switch to 64bit vectors behind our back.

On ARMv7, they have more stringent alignment requirements,
which aren't accounted for.

Fix #708