### PR TITLE
Add CI run that tests UNALIGNED_OK without UNALIGNED64_OK.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -14,10 +14,10 @@ jobs:
             cmake-args: -DWITH_SANITIZERS=ON
             codecov: ubuntu_gcc
 
-          - name: Ubuntu GCC OSB -O1 No Unaligned
+          - name: Ubuntu GCC OSB -O1 No Unaligned64
             os: ubuntu-latest
             compiler: gcc
-            cmake-args: -DWITH_SANITIZERS=ON -DWITH_UNALIGNED=OFF
+            cmake-args: -DWITH_SANITIZERS=ON -DWITH_UNALIGNED=ON -DUNALIGNED64_OK=OFF
             build-dir: ../build
             build-src-dir: ../zlib-ng
             codecov: ubuntu_gcc_osb


### PR DESCRIPTION
We have no code coverage for some parts of the code where UNALIGNED_OK has a different codepath than UNALIGNED64_OK.

This PR adds one run that tests those codepaths.