### PR TITLE
Optimize inflate_fast for a 0.8% speedup

### DIFF
--- a/inffast.c
+++ b/inffast.c
@@ -171,15 +171,13 @@ void ZLIB_INTERNAL zng_inflate_fast(PREFIX3(stream) *strm, unsigned long start) 
         } else if (op & 16) {                     /* length base */
             len = here->val;
             op &= 15;                           /* number of extra bits */
-            if (op) {
-                if (bits < op) {
-                    hold |= load_64_bits(in, bits);
-                    in += 6;
-                    bits += 48;
-                }
-                len += BITS(op);
-                DROPBITS(op);
+            if (bits < op) {
+                hold |= load_64_bits(in, bits);
+                in += 6;
+                bits += 48;
             }
+            len += BITS(op);
+            DROPBITS(op);
             Tracevv((stderr, "inflate:         length %u\n", len));
             if (bits < 15) {
                 hold |= load_64_bits(in, bits);


### PR DESCRIPTION
When inflate_fast checks for extra length bits, it first checks if the
number of extra length bits (in op) is non-zero. However, if the number
of extra length bits is 0, the `bits < op` check will be false, BITS(op)
will be 0, and DROPBITS(op) will do nothing. So, drop the conditional,
for a speedup of about 0.8%.

This makes the handling of extra length bits match the handling of extra
dist bits, which already lacks the extra conditional.