### PR TITLE
Fixed previous match length not reset when match start reset.

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -1246,7 +1246,12 @@ void Z_INTERNAL fill_window(deflate_state *s) {
          */
         if (s->strstart >= wsize+MAX_DIST(s)) {
             memcpy(s->window, s->window+wsize, (unsigned)wsize);
-            s->match_start = (s->match_start >= wsize) ? s->match_start - wsize : 0;
+            if (s->match_start >= wsize) {
+                s->match_start -= wsize;
+            } else {
+                s->match_start = 0;
+                s->prev_length = 0;
+            }
             s->strstart    -= wsize; /* we now have strstart >= MAX_DIST */
             s->block_start -= (int)wsize;
             if (s->insert > s->strstart)


### PR DESCRIPTION
See #815 
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=24294

Using test case from OSS-Fuzz:

- match of length 25 is found at `wsize-1` 
- `prev_match` and `prev_length` is set
- `fill_window` is called and `memcpy` occurs which moves buffer
- `s->match_start` is reset to 0
- `check_match` fails since match start no longer points to start of match
