### PR TITLE
Revert "zng_tr_tally_lit: disable -Wtype-limits"

### DIFF
--- a/deflate_p.h
+++ b/deflate_p.h
@@ -33,10 +33,7 @@ static inline int zng_tr_tally_lit(deflate_state *s, unsigned char c) {
     s->sym_buf[s->sym_next++] = c;
     s->dyn_ltree[c].Freq++;
     Tracevv((stderr, "%c", c));
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wtype-limits"
     Assert(c <= (MAX_MATCH-MIN_MATCH), "zng_tr_tally: bad literal");
-#pragma GCC diagnostic pop
     return (s->sym_next == s->sym_end);
 }
 


### PR DESCRIPTION
This makes MSVC unhappy:

https://github.com/zlib-ng/zlib-ng/pull/726#issuecomment-681128124

D:\a\zlib-ng\zlib-ng\deflate_p.h(36,9): warning C4068: unknown pragma 'GCC' [D:\a\zlib-ng\zlib-ng\zlib.vcxproj]

This reverts commit 24c442c606d9121da64b25693c9bb1a898b3553f.