### PR TITLE
Simplify and optimize insert_string template

### DIFF
--- a/functable.c
+++ b/functable.c
@@ -15,11 +15,11 @@
 #endif
 
 /* insert_string */
-extern Pos insert_string_c(deflate_state *const s, const uint32_t str, uint32_t count);
+extern void insert_string_c(deflate_state *const s, const uint32_t str, uint32_t count);
 #ifdef X86_SSE42_CRC_HASH
-extern Pos insert_string_sse4(deflate_state *const s, const uint32_t str, uint32_t count);
+extern void insert_string_sse4(deflate_state *const s, const uint32_t str, uint32_t count);
 #elif defined(ARM_ACLE_CRC_HASH)
-extern Pos insert_string_acle(deflate_state *const s, const uint32_t str, uint32_t count);
+extern void insert_string_acle(deflate_state *const s, const uint32_t str, uint32_t count);
 #endif
 
 /* quick_insert_string */
@@ -144,7 +144,7 @@ ZLIB_INTERNAL void cpu_check_features(void)
 }
 
 /* stub functions */
-ZLIB_INTERNAL Pos insert_string_stub(deflate_state *const s, const uint32_t str, uint32_t count) {
+ZLIB_INTERNAL void insert_string_stub(deflate_state *const s, const uint32_t str, uint32_t count) {
     // Initialize default
 
     functable.insert_string = &insert_string_c;
@@ -158,7 +158,7 @@ ZLIB_INTERNAL Pos insert_string_stub(deflate_state *const s, const uint32_t str,
         functable.insert_string = &insert_string_acle;
 #endif
 
-    return functable.insert_string(s, str, count);
+    functable.insert_string(s, str, count);
 }
 
 ZLIB_INTERNAL Pos quick_insert_string_stub(deflate_state *const s, const uint32_t str) {

--- a/functable.h
+++ b/functable.h
@@ -9,7 +9,7 @@
 #include "deflate.h"
 
 struct functable_s {
-    Pos      (* insert_string)      (deflate_state *const s, const uint32_t str, uint32_t count);
+    void     (* insert_string)      (deflate_state *const s, const uint32_t str, uint32_t count);
     Pos      (* quick_insert_string)(deflate_state *const s, const uint32_t str);
     uint32_t (* adler32)            (uint32_t adler, const unsigned char *buf, size_t len);
     uint32_t (* crc32)              (uint32_t crc, const unsigned char *buf, uint64_t len);

--- a/insert_string_tpl.h
+++ b/insert_string_tpl.h
@@ -61,7 +61,7 @@ ZLIB_INTERNAL Pos QUICK_INSERT_STRING(deflate_state *const s, const uint32_t str
  *    (except for the last MIN_MATCH-1 bytes of the input file).
  */
 ZLIB_INTERNAL Pos INSERT_STRING(deflate_state *const s, const uint32_t str, uint32_t count) {
-    Pos head, idx, ret = 0;
+    Pos head = 0, idx;
     uint8_t *strstart = s->window + str;
     uint8_t *strend = strstart + count - 1; /* last position */
     uint32_t hash_mask = s->hash_mask;
@@ -88,12 +88,6 @@ ZLIB_INTERNAL Pos INSERT_STRING(deflate_state *const s, const uint32_t str, uint
         }
     }
 
-    if (strstart == strend) {
-        if (head != idx)
-            ret = head;
-        else
-            ret = idx;
-    }
-    return ret;
+    return head;
 }
 #endif

--- a/insert_string_tpl.h
+++ b/insert_string_tpl.h
@@ -60,13 +60,12 @@ ZLIB_INTERNAL Pos QUICK_INSERT_STRING(deflate_state *const s, const uint32_t str
  *    input characters and the first MIN_MATCH bytes of str are valid
  *    (except for the last MIN_MATCH-1 bytes of the input file).
  */
-ZLIB_INTERNAL Pos INSERT_STRING(deflate_state *const s, const uint32_t str, uint32_t count) {
-    Pos head = 0, idx;
+ZLIB_INTERNAL void INSERT_STRING(deflate_state *const s, const uint32_t str, uint32_t count) {
     uint8_t *strstart = s->window + str;
     uint8_t *strend = strstart + count - 1; /* last position */
     uint32_t hash_mask = s->hash_mask;
 
-    for (idx = str; strstart <= strend; idx++, strstart++) {
+    for (Pos idx = str; strstart <= strend; idx++, strstart++) {
         uint32_t val, hm, h = 0;
 
 #ifdef UNALIGNED_OK
@@ -81,13 +80,11 @@ ZLIB_INTERNAL Pos INSERT_STRING(deflate_state *const s, const uint32_t str, uint
         UPDATE_HASH(s, h, val);
         hm = h & hash_mask;
 
-        head = s->head[hm];
+        Pos head = s->head[hm];
         if (LIKELY(head != idx)) {
             s->prev[idx & s->w_mask] = head;
             s->head[hm] = idx;
         }
     }
-
-    return head;
 }
 #endif


### PR DESCRIPTION
This moves unnecessary code out of the loop in insert_string, and adds a compiler hint to both quick_insert_string and insert_string.

Result is ~0.4% faster in my benchmarks.
See benchmarks in comment below.

PS: I recommend looking at/reviewing the two commits separately, it is split up to make it easier to understand why the changes were made.

