### PR TITLE
test/abicheck.sh: new script to verify abi compatibility with older versions

### DIFF
--- a/.github/workflows/pkgcheck.yml
+++ b/.github/workflows/pkgcheck.yml
@@ -69,7 +69,7 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends ninja-build ${{ matrix.packages }}
+        sudo apt-get install -y --no-install-recommends abigail-tools ninja-build ${{ matrix.packages }}
 
     - name: Install packages (macOS)
       if: runner.os == 'macOS'
@@ -94,4 +94,22 @@ jobs:
         CFLAGS: ${{ matrix.cflags }}
         CHOST: ${{ matrix.chost }}
         CMAKE_ARGS: ${{ matrix.cmake-args }}
+        LDFLAGS: ${{ matrix.ldflags }}
+
+    - name: Check ABI
+      run: |
+        sh test/abicheck.sh --refresh_if
+      env:
+        CC: ${{ matrix.compiler }}
+        CFLAGS: ${{ matrix.cflags }}
+        CHOST: ${{ matrix.chost }}
+        LDFLAGS: ${{ matrix.ldflags }}
+
+    - name: Check ABI (compat)
+      run: |
+        if test "$CHOST" = "powerpc-linux-gnu" || test "$CFLAGS" = "-m32"; then echo "SKIP 32 bit compat broken, see issue 705"; else sh test/abicheck.sh --zlib-compat --refresh_if; fi
+      env:
+        CC: ${{ matrix.compiler }}
+        CFLAGS: ${{ matrix.cflags }}
+        CHOST: ${{ matrix.chost }}
         LDFLAGS: ${{ matrix.ldflags }}

--- a/test/abi/ignore
+++ b/test/abi/ignore
@@ -1,0 +1,12 @@
+# See https://sourceware.org/libabigail/manual/libabigail-concepts.html#suppression-specifications
+
+[suppress_type]
+  name = internal_state
+
+[suppress_type]
+  name_regexp = z_stream.*
+
+# Size varies with version number
+[suppress_variable]
+  name = zlibng_string
+

--- a/test/abi/zlib-v1.2.11-arm-linux-gnueabihf.abi
+++ b/test/abi/zlib-v1.2.11-arm-linux-gnueabihf.abi
@@ -1,0 +1,119 @@
+<abi-corpus path='btmp1/libz.so.1.2.11' architecture='elf-arm' soname='libz.so.1'>
+  <elf-needed>
+    <dependency name='libc.so.6'/>
+    <dependency name='ld-linux-armhf.so.3'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='adler32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='adler32_combine64' version='ZLIB_1.2.3.3' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='adler32_combine' version='ZLIB_1.2.2' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='adler32_z' version='ZLIB_1.2.9' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='compress' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='compress2' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='compressBound' version='ZLIB_1.2.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='crc32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='crc32_combine64' version='ZLIB_1.2.3.3' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='crc32_combine' version='ZLIB_1.2.2' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='crc32_z' version='ZLIB_1.2.9' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflate' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflateBound' version='ZLIB_1.2.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflateCopy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflateEnd' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflateGetDictionary' version='ZLIB_1.2.9' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflateInit2_' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflateInit_' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflateParams' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflatePending' version='ZLIB_1.2.5.1' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflatePrime' version='ZLIB_1.2.0.8' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflateReset' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflateResetKeep' version='ZLIB_1.2.5.2' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflateSetDictionary' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflateSetHeader' version='ZLIB_1.2.2' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflateTune' version='ZLIB_1.2.2.3' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='get_crc_table' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzbuffer' version='ZLIB_1.2.3.5' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzclearerr' version='ZLIB_1.2.0.2' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzclose' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzclose_r' version='ZLIB_1.2.3.5' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzclose_w' version='ZLIB_1.2.3.5' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzdirect' version='ZLIB_1.2.2.3' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzdopen' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzeof' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzerror' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzflush' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzfread' version='ZLIB_1.2.9' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzfwrite' version='ZLIB_1.2.9' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzgetc' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzgetc_' version='ZLIB_1.2.5.2' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzgets' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzoffset64' version='ZLIB_1.2.3.5' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzoffset' version='ZLIB_1.2.3.5' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzopen' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzopen64' version='ZLIB_1.2.3.3' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzprintf' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzputc' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzputs' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzread' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzrewind' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzseek' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzseek64' version='ZLIB_1.2.3.3' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzsetparams' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gztell' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gztell64' version='ZLIB_1.2.3.3' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzungetc' version='ZLIB_1.2.0.2' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzvprintf' version='ZLIB_1.2.7.1' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzwrite' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflate' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateBack' version='ZLIB_1.2.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateBackEnd' version='ZLIB_1.2.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateBackInit_' version='ZLIB_1.2.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateCodesUsed' version='ZLIB_1.2.9' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateCopy' version='ZLIB_1.2.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateEnd' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateGetDictionary' version='ZLIB_1.2.7.1' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateGetHeader' version='ZLIB_1.2.2' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateInit2_' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateInit_' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateMark' version='ZLIB_1.2.3.4' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflatePrime' version='ZLIB_1.2.2.4' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateReset' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateReset2' version='ZLIB_1.2.3.4' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateResetKeep' version='ZLIB_1.2.5.2' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateSetDictionary' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateSync' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateSyncPoint' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateUndermine' version='ZLIB_1.2.3.3' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateValidate' version='ZLIB_1.2.9' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uncompress' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uncompress2' version='ZLIB_1.2.9' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zError' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zlibCompileFlags' version='ZLIB_1.2.0.2' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zlibVersion' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <abi-instr version='1.0' address-size='32' path='src.d/trees.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C99'>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-1'/>
+    <typedef-decl name='uch' type-id='type-id-1' filepath='src.d/zutil.h' line='43' column='1' id='type-id-2'/>
+    <qualified-type-def type-id='type-id-2' const='yes' id='type-id-3'/>
+
+    <array-type-def dimensions='1' type-id='type-id-3' size-in-bits='infinite' id='type-id-4'>
+      <subrange length='infinite' id='type-id-5'/>
+
+    </array-type-def>
+    <qualified-type-def type-id='type-id-4' const='yes' id='type-id-6'/>
+    <var-decl name='_dist_code' type-id='type-id-6' visibility='default' filepath='src.d/deflate.h' line='323' column='1'/>
+    <var-decl name='_length_code' type-id='type-id-6' visibility='default' filepath='src.d/deflate.h' line='322' column='1'/>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='32' path='src.d/zutil.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C99'>
+    <type-decl name='char' size-in-bits='8' id='type-id-7'/>
+    <pointer-type-def type-id='type-id-7' size-in-bits='32' id='type-id-8'/>
+    <qualified-type-def type-id='type-id-8' const='yes' id='type-id-9'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-10'/>
+
+    <array-type-def dimensions='1' type-id='type-id-9' size-in-bits='320' id='type-id-11'>
+      <subrange length='10' type-id='type-id-10' id='type-id-12'/>
+
+    </array-type-def>
+    <qualified-type-def type-id='type-id-11' const='yes' id='type-id-13'/>
+    <var-decl name='z_errmsg' type-id='type-id-13' visibility='default' filepath='src.d/zutil.h' line='49' column='1'/>
+  </abi-instr>
+</abi-corpus>

