### PR TITLE
Remove gcov-7 install since warnings on gcov-8 no longer occur 

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -378,13 +378,6 @@ jobs:
       run: |
         choco install ninja ${{ matrix.packages }} --no-progress
 
-    - name: Install packages (Windows/GCC)
-      if: runner.os == 'Windows' && matrix.codecov && matrix.compiler == 'gcc'
-      # Use gcov-7 via mingw on windows because gcov-8 throws tons of warnings
-      # https://partner-bugzilla.redhat.com/show_bug.cgi?id=1577508
-      run: |
-        choco install mingw --version=7.3.0 --force --allow-downgrade --no-progress
-
     - name: Install packages (macOS)
       if: runner.os == 'macOS'
       run: |


### PR DESCRIPTION
This is a Windows CI issue. It appears that the error messages that once occured on Windows CI no longer do. It might have been due to a version mismatch between gcc & gcov on the GitHub Windows CI instances.