### PR TITLE
coveralls.io support

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         name: [
           Ubuntu GCC,
-          Ubuntu GCC OSB -O1,
+          Ubuntu GCC OSB,
           Ubuntu GCC Link Zlib,
           Ubuntu GCC No AVX2,
           Ubuntu GCC No SSE2,
@@ -55,14 +55,13 @@ jobs:
             cmake-args: -DWITH_SANITIZERS=ON
             codecov: ubuntu_gcc
 
-          - name: Ubuntu GCC OSB -O1
+          - name: Ubuntu GCC OSB
             os: ubuntu-latest
             compiler: gcc
             cmake-args: -DWITH_SANITIZERS=ON
             build-dir: ../build
             build-src-dir: ../zlib-ng
             codecov: ubuntu_gcc_osb
-            cflags: -O1 -g3
 
           - name: Ubuntu GCC Link Zlib
             os: ubuntu-latest
@@ -331,10 +330,10 @@ jobs:
         path: test/data
 
     - name: Install packages (Ubuntu)
-      if: runner.os == 'Linux' && matrix.packages
+      if: runner.os == 'Linux'
       run: |
         sudo apt-get update
-        sudo apt-get install -y ${{ matrix.packages }}
+        sudo apt-get install -y lcov ${{ matrix.packages }}
 
     - name: Set environment variables (Windows)
       run:  echo "::set-env name=temp::$($env:TEMP)"
@@ -398,7 +397,18 @@ jobs:
         TSAN_OPTIONS: ${{ matrix.tsan-options || 'verbosity=1' }}
         LSAN_OPTIONS: ${{ matrix.lsan-options || 'verbosity=1' }}
 
-    - name: Upload coverage report
+    - name: Generate lcov.info file
+      run: |
+        mkdir coverage
+        lcov -c --directory ${{ matrix.build-dir || '.' }} --output-file coverage/lcov.info
+
+    - name: Upload Coveralls coverage report
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.github_token }}
+        flag-name: run-${{ matrix.name }}
+
+    - name: Upload Codecov.io coverage report
       if: matrix.codecov && ( env.CODECOV_TOKEN_SECRET != '' || github.repository == 'zlib-ng/zlib-ng' )
       shell: bash
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,12 +309,12 @@ endif()
 # Set code coverage compiler flags
 if(WITH_CODE_COVERAGE)
     if(CMAKE_C_COMPILER_ID MATCHES "Clang")
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -coverage")
+        set(CMAKE_C_FLAGS "-O0 ${CMAKE_C_FLAGS} -coverage")
     elseif(__GNUC__)
         # Some versions of GCC don't support -coverage shorthand
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fprofile-arcs -ftest-coverage")
-        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lgcov")
-        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -lgcov")
+        set(CMAKE_C_FLAGS "-O0 ${CMAKE_C_FLAGS} -ftest-coverage -fprofile-arcs -fprofile-values")
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lgcov -fprofile-arcs")
+        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -lgcov -fprofile-arcs")
     endif()
 endif()
 


### PR DESCRIPTION
This is (for now) a hack to add partial coveralls.io support to our CI runs, so we can decide whether to improve that support or drop it.

Have a good look at https://coveralls.io/builds/33411175 to see what the data looks like.
Since codecov.io is unable to fix their systems, hopefully coveralls.io works better..