--- a/test/abi/zlib-v1.2.11-x86_64-linux-gnu.abi
+++ b/test/abi/zlib-v1.2.11-x86_64-linux-gnu.abi
@@ -1,0 +1,1037 @@
+<abi-corpus path='btmp1/libz.so.1.2.11' architecture='elf-amd-x86_64' soname='libz.so.1'>
+  <elf-needed>
+    <dependency name='libc.so.6'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='adler32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='adler32_combine64' version='ZLIB_1.2.3.3' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='adler32_combine' version='ZLIB_1.2.2' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='adler32_z' version='ZLIB_1.2.9' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='compress' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='compress2' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='compressBound' version='ZLIB_1.2.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='crc32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='crc32_combine64' version='ZLIB_1.2.3.3' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='crc32_combine' version='ZLIB_1.2.2' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='crc32_z' version='ZLIB_1.2.9' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflate' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflateBound' version='ZLIB_1.2.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflateCopy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflateEnd' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflateGetDictionary' version='ZLIB_1.2.9' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflateInit2_' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflateInit_' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflateParams' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflatePending' version='ZLIB_1.2.5.1' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflatePrime' version='ZLIB_1.2.0.8' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflateReset' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflateResetKeep' version='ZLIB_1.2.5.2' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflateSetDictionary' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflateSetHeader' version='ZLIB_1.2.2' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflateTune' version='ZLIB_1.2.2.3' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='get_crc_table' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzbuffer' version='ZLIB_1.2.3.5' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzclearerr' version='ZLIB_1.2.0.2' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzclose' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzclose_r' version='ZLIB_1.2.3.5' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzclose_w' version='ZLIB_1.2.3.5' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzdirect' version='ZLIB_1.2.2.3' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzdopen' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzeof' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzerror' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzflush' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzfread' version='ZLIB_1.2.9' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzfwrite' version='ZLIB_1.2.9' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzgetc' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzgetc_' version='ZLIB_1.2.5.2' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzgets' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzoffset64' version='ZLIB_1.2.3.5' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzoffset' version='ZLIB_1.2.3.5' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzopen' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzopen64' version='ZLIB_1.2.3.3' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzprintf' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzputc' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzputs' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzread' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzrewind' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzseek' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzseek64' version='ZLIB_1.2.3.3' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzsetparams' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gztell' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gztell64' version='ZLIB_1.2.3.3' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzungetc' version='ZLIB_1.2.0.2' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzvprintf' version='ZLIB_1.2.7.1' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzwrite' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflate' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateBack' version='ZLIB_1.2.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateBackEnd' version='ZLIB_1.2.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateBackInit_' version='ZLIB_1.2.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateCodesUsed' version='ZLIB_1.2.9' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateCopy' version='ZLIB_1.2.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateEnd' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateGetDictionary' version='ZLIB_1.2.7.1' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateGetHeader' version='ZLIB_1.2.2' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateInit2_' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateInit_' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateMark' version='ZLIB_1.2.3.4' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflatePrime' version='ZLIB_1.2.2.4' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateReset' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateReset2' version='ZLIB_1.2.3.4' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateResetKeep' version='ZLIB_1.2.5.2' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateSetDictionary' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateSync' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateSyncPoint' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateUndermine' version='ZLIB_1.2.3.3' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateValidate' version='ZLIB_1.2.9' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uncompress' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uncompress2' version='ZLIB_1.2.9' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zError' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zlibCompileFlags' version='ZLIB_1.2.0.2' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zlibVersion' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <abi-instr version='1.0' address-size='64' path='src.d/adler32.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C99'>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-1'/>
+    <typedef-decl name='uLong' type-id='type-id-1' filepath='./zconf.h' line='394' column='1' id='type-id-2'/>
+    <type-decl name='long int' size-in-bits='64' id='type-id-3'/>
+    <typedef-decl name='__off64_t' type-id='type-id-3' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='153' column='1' id='type-id-4'/>
+    <typedef-decl name='off64_t' type-id='type-id-4' filepath='/usr/include/x86_64-linux-gnu/sys/types.h' line='92' column='1' id='type-id-5'/>
+    <function-decl name='adler32_combine64' mangled-name='adler32_combine64' filepath='src.d/adler32.c' line='180' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='adler32_combine64@@ZLIB_1.2.3.3'>
+      <parameter type-id='type-id-2' name='adler1' filepath='src.d/adler32.c' line='181' column='1'/>
+      <parameter type-id='type-id-2' name='adler2' filepath='src.d/adler32.c' line='182' column='1'/>
+      <parameter type-id='type-id-5' name='len2' filepath='src.d/adler32.c' line='183' column='1'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <typedef-decl name='__off_t' type-id='type-id-3' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='152' column='1' id='type-id-6'/>
+    <typedef-decl name='off_t' type-id='type-id-6' filepath='/usr/include/x86_64-linux-gnu/sys/types.h' line='85' column='1' id='type-id-7'/>
+    <function-decl name='adler32_combine' mangled-name='adler32_combine' filepath='src.d/adler32.c' line='172' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='adler32_combine@@ZLIB_1.2.2'>
+      <parameter type-id='type-id-2' name='adler1' filepath='src.d/adler32.c' line='173' column='1'/>
+      <parameter type-id='type-id-2' name='adler2' filepath='src.d/adler32.c' line='174' column='1'/>
+      <parameter type-id='type-id-7' name='len2' filepath='src.d/adler32.c' line='175' column='1'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-8'/>
+    <typedef-decl name='Byte' type-id='type-id-8' filepath='./zconf.h' line='391' column='1' id='type-id-9'/>
+    <typedef-decl name='Bytef' type-id='type-id-9' filepath='./zconf.h' line='400' column='1' id='type-id-10'/>
+    <qualified-type-def type-id='type-id-10' const='yes' id='type-id-11'/>
+    <pointer-type-def type-id='type-id-11' size-in-bits='64' id='type-id-12'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-13'/>
+    <typedef-decl name='uInt' type-id='type-id-13' filepath='./zconf.h' line='393' column='1' id='type-id-14'/>
+    <function-decl name='adler32' mangled-name='adler32' filepath='src.d/adler32.c' line='134' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='adler32'>
+      <parameter type-id='type-id-2' name='adler' filepath='src.d/adler32.c' line='135' column='1'/>
+      <parameter type-id='type-id-12' name='buf' filepath='src.d/adler32.c' line='136' column='1'/>
+      <parameter type-id='type-id-14' name='len' filepath='src.d/adler32.c' line='137' column='1'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <typedef-decl name='size_t' type-id='type-id-1' filepath='/usr/lib/gcc/x86_64-linux-gnu/9/include/stddef.h' line='209' column='1' id='type-id-15'/>
+    <typedef-decl name='z_size_t' type-id='type-id-15' filepath='./zconf.h' line='248' column='1' id='type-id-16'/>
+    <function-decl name='adler32_z' mangled-name='adler32_z' filepath='src.d/adler32.c' line='63' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='adler32_z@@ZLIB_1.2.9'>
+      <parameter type-id='type-id-2' name='adler' filepath='src.d/adler32.c' line='64' column='1'/>
+      <parameter type-id='type-id-12' name='buf' filepath='src.d/adler32.c' line='65' column='1'/>
+      <parameter type-id='type-id-16' name='len' filepath='src.d/adler32.c' line='66' column='1'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='src.d/crc32.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C99'>
+    <function-decl name='crc32_combine64' mangled-name='crc32_combine64' filepath='src.d/crc32.c' line='436' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_combine64@@ZLIB_1.2.3.3'>
+      <parameter type-id='type-id-2' name='adler1' filepath='src.d/adler32.c' line='181' column='1'/>
+      <parameter type-id='type-id-2' name='adler2' filepath='src.d/adler32.c' line='182' column='1'/>
+      <parameter type-id='type-id-5' name='len2' filepath='src.d/adler32.c' line='183' column='1'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='crc32_combine' mangled-name='crc32_combine' filepath='src.d/crc32.c' line='428' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_combine@@ZLIB_1.2.2'>
+      <parameter type-id='type-id-2' name='adler1' filepath='src.d/adler32.c' line='173' column='1'/>
+      <parameter type-id='type-id-2' name='adler2' filepath='src.d/adler32.c' line='174' column='1'/>
+      <parameter type-id='type-id-7' name='len2' filepath='src.d/adler32.c' line='175' column='1'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-8' const='yes' id='type-id-17'/>
+    <pointer-type-def type-id='type-id-17' size-in-bits='64' id='type-id-18'/>
+    <function-decl name='crc32' mangled-name='crc32' filepath='src.d/crc32.c' line='237' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32'>
+      <parameter type-id='type-id-1' name='crc' filepath='src.d/crc32.c' line='238' column='1'/>
+      <parameter type-id='type-id-18' name='buf' filepath='src.d/crc32.c' line='239' column='1'/>
+      <parameter type-id='type-id-14' name='len' filepath='src.d/crc32.c' line='240' column='1'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='crc32_z' mangled-name='crc32_z' filepath='src.d/crc32.c' line='202' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_z@@ZLIB_1.2.9'>
+      <parameter type-id='type-id-1' name='crc' filepath='src.d/crc32.c' line='203' column='1'/>
+      <parameter type-id='type-id-18' name='buf' filepath='src.d/crc32.c' line='204' column='1'/>
+      <parameter type-id='type-id-16' name='len' filepath='src.d/crc32.c' line='205' column='1'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <typedef-decl name='z_crc_t' type-id='type-id-13' filepath='./zconf.h' line='429' column='1' id='type-id-19'/>
+    <qualified-type-def type-id='type-id-19' const='yes' id='type-id-20'/>
+    <pointer-type-def type-id='type-id-20' size-in-bits='64' id='type-id-21'/>
+    <function-decl name='get_crc_table' mangled-name='get_crc_table' filepath='src.d/crc32.c' line='188' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='get_crc_table'>
+      <return type-id='type-id-21'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='src.d/deflate.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C99'>
+    <type-decl name='int' size-in-bits='32' id='type-id-22'/>
+    <class-decl name='z_stream_s' size-in-bits='896' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='86' column='1' id='type-id-23'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next_in' type-id='type-id-24' visibility='default' filepath='src.d/zlib.h' line='87' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='avail_in' type-id='type-id-14' visibility='default' filepath='src.d/zlib.h' line='88' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='total_in' type-id='type-id-2' visibility='default' filepath='src.d/zlib.h' line='89' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='next_out' type-id='type-id-24' visibility='default' filepath='src.d/zlib.h' line='91' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='avail_out' type-id='type-id-14' visibility='default' filepath='src.d/zlib.h' line='92' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='total_out' type-id='type-id-2' visibility='default' filepath='src.d/zlib.h' line='93' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='msg' type-id='type-id-25' visibility='default' filepath='src.d/zlib.h' line='95' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='state' type-id='type-id-26' visibility='default' filepath='src.d/zlib.h' line='96' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='zalloc' type-id='type-id-27' visibility='default' filepath='src.d/zlib.h' line='98' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='zfree' type-id='type-id-28' visibility='default' filepath='src.d/zlib.h' line='99' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='opaque' type-id='type-id-29' visibility='default' filepath='src.d/zlib.h' line='100' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='data_type' type-id='type-id-22' visibility='default' filepath='src.d/zlib.h' line='102' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='adler' type-id='type-id-2' visibility='default' filepath='src.d/zlib.h' line='104' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='reserved' type-id='type-id-2' visibility='default' filepath='src.d/zlib.h' line='105' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-10' size-in-bits='64' id='type-id-24'/>
+    <type-decl name='char' size-in-bits='8' id='type-id-30'/>
+    <pointer-type-def type-id='type-id-30' size-in-bits='64' id='type-id-25'/>
+    <class-decl name='internal_state' size-in-bits='47616' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='100' column='1' id='type-id-31'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='strm' type-id='type-id-32' visibility='default' filepath='src.d/deflate.h' line='101' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='status' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='102' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='pending_buf' type-id='type-id-24' visibility='default' filepath='src.d/deflate.h' line='103' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='pending_buf_size' type-id='type-id-33' visibility='default' filepath='src.d/deflate.h' line='104' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='pending_out' type-id='type-id-24' visibility='default' filepath='src.d/deflate.h' line='105' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='pending' type-id='type-id-33' visibility='default' filepath='src.d/deflate.h' line='106' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='wrap' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='107' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='gzhead' type-id='type-id-34' visibility='default' filepath='src.d/deflate.h' line='108' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='gzindex' type-id='type-id-33' visibility='default' filepath='src.d/deflate.h' line='109' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='method' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='110' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='608'>
+        <var-decl name='last_flush' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='111' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='w_size' type-id='type-id-14' visibility='default' filepath='src.d/deflate.h' line='115' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='672'>
+        <var-decl name='w_bits' type-id='type-id-14' visibility='default' filepath='src.d/deflate.h' line='116' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='w_mask' type-id='type-id-14' visibility='default' filepath='src.d/deflate.h' line='117' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='window' type-id='type-id-24' visibility='default' filepath='src.d/deflate.h' line='119' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='window_size' type-id='type-id-33' visibility='default' filepath='src.d/deflate.h' line='129' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='prev' type-id='type-id-35' visibility='default' filepath='src.d/deflate.h' line='134' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='head' type-id='type-id-35' visibility='default' filepath='src.d/deflate.h' line='140' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='ins_h' type-id='type-id-14' visibility='default' filepath='src.d/deflate.h' line='142' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1056'>
+        <var-decl name='hash_size' type-id='type-id-14' visibility='default' filepath='src.d/deflate.h' line='143' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1088'>
+        <var-decl name='hash_bits' type-id='type-id-14' visibility='default' filepath='src.d/deflate.h' line='144' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1120'>
+        <var-decl name='hash_mask' type-id='type-id-14' visibility='default' filepath='src.d/deflate.h' line='145' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1152'>
+        <var-decl name='hash_shift' type-id='type-id-14' visibility='default' filepath='src.d/deflate.h' line='147' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1216'>
+        <var-decl name='block_start' type-id='type-id-3' visibility='default' filepath='src.d/deflate.h' line='154' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='match_length' type-id='type-id-14' visibility='default' filepath='src.d/deflate.h' line='159' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1312'>
+        <var-decl name='prev_match' type-id='type-id-36' visibility='default' filepath='src.d/deflate.h' line='160' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1344'>
+        <var-decl name='match_available' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='161' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1376'>
+        <var-decl name='strstart' type-id='type-id-14' visibility='default' filepath='src.d/deflate.h' line='162' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1408'>
+        <var-decl name='match_start' type-id='type-id-14' visibility='default' filepath='src.d/deflate.h' line='163' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1440'>
+        <var-decl name='lookahead' type-id='type-id-14' visibility='default' filepath='src.d/deflate.h' line='164' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1472'>
+        <var-decl name='prev_length' type-id='type-id-14' visibility='default' filepath='src.d/deflate.h' line='166' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1504'>
+        <var-decl name='max_chain_length' type-id='type-id-14' visibility='default' filepath='src.d/deflate.h' line='171' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1536'>
+        <var-decl name='max_lazy_match' type-id='type-id-14' visibility='default' filepath='src.d/deflate.h' line='177' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1568'>
+        <var-decl name='level' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='188' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1600'>
+        <var-decl name='strategy' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='189' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1632'>
+        <var-decl name='good_match' type-id='type-id-14' visibility='default' filepath='src.d/deflate.h' line='191' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1664'>
+        <var-decl name='nice_match' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='194' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1696'>
+        <var-decl name='dyn_ltree' type-id='type-id-37' visibility='default' filepath='src.d/deflate.h' line='198' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='20032'>
+        <var-decl name='dyn_dtree' type-id='type-id-38' visibility='default' filepath='src.d/deflate.h' line='199' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='21984'>
+        <var-decl name='bl_tree' type-id='type-id-39' visibility='default' filepath='src.d/deflate.h' line='200' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='23232'>
+        <var-decl name='l_desc' type-id='type-id-40' visibility='default' filepath='src.d/deflate.h' line='202' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='23424'>
+        <var-decl name='d_desc' type-id='type-id-40' visibility='default' filepath='src.d/deflate.h' line='203' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='23616'>
+        <var-decl name='bl_desc' type-id='type-id-40' visibility='default' filepath='src.d/deflate.h' line='204' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='23808'>
+        <var-decl name='bl_count' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='206' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='24064'>
+        <var-decl name='heap' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='209' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='42400'>
+        <var-decl name='heap_len' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='210' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='42432'>
+        <var-decl name='heap_max' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='211' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='42464'>
+        <var-decl name='depth' type-id='type-id-43' visibility='default' filepath='src.d/deflate.h' line='216' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47104'>
+        <var-decl name='l_buf' type-id='type-id-44' visibility='default' filepath='src.d/deflate.h' line='220' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47168'>
+        <var-decl name='lit_bufsize' type-id='type-id-14' visibility='default' filepath='src.d/deflate.h' line='222' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47200'>
+        <var-decl name='last_lit' type-id='type-id-14' visibility='default' filepath='src.d/deflate.h' line='242' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47232'>
+        <var-decl name='d_buf' type-id='type-id-45' visibility='default' filepath='src.d/deflate.h' line='244' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47296'>
+        <var-decl name='opt_len' type-id='type-id-33' visibility='default' filepath='src.d/deflate.h' line='250' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47360'>
+        <var-decl name='static_len' type-id='type-id-33' visibility='default' filepath='src.d/deflate.h' line='251' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47424'>
+        <var-decl name='matches' type-id='type-id-14' visibility='default' filepath='src.d/deflate.h' line='252' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47456'>
+        <var-decl name='insert' type-id='type-id-14' visibility='default' filepath='src.d/deflate.h' line='253' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47488'>
+        <var-decl name='bi_buf' type-id='type-id-46' visibility='default' filepath='src.d/deflate.h' line='260' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47520'>
+        <var-decl name='bi_valid' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='264' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47552'>
+        <var-decl name='high_water' type-id='type-id-33' visibility='default' filepath='src.d/deflate.h' line='269' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='z_stream' type-id='type-id-23' filepath='src.d/zlib.h' line='106' column='1' id='type-id-47'/>
+    <pointer-type-def type-id='type-id-47' size-in-bits='64' id='type-id-48'/>
+    <typedef-decl name='z_streamp' type-id='type-id-48' filepath='src.d/zlib.h' line='108' column='1' id='type-id-32'/>
+    <typedef-decl name='ulg' type-id='type-id-1' filepath='src.d/zutil.h' line='47' column='1' id='type-id-33'/>
+    <class-decl name='gz_header_s' size-in-bits='640' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='114' column='1' id='type-id-49'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='text' type-id='type-id-22' visibility='default' filepath='src.d/zlib.h' line='115' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='time' type-id='type-id-2' visibility='default' filepath='src.d/zlib.h' line='116' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='xflags' type-id='type-id-22' visibility='default' filepath='src.d/zlib.h' line='117' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='os' type-id='type-id-22' visibility='default' filepath='src.d/zlib.h' line='118' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='extra' type-id='type-id-24' visibility='default' filepath='src.d/zlib.h' line='119' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='extra_len' type-id='type-id-14' visibility='default' filepath='src.d/zlib.h' line='120' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='extra_max' type-id='type-id-14' visibility='default' filepath='src.d/zlib.h' line='121' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='name' type-id='type-id-24' visibility='default' filepath='src.d/zlib.h' line='122' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='name_max' type-id='type-id-14' visibility='default' filepath='src.d/zlib.h' line='123' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='comment' type-id='type-id-24' visibility='default' filepath='src.d/zlib.h' line='124' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='comm_max' type-id='type-id-14' visibility='default' filepath='src.d/zlib.h' line='125' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='544'>
+        <var-decl name='hcrc' type-id='type-id-22' visibility='default' filepath='src.d/zlib.h' line='126' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='done' type-id='type-id-22' visibility='default' filepath='src.d/zlib.h' line='127' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='gz_header' type-id='type-id-49' filepath='src.d/zlib.h' line='129' column='1' id='type-id-50'/>
+    <pointer-type-def type-id='type-id-50' size-in-bits='64' id='type-id-51'/>
+    <typedef-decl name='gz_headerp' type-id='type-id-51' filepath='src.d/zlib.h' line='131' column='1' id='type-id-34'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-52'/>
+    <typedef-decl name='ush' type-id='type-id-52' filepath='src.d/zutil.h' line='45' column='1' id='type-id-46'/>
+    <typedef-decl name='Pos' type-id='type-id-46' filepath='src.d/deflate.h' line='92' column='1' id='type-id-53'/>
+    <typedef-decl name='Posf' type-id='type-id-53' filepath='src.d/deflate.h' line='93' column='1' id='type-id-54'/>
+    <pointer-type-def type-id='type-id-54' size-in-bits='64' id='type-id-35'/>
+    <typedef-decl name='IPos' type-id='type-id-13' filepath='src.d/deflate.h' line='94' column='1' id='type-id-36'/>
+    <class-decl name='ct_data_s' size-in-bits='32' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='68' column='1' id='type-id-55'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='fc' type-id='type-id-56' visibility='default' filepath='src.d/deflate.h' line='72' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='dl' type-id='type-id-57' visibility='default' filepath='src.d/deflate.h' line='76' column='1'/>
+      </data-member>
+    </class-decl>
+    <union-decl name='__anonymous_union__' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='69' column='1' id='type-id-56'>
+      <data-member access='private'>
+        <var-decl name='freq' type-id='type-id-46' visibility='default' filepath='src.d/deflate.h' line='70' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='code' type-id='type-id-46' visibility='default' filepath='src.d/deflate.h' line='71' column='1'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='__anonymous_union__' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='73' column='1' id='type-id-57'>
+      <data-member access='private'>
+        <var-decl name='dad' type-id='type-id-46' visibility='default' filepath='src.d/deflate.h' line='74' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='len' type-id='type-id-46' visibility='default' filepath='src.d/deflate.h' line='75' column='1'/>
+      </data-member>
+    </union-decl>
+
+    <array-type-def dimensions='1' type-id='type-id-55' size-in-bits='18336' id='type-id-37'>
+      <subrange length='573' type-id='type-id-1' id='type-id-58'/>
+
+    </array-type-def>
+
+    <array-type-def dimensions='1' type-id='type-id-55' size-in-bits='1952' id='type-id-38'>
+      <subrange length='61' type-id='type-id-1' id='type-id-59'/>
+
+    </array-type-def>
+
+    <array-type-def dimensions='1' type-id='type-id-55' size-in-bits='1248' id='type-id-39'>
+      <subrange length='39' type-id='type-id-1' id='type-id-60'/>
+
+    </array-type-def>
+    <class-decl name='tree_desc_s' size-in-bits='192' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='86' column='1' id='type-id-40'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dyn_tree' type-id='type-id-61' visibility='default' filepath='src.d/deflate.h' line='87' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='max_code' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='88' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='stat_desc' type-id='type-id-62' visibility='default' filepath='src.d/deflate.h' line='89' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='ct_data' type-id='type-id-55' filepath='src.d/deflate.h' line='77' column='1' id='type-id-63'/>
+    <pointer-type-def type-id='type-id-63' size-in-bits='64' id='type-id-61'/>
+    <class-decl name='static_tree_desc_s' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-64'/>
+    <typedef-decl name='static_tree_desc' type-id='type-id-64' filepath='src.d/deflate.h' line='84' column='1' id='type-id-65'/>
+    <qualified-type-def type-id='type-id-65' const='yes' id='type-id-66'/>
+    <pointer-type-def type-id='type-id-66' size-in-bits='64' id='type-id-62'/>
+
+    <array-type-def dimensions='1' type-id='type-id-46' size-in-bits='256' id='type-id-41'>
+      <subrange length='16' type-id='type-id-1' id='type-id-67'/>
+
+    </array-type-def>
+
+    <array-type-def dimensions='1' type-id='type-id-22' size-in-bits='18336' id='type-id-42'>
+      <subrange length='573' type-id='type-id-1' id='type-id-58'/>
+
+    </array-type-def>
+    <typedef-decl name='uch' type-id='type-id-8' filepath='src.d/zutil.h' line='43' column='1' id='type-id-68'/>
+
+    <array-type-def dimensions='1' type-id='type-id-68' size-in-bits='4584' id='type-id-43'>
+      <subrange length='573' type-id='type-id-1' id='type-id-58'/>
+
+    </array-type-def>
+    <typedef-decl name='uchf' type-id='type-id-68' filepath='src.d/zutil.h' line='44' column='1' id='type-id-69'/>
+    <pointer-type-def type-id='type-id-69' size-in-bits='64' id='type-id-44'/>
+    <typedef-decl name='ushf' type-id='type-id-46' filepath='src.d/zutil.h' line='46' column='1' id='type-id-70'/>
+    <pointer-type-def type-id='type-id-70' size-in-bits='64' id='type-id-45'/>
+    <pointer-type-def type-id='type-id-31' size-in-bits='64' id='type-id-26'/>
+    <type-decl name='void' id='type-id-71'/>
+    <pointer-type-def type-id='type-id-71' size-in-bits='64' id='type-id-72'/>
+    <typedef-decl name='voidpf' type-id='type-id-72' filepath='./zconf.h' line='409' column='1' id='type-id-29'/>
+    <pointer-type-def type-id='type-id-73' size-in-bits='64' id='type-id-74'/>
+    <typedef-decl name='alloc_func' type-id='type-id-74' filepath='src.d/zlib.h' line='81' column='1' id='type-id-27'/>
+    <pointer-type-def type-id='type-id-75' size-in-bits='64' id='type-id-76'/>
+    <typedef-decl name='free_func' type-id='type-id-76' filepath='src.d/zlib.h' line='82' column='1' id='type-id-28'/>
+    <function-decl name='deflateCopy' mangled-name='deflateCopy' filepath='src.d/deflate.c' line='1102' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateCopy'>
+      <parameter type-id='type-id-32' name='dest' filepath='src.d/deflate.c' line='1103' column='1'/>
+      <parameter type-id='type-id-32' name='source' filepath='src.d/deflate.c' line='1104' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='deflateEnd' mangled-name='deflateEnd' filepath='src.d/deflate.c' line='1076' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateEnd'>
+      <parameter type-id='type-id-32' name='strm' filepath='src.d/deflate.c' line='1077' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='deflate' mangled-name='deflate' filepath='src.d/deflate.c' line='763' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflate'>
+      <parameter type-id='type-id-32' name='strm' filepath='src.d/deflate.c' line='764' column='1'/>
+      <parameter type-id='type-id-22' name='flush' filepath='src.d/deflate.c' line='765' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='deflateBound' mangled-name='deflateBound' filepath='src.d/deflate.c' line='652' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateBound@@ZLIB_1.2.0'>
+      <parameter type-id='type-id-32' name='strm' filepath='src.d/deflate.c' line='653' column='1'/>
+      <parameter type-id='type-id-2' name='sourceLen' filepath='src.d/deflate.c' line='654' column='1'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='deflateTune' mangled-name='deflateTune' filepath='src.d/deflate.c' line='617' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateTune@@ZLIB_1.2.2.3'>
+      <parameter type-id='type-id-32' name='strm' filepath='src.d/deflate.c' line='618' column='1'/>
+      <parameter type-id='type-id-22' name='good_length' filepath='src.d/deflate.c' line='619' column='1'/>
+      <parameter type-id='type-id-22' name='max_lazy' filepath='src.d/deflate.c' line='620' column='1'/>
+      <parameter type-id='type-id-22' name='nice_length' filepath='src.d/deflate.c' line='621' column='1'/>
+      <parameter type-id='type-id-22' name='max_chain' filepath='src.d/deflate.c' line='622' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='deflateParams' mangled-name='deflateParams' filepath='src.d/deflate.c' line='568' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateParams'>
+      <parameter type-id='type-id-32' name='strm' filepath='src.d/deflate.c' line='569' column='1'/>
+      <parameter type-id='type-id-22' name='level' filepath='src.d/deflate.c' line='570' column='1'/>
+      <parameter type-id='type-id-22' name='strategy' filepath='src.d/deflate.c' line='571' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='deflatePrime' mangled-name='deflatePrime' filepath='src.d/deflate.c' line='542' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflatePrime@@ZLIB_1.2.0.8'>
+      <parameter type-id='type-id-32' name='strm' filepath='src.d/deflate.c' line='543' column='1'/>
+      <parameter type-id='type-id-22' name='bits' filepath='src.d/deflate.c' line='544' column='1'/>
+      <parameter type-id='type-id-22' name='value' filepath='src.d/deflate.c' line='545' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-13' size-in-bits='64' id='type-id-77'/>
+    <pointer-type-def type-id='type-id-22' size-in-bits='64' id='type-id-78'/>
+    <function-decl name='deflatePending' mangled-name='deflatePending' filepath='src.d/deflate.c' line='528' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflatePending@@ZLIB_1.2.5.1'>
+      <parameter type-id='type-id-32' name='strm' filepath='src.d/deflate.c' line='531' column='1'/>
+      <parameter type-id='type-id-77' name='pending' filepath='src.d/deflate.c' line='529' column='1'/>
+      <parameter type-id='type-id-78' name='bits' filepath='src.d/deflate.c' line='530' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='deflateSetHeader' mangled-name='deflateSetHeader' filepath='src.d/deflate.c' line='517' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateSetHeader@@ZLIB_1.2.2'>
+      <parameter type-id='type-id-32' name='strm' filepath='src.d/deflate.c' line='518' column='1'/>
+      <parameter type-id='type-id-34' name='head' filepath='src.d/deflate.c' line='519' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='deflateReset' mangled-name='deflateReset' filepath='src.d/deflate.c' line='505' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateReset'>
+      <parameter type-id='type-id-32' name='strm' filepath='src.d/deflate.c' line='1077' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='deflateResetKeep' mangled-name='deflateResetKeep' filepath='src.d/deflate.c' line='467' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateResetKeep@@ZLIB_1.2.5.2'>
+      <parameter type-id='type-id-32' name='strm' filepath='src.d/deflate.c' line='1077' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-14' size-in-bits='64' id='type-id-79'/>
+    <function-decl name='deflateGetDictionary' mangled-name='deflateGetDictionary' filepath='src.d/deflate.c' line='445' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateGetDictionary@@ZLIB_1.2.9'>
+      <parameter type-id='type-id-32' name='strm' filepath='src.d/deflate.c' line='446' column='1'/>
+      <parameter type-id='type-id-24' name='dictionary' filepath='src.d/deflate.c' line='447' column='1'/>
+      <parameter type-id='type-id-79' name='dictLength' filepath='src.d/deflate.c' line='448' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='deflateSetDictionary' mangled-name='deflateSetDictionary' filepath='src.d/deflate.c' line='376' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateSetDictionary'>
+      <parameter type-id='type-id-32' name='strm' filepath='src.d/deflate.c' line='377' column='1'/>
+      <parameter type-id='type-id-12' name='dictionary' filepath='src.d/deflate.c' line='378' column='1'/>
+      <parameter type-id='type-id-14' name='dictLength' filepath='src.d/deflate.c' line='379' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <qualified-type-def type-id='type-id-30' const='yes' id='type-id-80'/>
+    <pointer-type-def type-id='type-id-80' size-in-bits='64' id='type-id-81'/>
+    <function-decl name='deflateInit2_' mangled-name='deflateInit2_' filepath='src.d/deflate.c' line='240' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateInit2_'>
+      <parameter type-id='type-id-32' name='strm' filepath='src.d/deflate.c' line='242' column='1'/>
+      <parameter type-id='type-id-22' name='level' filepath='src.d/deflate.c' line='243' column='1'/>
+      <parameter type-id='type-id-22' name='method' filepath='src.d/deflate.c' line='244' column='1'/>
+      <parameter type-id='type-id-22' name='windowBits' filepath='src.d/deflate.c' line='245' column='1'/>
+      <parameter type-id='type-id-22' name='memLevel' filepath='src.d/deflate.c' line='246' column='1'/>
+      <parameter type-id='type-id-22' name='strategy' filepath='src.d/deflate.c' line='247' column='1'/>
+      <parameter type-id='type-id-81' name='version' filepath='src.d/deflate.c' line='248' column='1'/>
+      <parameter type-id='type-id-22' name='stream_size' filepath='src.d/deflate.c' line='249' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='deflateInit_' mangled-name='deflateInit_' filepath='src.d/deflate.c' line='228' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateInit_'>
+      <parameter type-id='type-id-32' name='strm' filepath='src.d/deflate.c' line='229' column='1'/>
+      <parameter type-id='type-id-22' name='level' filepath='src.d/deflate.c' line='230' column='1'/>
+      <parameter type-id='type-id-81' name='version' filepath='src.d/deflate.c' line='231' column='1'/>
+      <parameter type-id='type-id-22' name='stream_size' filepath='src.d/deflate.c' line='232' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-73'>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-14'/>
+      <parameter type-id='type-id-14'/>
+      <return type-id='type-id-29'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-75'>
+      <parameter type-id='type-id-29'/>
+      <parameter type-id='type-id-29'/>
+      <return type-id='type-id-71'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='src.d/infback.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C99'>
+    <function-decl name='inflateBackEnd' mangled-name='inflateBackEnd' filepath='src.d/infback.c' line='631' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateBackEnd@@ZLIB_1.2.0'>
+      <parameter type-id='type-id-32' name='strm' filepath='src.d/infback.c' line='632' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-8' size-in-bits='64' id='type-id-82'/>
+    <pointer-type-def type-id='type-id-82' size-in-bits='64' id='type-id-83'/>
+    <pointer-type-def type-id='type-id-84' size-in-bits='64' id='type-id-85'/>
+    <typedef-decl name='in_func' type-id='type-id-85' filepath='src.d/zlib.h' line='1092' column='1' id='type-id-86'/>
+    <pointer-type-def type-id='type-id-87' size-in-bits='64' id='type-id-88'/>
+    <typedef-decl name='out_func' type-id='type-id-88' filepath='src.d/zlib.h' line='1094' column='1' id='type-id-89'/>
+    <function-decl name='inflateBack' mangled-name='inflateBack' filepath='src.d/infback.c' line='250' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateBack@@ZLIB_1.2.0'>
+      <parameter type-id='type-id-32' name='strm' filepath='src.d/infback.c' line='251' column='1'/>
+      <parameter type-id='type-id-86' name='in' filepath='src.d/infback.c' line='252' column='1'/>
+      <parameter type-id='type-id-72' name='in_desc' filepath='src.d/infback.c' line='253' column='1'/>
+      <parameter type-id='type-id-89' name='out' filepath='src.d/infback.c' line='254' column='1'/>
+      <parameter type-id='type-id-72' name='out_desc' filepath='src.d/infback.c' line='255' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='inflateBackInit_' mangled-name='inflateBackInit_' filepath='src.d/infback.c' line='28' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateBackInit_@@ZLIB_1.2.0'>
+      <parameter type-id='type-id-32' name='strm' filepath='src.d/infback.c' line='29' column='1'/>
+      <parameter type-id='type-id-22' name='windowBits' filepath='src.d/infback.c' line='30' column='1'/>
+      <parameter type-id='type-id-82' name='window' filepath='src.d/infback.c' line='31' column='1'/>
+      <parameter type-id='type-id-81' name='version' filepath='src.d/infback.c' line='32' column='1'/>
+      <parameter type-id='type-id-22' name='stream_size' filepath='src.d/infback.c' line='33' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-87'>
+      <parameter type-id='type-id-72'/>
+      <parameter type-id='type-id-82'/>
+      <parameter type-id='type-id-13'/>
+      <return type-id='type-id-22'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-84'>
+      <parameter type-id='type-id-72'/>
+      <parameter type-id='type-id-83'/>
+      <return type-id='type-id-13'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='src.d/inflate.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C99'>
+    <function-decl name='inflateCodesUsed' mangled-name='inflateCodesUsed' filepath='src.d/inflate.c' line='1554' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateCodesUsed@@ZLIB_1.2.9'>
+      <parameter type-id='type-id-32' name='strm' filepath='src.d/inflate.c' line='1555' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='inflateMark' mangled-name='inflateMark' filepath='src.d/inflate.c' line='1541' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateMark@@ZLIB_1.2.3.4'>
+      <parameter type-id='type-id-32' name='strm' filepath='src.d/inflate.c' line='1542' column='1'/>
+      <return type-id='type-id-3'/>
+    </function-decl>
+    <function-decl name='inflateValidate' mangled-name='inflateValidate' filepath='src.d/inflate.c' line='1526' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateValidate@@ZLIB_1.2.9'>
+      <parameter type-id='type-id-32' name='strm' filepath='src.d/inflate.c' line='1527' column='1'/>
+      <parameter type-id='type-id-22' name='check' filepath='src.d/inflate.c' line='1528' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='inflateUndermine' mangled-name='inflateUndermine' filepath='src.d/inflate.c' line='1508' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateUndermine@@ZLIB_1.2.3.3'>
+      <parameter type-id='type-id-32' name='strm' filepath='src.d/inflate.c' line='1527' column='1'/>
+      <parameter type-id='type-id-22' name='check' filepath='src.d/inflate.c' line='1528' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='inflateCopy' mangled-name='inflateCopy' filepath='src.d/inflate.c' line='1461' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateCopy@@ZLIB_1.2.0'>
+      <parameter type-id='type-id-32' name='dest' filepath='src.d/inflate.c' line='1462' column='1'/>
+      <parameter type-id='type-id-32' name='source' filepath='src.d/inflate.c' line='1463' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='inflateSyncPoint' mangled-name='inflateSyncPoint' filepath='src.d/inflate.c' line='1451' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateSyncPoint'>
+      <parameter type-id='type-id-32' name='strm' filepath='src.d/inflate.c' line='1452' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='inflateSync' mangled-name='inflateSync' filepath='src.d/inflate.c' line='1400' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateSync'>
+      <parameter type-id='type-id-32' name='strm' filepath='src.d/inflate.c' line='1401' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='inflateGetHeader' mangled-name='inflateGetHeader' filepath='src.d/inflate.c' line='1349' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateGetHeader@@ZLIB_1.2.2'>
+      <parameter type-id='type-id-32' name='strm' filepath='src.d/inflate.c' line='1350' column='1'/>
+      <parameter type-id='type-id-34' name='head' filepath='src.d/inflate.c' line='1351' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='inflateSetDictionary' mangled-name='inflateSetDictionary' filepath='src.d/inflate.c' line='1314' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateSetDictionary'>
+      <parameter type-id='type-id-32' name='strm' filepath='src.d/inflate.c' line='1315' column='1'/>
+      <parameter type-id='type-id-12' name='dictionary' filepath='src.d/inflate.c' line='1316' column='1'/>
+      <parameter type-id='type-id-14' name='dictLength' filepath='src.d/inflate.c' line='1317' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='inflateGetDictionary' mangled-name='inflateGetDictionary' filepath='src.d/inflate.c' line='1291' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateGetDictionary@@ZLIB_1.2.7.1'>
+      <parameter type-id='type-id-32' name='strm' filepath='src.d/inflate.c' line='1292' column='1'/>
+      <parameter type-id='type-id-24' name='dictionary' filepath='src.d/inflate.c' line='1293' column='1'/>
+      <parameter type-id='type-id-79' name='dictLength' filepath='src.d/inflate.c' line='1294' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='inflateEnd' mangled-name='inflateEnd' filepath='src.d/inflate.c' line='1277' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateEnd'>
+      <parameter type-id='type-id-32' name='strm' filepath='src.d/inflate.c' line='1452' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='inflate' mangled-name='inflate' filepath='src.d/inflate.c' line='622' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflate'>
+      <parameter type-id='type-id-32' name='strm' filepath='src.d/inflate.c' line='623' column='1'/>
+      <parameter type-id='type-id-22' name='flush' filepath='src.d/inflate.c' line='624' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='inflatePrime' mangled-name='inflatePrime' filepath='src.d/inflate.c' line='247' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflatePrime@@ZLIB_1.2.2.4'>
+      <parameter type-id='type-id-32' name='strm' filepath='src.d/inflate.c' line='248' column='1'/>
+      <parameter type-id='type-id-22' name='bits' filepath='src.d/inflate.c' line='249' column='1'/>
+      <parameter type-id='type-id-22' name='value' filepath='src.d/inflate.c' line='250' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='inflateInit_' mangled-name='inflateInit_' filepath='src.d/inflate.c' line='239' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateInit_'>
+      <parameter type-id='type-id-32' name='strm' filepath='src.d/inflate.c' line='240' column='1'/>
+      <parameter type-id='type-id-81' name='version' filepath='src.d/inflate.c' line='241' column='1'/>
+      <parameter type-id='type-id-22' name='stream_size' filepath='src.d/inflate.c' line='242' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='inflateInit2_' mangled-name='inflateInit2_' filepath='src.d/inflate.c' line='195' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateInit2_'>
+      <parameter type-id='type-id-32' name='strm' filepath='src.d/inflate.c' line='196' column='1'/>
+      <parameter type-id='type-id-22' name='windowBits' filepath='src.d/inflate.c' line='197' column='1'/>
+      <parameter type-id='type-id-81' name='version' filepath='src.d/inflate.c' line='198' column='1'/>
+      <parameter type-id='type-id-22' name='stream_size' filepath='src.d/inflate.c' line='199' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='inflateReset2' mangled-name='inflateReset2' filepath='src.d/inflate.c' line='157' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateReset2@@ZLIB_1.2.3.4'>
+      <parameter type-id='type-id-32' name='strm' filepath='src.d/inflate.c' line='158' column='1'/>
+      <parameter type-id='type-id-22' name='windowBits' filepath='src.d/inflate.c' line='159' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='inflateReset' mangled-name='inflateReset' filepath='src.d/inflate.c' line='144' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateReset'>
+      <parameter type-id='type-id-32' name='strm' filepath='src.d/inflate.c' line='1452' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='inflateResetKeep' mangled-name='inflateResetKeep' filepath='src.d/inflate.c' line='119' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateResetKeep@@ZLIB_1.2.5.2'>
+      <parameter type-id='type-id-32' name='strm' filepath='src.d/inflate.c' line='1452' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='src.d/trees.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C99'>
+    <qualified-type-def type-id='type-id-68' const='yes' id='type-id-90'/>
+
+    <array-type-def dimensions='1' type-id='type-id-90' size-in-bits='infinite' id='type-id-91'>
+      <subrange length='infinite' id='type-id-92'/>
+
+    </array-type-def>
+    <qualified-type-def type-id='type-id-91' const='yes' id='type-id-93'/>
+    <var-decl name='_dist_code' type-id='type-id-93' visibility='default' filepath='src.d/deflate.h' line='323' column='1'/>
+    <var-decl name='_length_code' type-id='type-id-93' visibility='default' filepath='src.d/deflate.h' line='322' column='1'/>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='src.d/zutil.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C99'>
+    <qualified-type-def type-id='type-id-25' const='yes' id='type-id-94'/>
+
+    <array-type-def dimensions='1' type-id='type-id-94' size-in-bits='640' id='type-id-95'>
+      <subrange length='10' type-id='type-id-1' id='type-id-96'/>
+
+    </array-type-def>
+    <qualified-type-def type-id='type-id-95' const='yes' id='type-id-97'/>
+    <var-decl name='z_errmsg' type-id='type-id-97' visibility='default' filepath='src.d/zutil.h' line='49' column='1'/>
+    <function-decl name='zError' mangled-name='zError' filepath='src.d/zutil.c' line='133' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zError'>
+      <parameter type-id='type-id-22' name='err' filepath='src.d/zutil.c' line='134' column='1'/>
+      <return type-id='type-id-81'/>
+    </function-decl>
+    <function-decl name='zlibCompileFlags' mangled-name='zlibCompileFlags' filepath='src.d/zutil.c' line='32' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zlibCompileFlags@@ZLIB_1.2.0.2'>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <function-decl name='zlibVersion' mangled-name='zlibVersion' filepath='src.d/zutil.c' line='27' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zlibVersion'>
+      <return type-id='type-id-81'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='src.d/compress.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C99'>
+    <function-decl name='compressBound' mangled-name='compressBound' filepath='src.d/compress.c' line='81' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='compressBound@@ZLIB_1.2.0'>
+      <parameter type-id='type-id-2' name='sourceLen' filepath='src.d/compress.c' line='82' column='1'/>
+      <return type-id='type-id-2'/>
+    </function-decl>
+    <typedef-decl name='uLongf' type-id='type-id-2' filepath='./zconf.h' line='405' column='1' id='type-id-98'/>
+    <pointer-type-def type-id='type-id-98' size-in-bits='64' id='type-id-99'/>
+    <function-decl name='compress' mangled-name='compress' filepath='src.d/compress.c' line='68' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='compress'>
+      <parameter type-id='type-id-24' name='dest' filepath='src.d/compress.c' line='69' column='1'/>
+      <parameter type-id='type-id-99' name='destLen' filepath='src.d/compress.c' line='70' column='1'/>
+      <parameter type-id='type-id-12' name='source' filepath='src.d/compress.c' line='71' column='1'/>
+      <parameter type-id='type-id-2' name='sourceLen' filepath='src.d/compress.c' line='72' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='compress2' mangled-name='compress2' filepath='src.d/compress.c' line='22' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='compress2'>
+      <parameter type-id='type-id-24' name='dest' filepath='src.d/compress.c' line='23' column='1'/>
+      <parameter type-id='type-id-99' name='destLen' filepath='src.d/compress.c' line='24' column='1'/>
+      <parameter type-id='type-id-12' name='source' filepath='src.d/compress.c' line='25' column='1'/>
+      <parameter type-id='type-id-2' name='sourceLen' filepath='src.d/compress.c' line='26' column='1'/>
+      <parameter type-id='type-id-22' name='level' filepath='src.d/compress.c' line='27' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='src.d/uncompr.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C99'>
+    <function-decl name='uncompress' mangled-name='uncompress' filepath='src.d/uncompr.c' line='86' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uncompress'>
+      <parameter type-id='type-id-24' name='dest' filepath='src.d/compress.c' line='69' column='1'/>
+      <parameter type-id='type-id-99' name='destLen' filepath='src.d/compress.c' line='70' column='1'/>
+      <parameter type-id='type-id-12' name='source' filepath='src.d/compress.c' line='71' column='1'/>
+      <parameter type-id='type-id-2' name='sourceLen' filepath='src.d/compress.c' line='72' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-2' size-in-bits='64' id='type-id-100'/>
+    <function-decl name='uncompress2' mangled-name='uncompress2' filepath='src.d/uncompr.c' line='27' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uncompress2@@ZLIB_1.2.9'>
+      <parameter type-id='type-id-24' name='dest' filepath='src.d/uncompr.c' line='28' column='1'/>
+      <parameter type-id='type-id-99' name='destLen' filepath='src.d/uncompr.c' line='29' column='1'/>
+      <parameter type-id='type-id-12' name='source' filepath='src.d/uncompr.c' line='30' column='1'/>
+      <parameter type-id='type-id-100' name='sourceLen' filepath='src.d/uncompr.c' line='31' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='src.d/gzclose.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C99'>
+    <class-decl name='gzFile_s' size-in-bits='192' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='1817' column='1' id='type-id-101'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='have' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='1818' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='next' type-id='type-id-82' visibility='default' filepath='src.d/zlib.h' line='1819' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='pos' type-id='type-id-5' visibility='default' filepath='src.d/zlib.h' line='1820' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-101' size-in-bits='64' id='type-id-102'/>
+    <typedef-decl name='gzFile' type-id='type-id-102' filepath='src.d/zlib.h' line='1300' column='1' id='type-id-103'/>
+    <function-decl name='gzclose' mangled-name='gzclose' filepath='src.d/gzclose.c' line='11' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzclose'>
+      <parameter type-id='type-id-103' name='file' filepath='src.d/gzclose.c' line='12' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='src.d/gzlib.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C99'>
+    <function-decl name='gzclearerr' mangled-name='gzclearerr' filepath='src.d/gzlib.c' line='553' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzclearerr@@ZLIB_1.2.0.2'>
+      <parameter type-id='type-id-103' name='file' filepath='src.d/gzlib.c' line='554' column='1'/>
+      <return type-id='type-id-71'/>
+    </function-decl>
+    <function-decl name='gzerror' mangled-name='gzerror' filepath='src.d/gzlib.c' line='532' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzerror'>
+      <parameter type-id='type-id-103' name='file' filepath='src.d/gzlib.c' line='533' column='1'/>
+      <parameter type-id='type-id-78' name='errnum' filepath='src.d/gzlib.c' line='534' column='1'/>
+      <return type-id='type-id-81'/>
+    </function-decl>
+    <function-decl name='gzeof' mangled-name='gzeof' filepath='src.d/gzlib.c' line='515' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzeof'>
+      <parameter type-id='type-id-103' name='file' filepath='src.d/gzclose.c' line='12' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='gzoffset' mangled-name='gzoffset' filepath='src.d/gzlib.c' line='505' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzoffset@@ZLIB_1.2.3.5'>
+      <parameter type-id='type-id-103' name='file' filepath='src.d/gzlib.c' line='506' column='1'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='gzoffset64' mangled-name='gzoffset64' filepath='src.d/gzlib.c' line='482' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzoffset64@@ZLIB_1.2.3.5'>
+      <parameter type-id='type-id-103' name='file' filepath='src.d/gzlib.c' line='483' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='gztell' mangled-name='gztell' filepath='src.d/gzlib.c' line='472' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gztell'>
+      <parameter type-id='type-id-103' name='file' filepath='src.d/gzlib.c' line='506' column='1'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='gztell64' mangled-name='gztell64' filepath='src.d/gzlib.c' line='455' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gztell64@@ZLIB_1.2.3.3'>
+      <parameter type-id='type-id-103' name='file' filepath='src.d/gzlib.c' line='456' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='gzseek' mangled-name='gzseek' filepath='src.d/gzlib.c' line='443' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzseek'>
+      <parameter type-id='type-id-103' name='file' filepath='src.d/gzlib.c' line='444' column='1'/>
+      <parameter type-id='type-id-7' name='offset' filepath='src.d/gzlib.c' line='445' column='1'/>
+      <parameter type-id='type-id-22' name='whence' filepath='src.d/gzlib.c' line='446' column='1'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='gzseek64' mangled-name='gzseek64' filepath='src.d/gzlib.c' line='366' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzseek64@@ZLIB_1.2.3.3'>
+      <parameter type-id='type-id-103' name='file' filepath='src.d/gzlib.c' line='367' column='1'/>
+      <parameter type-id='type-id-5' name='offset' filepath='src.d/gzlib.c' line='368' column='1'/>
+      <parameter type-id='type-id-22' name='whence' filepath='src.d/gzlib.c' line='369' column='1'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='gzrewind' mangled-name='gzrewind' filepath='src.d/gzlib.c' line='343' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzrewind'>
+      <parameter type-id='type-id-103' name='file' filepath='src.d/gzclose.c' line='12' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='gzbuffer' mangled-name='gzbuffer' filepath='src.d/gzlib.c' line='316' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzbuffer@@ZLIB_1.2.3.5'>
+      <parameter type-id='type-id-103' name='file' filepath='src.d/gzlib.c' line='317' column='1'/>
+      <parameter type-id='type-id-13' name='size' filepath='src.d/gzlib.c' line='318' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='gzdopen' mangled-name='gzdopen' filepath='src.d/gzlib.c' line='286' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzdopen'>
+      <parameter type-id='type-id-22' name='fd' filepath='src.d/gzlib.c' line='287' column='1'/>
+      <parameter type-id='type-id-81' name='mode' filepath='src.d/gzlib.c' line='288' column='1'/>
+      <return type-id='type-id-103'/>
+    </function-decl>
+    <function-decl name='gzopen64' mangled-name='gzopen64' filepath='src.d/gzlib.c' line='278' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzopen64@@ZLIB_1.2.3.3'>
+      <parameter type-id='type-id-81' name='path' filepath='src.d/gzlib.c' line='279' column='1'/>
+      <parameter type-id='type-id-81' name='mode' filepath='src.d/gzlib.c' line='280' column='1'/>
+      <return type-id='type-id-103'/>
+    </function-decl>
+    <function-decl name='gzopen' mangled-name='gzopen' filepath='src.d/gzlib.c' line='270' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzopen'>
+      <parameter type-id='type-id-81' name='path' filepath='src.d/gzlib.c' line='279' column='1'/>
+      <parameter type-id='type-id-81' name='mode' filepath='src.d/gzlib.c' line='280' column='1'/>
+      <return type-id='type-id-103'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='src.d/gzread.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C99'>
+    <function-decl name='gzclose_r' mangled-name='gzclose_r' filepath='src.d/gzread.c' line='627' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzclose_r@@ZLIB_1.2.3.5'>
+      <parameter type-id='type-id-103' name='file' filepath='src.d/gzread.c' line='628' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='gzdirect' mangled-name='gzdirect' filepath='src.d/gzread.c' line='607' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzdirect@@ZLIB_1.2.2.3'>
+      <parameter type-id='type-id-103' name='file' filepath='src.d/gzclose.c' line='12' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='gzgets' mangled-name='gzgets' filepath='src.d/gzread.c' line='543' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzgets'>
+      <parameter type-id='type-id-103' name='file' filepath='src.d/gzread.c' line='544' column='1'/>
+      <parameter type-id='type-id-25' name='buf' filepath='src.d/gzread.c' line='545' column='1'/>
+      <parameter type-id='type-id-22' name='len' filepath='src.d/gzread.c' line='546' column='1'/>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='gzungetc' mangled-name='gzungetc' filepath='src.d/gzread.c' line='483' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzungetc@@ZLIB_1.2.0.2'>
+      <parameter type-id='type-id-22' name='c' filepath='src.d/gzread.c' line='484' column='1'/>
+      <parameter type-id='type-id-103' name='file' filepath='src.d/gzread.c' line='485' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='gzgetc_' mangled-name='gzgetc_' filepath='src.d/gzread.c' line='476' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzgetc_@@ZLIB_1.2.5.2'>
+      <parameter type-id='type-id-103' name='file' filepath='src.d/gzread.c' line='477' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='gzgetc' mangled-name='gzgetc' filepath='src.d/gzread.c' line='447' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzgetc'>
+      <parameter type-id='type-id-103' name='file' filepath='src.d/gzread.c' line='628' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <typedef-decl name='voidp' type-id='type-id-72' filepath='./zconf.h' line='410' column='1' id='type-id-104'/>
+    <function-decl name='gzfread' mangled-name='gzfread' filepath='src.d/gzread.c' line='411' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzfread@@ZLIB_1.2.9'>
+      <parameter type-id='type-id-104' name='buf' filepath='src.d/gzread.c' line='412' column='1'/>
+      <parameter type-id='type-id-16' name='size' filepath='src.d/gzread.c' line='413' column='1'/>
+      <parameter type-id='type-id-16' name='nitems' filepath='src.d/gzread.c' line='414' column='1'/>
+      <parameter type-id='type-id-103' name='file' filepath='src.d/gzread.c' line='415' column='1'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='gzread' mangled-name='gzread' filepath='src.d/gzread.c' line='375' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzread'>
+      <parameter type-id='type-id-103' name='file' filepath='src.d/gzread.c' line='376' column='1'/>
+      <parameter type-id='type-id-104' name='buf' filepath='src.d/gzread.c' line='377' column='1'/>
+      <parameter type-id='type-id-13' name='len' filepath='src.d/gzread.c' line='378' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='src.d/gzwrite.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C99'>
+    <function-decl name='gzclose_w' mangled-name='gzclose_w' filepath='src.d/gzwrite.c' line='627' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzclose_w@@ZLIB_1.2.3.5'>
+      <parameter type-id='type-id-103' name='file' filepath='src.d/gzwrite.c' line='628' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='gzsetparams' mangled-name='gzsetparams' filepath='src.d/gzwrite.c' line='585' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzsetparams'>
+      <parameter type-id='type-id-103' name='file' filepath='src.d/gzwrite.c' line='586' column='1'/>
+      <parameter type-id='type-id-22' name='level' filepath='src.d/gzwrite.c' line='587' column='1'/>
+      <parameter type-id='type-id-22' name='strategy' filepath='src.d/gzwrite.c' line='588' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='gzflush' mangled-name='gzflush' filepath='src.d/gzwrite.c' line='553' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzflush'>
+      <parameter type-id='type-id-103' name='file' filepath='src.d/gzwrite.c' line='554' column='1'/>
+      <parameter type-id='type-id-22' name='flush' filepath='src.d/gzwrite.c' line='555' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='gzprintf' mangled-name='gzprintf' filepath='src.d/gzwrite.c' line='451' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzprintf'>
+      <parameter type-id='type-id-103' name='file' filepath='src.d/gzwrite.c' line='451' column='1'/>
+      <parameter type-id='type-id-81' name='format' filepath='src.d/gzwrite.c' line='451' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <class-decl name='__va_list_tag' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-105'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='gp_offset' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='fp_offset' type-id='type-id-13' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='overflow_arg_area' type-id='type-id-72' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='reg_save_area' type-id='type-id-72' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-105' size-in-bits='64' id='type-id-106'/>
+    <function-decl name='gzvprintf' mangled-name='gzvprintf' filepath='src.d/gzwrite.c' line='379' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzvprintf@@ZLIB_1.2.7.1'>
+      <parameter type-id='type-id-103' name='file' filepath='src.d/gzwrite.c' line='379' column='1'/>
+      <parameter type-id='type-id-81' name='format' filepath='src.d/gzwrite.c' line='379' column='1'/>
+      <parameter type-id='type-id-106' name='va' filepath='src.d/gzwrite.c' line='379' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='gzputs' mangled-name='gzputs' filepath='src.d/gzwrite.c' line='352' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzputs'>
+      <parameter type-id='type-id-103' name='file' filepath='src.d/gzwrite.c' line='353' column='1'/>
+      <parameter type-id='type-id-81' name='str' filepath='src.d/gzwrite.c' line='354' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='gzputc' mangled-name='gzputc' filepath='src.d/gzwrite.c' line='304' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzputc'>
+      <parameter type-id='type-id-103' name='file' filepath='src.d/gzwrite.c' line='305' column='1'/>
+      <parameter type-id='type-id-22' name='c' filepath='src.d/gzwrite.c' line='306' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <typedef-decl name='voidpc' type-id='type-id-72' filepath='./zconf.h' line='408' column='1' id='type-id-107'/>
+    <function-decl name='gzfwrite' mangled-name='gzfwrite' filepath='src.d/gzwrite.c' line='274' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzfwrite@@ZLIB_1.2.9'>
+      <parameter type-id='type-id-107' name='buf' filepath='src.d/gzwrite.c' line='275' column='1'/>
+      <parameter type-id='type-id-16' name='size' filepath='src.d/gzwrite.c' line='276' column='1'/>
+      <parameter type-id='type-id-16' name='nitems' filepath='src.d/gzwrite.c' line='277' column='1'/>
+      <parameter type-id='type-id-103' name='file' filepath='src.d/gzwrite.c' line='278' column='1'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='gzwrite' mangled-name='gzwrite' filepath='src.d/gzwrite.c' line='246' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzwrite'>
+      <parameter type-id='type-id-103' name='file' filepath='src.d/gzwrite.c' line='247' column='1'/>
+      <parameter type-id='type-id-107' name='buf' filepath='src.d/gzwrite.c' line='248' column='1'/>
+      <parameter type-id='type-id-13' name='len' filepath='src.d/gzwrite.c' line='249' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+  </abi-instr>
+</abi-corpus>

