### PR TITLE
More struct and deflate-related cleanups and optimizations

### DIFF
--- a/arch/x86/compare258_avx.c
+++ b/arch/x86/compare258_avx.c
@@ -16,18 +16,18 @@
 #endif
 
 /* UNALIGNED_OK, AVX2 intrinsic comparison */
-static inline int32_t compare256_unaligned_avx2_static(const unsigned char *src0, const unsigned char *src1) {
-    int32_t len = 0;
+static inline uint32_t compare256_unaligned_avx2_static(const unsigned char *src0, const unsigned char *src1) {
+    uint32_t len = 0;
 
     do {
         __m256i ymm_src0, ymm_src1, ymm_cmp;
         ymm_src0 = _mm256_loadu_si256((__m256i*)src0);
         ymm_src1 = _mm256_loadu_si256((__m256i*)src1);
         ymm_cmp = _mm256_cmpeq_epi8(ymm_src0, ymm_src1); /* non-identical bytes = 00, identical bytes = FF */
-        int mask = _mm256_movemask_epi8(ymm_cmp);
-        if ((unsigned int)mask != 0xFFFFFFFF) {
-            int match_byte = __builtin_ctz(~mask); /* Invert bits so identical = 0 */
-            return (int32_t)(len + match_byte);
+        unsigned mask = (unsigned)_mm256_movemask_epi8(ymm_cmp);
+        if (mask != 0xFFFFFFFF) {
+            uint32_t match_byte = (uint32_t)__builtin_ctz(~mask); /* Invert bits so identical = 0 */
+            return len + match_byte;
         }
 
         src0 += 32, src1 += 32, len += 32;
@@ -35,10 +35,10 @@ static inline int32_t compare256_unaligned_avx2_static(const unsigned char *src0
         ymm_src0 = _mm256_loadu_si256((__m256i*)src0);
         ymm_src1 = _mm256_loadu_si256((__m256i*)src1);
         ymm_cmp = _mm256_cmpeq_epi8(ymm_src0, ymm_src1);
-        mask = _mm256_movemask_epi8(ymm_cmp);
-        if ((unsigned int)mask != 0xFFFFFFFF) {
-            int match_byte = __builtin_ctz(~mask);
-            return (int32_t)(len + match_byte);
+        mask = (unsigned)_mm256_movemask_epi8(ymm_cmp);
+        if (mask != 0xFFFFFFFF) {
+            uint32_t match_byte = (uint32_t)__builtin_ctz(~mask);
+            return len + match_byte;
         }
 
         src0 += 32, src1 += 32, len += 32;
@@ -47,14 +47,14 @@ static inline int32_t compare256_unaligned_avx2_static(const unsigned char *src0
     return 256;
 }
 
-static inline int32_t compare258_unaligned_avx2_static(const unsigned char *src0, const unsigned char *src1) {
+static inline uint32_t compare258_unaligned_avx2_static(const unsigned char *src0, const unsigned char *src1) {
     if (*(uint16_t *)src0 != *(uint16_t *)src1)
         return (*src0 == *src1);
 
     return compare256_unaligned_avx2_static(src0+2, src1+2) + 2;
 }
 
-Z_INTERNAL int32_t compare258_unaligned_avx2(const unsigned char *src0, const unsigned char *src1) {
+Z_INTERNAL uint32_t compare258_unaligned_avx2(const unsigned char *src0, const unsigned char *src1) {
     return compare258_unaligned_avx2_static(src0, src1);
 }
 

--- a/arch/x86/compare258_sse.c
+++ b/arch/x86/compare258_sse.c
@@ -26,27 +26,27 @@
 #endif
 
 /* UNALIGNED_OK, SSE4.2 intrinsic comparison */
-static inline int32_t compare256_unaligned_sse4_static(const unsigned char *src0, const unsigned char *src1) {
-    int32_t len = 0;
+static inline uint32_t compare256_unaligned_sse4_static(const unsigned char *src0, const unsigned char *src1) {
+    uint32_t len = 0;
 
     do {
         #define mode _SIDD_UBYTE_OPS | _SIDD_CMP_EQUAL_EACH | _SIDD_NEGATIVE_POLARITY
         __m128i xmm_src0, xmm_src1;
-        int ret;
+        uint32_t ret;
 
         xmm_src0 = _mm_loadu_si128((__m128i *)src0);
         xmm_src1 = _mm_loadu_si128((__m128i *)src1);
-        ret = _mm_cmpestri(xmm_src0, 16, xmm_src1, 16, mode);
+        ret = (uint32_t)_mm_cmpestri(xmm_src0, 16, xmm_src1, 16, mode);
         if (_mm_cmpestrc(xmm_src0, 16, xmm_src1, 16, mode)) {
-            return (int32_t)(len + ret);
+            return len + ret;
         }
         src0 += 16, src1 += 16, len += 16;
 
         xmm_src0 = _mm_loadu_si128((__m128i *)src0);
         xmm_src1 = _mm_loadu_si128((__m128i *)src1);
-        ret = _mm_cmpestri(xmm_src0, 16, xmm_src1, 16, mode);
+        ret = (uint32_t)_mm_cmpestri(xmm_src0, 16, xmm_src1, 16, mode);
         if (_mm_cmpestrc(xmm_src0, 16, xmm_src1, 16, mode)) {
-            return (int32_t)(len + ret);
+            return len + ret;
         }
         src0 += 16, src1 += 16, len += 16;
     } while (len < 256);
@@ -54,14 +54,14 @@ static inline int32_t compare256_unaligned_sse4_static(const unsigned char *src0
     return 256;
 }
 
-static inline int32_t compare258_unaligned_sse4_static(const unsigned char *src0, const unsigned char *src1) {
+static inline uint32_t compare258_unaligned_sse4_static(const unsigned char *src0, const unsigned char *src1) {
     if (*(uint16_t *)src0 != *(uint16_t *)src1)
         return (*src0 == *src1);
 
     return compare256_unaligned_sse4_static(src0+2, src1+2) + 2;
 }
 
-Z_INTERNAL int32_t compare258_unaligned_sse4(const unsigned char *src0, const unsigned char *src1) {
+Z_INTERNAL uint32_t compare258_unaligned_sse4(const unsigned char *src0, const unsigned char *src1) {
     return compare258_unaligned_sse4_static(src0, src1);
 }
 

--- a/arch/x86/slide_avx.c
+++ b/arch/x86/slide_avx.c
@@ -18,7 +18,7 @@ Z_INTERNAL void slide_hash_avx2(deflate_state *s) {
     Pos *p;
     unsigned n;
     uint16_t wsize = (uint16_t)s->w_size;
-    const __m256i zmm_wsize = _mm256_set1_epi16(wsize);
+    const __m256i zmm_wsize = _mm256_set1_epi16((short)wsize);
 
     n = HASH_SIZE;
     p = &s->head[n] - 16;

--- a/arch/x86/slide_sse.c
+++ b/arch/x86/slide_sse.c
@@ -17,7 +17,7 @@ Z_INTERNAL void slide_hash_sse2(deflate_state *s) {
     Pos *p;
     unsigned n;
     uint16_t wsize = (uint16_t)s->w_size;
-    const __m128i xmm_wsize = _mm_set1_epi16(wsize);
+    const __m128i xmm_wsize = _mm_set1_epi16((short)wsize);
 
     n = HASH_SIZE;
     p = &s->head[n] - 8;

--- a/compare258.c
+++ b/compare258.c
@@ -9,8 +9,8 @@
 #include "fallback_builtins.h"
 
 /* ALIGNED, byte comparison */
-static inline int32_t compare256_c_static(const unsigned char *src0, const unsigned char *src1) {
-    int32_t len = 0;
+static inline uint32_t compare256_c_static(const unsigned char *src0, const unsigned char *src1) {
+    uint32_t len = 0;
 
     do {
         if (*src0 != *src1)
@@ -42,7 +42,7 @@ static inline int32_t compare256_c_static(const unsigned char *src0, const unsig
     return 256;
 }
 
-static inline int32_t compare258_c_static(const unsigned char *src0, const unsigned char *src1) {
+static inline uint32_t compare258_c_static(const unsigned char *src0, const unsigned char *src1) {
     if (*src0 != *src1)
         return 0;
     src0 += 1, src1 += 1;
@@ -53,7 +53,7 @@ static inline int32_t compare258_c_static(const unsigned char *src0, const unsig
     return compare256_c_static(src0, src1) + 2;
 }
 
-Z_INTERNAL int32_t compare258_c(const unsigned char *src0, const unsigned char *src1) {
+Z_INTERNAL uint32_t compare258_c(const unsigned char *src0, const unsigned char *src1) {
     return compare258_c_static(src0, src1);
 }
 
@@ -65,8 +65,8 @@ Z_INTERNAL int32_t compare258_c(const unsigned char *src0, const unsigned char *
 
 #ifdef UNALIGNED_OK
 /* UNALIGNED_OK, 16-bit integer comparison */
-static inline int32_t compare256_unaligned_16_static(const unsigned char *src0, const unsigned char *src1) {
-    int32_t len = 0;
+static inline uint32_t compare256_unaligned_16_static(const unsigned char *src0, const unsigned char *src1) {
+    uint32_t len = 0;
 
     do {
         if (*(uint16_t *)src0 != *(uint16_t *)src1)
@@ -86,14 +86,14 @@ static inline int32_t compare256_unaligned_16_static(const unsigned char *src0, 
     return 256;
 }
 
-static inline int32_t compare258_unaligned_16_static(const unsigned char *src0, const unsigned char *src1) {
+static inline uint32_t compare258_unaligned_16_static(const unsigned char *src0, const unsigned char *src1) {
     if (*(uint16_t *)src0 != *(uint16_t *)src1)
         return (*src0 == *src1);
 
     return compare256_unaligned_16_static(src0+2, src1+2) + 2;
 }
 
-Z_INTERNAL int32_t compare258_unaligned_16(const unsigned char *src0, const unsigned char *src1) {
+Z_INTERNAL uint32_t compare258_unaligned_16(const unsigned char *src0, const unsigned char *src1) {
     return compare258_unaligned_16_static(src0, src1);
 }
 
@@ -105,8 +105,8 @@ Z_INTERNAL int32_t compare258_unaligned_16(const unsigned char *src0, const unsi
 
 #ifdef HAVE_BUILTIN_CTZ
 /* UNALIGNED_OK, 32-bit integer comparison */
-static inline int32_t compare256_unaligned_32_static(const unsigned char *src0, const unsigned char *src1) {
-    int32_t len = 0;
+static inline uint32_t compare256_unaligned_32_static(const unsigned char *src0, const unsigned char *src1) {
+    uint32_t len = 0;
 
     do {
         uint32_t sv = *(uint32_t *)src0;
@@ -115,7 +115,7 @@ static inline int32_t compare256_unaligned_32_static(const unsigned char *src0, 
 
         if (diff) {
             uint32_t match_byte = __builtin_ctz(diff) / 8;
-            return (int32_t)(len + match_byte);
+            return len + match_byte;
         }
 
         src0 += 4, src1 += 4, len += 4;
@@ -124,14 +124,14 @@ static inline int32_t compare256_unaligned_32_static(const unsigned char *src0, 
     return 256;
 }
 
-static inline int32_t compare258_unaligned_32_static(const unsigned char *src0, const unsigned char *src1) {
+static inline uint32_t compare258_unaligned_32_static(const unsigned char *src0, const unsigned char *src1) {
     if (*(uint16_t *)src0 != *(uint16_t *)src1)
         return (*src0 == *src1);
 
     return compare256_unaligned_32_static(src0+2, src1+2) + 2;
 }
 
-Z_INTERNAL int32_t compare258_unaligned_32(const unsigned char *src0, const unsigned char *src1) {
+Z_INTERNAL uint32_t compare258_unaligned_32(const unsigned char *src0, const unsigned char *src1) {
     return compare258_unaligned_32_static(src0, src1);
 }
 
@@ -145,8 +145,8 @@ Z_INTERNAL int32_t compare258_unaligned_32(const unsigned char *src0, const unsi
 
 #if defined(UNALIGNED64_OK) && defined(HAVE_BUILTIN_CTZLL)
 /* UNALIGNED64_OK, 64-bit integer comparison */
-static inline int32_t compare256_unaligned_64_static(const unsigned char *src0, const unsigned char *src1) {
-    int32_t len = 0;
+static inline uint32_t compare256_unaligned_64_static(const unsigned char *src0, const unsigned char *src1) {
+    uint32_t len = 0;
 
     do {
         uint64_t sv = *(uint64_t *)src0;
@@ -155,7 +155,7 @@ static inline int32_t compare256_unaligned_64_static(const unsigned char *src0, 
 
         if (diff) {
             uint64_t match_byte = __builtin_ctzll(diff) / 8;
-            return (int32_t)(len + match_byte);
+            return len + match_byte;
         }
 
         src0 += 8, src1 += 8, len += 8;
@@ -164,14 +164,14 @@ static inline int32_t compare256_unaligned_64_static(const unsigned char *src0, 
     return 256;
 }
 
-static inline int32_t compare258_unaligned_64_static(const unsigned char *src0, const unsigned char *src1) {
+static inline uint32_t compare258_unaligned_64_static(const unsigned char *src0, const unsigned char *src1) {
     if (*(uint16_t *)src0 != *(uint16_t *)src1)
         return (*src0 == *src1);
 
     return compare256_unaligned_64_static(src0+2, src1+2) + 2;
 }
 
-Z_INTERNAL int32_t compare258_unaligned_64(const unsigned char *src0, const unsigned char *src1) {
+Z_INTERNAL uint32_t compare258_unaligned_64(const unsigned char *src0, const unsigned char *src1) {
     return compare258_unaligned_64_static(src0, src1);
 }
 

--- a/deflate.c
+++ b/deflate.c
@@ -391,7 +391,6 @@ int32_t Z_EXPORT PREFIX(deflateInit2_)(PREFIX3(stream) *strm, int32_t level, int
 
     s->level = level;
     s->strategy = strategy;
-    s->method = (unsigned char)method;
     s->block_open = 0;
     s->reproducible = 0;
 

--- a/deflate.c
+++ b/deflate.c
@@ -375,8 +375,7 @@ int32_t Z_EXPORT PREFIX(deflateInit2_)(PREFIX3(stream) *strm, int32_t level, int
     s->pending_buf = (unsigned char *) ZALLOC(strm, s->lit_bufsize, 4);
     s->pending_buf_size = s->lit_bufsize * 4;
 
-    if (s->window == NULL || s->prev == NULL || s->head == NULL ||
-        s->pending_buf == NULL) {
+    if (s->window == NULL || s->prev == NULL || s->head == NULL || s->pending_buf == NULL) {
         s->status = FINISH_STATE;
         strm->msg = ERR_MSG(Z_MEM_ERROR);
         PREFIX(deflateEnd)(strm);
@@ -402,8 +401,7 @@ int32_t Z_EXPORT PREFIX(deflateInit2_)(PREFIX3(stream) *strm, int32_t level, int
  */
 static int deflateStateCheck (PREFIX3(stream) *strm) {
     deflate_state *s;
-    if (strm == NULL ||
-        strm->zalloc == (alloc_func)0 || strm->zfree == (free_func)0)
+    if (strm == NULL || strm->zalloc == (alloc_func)0 || strm->zfree == (free_func)0)
         return 1;
     s = strm->state;
     if (s == NULL || s->strm != strm || (s->status != INIT_STATE &&
@@ -502,9 +500,8 @@ int32_t Z_EXPORT PREFIX(deflateGetDictionary)(PREFIX3(stream) *strm, uint8_t *di
 int32_t Z_EXPORT PREFIX(deflateResetKeep)(PREFIX3(stream) *strm) {
     deflate_state *s;
 
-    if (deflateStateCheck(strm)) {
+    if (deflateStateCheck(strm))
         return Z_STREAM_ERROR;
-    }
 
     strm->total_in = strm->total_out = 0;
     strm->msg = NULL; /* use zfree if we ever allocate msg dynamically */
@@ -514,9 +511,9 @@ int32_t Z_EXPORT PREFIX(deflateResetKeep)(PREFIX3(stream) *strm) {
     s->pending = 0;
     s->pending_out = s->pending_buf;
 
-    if (s->wrap < 0) {
+    if (s->wrap < 0)
         s->wrap = -s->wrap; /* was made negative by deflate(..., Z_FINISH); */
-    }
+
     s->status =
 #ifdef GZIP
         s->wrap == 2 ? GZIP_STATE :
@@ -607,14 +604,13 @@ int32_t Z_EXPORT PREFIX(deflateParams)(PREFIX3(stream) *strm, int32_t level, int
 
     if (level == Z_DEFAULT_COMPRESSION)
         level = 6;
-    if (level < 0 || level > 9 || strategy < 0 || strategy > Z_FIXED) {
+    if (level < 0 || level > 9 || strategy < 0 || strategy > Z_FIXED)
         return Z_STREAM_ERROR;
-    }
     DEFLATE_PARAMS_HOOK(strm, level, strategy, &hook_flush);  /* hook for IBM Z DFLTCC */
     func = configuration_table[s->level].func;
 
-    if (((strategy != s->strategy || func != configuration_table[level].func) && s->last_flush != -2) ||
-        hook_flush != Z_NO_FLUSH) {
+    if (((strategy != s->strategy || func != configuration_table[level].func) && s->last_flush != -2)
+        || hook_flush != Z_NO_FLUSH) {
         /* Flush the last buffer. Use Z_BLOCK mode, unless the hook requests a "stronger" one. */
         int flush = RANK(hook_flush) > RANK(Z_BLOCK) ? hook_flush : Z_BLOCK;
         int err = PREFIX(deflate)(strm, flush);
@@ -756,9 +752,8 @@ Z_INTERNAL void flush_pending(PREFIX3(stream) *strm) {
     strm->total_out += len;
     strm->avail_out -= len;
     s->pending      -= len;
-    if (s->pending == 0) {
+    if (s->pending == 0)
         s->pending_out = s->pending_buf;
-    }
 }
 
 /* ===========================================================================
@@ -775,17 +770,17 @@ int32_t Z_EXPORT PREFIX(deflate)(PREFIX3(stream) *strm, int32_t flush) {
     int32_t old_flush; /* value of flush param for previous deflate call */
     deflate_state *s;
 
-    if (deflateStateCheck(strm) || flush > Z_BLOCK || flush < 0) {
+    if (deflateStateCheck(strm) || flush > Z_BLOCK || flush < 0)
         return Z_STREAM_ERROR;
-    }
     s = strm->state;
 
-    if (strm->next_out == NULL || (strm->avail_in != 0 && strm->next_in == NULL) ||
-        (s->status == FINISH_STATE && flush != Z_FINISH)) {
+    if (strm->next_out == NULL || (strm->avail_in != 0 && strm->next_in == NULL)
+        || (s->status == FINISH_STATE && flush != Z_FINISH)) {
         ERR_RETURN(strm, Z_STREAM_ERROR);
     }
-    if (strm->avail_out == 0)
+    if (strm->avail_out == 0) {
         ERR_RETURN(strm, Z_BUF_ERROR);
+    }
 
     old_flush = s->last_flush;
     s->last_flush = flush;
@@ -808,13 +803,12 @@ int32_t Z_EXPORT PREFIX(deflate)(PREFIX3(stream) *strm, int32_t flush) {
          * flushes. For repeated and useless calls with Z_FINISH, we keep
          * returning Z_STREAM_END instead of Z_BUF_ERROR.
          */
-    } else if (strm->avail_in == 0 && RANK(flush) <= RANK(old_flush) &&
-               flush != Z_FINISH) {
+    } else if (strm->avail_in == 0 && RANK(flush) <= RANK(old_flush) && flush != Z_FINISH) {
         ERR_RETURN(strm, Z_BUF_ERROR);
     }
 
     /* User must not provide more input after the first FINISH: */
-    if (s->status == FINISH_STATE && strm->avail_in != 0) {
+    if (s->status == FINISH_STATE && strm->avail_in != 0)   {
         ERR_RETURN(strm, Z_BUF_ERROR);
     }
 
@@ -835,15 +829,15 @@ int32_t Z_EXPORT PREFIX(deflate)(PREFIX3(stream) *strm, int32_t flush) {
         else
             level_flags = 3;
         header |= (level_flags << 6);
-        if (s->strstart != 0) header |= PRESET_DICT;
+        if (s->strstart != 0)
+            header |= PRESET_DICT;
         header += 31 - (header % 31);
 
         put_short_msb(s, (uint16_t)header);
 
         /* Save the adler32 of the preset dictionary: */
-        if (s->strstart != 0) {
+        if (s->strstart != 0)
             put_uint32_msb(s, strm->adler);
-        }
         strm->adler = ADLER32_INITIAL_VALUE;
         s->status = BUSY_STATE;
 
@@ -883,12 +877,10 @@ int32_t Z_EXPORT PREFIX(deflate)(PREFIX3(stream) *strm, int32_t flush) {
                      (s->gzhead->comment == NULL ? 0 : 16)
                      );
             put_uint32(s, s->gzhead->time);
-            put_byte(s, s->level == 9 ? 2 :
-                     (s->strategy >= Z_HUFFMAN_ONLY || s->level < 2 ? 4 : 0));
+            put_byte(s, s->level == 9 ? 2 : (s->strategy >= Z_HUFFMAN_ONLY || s->level < 2 ? 4 : 0));
             put_byte(s, s->gzhead->os & 0xff);
-            if (s->gzhead->extra != NULL) {
+            if (s->gzhead->extra != NULL)
                 put_short(s, (uint16_t)s->gzhead->extra_len);
-            }
             if (s->gzhead->hcrc)
                 strm->adler = PREFIX(crc32)(strm->adler, s->pending_buf, s->pending);
             s->gzindex = 0;
@@ -1054,9 +1046,8 @@ int32_t Z_EXPORT PREFIX(deflate)(PREFIX3(stream) *strm, int32_t flush) {
         put_uint32(s, (uint32_t)strm->total_in);
     } else
 #endif
-    if (s->wrap == 1) {
+    if (s->wrap == 1)
         put_uint32_msb(s, strm->adler);
-    }
     flush_pending(strm);
     /* If avail_out is zero, the application will call deflate again
      * to flush the rest.
@@ -1099,9 +1090,8 @@ int32_t Z_EXPORT PREFIX(deflateCopy)(PREFIX3(stream) *dest, PREFIX3(stream) *sou
     deflate_state *ss;
     uint32_t window_padding = 0;
 
-    if (deflateStateCheck(source) || dest == NULL) {
+    if (deflateStateCheck(source) || dest == NULL)
         return Z_STREAM_ERROR;
-    }
 
     ss = source->state;
 
@@ -1162,13 +1152,11 @@ Z_INTERNAL unsigned read_buf(PREFIX3(stream) *strm, unsigned char *buf, unsigned
 
     if (!DEFLATE_NEED_CHECKSUM(strm)) {
         memcpy(buf, strm->next_in, len);
-    } else
 #ifdef GZIP
-    if (strm->state->wrap == 2)
+    } else if (strm->state->wrap == 2) {
         copy_with_crc(strm, buf, len);
-    else
 #endif
-    {
+    } else {
         memcpy(buf, strm->next_in, len);
         if (strm->state->wrap == 1)
             strm->adler = functable.adler32(strm->adler, buf, len);
@@ -1491,8 +1479,7 @@ static block_state deflate_stored(deflate_state *s, int flush) {
         return finish_done;
 
     /* If flushing and all input has been consumed, then done. */
-    if (flush != Z_NO_FLUSH && flush != Z_FINISH &&
-        s->strm->avail_in == 0 && (int)s->strstart == s->block_start)
+    if (flush != Z_NO_FLUSH && flush != Z_FINISH && s->strm->avail_in == 0 && (int)s->strstart == s->block_start)
         return block_done;
 
     /* Fill the window with any remaining input. */
@@ -1528,12 +1515,9 @@ static block_state deflate_stored(deflate_state *s, int flush) {
     have = MIN(s->pending_buf_size - have, MAX_STORED);
     min_block = MIN(have, s->w_size);
     left = (int)s->strstart - s->block_start;
-    if (left >= min_block ||
-        ((left || flush == Z_FINISH) && flush != Z_NO_FLUSH &&
-         s->strm->avail_in == 0 && left <= have)) {
+    if (left >= min_block || ((left || flush == Z_FINISH) && flush != Z_NO_FLUSH && s->strm->avail_in == 0 && left <= have)) {
         len = MIN(left, have);
-        last = flush == Z_FINISH && s->strm->avail_in == 0 &&
-               len == left ? 1 : 0;
+        last = flush == Z_FINISH && s->strm->avail_in == 0 && len == left ? 1 : 0;
         zng_tr_stored_block(s, (char *)s->window + s->block_start, len, last);
         s->block_start += (int)len;
         flush_pending(s->strm);
@@ -1562,9 +1546,8 @@ static block_state deflate_rle(deflate_state *s, int flush) {
          */
         if (s->lookahead <= MAX_MATCH) {
             fill_window(s);
-            if (s->lookahead <= MAX_MATCH && flush == Z_NO_FLUSH) {
+            if (s->lookahead <= MAX_MATCH && flush == Z_NO_FLUSH)
                 return need_more;
-            }
             if (s->lookahead == 0)
                 break; /* flush the current block */
         }
@@ -1730,9 +1713,9 @@ int32_t Z_EXPORT zng_deflateSetParams(zng_stream *strm, zng_deflate_param_value 
     }
     if (new_reproducible != NULL) {
         val = *(int *)new_reproducible->buf;
-        if (DEFLATE_CAN_SET_REPRODUCIBLE(strm, val))
+        if (DEFLATE_CAN_SET_REPRODUCIBLE(strm, val)) {
             s->reproducible = val;
-        else {
+        } else {
             new_reproducible->status = Z_STREAM_ERROR;
             stream_error = 1;
         }

--- a/deflate.c
+++ b/deflate.c
@@ -373,7 +373,7 @@ int32_t Z_EXPORT PREFIX(deflateInit2_)(PREFIX3(stream) *strm, int32_t level, int
      */
 
     s->pending_buf = (unsigned char *) ZALLOC(strm, s->lit_bufsize, 4);
-    s->pending_buf_size = (unsigned long)s->lit_bufsize * 4;
+    s->pending_buf_size = s->lit_bufsize * 4;
 
     if (s->window == NULL || s->prev == NULL || s->head == NULL ||
         s->pending_buf == NULL) {
@@ -1132,7 +1132,7 @@ int32_t Z_EXPORT PREFIX(deflateCopy)(PREFIX3(stream) *dest, PREFIX3(stream) *sou
     memcpy(ds->window, ss->window, ds->w_size * 2 * sizeof(unsigned char));
     memcpy((void *)ds->prev, (void *)ss->prev, ds->w_size * sizeof(Pos));
     memcpy((void *)ds->head, (void *)ss->head, HASH_SIZE * sizeof(Pos));
-    memcpy(ds->pending_buf, ss->pending_buf, (unsigned int)ds->pending_buf_size);
+    memcpy(ds->pending_buf, ss->pending_buf, ds->pending_buf_size);
 
     ds->pending_out = ds->pending_buf + (ss->pending_out - ss->pending_buf);
     ds->sym_buf = ds->pending_buf + ds->lit_bufsize;

--- a/deflate.h
+++ b/deflate.h
@@ -176,15 +176,13 @@ typedef struct internal_state {
      */
 
     unsigned int max_chain_length;
-    /* To speed up deflation, hash chains are never searched beyond this
-     * length.  A higher limit improves compression ratio but degrades the
-     * speed.
+    /* To speed up deflation, hash chains are never searched beyond this length.
+     * A higher limit improves compression ratio but degrades the speed.
      */
 
     unsigned int max_lazy_match;
-    /* Attempt to find a better match only when the current match is strictly
-     * smaller than this value. This mechanism is used only for compression
-     * levels >= 4.
+    /* Attempt to find a better match only when the current match is strictly smaller
+     * than this value. This mechanism is used only for compression levels >= 4.
      */
 #   define max_insert_length  max_lazy_match
     /* Insert new strings in the hash table only if the match length is not
@@ -263,13 +261,10 @@ typedef struct internal_state {
 #endif
 
     uint64_t bi_buf;
-    /* Output buffer. bits are inserted starting at the bottom (least
-     * significant bits).
-     */
+    /* Output buffer. bits are inserted starting at the bottom (least significant bits). */
+
     int32_t bi_valid;
-    /* Number of valid bits in bi_buf.  All bits above the last valid bit
-     * are always zero.
-     */
+    /* Number of valid bits in bi_buf.  All bits above the last valid bit are always zero. */
 
 } deflate_state;
 

--- a/deflate.h
+++ b/deflate.h
@@ -115,6 +115,12 @@ typedef struct internal_state {
     PREFIX(gz_headerp)   gzhead;           /* gzip header information to write */
     int                  status;           /* as the name implies */
     int                  last_flush;       /* value of flush param for previous deflate call */
+    int                  reproducible;     /* Whether reproducible compression results are required. */
+
+    int block_open;
+    /* Whether or not a block is currently open for the QUICK deflation scheme.
+     * This is set to 1 if there is an active block, or 0 if the block was just closed.
+     */
 
                 /* used by deflate.c: */
 
@@ -197,6 +203,7 @@ typedef struct internal_state {
 #ifdef X86_PCLMULQDQ_CRC
     unsigned crc0[4 * 5];
 #endif
+
                 /* used by trees.c: */
     /* Didn't use ct_data typedef below to suppress compiler warning */
     struct ct_data_s dyn_ltree[HEAP_SIZE];   /* literal and length tree */
@@ -262,15 +269,6 @@ typedef struct internal_state {
     int32_t bi_valid;
     /* Number of valid bits in bi_buf.  All bits above the last valid bit
      * are always zero.
-     */
-
-    int block_open;
-    /* Whether or not a block is currently open for the QUICK deflation scheme.
-     * This is set to 1 if there is an active block, or 0 if the block was just
-     * closed.
-     */
-    int reproducible;
-    /* Whether reproducible compression results are required.
      */
 
 } deflate_state;

--- a/deflate.h
+++ b/deflate.h
@@ -114,7 +114,6 @@ typedef struct internal_state {
     uint32_t             gzindex;          /* where in extra, name, or comment */
     PREFIX(gz_headerp)   gzhead;           /* gzip header information to write */
     int                  status;           /* as the name implies */
-    unsigned char        method;           /* can only be DEFLATED */
     int                  last_flush;       /* value of flush param for previous deflate call */
 
                 /* used by deflate.c: */

--- a/deflate.h
+++ b/deflate.h
@@ -107,12 +107,12 @@ typedef uint16_t Pos;
 typedef struct internal_state {
     PREFIX3(stream)      *strm;            /* pointer back to this zlib stream */
     unsigned char        *pending_buf;     /* output still pending */
-    unsigned long        pending_buf_size; /* size of pending_buf */
     unsigned char        *pending_out;     /* next pending byte to output to the stream */
+    uint32_t             pending_buf_size; /* size of pending_buf */
     uint32_t             pending;          /* nb of bytes in the pending buffer */
     int                  wrap;             /* bit 0 true for zlib, bit 1 true for gzip */
-    PREFIX(gz_headerp)   gzhead;           /* gzip header information to write */
     uint32_t             gzindex;          /* where in extra, name, or comment */
+    PREFIX(gz_headerp)   gzhead;           /* gzip header information to write */
     int                  status;           /* as the name implies */
     unsigned char        method;           /* can only be DEFLATED */
     int                  last_flush;       /* value of flush param for previous deflate call */

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -213,7 +213,7 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
                  * of window index 0 (in particular we have to avoid a match
                  * of the string with itself at the start of the input file).
                  */
-                current_match.match_length = functable.longest_match(s, hash_head);
+                current_match.match_length = (uint16_t)functable.longest_match(s, hash_head);
                 current_match.match_start = s->match_start;
                 if (UNLIKELY(current_match.match_length < MIN_MATCH))
                     current_match.match_length = 1;
@@ -246,7 +246,7 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
                  * of window index 0 (in particular we have to avoid a match
                  * of the string with itself at the start of the input file).
                  */
-                next_match.match_length = functable.longest_match(s, hash_head);
+                next_match.match_length = (uint16_t)functable.longest_match(s, hash_head);
                 next_match.match_start = s->match_start;
                 if (UNLIKELY(next_match.match_start >= next_match.strstart)) {
                     /* this can happen due to some restarts */

--- a/functable.c
+++ b/functable.c
@@ -95,34 +95,34 @@ extern uint32_t crc32_big(uint32_t, const unsigned char *, uint64_t);
 #endif
 
 /* compare258 */
-extern int32_t compare258_c(const unsigned char *src0, const unsigned char *src1);
+extern uint32_t compare258_c(const unsigned char *src0, const unsigned char *src1);
 #ifdef UNALIGNED_OK
-extern int32_t compare258_unaligned_16(const unsigned char *src0, const unsigned char *src1);
-extern int32_t compare258_unaligned_32(const unsigned char *src0, const unsigned char *src1);
+extern uint32_t compare258_unaligned_16(const unsigned char *src0, const unsigned char *src1);
+extern uint32_t compare258_unaligned_32(const unsigned char *src0, const unsigned char *src1);
 #ifdef UNALIGNED64_OK
-extern int32_t compare258_unaligned_64(const unsigned char *src0, const unsigned char *src1);
+extern uint32_t compare258_unaligned_64(const unsigned char *src0, const unsigned char *src1);
 #endif
 #ifdef X86_SSE42_CMP_STR
-extern int32_t compare258_unaligned_sse4(const unsigned char *src0, const unsigned char *src1);
+extern uint32_t compare258_unaligned_sse4(const unsigned char *src0, const unsigned char *src1);
 #endif
 #if defined(X86_AVX2) && defined(HAVE_BUILTIN_CTZ)
-extern int32_t compare258_unaligned_avx2(const unsigned char *src0, const unsigned char *src1);
+extern uint32_t compare258_unaligned_avx2(const unsigned char *src0, const unsigned char *src1);
 #endif
 #endif
 
 /* longest_match */
-extern int32_t longest_match_c(deflate_state *const s, Pos cur_match);
+extern uint32_t longest_match_c(deflate_state *const s, Pos cur_match);
 #ifdef UNALIGNED_OK
-extern int32_t longest_match_unaligned_16(deflate_state *const s, Pos cur_match);
-extern int32_t longest_match_unaligned_32(deflate_state *const s, Pos cur_match);
+extern uint32_t longest_match_unaligned_16(deflate_state *const s, Pos cur_match);
+extern uint32_t longest_match_unaligned_32(deflate_state *const s, Pos cur_match);
 #ifdef UNALIGNED64_OK
-extern int32_t longest_match_unaligned_64(deflate_state *const s, Pos cur_match);
+extern uint32_t longest_match_unaligned_64(deflate_state *const s, Pos cur_match);
 #endif
 #ifdef X86_SSE42_CMP_STR
-extern int32_t longest_match_unaligned_sse4(deflate_state *const s, Pos cur_match);
+extern uint32_t longest_match_unaligned_sse4(deflate_state *const s, Pos cur_match);
 #endif
 #if defined(X86_AVX2) && defined(HAVE_BUILTIN_CTZ)
-extern int32_t longest_match_unaligned_avx2(deflate_state *const s, Pos cur_match);
+extern uint32_t longest_match_unaligned_avx2(deflate_state *const s, Pos cur_match);
 #endif
 #endif
 
@@ -365,7 +365,7 @@ Z_INTERNAL uint32_t crc32_stub(uint32_t crc, const unsigned char *buf, uint64_t 
     return functable.crc32(crc, buf, len);
 }
 
-Z_INTERNAL int32_t compare258_stub(const unsigned char *src0, const unsigned char *src1) {
+Z_INTERNAL uint32_t compare258_stub(const unsigned char *src0, const unsigned char *src1) {
 
     functable.compare258 = &compare258_c;
 
@@ -390,7 +390,7 @@ Z_INTERNAL int32_t compare258_stub(const unsigned char *src0, const unsigned cha
     return functable.compare258(src0, src1);
 }
 
-Z_INTERNAL int32_t longest_match_stub(deflate_state *const s, Pos cur_match) {
+Z_INTERNAL uint32_t longest_match_stub(deflate_state *const s, Pos cur_match) {
 
     functable.longest_match = &longest_match_c;
 

--- a/functable.h
+++ b/functable.h
@@ -14,8 +14,8 @@ struct functable_s {
     uint32_t (* adler32)            (uint32_t adler, const unsigned char *buf, size_t len);
     uint32_t (* crc32)              (uint32_t crc, const unsigned char *buf, uint64_t len);
     void     (* slide_hash)         (deflate_state *s);
-    int32_t  (* compare258)         (const unsigned char *src0, const unsigned char *src1);
-    int32_t  (* longest_match)      (deflate_state *const s, Pos cur_match);
+    uint32_t (* compare258)         (const unsigned char *src0, const unsigned char *src1);
+    uint32_t (* longest_match)      (deflate_state *const s, Pos cur_match);
     uint32_t (* chunksize)          (void);
     uint8_t* (* chunkcopy)          (uint8_t *out, uint8_t const *from, unsigned len);
     uint8_t* (* chunkcopy_safe)     (uint8_t *out, uint8_t const *from, unsigned len, uint8_t *safe);

--- a/match_tpl.h
+++ b/match_tpl.h
@@ -28,7 +28,7 @@ typedef uint8_t         bestcmp_t;
  * string (strstart) and its distance is <= MAX_DIST, and prev_length >=1
  * OUT assertion: the match length is not greater than s->lookahead
  */
-Z_INTERNAL int32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
+Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
     unsigned int strstart = s->strstart;
     const unsigned wmask = s->w_mask;
     unsigned char *window = s->window;

--- a/match_tpl.h
+++ b/match_tpl.h
@@ -20,8 +20,7 @@ typedef uint8_t         bestcmp_t;
 
 #endif
 
-/*
- * Set match_start to the longest match starting at the given string and
+/* Set match_start to the longest match starting at the given string and
  * return its length. Matches shorter or equal to prev_length are discarded,
  * in which case the result is equal to prev_length and match_start is garbage.
  *
@@ -52,15 +51,12 @@ Z_INTERNAL int32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
         continue; \
     return best_len;
 
-    /*
-     * The code is optimized for MAX_MATCH-2 multiple of 16.
-     */
+    /* The code is optimized for MAX_MATCH-2 multiple of 16. */
     Assert(MAX_MATCH == 258, "Code too clever");
 
     best_len = s->prev_length ? s->prev_length : 1;
 
-    /* 
-     * Calculate read offset which should only extend an extra byte 
+    /* Calculate read offset which should only extend an extra byte
      * to find the next best match length.
      */
     offset = best_len-1;
@@ -82,16 +78,13 @@ Z_INTERNAL int32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
 #endif
     mbase_end  = (mbase_start+offset);
 
-    /*
-     * Do not waste too much time if we already have a good match
-     */
+    /* Do not waste too much time if we already have a good match */
     chain_length = s->max_chain_length;
     if (best_len >= s->good_match)
         chain_length >>= 2;
     nice_match = (uint32_t)s->nice_match;
 
-    /*
-     * Stop when cur_match becomes <= limit. To simplify the code,
+    /* Stop when cur_match becomes <= limit. To simplify the code,
      * we prevent matches with the string of window index 0
      */
     limit = strstart > MAX_DIST(s) ? (Pos)(strstart - MAX_DIST(s)) : 0;
@@ -102,15 +95,12 @@ Z_INTERNAL int32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
         if (cur_match >= strstart)
             break;
 
-        /*
-         * Skip to next match if the match length cannot increase
-         * or if the match length is less than 2. Note that the checks
-         * below for insufficient lookahead only occur occasionally
-         * for performance reasons. Therefore uninitialized memory
-         * will be accessed and conditional jumps will be made that
-         * depend on those values. However the length of the match
-         * is limited to the lookahead, so the output of deflate is not
-         * affected by the uninitialized values.
+        /* Skip to next match if the match length cannot increase or if the match length is
+         * less than 2. Note that the checks below for insufficient lookahead only occur
+         * occasionally for performance reasons.
+         * Therefore uninitialized memory will be accessed and conditional jumps will be made
+         * that depend on those values. However the length of the match is limited to the
+         * lookahead, so the output of deflate is not affected by the uninitialized values.
          */
 #ifdef UNALIGNED_OK
         if (best_len < sizeof(uint32_t)) {
@@ -173,10 +163,8 @@ Z_INTERNAL int32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
 #endif
             mbase_end = (mbase_start+offset);
         } else {
-            /*
-             * The probability of finding a match later if we here
-             * is pretty low, so for performance it's best to
-             * outright stop here for the lower compression levels
+            /* The probability of finding a match later if we here is pretty low, so for
+             * performance it's best to outright stop here for the lower compression levels
              */
             if (s->level < EARLY_EXIT_TRIGGER_LEVEL)
                 break;

--- a/trees.c
+++ b/trees.c
@@ -333,7 +333,8 @@ static void build_tree(deflate_state *s, tree_desc *desc) {
      * heap[SMALLEST]. The sons of heap[n] are heap[2*n] and heap[2*n+1].
      * heap[0] is not used.
      */
-    s->heap_len = 0, s->heap_max = HEAP_SIZE;
+    s->heap_len = 0;
+    s->heap_max = HEAP_SIZE;
 
     for (n = 0; n < elems; n++) {
         if (tree[n].Freq != 0) {


### PR DESCRIPTION
This PR is a little all over the place, since I was hunting warnings all over, and it represents about 2 full days of testing and tweaking.
I did have to give up on shrinking s->heap, and also on getting rid of all of the bi_valid warnings, after numerous attemtpts from scratch, all resulting in incorrect deflate output data for unknown reasons (I have theories, but don't know exactly where the errors happen).

I don't know how many warnings got fixed and/or silenced, but I'd estimate 20 (when excluding duplicates), still lots more (and quite a lot of them false due to a GCC bug, makes it hard to spot the real ones).

This shrinks the deflate internal_state struct by 8 bytes. Before:
```
        /* size: 5984, cachelines: 94, members: 57 */
        /* sum members: 5972, holes: 3, sum holes: 8 */
        /* padding: 4 */
        /* last cacheline: 32 bytes */
```
After:
```
        /* size: 5976, cachelines: 94, members: 56 */
        /* sum members: 5967, holes: 2, sum holes: 5 */
        /* padding: 4 */
        /* last cacheline: 24 bytes */
```

PS: To review this, please look at each commit separately, otherwise it'll be very difficult to get an overview of what is happening.