### PR TITLE
Add optional support for thread local storage.

### DIFF
--- a/functable.c
+++ b/functable.c
@@ -126,7 +126,7 @@ extern int32_t longest_match_unaligned_avx2(deflate_state *const s, Pos cur_matc
 #endif
 #endif
 
-ZLIB_INTERNAL __thread struct functable_s functable;
+ZLIB_INTERNAL Z_TLS struct functable_s functable;
 
 ZLIB_INTERNAL void cpu_check_features(void)
 {
@@ -416,7 +416,7 @@ ZLIB_INTERNAL int32_t longest_match_stub(deflate_state *const s, Pos cur_match) 
 }
 
 /* functable init */
-ZLIB_INTERNAL __thread struct functable_s functable = {
+ZLIB_INTERNAL Z_TLS struct functable_s functable = {
     insert_string_stub,
     quick_insert_string_stub,
     adler32_stub,

--- a/functable.h
+++ b/functable.h
@@ -24,6 +24,6 @@ struct functable_s {
     uint8_t* (* chunkmemset_safe)   (uint8_t *out, unsigned dist, unsigned len, unsigned left);
 };
 
-ZLIB_INTERNAL extern __thread struct functable_s functable;
+ZLIB_INTERNAL extern Z_TLS struct functable_s functable;
 
 #endif

--- a/zbuild.h
+++ b/zbuild.h
@@ -8,7 +8,6 @@
 #  else
     typedef long ssize_t;
 #  endif
-#  define __thread __declspec(thread)
 #endif
 
 #if defined(ZLIB_COMPAT)

--- a/zutil.h
+++ b/zutil.h
@@ -24,6 +24,10 @@
 #  define ZLIB_REGISTER
 #endif
 
+#ifndef Z_TLS
+#  define Z_TLS
+#endif
+
 #include <stddef.h>
 #include <string.h>
 #include <stdlib.h>


### PR DESCRIPTION
It is possible to predefine `ZTHREAD` to disable thread local storage.
```
cmake . -DCMAKE_C_FLAGS=-DZTHREAD=
```

I used `ZTHREAD` to coincide with `ZEXPORT` and `ZEXTERN`.

See #570 for previous discussion.