### PR TITLE
Fixed match_byte casting warning in compare256_unaligned_64_static.

### DIFF
--- a/compare258.c
+++ b/compare258.c
@@ -155,7 +155,7 @@ static inline uint32_t compare256_unaligned_64_static(const unsigned char *src0,
 
         if (diff) {
             uint64_t match_byte = __builtin_ctzll(diff) / 8;
-            return len + match_byte;
+            return len + (uint32_t)match_byte;
         }
 
         src0 += 8, src1 += 8, len += 8;


### PR DESCRIPTION
I encountered this warning on MSVC.

```
compare258.c(158,36): warning C4244: 'return': conversion from 'uint64_t' to 'uint32_t', possible loss of data
```