### PR TITLE
Fixed left shift ubsan warning in PULLBYTE.

### DIFF
--- a/infback.c
+++ b/infback.c
@@ -80,7 +80,7 @@ int32_t Z_EXPORT PREFIX(inflateBackInit_)(PREFIX3(stream) *strm, int32_t windowB
     do { \
         PULL(); \
         have--; \
-        hold += (*next++ << bits); \
+        hold += ((unsigned)(*next++) << bits); \
         bits += 8; \
     } while (0)
 


### PR DESCRIPTION
Mentioned in #784. Both `PULLBYTE` definitions should be the same now.
```
  infback.c:200:13: runtime error: left shift of 255 by 24 places cannot be represented in type 'int'
  624: SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/runner/work/zlib-ng/zlib-ng/infback.c:200:13 in
```