### PR TITLE
Add missing z_const to fuzzers.

### DIFF
--- a/test/fuzz/example_dict_fuzzer.c
+++ b/test/fuzz/example_dict_fuzzer.c
@@ -79,7 +79,7 @@ void test_dict_deflate(unsigned char **compr, size_t *comprLen) {
     c_stream.next_out = *compr;
     c_stream.avail_out = (unsigned int)(*comprLen);
 
-    c_stream.next_in = data;
+    c_stream.next_in = (z_const unsigned char *)data;
     c_stream.avail_in = (uint32_t)dataLen;
 
     err = PREFIX(deflate)(&c_stream, Z_FINISH);

--- a/test/fuzz/example_flush_fuzzer.c
+++ b/test/fuzz/example_flush_fuzzer.c
@@ -40,7 +40,7 @@ void test_flush(unsigned char *compr, z_size_t *comprLen) {
     err = PREFIX(deflateInit)(&c_stream, Z_DEFAULT_COMPRESSION);
     CHECK_ERR(err, "deflateInit");
 
-    c_stream.next_in = (const unsigned char *)data;
+    c_stream.next_in = (z_const unsigned char *)data;
     c_stream.next_out = compr;
     c_stream.avail_in = 3;
     c_stream.avail_out = (unsigned int)*comprLen;

--- a/test/fuzz/example_small_fuzzer.c
+++ b/test/fuzz/example_small_fuzzer.c
@@ -40,7 +40,7 @@ void test_deflate(unsigned char *compr, size_t comprLen) {
     err = PREFIX(deflateInit)(&c_stream, Z_DEFAULT_COMPRESSION);
     CHECK_ERR(err, "deflateInit");
 
-    c_stream.next_in = (const unsigned char *)data;
+    c_stream.next_in = (z_const unsigned char *)data;
     c_stream.next_out = compr;
 
     while (c_stream.total_in != len && c_stream.total_out < comprLen) {


### PR DESCRIPTION
* Fixes warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]