### PR TITLE
Set tag environment variable using new GHA environment files.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
 
     - name: Set environment variables
       shell: bash
-      run:  echo "::set-env name=tag::${GITHUB_REF/refs\/tags\//}"
+      run:  echo "tag=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
 
     - name: Generate project files
       run: |


### PR DESCRIPTION
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files

I have tested it in my fork, works well.
https://github.com/nmoinvaz/zlib-ng/releases/tag/mytag