### PR TITLE
zlib.h: Use unsigned long for totals, for compatibility with zlib on 64-bit Windows

### DIFF
--- a/test/example.c
+++ b/test/example.c
@@ -16,6 +16,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <inttypes.h>
+#include <stdint.h>
 
 #define TESTFILE "foo.gz"
 
@@ -452,7 +453,7 @@ void test_large_inflate(unsigned char *compr, size_t comprLen, unsigned char *un
     CHECK_ERR(err, "inflateEnd");
 
     if (d_stream.total_out != 2*uncomprLen + diff) {
-        fprintf(stderr, "bad large inflate: %zu\n", d_stream.total_out);
+        fprintf(stderr, "bad large inflate: %" PRIu64 "\n", (uint64_t)d_stream.total_out);
         exit(1);
     } else {
         printf("large_inflate(): OK\n");

--- a/test/fuzz/example_large_fuzzer.c
+++ b/test/fuzz/example_large_fuzzer.c
@@ -109,7 +109,7 @@ void test_large_inflate(unsigned char *compr, size_t comprLen, unsigned char *un
     CHECK_ERR(err, "inflateEnd");
 
     if (d_stream.total_out != 2 * uncomprLen + diff) {
-        fprintf(stderr, "bad large inflate: %zu\n", d_stream.total_out);
+        fprintf(stderr, "bad large inflate: %" PRIu64 "\n", (uint64_t)d_stream.total_out);
         exit(1);
     }
 }

--- a/test/infcover.c
+++ b/test/infcover.c
@@ -10,6 +10,8 @@
 #include <string.h>
 #undef NDEBUG
 #include <assert.h>
+#include <inttypes.h>
+#include <stdint.h>
 
 /* get definition of internal structure so we can mess with it (see pull()),
    and so we can call inflate_trees() (see cover5()) */
@@ -184,14 +186,14 @@ static void mem_limit(PREFIX3(stream) *strm, size_t limit) {
 static void mem_used(PREFIX3(stream) *strm, char *prefix) {
     struct mem_zone *zone = strm->opaque;
 
-    fprintf(stderr, "%s: %zu allocated\n", prefix, zone->total);
+    fprintf(stderr, "%s: %" PRIu64 " allocated\n", prefix, (uint64_t)zone->total);
 }
 
 /* show the high water allocation in bytes */
 static void mem_high(PREFIX3(stream) *strm, char *prefix) {
     struct mem_zone *zone = strm->opaque;
 
-    fprintf(stderr, "%s: %zu high water mark\n", prefix, zone->highwater);
+    fprintf(stderr, "%s: %" PRIu64 " high water mark\n", prefix, (uint64_t)zone->highwater);
 }
 
 /* release the memory allocation zone -- if there are any surprises, notify */
@@ -215,8 +217,8 @@ static void mem_done(PREFIX3(stream) *strm, char *prefix) {
 
     /* issue alerts about anything unexpected */
     if (count || zone->total)
-        fprintf(stderr, "** %s: %zu bytes in %d blocks not freed\n",
-                prefix, zone->total, count);
+        fprintf(stderr, "** %s: %" PRIu64 " bytes in %d blocks not freed\n",
+                prefix, (uint64_t)zone->total, count);
     if (zone->notlifo)
         fprintf(stderr, "** %s: %d frees not LIFO\n", prefix, zone->notlifo);
     if (zone->rogue)

--- a/trees_emit.h
+++ b/trees_emit.h
@@ -6,7 +6,10 @@
 
 #ifdef ZLIB_DEBUG
 #  include <ctype.h>
+#  include <inttypes.h>
+#  include <stdint.h>
 #endif
+
 
 /* trees.h */
 extern ZLIB_INTERNAL const ct_data static_ltree[L_CODES+2];
@@ -170,8 +173,8 @@ static inline void zng_emit_end_block(deflate_state *s, const ct_data *ltree, co
     send_code(s, END_BLOCK, ltree, bi_buf, bi_valid);
     s->bi_valid = bi_valid;
     s->bi_buf = bi_buf;
-    Tracev((stderr, "\n+++ Emit End Block: Last: %u Pending: %u Total Out: %zu\n",
-        last, s->pending, s->strm->total_out));
+    Tracev((stderr, "\n+++ Emit End Block: Last: %u Pending: %u Total Out: %" PRIu64 "\n",
+        last, s->pending, (uint64_t)s->strm->total_out));
     (void)last;
 }
 

--- a/zlib.h
+++ b/zlib.h
@@ -94,11 +94,11 @@ struct internal_state;
 typedef struct z_stream_s {
     const unsigned char   *next_in;   /* next input byte */
     uint32_t              avail_in;   /* number of bytes available at next_in */
-    size_t                total_in;   /* total number of input bytes read so far */
+    unsigned long         total_in;   /* total number of input bytes read so far */
 
     unsigned char         *next_out;  /* next output byte will go here */
     uint32_t              avail_out;  /* remaining free space at next_out */
-    size_t                total_out;  /* total number of bytes output so far */
+    unsigned long         total_out;  /* total number of bytes output so far */
 
     const char            *msg;       /* last error message, NULL if no error */
     struct internal_state *state;     /* not visible by applications */


### PR DESCRIPTION
Stock zlib uses unsigned long for total_in and total_out. On 64-bit
Windows, that isn't the same as size_t.
