### PR TITLE
Fixed minigzip_fuzzer not compiling on latest macOS

### DIFF
--- a/test/fuzz/minigzip_fuzzer.c
+++ b/test/fuzz/minigzip_fuzzer.c
@@ -13,6 +13,7 @@
  */
 
 #define _POSIX_SOURCE 1  /* This file needs POSIX for fileno(). */
+#define _POSIX_C_SOURCE 200112  /* For snprintf(). */
 
 #include "zbuild.h"
 #ifdef ZLIB_COMPAT


### PR DESCRIPTION
Looks like macOS was updated to the latest version for CI environments on GHA. `_POSIX_C_SOURCE` should be defined in minigzip_fuzzer same as in minigzip.c.

Here is the same code in minigzip.c:

https://github.com/zlib-ng/zlib-ng/blob/1da1491609c313eafbe6832d6cf024035f6261e6/test/minigzip.c#L15-L16

This will fix the errors being caused by my latest PRs on macOS.