### PR TITLE
Added verbose flag to CI to see sanitizer output.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -399,7 +399,7 @@ jobs:
       if: runner.os != 'Windows' || contains(matrix.name, 'ARM') == false
       run: |
         cd ${{ matrix.build-dir || '.' }}
-        ctest -C Release --output-on-failure --max-width 120 -j 6
+        ctest --verbose -C Release --output-on-failure --max-width 120 -j 6
       env:
         ASAN_OPTIONS: ${{ matrix.asan-options || 'verbosity=1' }}:abort_on_error=1
         MSAN_OPTIONS: ${{ matrix.msan-options || 'verbosity=1' }}:abort_on_error=1


### PR DESCRIPTION
I think it is best to have verbose logs on always. If there is a CI issue it is more likely we will catch it with verbose output always displayed. CTest will produce summary at the bottom either way.