### PR TITLE
Struct cleanup

### DIFF
--- a/deflate.h
+++ b/deflate.h
@@ -260,7 +260,7 @@ typedef struct internal_state {
     /* Output buffer. bits are inserted starting at the bottom (least
      * significant bits).
      */
-    int bi_valid;
+    int32_t bi_valid;
     /* Number of valid bits in bi_buf.  All bits above the last valid bit
      * are always zero.
      */
@@ -390,10 +390,10 @@ void ZLIB_INTERNAL slide_hash_c(deflate_state *s);
 
         /* in trees.c */
 void ZLIB_INTERNAL zng_tr_init(deflate_state *s);
-void ZLIB_INTERNAL zng_tr_flush_block(deflate_state *s, char *buf, unsigned long stored_len, int last);
+void ZLIB_INTERNAL zng_tr_flush_block(deflate_state *s, char *buf, uint32_t stored_len, int last);
 void ZLIB_INTERNAL zng_tr_flush_bits(deflate_state *s);
 void ZLIB_INTERNAL zng_tr_align(deflate_state *s);
-void ZLIB_INTERNAL zng_tr_stored_block(deflate_state *s, char *buf, unsigned long stored_len, int last);
+void ZLIB_INTERNAL zng_tr_stored_block(deflate_state *s, char *buf, uint32_t stored_len, int last);
 unsigned ZLIB_INTERNAL bi_reverse(unsigned code, int len);
 void ZLIB_INTERNAL flush_pending(PREFIX3(streamp) strm);
 

--- a/deflate_p.h
+++ b/deflate_p.h
@@ -64,7 +64,7 @@ static inline int zng_tr_tally_dist(deflate_state *s, unsigned dist, unsigned ch
     zng_tr_flush_block(s, (s->block_start >= 0 ? \
                    (char *)&s->window[(unsigned)s->block_start] : \
                    NULL), \
-                   (unsigned long)((int)s->strstart - s->block_start), \
+                   (uint32_t)((int)s->strstart - s->block_start), \
                    (last)); \
     s->block_start = (int)s->strstart; \
     flush_pending(s->strm); \

--- a/deflate_p.h
+++ b/deflate_p.h
@@ -61,12 +61,12 @@ static inline int zng_tr_tally_dist(deflate_state *s, unsigned dist, unsigned ch
  * IN assertion: strstart is set to the end of the current match.
  */
 #define FLUSH_BLOCK_ONLY(s, last) { \
-    zng_tr_flush_block(s, (s->block_start >= 0L ? \
+    zng_tr_flush_block(s, (s->block_start >= 0 ? \
                    (char *)&s->window[(unsigned)s->block_start] : \
                    NULL), \
-                   (unsigned long)((long)s->strstart - s->block_start), \
+                   (unsigned long)((int)s->strstart - s->block_start), \
                    (last)); \
-    s->block_start = s->strstart; \
+    s->block_start = (int)s->strstart; \
     flush_pending(s->strm); \
 }
 

--- a/deflate_quick.c
+++ b/deflate_quick.c
@@ -28,20 +28,20 @@ extern const ct_data static_dtree[D_CODES];
 
 #define QUICK_START_BLOCK(s, last) { \
     zng_tr_emit_tree(s, STATIC_TREES, last); \
-    s->block_open = 1 + last; \
-    s->block_start = s->strstart; \
+    s->block_open = 1 + (int)last; \
+    s->block_start = (int)s->strstart; \
 }
 
 #define QUICK_END_BLOCK(s, last) { \
     if (s->block_open) { \
         zng_tr_emit_end_block(s, static_ltree, last); \
         s->block_open = 0; \
-        s->block_start = s->strstart; \
+        s->block_start = (int)s->strstart; \
         flush_pending(s->strm); \
         if (s->strm->avail_out == 0) \
             return (last) ? finish_started : need_more; \
     } \
-} 
+}
 
 ZLIB_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
     Pos hash_head;

--- a/deflate_slow.c
+++ b/deflate_slow.c
@@ -45,7 +45,7 @@ ZLIB_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
 
         /* Find the longest match, discarding those <= prev_length.
          */
-        s->prev_match = s->match_start;
+        s->prev_match = (Pos)s->match_start;
         match_len = MIN_MATCH-1;
 
         if (hash_head != NIL && s->prev_length < s->max_lazy_match && s->strstart - hash_head <= MAX_DIST(s)) {

--- a/trees.c
+++ b/trees.c
@@ -206,11 +206,13 @@ static void gen_bitlen(deflate_state *s, tree_desc *desc) {
      */
     tree[s->heap[s->heap_max]].Len = 0; /* root of the heap */
 
-    for (h = s->heap_max+1; h < HEAP_SIZE; h++) {
+    for (h = s->heap_max + 1; h < HEAP_SIZE; h++) {
         n = s->heap[h];
-        bits = tree[tree[n].Dad].Len + 1;
-        if (bits > max_length)
-            bits = max_length, overflow++;
+        bits = tree[tree[n].Dad].Len + 1u;
+        if (bits > max_length){
+            bits = max_length;
+            overflow++;
+        }
         tree[n].Len = (uint16_t)bits;
         /* We overwrite tree[n].Dad which is no longer needed */
 
@@ -234,11 +236,11 @@ static void gen_bitlen(deflate_state *s, tree_desc *desc) {
 
     /* Find the first bit length which could increase: */
     do {
-        bits = max_length-1;
+        bits = max_length - 1;
         while (s->bl_count[bits] == 0)
             bits--;
-        s->bl_count[bits]--;      /* move one leaf down the tree */
-        s->bl_count[bits+1] += 2; /* move one overflow item as its brother */
+        s->bl_count[bits]--;       /* move one leaf down the tree */
+        s->bl_count[bits+1] += 2u; /* move one overflow item as its brother */
         s->bl_count[max_length]--;
         /* The brother of the overflow item also moves one step up,
          * but this does not affect bl_count[max_length]
@@ -587,7 +589,7 @@ static void send_all_trees(deflate_state *s, int lcodes, int dcodes, int blcodes
 /* ===========================================================================
  * Send a stored block
  */
-void ZLIB_INTERNAL zng_tr_stored_block(deflate_state *s, char *buf, unsigned long stored_len, int last) {
+void ZLIB_INTERNAL zng_tr_stored_block(deflate_state *s, char *buf, uint32_t stored_len, int last) {
     /* buf: input block */
     /* stored_len: length of input block */
     /* last: one if this is the last block for a file */
@@ -627,7 +629,7 @@ void ZLIB_INTERNAL zng_tr_align(deflate_state *s) {
  * Determine the best encoding for the current block: dynamic trees, static
  * trees or store, and write out the encoded block.
  */
-void ZLIB_INTERNAL zng_tr_flush_block(deflate_state *s, char *buf, unsigned long stored_len, int last) {
+void ZLIB_INTERNAL zng_tr_flush_block(deflate_state *s, char *buf, uint32_t stored_len, int last) {
     /* buf: input block, or NULL if too old */
     /* stored_len: length of input block */
     /* last: one if this is the last block for a file */


### PR DESCRIPTION
 Changes to deflate's internal_state struct members:
 - Change window_size from unsigned long to unsigned int
 - Change block_start from long to int
 - Change high_water from unsigned long to unsigned int
 - Reorder to promote cache locality in hot code and decrease holes.

On x86_64 this means the struct goes from:
```
        /* size: 6008, cachelines: 94, members: 57 */
        /* sum members: 5984, holes: 6, sum holes: 24 */
        /* last cacheline: 56 bytes */
```
To:
```
        /* size: 5984, cachelines: 94, members: 57 */
        /* sum members: 5972, holes: 3, sum holes: 8 */
        /* padding: 4 */
        /* last cacheline: 32 bytes */
```

- Fix some of the old and new conversion warnings in deflate*
- Fix more conversion warnings related to s->bi_valid, stored_len and misc.

Shrinking the deflate struct is helpful in zlib-compat, although I do not currently know how we are doing compared to stock zlib.
Also, cache locality can help performance.
I chose not to change signedness or change to stdint.h types with one exception, since this is already complex enough, but this should help make that easier.
We have hundreds of warnings of type -Wconversion and -Wsign-conversion, so that makes it really hard to spot what warnings are new after such changes. Therefore this PR fixes both new warnings and some existing warnings.
This might have created new warnings in other files, it is very hard to keep track.

Part of the code-size reduction this PR brings is actually from the two commits fixing conversion warnings, likely by letting the code optimize better when it understands we don't care about signedness and such.