### PR TITLE
zng_calloc/zng_cfree cleanup

### DIFF
--- a/gzlib.c
+++ b/gzlib.c
@@ -4,6 +4,7 @@
  */
 
 #include "zbuild.h"
+#include "zutil_p.h"
 #include "gzguts.h"
 
 #if defined(_WIN32)
@@ -53,7 +54,7 @@ static gzFile gz_open(const void *path, int fd, const char *mode) {
         return NULL;
 
     /* allocate gzFile structure to return */
-    state = (gz_state *)malloc(sizeof(gz_state));
+    state = (gz_state *)zng_alloc(sizeof(gz_state));
     if (state == NULL)
         return NULL;
     state->size = 0;            /* no buffers allocated yet */
@@ -82,7 +83,7 @@ static gzFile gz_open(const void *path, int fd, const char *mode) {
                 break;
 #endif
             case '+':       /* can't read and write at the same time */
-                free(state);
+                zng_free(state);
                 return NULL;
             case 'b':       /* ignore -- will request binary anyway */
                 break;
@@ -120,14 +121,14 @@ static gzFile gz_open(const void *path, int fd, const char *mode) {
 
     /* must provide an "r", "w", or "a" */
     if (state->mode == GZ_NONE) {
-        free(state);
+        zng_free(state);
         return NULL;
     }
 
     /* can't force transparent read */
     if (state->mode == GZ_READ) {
         if (state->direct) {
-            free(state);
+            zng_free(state);
             return NULL;
         }
         state->direct = 1;      /* for empty file */
@@ -144,7 +145,7 @@ static gzFile gz_open(const void *path, int fd, const char *mode) {
         len = strlen((const char *)path);
     state->path = (char *)malloc(len + 1);
     if (state->path == NULL) {
-        free(state);
+        zng_free(state);
         return NULL;
     }
 #ifdef WIDECHAR
@@ -189,7 +190,7 @@ static gzFile gz_open(const void *path, int fd, const char *mode) {
         open((const char *)path, oflag, 0666));
     if (state->fd == -1) {
         free(state->path);
-        free(state);
+        zng_free(state);
         return NULL;
     }
     if (state->mode == GZ_APPEND) {

--- a/gzread.c
+++ b/gzread.c
@@ -4,6 +4,7 @@
  */
 
 #include "zbuild.h"
+#include "zutil_p.h"
 #include "gzguts.h"
 
 /* Local functions */
@@ -83,11 +84,11 @@ static int gz_look(gz_state *state) {
     /* allocate read buffers and inflate memory */
     if (state->size == 0) {
         /* allocate buffers */
-        state->in = (unsigned char *)malloc(state->want);
-        state->out = (unsigned char *)malloc(state->want << 1);
+        state->in = (unsigned char *)zng_alloc(state->want);
+        state->out = (unsigned char *)zng_alloc(state->want << 1);
         if (state->in == NULL || state->out == NULL) {
-            free(state->out);
-            free(state->in);
+            zng_free(state->out);
+            zng_free(state->in);
             gz_error(state, Z_MEM_ERROR, "out of memory");
             return -1;
         }
@@ -100,8 +101,8 @@ static int gz_look(gz_state *state) {
         state->strm.avail_in = 0;
         state->strm.next_in = NULL;
         if (PREFIX(inflateInit2)(&(state->strm), 15 + 16) != Z_OK) {    /* gunzip */
-            free(state->out);
-            free(state->in);
+            zng_free(state->out);
+            zng_free(state->in);
             state->size = 0;
             gz_error(state, Z_MEM_ERROR, "out of memory");
             return -1;
@@ -589,13 +590,13 @@ int Z_EXPORT PREFIX(gzclose_r)(gzFile file) {
     /* free memory and close file */
     if (state->size) {
         PREFIX(inflateEnd)(&(state->strm));
-        free(state->out);
-        free(state->in);
+        zng_free(state->out);
+        zng_free(state->in);
     }
     err = state->err == Z_BUF_ERROR ? Z_BUF_ERROR : Z_OK;
     gz_error(state, Z_OK, NULL);
     free(state->path);
     ret = close(state->fd);
-    free(state);
+    zng_free(state);
     return ret ? Z_ERRNO : err;
 }

--- a/win32/Makefile.a64
+++ b/win32/Makefile.a64
@@ -152,9 +152,9 @@ adler32.obj: $(SRCDIR)/adler32.c $(SRCDIR)/zbuild.h $(SRCDIR)/zutil.h $(SRCDIR)/
 chunkset.obj: $(SRCDIR)/zbuild.h $(SRCDIR)/zutil.h
 functable.obj: $(SRCDIR)/functable.c $(SRCDIR)/zbuild.h $(SRCDIR)/functable.h $(SRCDIR)/deflate.h $(SRCDIR)/deflate_p.h $(SRCDIR)/zendian.h $(SRCDIR)/arch/x86/x86.h
 gzclose.obj: $(SRCDIR)/gzclose.c $(SRCDIR)/zbuild.h $(SRCDIR)/gzguts.h
-gzlib.obj: $(SRCDIR)/gzlib.c $(SRCDIR)/zbuild.h $(SRCDIR)/gzguts.h
-gzread.obj: $(SRCDIR)/gzread.c $(SRCDIR)/zbuild.h $(SRCDIR)/gzguts.h
-gzwrite.obj: $(SRCDIR)/gzwrite.c $(SRCDIR)/zbuild.h $(SRCDIR)/gzguts.h
+gzlib.obj: $(SRCDIR)/gzlib.c $(SRCDIR)/zbuild.h $(SRCDIR)/gzguts.h $(SRCDIR)/zutil_p.h
+gzread.obj: $(SRCDIR)/gzread.c $(SRCDIR)/zbuild.h $(SRCDIR)/gzguts.h $(SRCDIR)/zutil_p.h
+gzwrite.obj: $(SRCDIR)/gzwrite.c $(SRCDIR)/zbuild.h $(SRCDIR)/gzguts.h $(SRCDIR)/zutil_p.h
 compress.obj: $(SRCDIR)/compress.c $(SRCDIR)/zbuild.h $(SRCDIR)/zlib$(SUFFIX).h
 uncompr.obj: $(SRCDIR)/uncompr.c $(SRCDIR)/zbuild.h $(SRCDIR)/zlib$(SUFFIX).h
 crc32.obj: $(SRCDIR)/crc32.c $(SRCDIR)/zbuild.h $(SRCDIR)/zendian.h $(SRCDIR)/deflate.h $(SRCDIR)/functable.h $(SRCDIR)/crc32_tbl.h
@@ -168,7 +168,7 @@ inffast.obj: $(SRCDIR)/inffast.c $(SRCDIR)/zbuild.h $(SRCDIR)/zutil.h $(SRCDIR)/
 inflate.obj: $(SRCDIR)/inflate.c $(SRCDIR)/zbuild.h $(SRCDIR)/zutil.h $(SRCDIR)/inftrees.h $(SRCDIR)/inflate.h $(SRCDIR)/inffast.h $(SRCDIR)/functable.h $(SRCDIR)/functable.h
 inftrees.obj: $(SRCDIR)/inftrees.c $(SRCDIR)/zbuild.h $(SRCDIR)/zutil.h $(SRCDIR)/inftrees.h
 trees.obj: $(SRCDIR)/zbuild.h $(SRCDIR)/deflate.h $(SRCDIR)/trees_tbl.h
-zutil.obj: $(SRCDIR)/zbuild.h $(SRCDIR)/zutil.h $(SRCDIR)/gzguts.h
+zutil.obj: $(SRCDIR)/zbuild.h $(SRCDIR)/zutil.h $(SRCDIR)/zutil_p.h $(SRCDIR)/gzguts.h
 
 example.obj: $(TOP)/test/example.c $(TOP)/zbuild.h $(TOP)/zlib$(SUFFIX).h
 

--- a/win32/Makefile.arm
+++ b/win32/Makefile.arm
@@ -163,9 +163,9 @@ SRCDIR = $(TOP)
 adler32.obj: $(SRCDIR)/adler32.c $(SRCDIR)/zbuild.h $(SRCDIR)/zutil.h $(SRCDIR)/functable.h $(SRCDIR)/adler32_p.h
 functable.obj: $(SRCDIR)/functable.c $(SRCDIR)/zbuild.h $(SRCDIR)/functable.h $(SRCDIR)/deflate.h $(SRCDIR)/deflate_p.h $(SRCDIR)/zendian.h $(SRCDIR)/arch/x86/x86.h
 gzclose.obj: $(SRCDIR)/gzclose.c $(SRCDIR)/zbuild.h $(SRCDIR)/gzguts.h
-gzlib.obj: $(SRCDIR)/gzlib.c $(SRCDIR)/zbuild.h $(SRCDIR)/gzguts.h
-gzread.obj: $(SRCDIR)/gzread.c $(SRCDIR)/zbuild.h $(SRCDIR)/gzguts.h
-gzwrite.obj: $(SRCDIR)/gzwrite.c $(SRCDIR)/zbuild.h $(SRCDIR)/gzguts.h
+gzlib.obj: $(SRCDIR)/gzlib.c $(SRCDIR)/zbuild.h $(SRCDIR)/gzguts.h $(SRCDIR)/zutil_p.h
+gzread.obj: $(SRCDIR)/gzread.c $(SRCDIR)/zbuild.h $(SRCDIR)/gzguts.h $(SRCDIR)/zutil_p.h
+gzwrite.obj: $(SRCDIR)/gzwrite.c $(SRCDIR)/zbuild.h $(SRCDIR)/gzguts.h $(SRCDIR)/zutil_p.h
 compress.obj: $(SRCDIR)/compress.c $(SRCDIR)/zbuild.h $(SRCDIR)/zlib$(SUFFIX).h
 uncompr.obj: $(SRCDIR)/uncompr.c $(SRCDIR)/zbuild.h $(SRCDIR)/zlib$(SUFFIX).h
 chunkset.obj: $(SRCDIR)/zbuild.h $(SRCDIR)/zutil.h
@@ -180,7 +180,7 @@ inffast.obj: $(SRCDIR)/inffast.c $(SRCDIR)/zbuild.h $(SRCDIR)/zutil.h $(SRCDIR)/
 inflate.obj: $(SRCDIR)/inflate.c $(SRCDIR)/zbuild.h $(SRCDIR)/zutil.h $(SRCDIR)/inftrees.h $(SRCDIR)/inflate.h $(SRCDIR)/inffast.h $(SRCDIR)/functable.h $(SRCDIR)/functable.h
 inftrees.obj: $(SRCDIR)/inftrees.c $(SRCDIR)/zbuild.h $(SRCDIR)/zutil.h $(SRCDIR)/inftrees.h
 trees.obj: $(SRCDIR)/zbuild.h $(SRCDIR)/deflate.h $(SRCDIR)/trees_tbl.h
-zutil.obj: $(SRCDIR)/zbuild.h $(SRCDIR)/zutil.h $(SRCDIR)/gzguts.h
+zutil.obj: $(SRCDIR)/zbuild.h $(SRCDIR)/zutil.h $(SRCDIR)/zutil_p.h $(SRCDIR)/gzguts.h
 
 example.obj: $(TOP)/test/example.c $(TOP)/zbuild.h $(TOP)/zlib$(SUFFIX).h
 

--- a/win32/Makefile.msc
+++ b/win32/Makefile.msc
@@ -162,9 +162,9 @@ SRCDIR = $(TOP)
 adler32.obj: $(SRCDIR)/adler32.c $(SRCDIR)/zbuild.h $(SRCDIR)/zutil.h $(SRCDIR)/functable.h $(SRCDIR)/adler32_p.h
 functable.obj: $(SRCDIR)/functable.c $(SRCDIR)/zbuild.h $(SRCDIR)/functable.h $(SRCDIR)/deflate.h $(SRCDIR)/deflate_p.h $(SRCDIR)/zendian.h $(SRCDIR)/arch/x86/x86.h
 gzclose.obj: $(SRCDIR)/gzclose.c $(SRCDIR)/zbuild.h $(SRCDIR)/gzguts.h
-gzlib.obj: $(SRCDIR)/gzlib.c $(SRCDIR)/zbuild.h $(SRCDIR)/gzguts.h
-gzread.obj: $(SRCDIR)/gzread.c $(SRCDIR)/zbuild.h $(SRCDIR)/gzguts.h
-gzwrite.obj: $(SRCDIR)/gzwrite.c $(SRCDIR)/zbuild.h $(SRCDIR)/gzguts.h
+gzlib.obj: $(SRCDIR)/gzlib.c $(SRCDIR)/zbuild.h $(SRCDIR)/gzguts.h $(SRCDIR)/zutil_p.h
+gzread.obj: $(SRCDIR)/gzread.c $(SRCDIR)/zbuild.h $(SRCDIR)/gzguts.h $(SRCDIR)/zutil_p.h
+gzwrite.obj: $(SRCDIR)/gzwrite.c $(SRCDIR)/zbuild.h $(SRCDIR)/gzguts.h $(SRCDIR)/zutil_p.h
 compress.obj: $(SRCDIR)/compress.c $(SRCDIR)/zbuild.h $(SRCDIR)/zlib$(SUFFIX).h
 uncompr.obj: $(SRCDIR)/uncompr.c $(SRCDIR)/zbuild.h $(SRCDIR)/zlib$(SUFFIX).h
 chunkset.obj: $(SRCDIR)/zbuild.h $(SRCDIR)/zutil.h
@@ -182,7 +182,7 @@ inflate.obj: $(SRCDIR)/inflate.c $(SRCDIR)/zbuild.h $(SRCDIR)/zutil.h $(SRCDIR)/
 inftrees.obj: $(SRCDIR)/inftrees.c $(SRCDIR)/zbuild.h $(SRCDIR)/zutil.h $(SRCDIR)/inftrees.h
 slide_sse.obj: $(SRCDIR)/arch/x86/slide_sse.c $(SRCDIR)/deflate.h
 trees.obj: $(SRCDIR)/zbuild.h $(SRCDIR)/deflate.h $(SRCDIR)/trees_tbl.h
-zutil.obj: $(SRCDIR)/zbuild.h $(SRCDIR)/zutil.h $(SRCDIR)/gzguts.h
+zutil.obj: $(SRCDIR)/zbuild.h $(SRCDIR)/zutil.h $(SRCDIR)/zutil_p.h $(SRCDIR)/gzguts.h
 
 example.obj: $(TOP)/test/example.c $(TOP)/zbuild.h $(TOP)/zlib$(SUFFIX).h
 

--- a/zutil.c
+++ b/zutil.c
@@ -5,6 +5,7 @@
 
 #include "zbuild.h"
 #include "zutil.h"
+#include "zutil_p.h"
 #ifdef WITH_GZFILEOP
 #  include "gzguts.h"
 #endif
@@ -102,37 +103,12 @@ const char * Z_EXPORT PREFIX(zError)(int err) {
     return ERR_MSG(err);
 }
 
-#ifndef MY_ZCALLOC /* Any system without a special alloc function */
-
-#ifndef UNALIGNED_OK
-#  include <malloc.h>
-#  if defined(_WIN32)
-#    define zng_align_alloc(align, size) _aligned_malloc(size, align)
-#    define zng_align_free(ptr)          _aligned_free(ptr)
-#  else
-#    define zng_align_alloc              memalign
-#    define zng_align_free(ptr)          free(ptr)
-#  endif
-#endif
-
-void Z_INTERNAL *zng_calloc(void *opaque, unsigned items, unsigned size)
-{
+void Z_INTERNAL *zng_calloc(void *opaque, unsigned items, unsigned size) {
     (void)opaque;
-#ifndef UNALIGNED_OK
-    return zng_align_alloc(16, items * size);
-#else
-    return sizeof(unsigned int) > 2 ? (void *)malloc(items * size) :
-                              (void *)calloc(items, size);
-#endif
+    return zng_alloc((size_t)items * (size_t)size);
 }
 
 void Z_INTERNAL zng_cfree(void *opaque, void *ptr) {
     (void)opaque;
-#ifndef UNALIGNED_OK
-    zng_align_free(ptr);
-#else
-    free(ptr);
-#endif
+    zng_free(ptr);
 }
-
-#endif /* MY_ZCALLOC */

--- a/zutil.h
+++ b/zutil.h
@@ -100,9 +100,6 @@ extern z_const char * const PREFIX(z_errmsg)[10]; /* indexed by 2-zlib_error */
 
 #ifdef OS2
 #  define OS_CODE  6
-#  if defined(M_I86) && !defined(Z_SOLO)
-#    include <malloc.h>
-#  endif
 #endif
 
 #if defined(MACOS) || defined(TARGET_OS_MAC)

--- a/zutil_p.h
+++ b/zutil_p.h
@@ -1,0 +1,34 @@
+/* zutil_p.h -- Private inline functions used internally in zlib-ng
+ *
+ */
+
+#ifndef ZUTIL_P_H
+#define ZUTIL_P_H
+
+#ifdef __APPLE__
+#  include <stdlib.h>
+#else
+#  include <malloc.h>
+#endif
+
+/* Function to allocate 16-byte aligned memory */
+static inline void *zng_alloc(size_t size) {
+#if defined(_WIN32)
+    return (void *)_aligned_malloc(size, 16);
+#elif defined(__APPLE__)
+    return (void *)malloc(size);     /* MacOS always aligns to 16 bytes */
+#else
+    return (void *)memalign(16, size);
+#endif
+}
+
+/* Function that can free aligned memory */
+static inline void zng_free(void *ptr) {
+#if defined(_WIN32)
+    _aligned_free(ptr);
+#else
+    free(ptr);
+#endif
+}
+
+#endif

--- a/zutil_p.h
+++ b/zutil_p.h
@@ -11,14 +11,14 @@
 #  include <malloc.h>
 #endif
 
-/* Function to allocate 16-byte aligned memory */
+/* Function to allocate 16 or 64-byte aligned memory */
 static inline void *zng_alloc(size_t size) {
 #if defined(_WIN32)
-    return (void *)_aligned_malloc(size, 16);
+    return (void *)_aligned_malloc(size, 64);
 #elif defined(__APPLE__)
     return (void *)malloc(size);     /* MacOS always aligns to 16 bytes */
 #else
-    return (void *)memalign(16, size);
+    return (void *)memalign(64, size);
 #endif
 }
 


### PR DESCRIPTION
- Remove support for MY_ZCALLOC, as we don't use that and end-users that need that (if any) would probably be better off making a patch that apply on top of our code. (IMO MY_ZCALLOC made more sense before, when adding a file was easier than applying a patch)
- Remove special OS2 malloc.h handling (I doubt zlib-ng compiles cleanly on OS2 in any case)
- Remove special-handling for platforms with 16-bit int size, as we don't support those.
- Always request aligned memory. Not doing so just because the arch is able to do unaligned reads is strange, since aligned memory is usually faster, and making the deflate_state and inflate_state structs aligned is very much preferred (64-byte alignment is best as it aligns it on a cacheline, 16-byte is ok).
- Move logic to static zng_alloc() and zng_free() in zutil_p.h, so they can easily be used internally
- Have zng_calloc() and zng_cfree() use the new static functions above
- Change gzlib.c/gzread.c/gwrite.c from using malloc() to using zng_alloc() for allocating structs and in/out buffers, thus gaining alignment.
