### PR TITLE
Remove FORCE_STATIC and FORCE_STORED

### DIFF
--- a/trees.c
+++ b/trees.c
@@ -674,13 +674,9 @@ void Z_INTERNAL zng_tr_flush_block(deflate_state *s, char *buf, uint32_t stored_
         opt_lenb = static_lenb = stored_len + 5; /* force a stored block */
     }
 
-#ifdef FORCE_STORED
-    if (buf != NULL) { /* force stored block */
-#else
     if (stored_len+4 <= opt_lenb && buf != NULL) {
-        /* 4: two words for the lengths */
-#endif
-        /* The test buf != NULL is only necessary if LIT_BUFSIZE > WSIZE.
+        /* 4: two words for the lengths
+         * The test buf != NULL is only necessary if LIT_BUFSIZE > WSIZE.
          * Otherwise we can't have processed more than WSIZE input bytes since
          * the last block flush, because compression would have been
          * successful. If LIT_BUFSIZE <= WSIZE, it is never too late to
@@ -688,11 +684,7 @@ void Z_INTERNAL zng_tr_flush_block(deflate_state *s, char *buf, uint32_t stored_
          */
         zng_tr_stored_block(s, buf, stored_len, last);
 
-#ifdef FORCE_STATIC
-    } else if (static_lenb >= 0) { /* force static trees */
-#else
     } else if (s->strategy == Z_FIXED || static_lenb == opt_lenb) {
-#endif
         zng_tr_emit_tree(s, STATIC_TREES, last);
         compress_block(s, (const ct_data *)static_ltree, (const ct_data *)static_dtree);
         cmpr_bits_add(s, s->static_len);


### PR DESCRIPTION
- FORCE_STORED is kind of useless, unless you really need to make a valid deflate stream and your cpu/memory is too small to do compression, and in that case zlib-ng is not a good candidate in the first place.
- FORCE_STATIC is also not likely to be useful.

Both of them only represent just one line of code change, and are unlikely to break, but I am tempted to remove them nevertheless, just to reduce the amount of different possible configs.