### PR TITLE
Fix incorrect inflateSyncPoint() return value with DFLTCC

### DIFF
--- a/arch/s390/README.md
+++ b/arch/s390/README.md
@@ -48,6 +48,7 @@ DFLTCC does not support every single zlib-ng feature, in particular:
 * `inflate(Z_BLOCK)` and `inflate(Z_TREES)`
 * `inflateMark()`
 * `inflatePrime()`
+* `inflateSyncPoint()`
 
 When used, these functions will either switch to software, or, in case
 this is not possible, gracefully fail.
@@ -75,8 +76,9 @@ macros.
 parameter block using `DEFLATE_RESET_KEEP_HOOK()` and
 `INFLATE_RESET_KEEP_HOOK()` macros.
 
-`INFLATE_PRIME_HOOK()` and `INFLATE_MARK_HOOK()` macros make the
-unsupported `inflatePrime()` and `inflateMark()` calls fail gracefully.
+`INFLATE_PRIME_HOOK()`, `INFLATE_MARK_HOOK()` and
+`INFLATE_SYNC_POINT_HOOK()` macros make the respective unsupported
+calls gracefully fail.
 
 `DEFLATE_PARAMS_HOOK()` implements switching between hardware and
 software compression mid-stream using `deflateParams()`. Switching

--- a/arch/s390/dfltcc_inflate.h
+++ b/arch/s390/dfltcc_inflate.h
@@ -41,4 +41,9 @@ int Z_INTERNAL dfltcc_inflate_disable(PREFIX3(streamp) strm);
         if (dfltcc_was_inflate_used((strm))) return -(1L << 16); \
     } while (0)
 
+#define INFLATE_SYNC_POINT_HOOK(strm) \
+    do { \
+        if (dfltcc_was_inflate_used((strm))) return Z_STREAM_ERROR; \
+    } while (0)
+
 #endif

--- a/inflate.c
+++ b/inflate.c
@@ -35,6 +35,8 @@
 #  define INFLATE_NEED_UPDATEWINDOW(strm) 1
 /* Invoked at the beginning of inflateMark(). Useful for updating arch-specific pointers and offsets. */
 #  define INFLATE_MARK_HOOK(strm) do {} while (0)
+/* Invoked at the beginning of inflateSyncPoint(). Useful for performing arch-specific state checks. */
+#define INFLATE_SYNC_POINT_HOOK(strm) do {} while (0)
 #endif
 
 /* function prototypes */
@@ -1254,6 +1256,7 @@ int32_t Z_EXPORT PREFIX(inflateSyncPoint)(PREFIX3(stream) *strm) {
 
     if (inflateStateCheck(strm))
         return Z_STREAM_ERROR;
+    INFLATE_SYNC_POINT_HOOK(strm);
     state = (struct inflate_state *)strm->state;
     return state->mode == STORED && state->bits == 0;
 }


### PR DESCRIPTION
DFLTCC does not provide the necessary information to implement
inflateSyncPoint() - Incomplete-Function Status and Incomplete-Function
Length are the fields that provide the relevant information, but
unfortunately it's not enough. If DFLTCC is in use, the current code
checks software decompression state and always returns 0. This
(rightfully) confuses rsync, so fix by returning Z_STREAM_ERROR
instead.