### PR TITLE
docs: fix simple typo, stragety -> strategy

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -16,7 +16,7 @@ Contents
 | compress.c       | Compress a memory buffer                                       |
 | deflate.*        | Compress data using the deflate algorithm                      |
 | deflate_fast.c   | Compress data using the deflate algorithm with fast strategy   |
-| deflate_medium.c | Compress data using the deflate algorithm with medium stragety |
+| deflate_medium.c | Compress data using the deflate algorithm with medium strategy |
 | deflate_slow.c   | Compress data using the deflate algorithm with slow strategy   |
 | functable.*      | Struct containing function pointers to optimized functions     |
 | gzguts.h         | Internal definitions for gzip operations                       |


### PR DESCRIPTION
There is a small typo in INDEX.md.

Should read `strategy` rather than `stragety`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md