### PR TITLE
Fixed ubsan warning in gzfread due to size_t overflow. 

### DIFF
--- a/gzread.c
+++ b/gzread.c
@@ -395,11 +395,11 @@ size_t Z_EXPORT PREFIX(gzfread)(void *buf, size_t size, size_t nitems, gzFile fi
         return 0;
 
     /* compute bytes to read -- error on overflow */
-    len = nitems * size;
-    if (size && len / size != nitems) {
+    if (size && SIZE_MAX / size < nitems) {
         gz_error(state, Z_STREAM_ERROR, "request does not fit in a size_t");
         return 0;
     }
+    len = nitems * size;
 
     /* read len or fewer bytes to buf, return the number of full items read */
     return len ? gz_read(state, buf, len) / size : 0;


### PR DESCRIPTION
See #783
```
gzread.c:398:18: runtime error: unsigned integer overflow: 2 * 18446744073709551615 cannot be represented in type 'unsigned long'
    #0 0x10009d31e in zng_gzfread gzread.c:398
    #1 0x100005b1a in test_gzio example.c:213
    #2 0x10001093b in main example.c:1034
    #3 0x7fff71f57cc8 in start+0x0 (libdyld.dylib:x86_64+0x1acc8)
```