### PR TITLE
Fix unsigned integer overflow ASAN error for align_diff in crc_folding

### DIFF
--- a/arch/x86/crc_folding.c
+++ b/arch/x86/crc_folding.c
@@ -249,7 +249,7 @@ Z_INTERNAL void crc_fold_copy(deflate_state *const s, unsigned char *dst, const 
         goto partial;
     }
 
-    algn_diff = ((uintptr_t)0 - (uintptr_t)src) & 0xF;
+    algn_diff = ((uintptr_t)16 - ((uintptr_t)src & 0xF)) & 0xF;
     if (algn_diff) {
         xmm_crc_part = _mm_loadu_si128((__m128i *)src);
         _mm_storeu_si128((__m128i *)dst, xmm_crc_part);


### PR DESCRIPTION
```
  zlib-ng/arch/x86/crc_folding.c:252:31: runtime error: unsigned integer overflow: 0 - 108370614813184 cannot be represented in type 'unsigned long'
```