### PR TITLE
Fixed ubsan error when building tree with no symbols. 

### DIFF
--- a/trees.c
+++ b/trees.c
@@ -638,7 +638,11 @@ void Z_INTERNAL zng_tr_flush_block(deflate_state *s, char *buf, uint32_t stored_
     int max_blindex = 0;  /* index of last bit length code of non zero freq */
 
     /* Build the Huffman trees unless a stored block is forced */
-    if (s->level > 0) {
+    if (UNLIKELY(s->sym_next == 0)) {
+        /* Emit an empty static tree block with no codes */
+        opt_lenb = static_lenb = 0;
+        s->static_len = 7;
+    } else if (s->level > 0) {
         /* Check if the file is binary or text */
         if (s->strm->data_type == Z_UNKNOWN)
             s->strm->data_type = detect_data_type(s);


### PR DESCRIPTION
See #782 for background.

When there are no symbols in the tree we skip build_tree calculations and emit a block using static tree with no codes.
```
trees.c:357:19: runtime error: unsigned integer overflow: 0 - 1 cannot be represented in type 'unsigned long'
    #0 0x1000ed79b in build_tree trees.c:357
    #1 0x1000ea3f5 in zng_tr_flush_block trees.c:649
    #2 0x100090ab0 in deflate_slow deflate_slow.c:131
    #3 0x1000572bc in zng_deflate deflate.c:990
    #4 0x1000aecd3 in gz_comp gzwrite.c:125
    #5 0x1000b05df in zng_gzclose_w gzwrite.c:511
    #6 0x1000967a4 in zng_gzclose gzlib.c:253
    #7 0x100004f70 in test_gzio example.c:133
    #8 0x100010c5b in main example.c:1034
    #9 0x7fff71f57cc8 in start+0x0 (libdyld.dylib:x86_64+0x1acc8)
```
