### PR TITLE
Fixed macOS CI instance to use GCC

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -297,8 +297,10 @@ jobs:
 
           - name: macOS GCC
             os: macos-latest
-            compiler: gcc
+            compiler: gcc-10
             cmake-args: -DWITH_SANITIZER=Undefined
+            packages: gcc@10
+            gcov-exec: gcov-10
             codecov: macos_gcc
 
     steps:


### PR DESCRIPTION
macOS GCC CI instance has not been using GCC. Instead it has been using AppleClang because on macOS the `gcc` command points to Apple's clang compiler.