### PR TITLE
Avoid shifts of negative values inflateMark()

### DIFF
--- a/inflate.c
+++ b/inflate.c
@@ -1337,7 +1337,8 @@ long Z_EXPORT PREFIX(inflateMark)(PREFIX3(stream) *strm) {
         return -65536;
     INFLATE_MARK_HOOK(strm);  /* hook for IBM Z DFLTCC */
     state = (struct inflate_state *)strm->state;
-    return ((long)(state->back) << 16) + (state->mode == COPY ? state->length :
+    return (long)(((unsigned long)((long)state->back)) << 16) + 
+        (state->mode == COPY ? state->length :
             (state->mode == MATCH ? state->was - state->length : 0));
 }
 


### PR DESCRIPTION
https://github.com/madler/zlib/commit/e54e1299404101a5a9d0cf5e45512b543967f958
It appears when it was [initially ported](https://github.com/zlib-ng/zlib-ng/commit/65b008bac08db4ea436057b836b4af0c830e6459) that this line was skipped.
https://nvd.nist.gov/vuln/detail/CVE-2016-9842

UBSAN warning reported here: https://github.com/zlib-ng/zlib-ng/issues/784