### PR TITLE
Improvements to check_match

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -1201,6 +1201,13 @@ void check_match(deflate_state *s, Pos start, Pos match, int length) {
         fprintf(stderr, " start %u, match %u, length %d\n", start, match, length);
         z_error("invalid match length");
     }
+    /* check that the match isn't at the beginning of the window and that it isn't at
+     * the same position as the start string
+     */
+    if (match == 0 || match == start) {
+        fprintf(stderr, " start %u, match %u, length %d\n", start, match, length);
+        z_error("invalid match position");
+    }
     /* check that the match is indeed a match */
     if (memcmp(s->window + match, s->window + start, length) != EQUAL) {
         int32_t i = 0;

--- a/deflate.c
+++ b/deflate.c
@@ -1203,9 +1203,10 @@ void check_match(deflate_state *s, Pos start, Pos match, int length) {
     }
     /* check that the match is indeed a match */
     if (memcmp(s->window + match, s->window + start, length) != EQUAL) {
+        int32_t i = 0;
         fprintf(stderr, " start %u, match %u, length %d\n", start, match, length);
         do {
-            fprintf(stderr, "%c%c", s->window[match++], s->window[start++]);
+            fprintf(stderr, "  %03d: match [%02x] start [%02x]\n", i++, s->window[match++], s->window[start++]);
         } while (--length != 0);
         z_error("invalid match");
     }


### PR DESCRIPTION
- Print hex values of mismatch characters (previously it printed the ascii characters which only work well for ascii text not binary files).
- Check that `match` is not 0
- Check that `match` is not the same as `start`