### PR TITLE
Disable semantic interposition in ELF shared libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -364,6 +364,17 @@ elseif(WITH_SANITIZER STREQUAL "Memory")
 elseif(WITH_SANITIZER STREQUAL "Undefined")
     add_undefined_sanitizer()
 endif()
+
+#
+# Check whether compiler supports -fno-semantic-interposition parameter
+#
+set(CMAKE_REQUIRED_FLAGS "-fno-semantic-interposition")
+check_c_source_compiles(
+    "int main() { return 0; }"
+    HAVE_NO_INTERPOSITION
+)
+set(CMAKE_REQUIRED_FLAGS)
+
 #
 # Check if we can hide zlib internal symbols that are linked between separate source files using hidden
 #
@@ -936,6 +947,9 @@ if(NOT DEFINED BUILD_SHARED_LIBS OR BUILD_SHARED_LIBS)
     endif()
 
     if(UNIX)
+        if(HAVE_NO_INTERPOSITION)
+            set_target_properties(zlib PROPERTIES COMPILE_FLAGS "-fno-semantic-interposition")
+        endif()
         if(NOT APPLE)
             set_target_properties(zlib PROPERTIES LINK_FLAGS
                 "-Wl,--version-script,\"${CMAKE_CURRENT_SOURCE_DIR}/zlib${SUFFIX}.map\"")

--- a/configure
+++ b/configure
@@ -856,6 +856,18 @@ else
   leave 1
 fi
 
+# Check for -fno-semantic-interposition compiler support
+echo "" > test.c
+  cat > $test.c <<EOF
+int main() { return 0; }
+EOF
+if test "$gcc" -eq 1 && ($cc $CFLAGS -fno-semantic-interposition -c $test.c) >> configure.log 2>&1; then
+  echo "Checking for -no-semantic-interposition... Yes." | tee -a configure.log
+  SFLAGS="$SFLAGS -fno-semantic-interposition"
+else
+  echo "Checking for -no-semantic-interposition... No." | tee -a configure.log
+fi
+
 # see if we can hide zlib internal symbols that are linked between separate source files using hidden
 if test "$gcc" -eq 1; then
   echo >> configure.log


### PR DESCRIPTION
Disallow semantic interposition in ELF shared libraries if supported by the compiler.
This disallows calls to our own exported functions being replaced by LD_PRELOAD, thus
avoiding the potential bugs and allowing the compiler to optimize better.

The best/most detailed description of this compiler parameter I have found is here:
https://fedoraproject.org/wiki/Changes/PythonNoSemanticInterpositionSpeedup

I have not been able to reliably measure a performance difference with this, and that is
likely because we rarely call our own exported functions, and never in any hot areas.

This does give a little size reduction for the shared library.

```
Configure before
   text    data     bss     dec     hex filename
 106832    1368      32  108232   1a6c8 libz-ng.so.1.9.9

Configure with PR
   text    data     bss     dec     hex filename
 106504    1296      32  107832   1a538 libz-ng.so.1.9.9
 ```

```
Cmake before
   text    data     bss     dec     hex filename
 111456    1368      32  112856   1b8d8 libz-ng.so.1.9.9

Cmake with PR
   text    data     bss     dec     hex filename
 111064    1296      32  112392   1b708 libz-ng.so.1.9.9
 ```