--- a/test/abicheck.md
+++ b/test/abicheck.md
@@ -1,0 +1,59 @@
+ABI Compatibility test
+----------------------
+
+abicheck.sh uses libabigail to check ABI stability.
+It will abort if the current source
+tree has a change that breaks binary compatibility.
+
+This protects against the common scenario where:
+- an app is compiled against the current zlib-ng
+- the system package manager updates the zlib-ng shared library
+- the app now crashes because some symbol is
+  missing or some public structure or parameter
+  has changed type or size
+
+If run with --zlib-compat, it verifies that the
+current source tree generates a library that
+is ABI-compatible with the reference release
+of classic zlib.  This ensures that building
+zlib-ng with --zlib-compat does what it says on the tin.
+
+abicheck.sh is not perfect, but it can catch
+many common compatibility issues.
+
+Cached files test/abi/*.abi
+---------------------------
+
+Comparing to the old version of zlib (or zlib-ng)
+means someone has to check out and build
+the previous source tree and extract its .abi
+using abidw.  This can be slow.
+
+If you don't mind the slowness, run abicheck.sh --refresh_if,
+and it will download and build the reference version
+and extract the .abi on the spot if needed.
+(FIXME: should this be the default?)
+
+On the next run, the reference .abi file will already be
+present, and that step will be skipped.
+It's stored in the tests/abi directory,
+in a file with the architecture and git hash in the name.
+
+If you're running continuous integration
+which clear out the source tree on each run,
+and you don't want your build machines
+constantly downloading and building the old
+version, you can check the .abi file into git.
+
+To make this easier, a helper script could be written to automatically build
+all the configurations tested by .github/worflows/abicheck.yml
+Then they could be checked into git en masse by a maintainer
+when a new platform is added or a new major version (which
+intentionally breaks backwards compatibility) is being prepared.
+
+Further reading
+---------------
+
+- https://sourceware.org/libabigail/manual/
+- https://developers.redhat.com/blog/2014/10/23/comparing-abis-for-compatibility-with-libabigail-part-1/
+- https://developers.redhat.com/blog/2020/04/02/how-to-write-an-abi-compliance-checker-using-libabigail/

--- a/test/abicheck.sh
+++ b/test/abicheck.sh
@@ -1,0 +1,164 @@
+#!/bin/sh
+set -ex
+TESTDIR="$(cd $(dirname "$0"); pwd)"
+
+usage() {
+    cat <<_EOF_
+Usage: $0 [--zlib-compat][--refresh][--refresh-if]
+
+Build shared library with -ggdb, then compare its ABI to the stable
+ABI, and abort if differences found.
+
+Options:
+--zlib-compat  - check the ABI of the zlib-compatible flavor of zlib-ng.
+--refresh      - build the reference library and extract its ABI rather than using a stored ABI file.
+--refresh-if   - refresh only if ABI file not present.
+
+Obeys CHOST, CONFIGURE_ARGS, CFLAGS, and LDFLAGS.
+
+Requires libabigail (on Ubuntu, install package abigail-tools).
+_EOF_
+}
+
+# Print the multiarch tuple for the current (non-cross) machine,
+# or the empty string if unavailable.
+detect_chost() {
+    dpkg-architecture -qDEB_HOST_MULTIARCH ||
+     $CC -print-multiarch ||
+     $CC -print-search-dirs | sed 's/:/\n/g' | grep -E '^/lib/[^/]+$' | sed 's%.*/%%' ||
+     true
+}
+
+if ! test -f "configure"
+then
+  echo "Please run from top of source tree"
+  exit 1
+fi
+
+suffix="-ng"
+CONFIGURE_ARGS_NG="$CONFIGURE_ARGS"
+refresh=false
+refresh_if=false
+for arg
+do
+  case "$arg" in
+  --zlib-compat)
+    suffix=""
+    CONFIGURE_ARGS_NG="$CONFIGURE_ARGS_NG --zlib-compat"
+    ;;
+  --refresh)
+    refresh=true
+    ;;
+  --refresh_if)
+    refresh_if=true
+    ;;
+  --help)
+    usage
+    exit 0
+    ;;
+  *)
+    echo "Unknown arg '$arg'"
+    usage
+    exit 1
+    ;;
+  esac
+done
+
+# Choose reference repo and commit
+if test "$suffix" = ""
+then
+  # Reference is zlib 1.2.11
+  ABI_GIT_REPO=https://github.com/madler/zlib.git
+  ABI_GIT_COMMIT=v1.2.11
+else
+  # Reference should be the tag for zlib-ng 2.0
+  # but until that bright, shining day, use some
+  # random recent SHA.  Annoyingly, can't shorten it.
+  ABI_GIT_REPO=https://github.com/zlib-ng/zlib-ng.git
+  ABI_GIT_COMMIT=1d2504ddc4894786fdf61d41a9bfa435cd8b1935
+fi
+# FIXME: even when using a tag, check the hash.
+
+# Test compat build for ABI compatibility with zlib
+if test "$CHOST" = ""
+then
+  # Note: don't export CHOST here, as we don't want configure seeing it
+  # when it's just the name for the build machine.
+  # Leave it as a plain shell variable, not an environment variable.
+  CHOST=$(detect_chost)
+  # Support -m32 for non-cross builds.
+  case "$CFLAGS" in
+  *-m32*) M32="-m32";;
+  *) M32="";;
+  esac
+else
+  # Canonicalize CHOST to work around bug in original
+  # zlib's configure
+  export CHOST=$(sh $TESTDIR/../tools/config.sub $CHOST)
+fi
+if test "$CHOST" = ""
+then
+  echo "abicheck: SKIP, as we don't know CHOST"
+  exit 0
+fi
+
+ABIFILE="test/abi/zlib$suffix-$ABI_GIT_COMMIT-$CHOST$M32.abi"
+if ! $refresh && $refresh_if && ! test -f "$ABIFILE"
+then
+  refresh=true
+fi
+abidw --version
+
+if $refresh
+then
+  # Check out reference source
+  rm -rf btmp1
+  mkdir -p btmp1/src.d
+  cd btmp1/src.d
+  git init
+  git remote add origin $ABI_GIT_REPO
+  git fetch origin $ABI_GIT_COMMIT
+  git reset --hard FETCH_HEAD
+  cd ..
+  # Build unstripped, uninstalled, very debug shared library
+  CFLAGS="$CFLAGS -ggdb" sh src.d/configure $CONFIGURE_ARGS
+  make -j2
+  cd ..
+  # Find shared library, extract its abi
+  dylib1=$(find btmp1 -type f -name '*.dylib*' -print -o -type f -name '*.so.*' -print)
+  abidw $dylib1 > "$ABIFILE"
+  # Maintainers may wish to check $ABIFILE into git when a new
+  # target is added, or when a major release happens that is
+  # intended to change the ABI.  Alternately, this script could
+  # just always rebuild the reference source, and dispense with
+  # caching abi files in git (but that would slow builds down).
+fi
+
+if test -f "$ABIFILE"
+then
+  ABIFILE="$ABIFILE"
+else
+  echo "abicheck: SKIP: $ABIFILE not found; rerun with --refresh or --refresh_if"
+  exit 0
+fi
+
+# Build unstripped, uninstalled, very debug shared library
+rm -rf btmp2
+mkdir btmp2
+cd btmp2
+CFLAGS="$CFLAGS -ggdb" ../configure $CONFIGURE_ARGS_NG
+make -j2
+cd ..
+# Find shared library, extract its abi
+dylib2=$(find btmp2 -type f -name '*.dylib*' -print -o -type f -name '*.so.*' -print)
+abidw $dylib2 > btmp2/zlib${suffix}-built.abi
+
+# Compare it to the reference
+# FIXME: use --no-added-syms for now, but we probably want to be more strict.
+if abidiff --no-added-syms --suppressions test/abi/ignore "$ABIFILE" btmp2/zlib${suffix}-built.abi
+then
+  echo "abicheck: PASS"
+else
+  echo "abicheck: FAIL"
+  exit 1
+fi


### PR DESCRIPTION
Verifies that zlib-ng's ABI has not changed since the reference commit
(indicated by variables ABI_URL and ABI_COMMIT in the script).
If --zlib-compat is given, the reference commit is zlib's 1.2.11;
otherwise, it's zlib-ng's 1d2504ddc489 (for now).
    
Ignores new symbols entirely, as they probably don't break backwards compatibility.

Ignores warnings listed in test/abi/ignore, currently, just those related to internal_state or z_stream*.
    
If --refresh is given, actually checks out the reference commit,
builds it, and stores its ABI description into an .abi file;
otherwise just uses the .abi file saved in git for that CHOST.
--refresh_if is similar, but only refreshes if the .abi file is not present already.
    
Fixes https://github.com/zlib-ng/zlib-ng/issues/699
    
Known issues:
    - although it supports -m32 (if in both CFLAGS and LDFLAGS), it doesn't yet support -32 in CONFIGURE_ARGS.
    - only includes abi definitions for x86_64 and armhf; the rest can be added in a followon commit (see --refresh).
    - skips -m32 tests (loudly) because that's broken at moment, see #705 