### PR TITLE
Inflate cleanup

### DIFF
--- a/inffast.c
+++ b/inffast.c
@@ -260,11 +260,10 @@ void Z_INTERNAL zng_inflate_fast(PREFIX3(stream) *strm, unsigned long start) {
                         out = functable.chunkcopy_safe(out, from, len, safe);
                     }
                 } else {
-                    /* Whole reference is in range of current output.  No
-                       range checks are necessary because we start with room
-                       for at least 258 bytes of output, so unroll and roundoff
-                       operations can write beyond `out+len` so long as they
-                       stay within 258 bytes of `out`.
+                    /* Whole reference is in range of current output.  No range checks are
+                       necessary because we start with room for at least 258 bytes of output,
+                       so unroll and roundoff operations can write beyond `out+len` so long
+                       as they stay within 258 bytes of `out`.
                     */
                     if (dist >= len || dist >= state->chunksize)
                         out = functable.chunkcopy(out, out - dist, len);
@@ -300,12 +299,10 @@ void Z_INTERNAL zng_inflate_fast(PREFIX3(stream) *strm, unsigned long start) {
     /* update state and return */
     strm->next_in = in;
     strm->next_out = out;
-    strm->avail_in =
-        (unsigned)(in < last ? (INFLATE_FAST_MIN_HAVE - 1) + (last - in)
-                             : (INFLATE_FAST_MIN_HAVE - 1) - (in - last));
-    strm->avail_out =
-        (unsigned)(out < end ? (INFLATE_FAST_MIN_LEFT - 1) + (end - out)
-                             : (INFLATE_FAST_MIN_LEFT - 1) - (out - end));
+    strm->avail_in = (unsigned)(in < last ? (INFLATE_FAST_MIN_HAVE - 1) + (last - in)
+                                          : (INFLATE_FAST_MIN_HAVE - 1) - (in - last));
+    strm->avail_out = (unsigned)(out < end ? (INFLATE_FAST_MIN_LEFT - 1) + (end - out)
+                                           : (INFLATE_FAST_MIN_LEFT - 1) - (out - end));
 
     Assert(bits <= 32, "Remaining bits greater than 32");
     state->hold = (uint32_t)hold;

--- a/inffast.c
+++ b/inffast.c
@@ -199,8 +199,7 @@ void Z_INTERNAL zng_inflate_fast(PREFIX3(stream) *strm, unsigned long start) {
                 dist += BITS(op);
 #ifdef INFLATE_STRICT
                 if (dist > dmax) {
-                    strm->msg = (char *)"invalid distance too far back";
-                    state->mode = BAD;
+                    SET_BAD("invalid distance too far back");
                     break;
                 }
 #endif
@@ -211,8 +210,7 @@ void Z_INTERNAL zng_inflate_fast(PREFIX3(stream) *strm, unsigned long start) {
                     op = dist - op;             /* distance back in window */
                     if (op > whave) {
                         if (state->sane) {
-                            strm->msg = (char *)"invalid distance too far back";
-                            state->mode = BAD;
+                            SET_BAD("invalid distance too far back");
                             break;
                         }
 #ifdef INFLATE_ALLOW_INVALID_DISTANCE_TOOFAR_ARRR
@@ -277,8 +275,7 @@ void Z_INTERNAL zng_inflate_fast(PREFIX3(stream) *strm, unsigned long start) {
                 here = dcode + here->val + BITS(op);
                 goto dodist;
             } else {
-                strm->msg = (char *)"invalid distance code";
-                state->mode = BAD;
+                SET_BAD("invalid distance code");
                 break;
             }
         } else if ((op & 64) == 0) {              /* 2nd level length code */
@@ -289,8 +286,7 @@ void Z_INTERNAL zng_inflate_fast(PREFIX3(stream) *strm, unsigned long start) {
             state->mode = TYPE;
             break;
         } else {
-            strm->msg = (char *)"invalid literal/length code";
-            state->mode = BAD;
+            SET_BAD("invalid literal/length code");
             break;
         }
     } while (in < last && out < end);

--- a/inflate.c
+++ b/inflate.c
@@ -505,8 +505,7 @@ int32_t Z_EXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int32_t flush) {
                 if (copy > have)
                     copy = have;
                 if (copy) {
-                    if (state->head != NULL &&
-                        state->head->extra != NULL) {
+                    if (state->head != NULL && state->head->extra != NULL) {
                         len = state->head->extra_len - state->length;
                         memcpy(state->head->extra + len, next,
                                 len + copy > state->head->extra_max ?
@@ -798,8 +797,7 @@ int32_t Z_EXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int32_t flush) {
 
         case LEN:
             /* use inflate_fast() if we have enough input and output */
-            if (have >= INFLATE_FAST_MIN_HAVE &&
-                left >= INFLATE_FAST_MIN_LEFT) {
+            if (have >= INFLATE_FAST_MIN_HAVE && left >= INFLATE_FAST_MIN_LEFT) {
                 RESTORE();
                 zng_inflate_fast(strm, out);
                 LOAD();
@@ -1151,8 +1149,7 @@ int32_t Z_EXPORT PREFIX(inflateGetHeader)(PREFIX3(stream) *strm, PREFIX(gz_heade
    zero for the first call.
  */
 static uint32_t syncsearch(uint32_t *have, const uint8_t *buf, uint32_t len) {
-    uint32_t got;
-    uint32_t next;
+    uint32_t got, next;
 
     got = *have;
     next = 0;
@@ -1252,13 +1249,12 @@ int32_t Z_EXPORT PREFIX(inflateCopy)(PREFIX3(stream) *dest, PREFIX3(stream) *sou
     state = (struct inflate_state *)source->state;
 
     /* allocate space */
-    copy = (struct inflate_state *)
-           ZALLOC_STATE(source, 1, sizeof(struct inflate_state));
+    copy = (struct inflate_state *)ZALLOC_STATE(source, 1, sizeof(struct inflate_state));
     if (copy == NULL)
         return Z_MEM_ERROR;
     window = NULL;
     if (state->window != NULL) {
-        window = (unsigned char *) ZALLOC_WINDOW(source, 1U << state->wbits, sizeof(unsigned char));
+        window = (unsigned char *)ZALLOC_WINDOW(source, 1U << state->wbits, sizeof(unsigned char));
         if (window == NULL) {
             ZFREE_STATE(source, copy);
             return Z_MEM_ERROR;

--- a/inflate.h
+++ b/inflate.h
@@ -11,10 +11,9 @@
 #ifndef INFLATE_H_
 #define INFLATE_H_
 
-/* define NO_GZIP when compiling if you want to disable gzip header and
-   trailer decoding by inflate().  NO_GZIP would be used to avoid linking in
-   the crc code when it is not needed.  For shared libraries, gzip decoding
-   should be left enabled. */
+/* define NO_GZIP when compiling if you want to disable gzip header and trailer decoding by inflate().
+   NO_GZIP would be used to avoid linking in the crc code when it is not needed.
+   For shared libraries, gzip decoding should be left enabled. */
 #ifndef NO_GZIP
 #  define GUNZIP
 #endif

--- a/inflate_p.h
+++ b/inflate_p.h
@@ -92,3 +92,10 @@
     } while (0)
 
 #endif
+
+/* Set mode=BAD and prepare error message */
+#define SET_BAD(errmsg) \
+    do { \
+        state->mode = BAD; \
+        strm->msg = (char *)errmsg; \
+    } while (0)


### PR DESCRIPTION
First commit introduces SET_BAD macro, reducing the size of inflate.c and inffast.c and making the code more readable.
Second commit contains small formatting changes only.