### PR TITLE
Change to static hash-table size

### DIFF
--- a/arch/arm/slide_neon.c
+++ b/arch/arm/slide_neon.c
@@ -46,7 +46,7 @@ static inline void slide_hash_chain(Pos *table, unsigned int entries, uint16_t w
 ZLIB_INTERNAL void slide_hash_neon(deflate_state *s) {
     unsigned int wsize = s->w_size;
 
-    slide_hash_chain(s->head, s->hash_size, wsize);
+    slide_hash_chain(s->head, HASH_SIZE, wsize);
     slide_hash_chain(s->prev, wsize, wsize);
 }
 #endif

--- a/arch/power/slide_hash_power8.c
+++ b/arch/power/slide_hash_power8.c
@@ -48,7 +48,7 @@ void ZLIB_INTERNAL slide_hash_power8(deflate_state *s) {
     unsigned int n;
     Pos *p;
 
-    n = s->hash_size;
+    n = HASH_SIZE;
     p = &s->head[n];
     slide_hash_power8_loop(s,n,p);
 

--- a/arch/x86/slide_avx.c
+++ b/arch/x86/slide_avx.c
@@ -20,7 +20,7 @@ ZLIB_INTERNAL void slide_hash_avx2(deflate_state *s) {
     uint16_t wsize = (uint16_t)s->w_size;
     const __m256i zmm_wsize = _mm256_set1_epi16(wsize);
 
-    n = s->hash_size;
+    n = HASH_SIZE;
     p = &s->head[n] - 16;
     do {
         __m256i value, result;

--- a/arch/x86/slide_sse.c
+++ b/arch/x86/slide_sse.c
@@ -19,7 +19,7 @@ ZLIB_INTERNAL void slide_hash_sse2(deflate_state *s) {
     uint16_t wsize = (uint16_t)s->w_size;
     const __m128i xmm_wsize = _mm_set1_epi16(wsize);
 
-    n = s->hash_size;
+    n = HASH_SIZE;
     p = &s->head[n] - 8;
     do {
         __m128i value, result;

--- a/deflate.h
+++ b/deflate.h
@@ -68,6 +68,10 @@
 #define FINISH_STATE 666    /* stream complete */
 /* Stream status */
 
+#define HASH_BITS 15        /* log2(HASH_SIZE) */
+#define HASH_SIZE 32768     /* number of elements in hash table */
+#define HASH_MASK 0x7FFF    /* HASH_SIZE-1 */
+
 
 /* Data structure describing a single value and its code string. */
 typedef struct ct_data_s {
@@ -145,10 +149,6 @@ typedef struct internal_state {
      */
 
     Pos *head; /* Heads of the hash chains or NIL. */
-
-    unsigned int  hash_size;         /* number of elements in hash table */
-    unsigned int  hash_bits;         /* log2(hash_size) */
-    unsigned int  hash_mask;         /* hash_size-1 */
 
     long block_start;
     /* Window position at the beginning of the current output block. Gets

--- a/deflate.h
+++ b/deflate.h
@@ -68,9 +68,9 @@
 #define FINISH_STATE 666    /* stream complete */
 /* Stream status */
 
-#define HASH_BITS 15        /* log2(HASH_SIZE) */
-#define HASH_SIZE 32768     /* number of elements in hash table */
-#define HASH_MASK 0x7FFF    /* HASH_SIZE-1 */
+#define HASH_BITS    16u           /* log2(HASH_SIZE) */
+#define HASH_SIZE 65536u           /* number of elements in hash table */
+#define HASH_MASK (HASH_SIZE - 1u) /* HASH_SIZE-1 */
 
 
 /* Data structure describing a single value and its code string. */

--- a/insert_string.c
+++ b/insert_string.c
@@ -15,7 +15,7 @@
  *    previous key instead of complete recalculation each time.
  */
 #define UPDATE_HASH(s, h, val) \
-    h = ((val * 2654435761U) >> (32 - s->hash_bits));
+    h = ((val * 2654435761U) >> (32 - HASH_BITS));
 
 #define INSERT_STRING       insert_string_c
 #define QUICK_INSERT_STRING quick_insert_string_c

--- a/insert_string.c
+++ b/insert_string.c
@@ -14,8 +14,10 @@
  *    input characters, so that a running hash key can be computed from the
  *    previous key instead of complete recalculation each time.
  */
+#define HASH_SLIDE 16  // Number of bits to slide hash
+
 #define UPDATE_HASH(s, h, val) \
-    h = ((val * 2654435761U) >> (32 - HASH_BITS));
+    h = ((val * 2654435761U) >> HASH_SLIDE);
 
 #define INSERT_STRING       insert_string_c
 #define QUICK_INSERT_STRING quick_insert_string_c

--- a/insert_string_tpl.h
+++ b/insert_string_tpl.h
@@ -42,7 +42,7 @@ ZLIB_INTERNAL Pos QUICK_INSERT_STRING(deflate_state *const s, const uint32_t str
 #endif
 
     UPDATE_HASH(s, h, val);
-    hm = h & s->hash_mask;
+    hm = h & HASH_MASK;
 
     head = s->head[hm];
     if (LIKELY(head != str)) {
@@ -63,7 +63,6 @@ ZLIB_INTERNAL Pos QUICK_INSERT_STRING(deflate_state *const s, const uint32_t str
 ZLIB_INTERNAL void INSERT_STRING(deflate_state *const s, const uint32_t str, uint32_t count) {
     uint8_t *strstart = s->window + str;
     uint8_t *strend = strstart + count - 1; /* last position */
-    uint32_t hash_mask = s->hash_mask;
 
     for (Pos idx = str; strstart <= strend; idx++, strstart++) {
         uint32_t val, hm, h = 0;
@@ -78,7 +77,7 @@ ZLIB_INTERNAL void INSERT_STRING(deflate_state *const s, const uint32_t str, uin
 #endif
 
         UPDATE_HASH(s, h, val);
-        hm = h & hash_mask;
+        hm = h & HASH_MASK;
 
         Pos head = s->head[hm];
         if (LIKELY(head != idx)) {

--- a/match_tpl.h
+++ b/match_tpl.h
@@ -41,10 +41,9 @@ ZLIB_INTERNAL int32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
     bestcmp_t scan_end, scan_start;
 
     /*
-     * The code is optimized for HASH_BITS >= 8 and MAX_MATCH-2 multiple
-     * of 16. It is easy to get rid of this optimization if necessary.
+     * The code is optimized for MAX_MATCH-2 multiple of 16.
      */
-    Assert(s->hash_bits >= 8 && MAX_MATCH == 258, "Code too clever");
+    Assert(MAX_MATCH == 258, "Code too clever");
 
     /*
      * Do not waste too much time if we already have a good match


### PR DESCRIPTION
First commit removes hash_bits, hash_size and hash_mask from the deflate struct, and replaces them with defines.
Second commit doubles the size of the hash-table, this often leads to slightly better compression on all levels (sometimes slightly worse on the higher levels) and gives a very nice performance boost (looks to be because we AND the hash by 0xFFFF instead of by 0x7FFF, and that seems to be a lot more cpu-friendly).

I need help analyzing this, since it changes output data we need to be sure it is not exposing any new bugs.
I have not detected any invalid data in my tests, but I also cannot explain the sometimes increased output size.
Double the hash table size should decrease collisions (my understanding of the better compression), but will not make any new ones.
So, is the decreased compression because we detect a longer-distance match that would have otherwise been overwritten by a newer one?

PS: This is not the same as increasing memory-level, since that also affects the lit-buffer, and that cannot be increased beyond 16K entries without adding extra code to prevent invalid data.

See benchmarks in separate comment.