### PR TITLE
Incorporate fast-zlib changes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -821,6 +821,7 @@ set(ZLIB_SRCS
     inflate.c
     inftrees.c
     insert_string.c
+    insert_string_roll.c
     trees.c
     uncompr.c
     zutil.c

--- a/Makefile.in
+++ b/Makefile.in
@@ -92,6 +92,7 @@ OBJZ = \
 	inflate.o \
 	inftrees.o \
 	insert_string.o \
+	insert_string_roll.o \
 	trees.o \
 	uncompr.o \
 	zutil.o \
@@ -125,6 +126,7 @@ PIC_OBJZ = \
 	inflate.lo \
 	inftrees.lo \
 	insert_string.lo \
+	insert_string_roll.lo \
 	trees.lo \
 	uncompr.lo \
 	zutil.lo \

--- a/arch/arm/insert_string_acle.c
+++ b/arch/arm/insert_string_acle.c
@@ -1,4 +1,4 @@
-/* insert_string_acle.c -- insert_string variant using ACLE's CRC instructions
+/* insert_string_acle.c -- insert_string integer hash variant using ACLE's CRC instructions
  *
  * Copyright (C) 1995-2013 Jean-loup Gailly and Mark Adler
  * For conditions of distribution and use, see copyright notice in zlib.h
@@ -12,9 +12,13 @@
 #include "../../zbuild.h"
 #include "../../deflate.h"
 
-#define UPDATE_HASH(s, h, val) \
+#define HASH_CALC(s, h, val) \
     h = __crc32w(0, val)
 
+#define HASH_CALC_VAR       h
+#define HASH_CALC_VAR_INIT  uint32_t h = 0
+
+#define UPDATE_HASH         update_hash_acle
 #define INSERT_STRING       insert_string_acle
 #define QUICK_INSERT_STRING quick_insert_string_acle
 

--- a/arch/x86/compare258_avx.c
+++ b/arch/x86/compare258_avx.c
@@ -58,9 +58,16 @@ Z_INTERNAL uint32_t compare258_unaligned_avx2(const unsigned char *src0, const u
     return compare258_unaligned_avx2_static(src0, src1);
 }
 
-#define LONGEST_MATCH   longest_match_unaligned_avx2
-#define COMPARE256      compare256_unaligned_avx2_static
-#define COMPARE258      compare258_unaligned_avx2_static
+#define LONGEST_MATCH       longest_match_unaligned_avx2
+#define COMPARE256          compare256_unaligned_avx2_static
+#define COMPARE258          compare258_unaligned_avx2_static
+
+#include "match_tpl.h"
+
+#define LONGEST_MATCH_SLOW
+#define LONGEST_MATCH       longest_match_slow_unaligned_avx2
+#define COMPARE256          compare256_unaligned_avx2_static
+#define COMPARE258          compare258_unaligned_avx2_static
 
 #include "match_tpl.h"
 

--- a/arch/x86/compare258_sse.c
+++ b/arch/x86/compare258_sse.c
@@ -65,9 +65,16 @@ Z_INTERNAL uint32_t compare258_unaligned_sse4(const unsigned char *src0, const u
     return compare258_unaligned_sse4_static(src0, src1);
 }
 
-#define LONGEST_MATCH   longest_match_unaligned_sse4
-#define COMPARE256      compare256_unaligned_sse4_static
-#define COMPARE258      compare258_unaligned_sse4_static
+#define LONGEST_MATCH       longest_match_unaligned_sse4
+#define COMPARE256          compare256_unaligned_sse4_static
+#define COMPARE258          compare258_unaligned_sse4_static
+
+#include "match_tpl.h"
+
+#define LONGEST_MATCH_SLOW
+#define LONGEST_MATCH       longest_match_slow_unaligned_sse4
+#define COMPARE256          compare256_unaligned_sse4_static
+#define COMPARE258          compare258_unaligned_sse4_static
 
 #include "match_tpl.h"
 

--- a/arch/x86/insert_string_sse.c
+++ b/arch/x86/insert_string_sse.c
@@ -1,4 +1,4 @@
-/* insert_string_sse -- insert_string variant using SSE4.2's CRC instructions
+/* insert_string_sse.c -- insert_string integer hash variant using SSE4.2's CRC instructions
  *
  * Copyright (C) 1995-2013 Jean-loup Gailly and Mark Adler
  * For conditions of distribution and use, see copyright notice in zlib.h
@@ -14,22 +14,22 @@
 
 #ifdef X86_SSE42_CRC_INTRIN
 #  ifdef _MSC_VER
-#    define UPDATE_HASH(s, h, val)\
+#    define HASH_CALC(s, h, val)\
         h = _mm_crc32_u32(h, val)
 #  else
-#    define UPDATE_HASH(s, h, val)\
+#    define HASH_CALC(s, h, val)\
         h = __builtin_ia32_crc32si(h, val)
 #  endif
 #else
 #  ifdef _MSC_VER
-#    define UPDATE_HASH(s, h, val) {\
+#    define HASH_CALC(s, h, val) {\
         __asm mov edx, h\
         __asm mov eax, val\
         __asm crc32 eax, edx\
         __asm mov val, eax\
     }
 #  else
-#    define UPDATE_HASH(s, h, val) \
+#    define HASH_CALC(s, h, val) \
         __asm__ __volatile__ (\
             "crc32 %1,%0\n\t"\
             : "+r" (h)\
@@ -38,6 +38,10 @@
 #  endif
 #endif
 
+#define HASH_CALC_VAR       h
+#define HASH_CALC_VAR_INIT  uint32_t h = 0
+
+#define UPDATE_HASH         update_hash_sse4
 #define INSERT_STRING       insert_string_sse4
 #define QUICK_INSERT_STRING quick_insert_string_sse4
 

--- a/compare258.c
+++ b/compare258.c
@@ -57,9 +57,16 @@ Z_INTERNAL uint32_t compare258_c(const unsigned char *src0, const unsigned char 
     return compare258_c_static(src0, src1);
 }
 
-#define LONGEST_MATCH   longest_match_c
-#define COMPARE256      compare256_c_static
-#define COMPARE258      compare258_c_static
+#define LONGEST_MATCH       longest_match_c
+#define COMPARE256          compare256_c_static
+#define COMPARE258          compare258_c_static
+
+#include "match_tpl.h"
+
+#define LONGEST_MATCH_SLOW
+#define LONGEST_MATCH       longest_match_slow_c
+#define COMPARE256          compare256_c_static
+#define COMPARE258          compare258_c_staticc
 
 #include "match_tpl.h"
 
@@ -97,9 +104,16 @@ Z_INTERNAL uint32_t compare258_unaligned_16(const unsigned char *src0, const uns
     return compare258_unaligned_16_static(src0, src1);
 }
 
-#define LONGEST_MATCH   longest_match_unaligned_16
-#define COMPARE256      compare256_unaligned_16_static
-#define COMPARE258      compare258_unaligned_16_static
+#define LONGEST_MATCH       longest_match_unaligned_16
+#define COMPARE256          compare256_unaligned_16_static
+#define COMPARE258          compare258_unaligned_16_static
+
+#include "match_tpl.h"
+
+#define LONGEST_MATCH_SLOW
+#define LONGEST_MATCH       longest_match_slow_unaligned_16
+#define COMPARE256          compare256_unaligned_16_static
+#define COMPARE258          compare258_unaligned_16_static
 
 #include "match_tpl.h"
 
@@ -135,9 +149,16 @@ Z_INTERNAL uint32_t compare258_unaligned_32(const unsigned char *src0, const uns
     return compare258_unaligned_32_static(src0, src1);
 }
 
-#define LONGEST_MATCH   longest_match_unaligned_32
-#define COMPARE256      compare256_unaligned_32_static
-#define COMPARE258      compare258_unaligned_32_static
+#define LONGEST_MATCH       longest_match_unaligned_32
+#define COMPARE256          compare256_unaligned_32_static
+#define COMPARE258          compare258_unaligned_32_static
+
+#include "match_tpl.h"
+
+#define LONGEST_MATCH_SLOW
+#define LONGEST_MATCH       longest_match_slow_unaligned_32
+#define COMPARE256          compare256_unaligned_32_static
+#define COMPARE258          compare258_unaligned_32_static
 
 #include "match_tpl.h"
 
@@ -175,9 +196,16 @@ Z_INTERNAL uint32_t compare258_unaligned_64(const unsigned char *src0, const uns
     return compare258_unaligned_64_static(src0, src1);
 }
 
-#define LONGEST_MATCH   longest_match_unaligned_64
-#define COMPARE256      compare256_unaligned_64_static
-#define COMPARE258      compare258_unaligned_64_static
+#define LONGEST_MATCH       longest_match_unaligned_64
+#define COMPARE256          compare256_unaligned_64_static
+#define COMPARE258          compare258_unaligned_64_static
+
+#include "match_tpl.h"
+
+#define LONGEST_MATCH_SLOW
+#define LONGEST_MATCH       longest_match_slow_unaligned_64
+#define COMPARE256          compare256_unaligned_64_static
+#define COMPARE258          compare258_unaligned_64_static
 
 #include "match_tpl.h"
 

--- a/deflate.c
+++ b/deflate.c
@@ -100,9 +100,6 @@ const char PREFIX(deflate_copyright)[] = " deflate 1.2.11.f Copyright 1995-2016 
 /* ===========================================================================
  *  Function prototypes.
  */
-typedef block_state (*compress_func) (deflate_state *s, int flush);
-/* Compression function. Returns the block state after the call. */
-
 static int deflateStateCheck      (PREFIX3(stream) *strm);
 Z_INTERNAL block_state deflate_stored(deflate_state *s, int flush);
 Z_INTERNAL block_state deflate_fast  (deflate_state *s, int flush);

--- a/deflate.c
+++ b/deflate.c
@@ -1162,6 +1162,7 @@ static void lm_init(deflate_state *s) {
     s->prev_length = 0;
     s->match_available = 0;
     s->match_start = 0;
+    s->ins_h = 0;
 }
 
 /* ===========================================================================

--- a/deflate.c
+++ b/deflate.c
@@ -1250,7 +1250,7 @@ void Z_INTERNAL fill_window(deflate_state *s) {
         /* Initialize the hash value now that we have some input: */
         if (s->lookahead + s->insert >= STD_MIN_MATCH) {
             unsigned int str = s->strstart - s->insert;
-            if (s->max_chain_length > 1024) {
+            if (UNLIKELY(s->max_chain_length > 1024)) {
                 s->ins_h = s->update_hash(s, s->window[str], s->window[str+1]);
             } else if (str >= 1) {
                 s->quick_insert_string(s, str + 2 - STD_MIN_MATCH);

--- a/deflate.h
+++ b/deflate.h
@@ -155,6 +155,8 @@ typedef struct internal_state {
 
     Pos *head; /* Heads of the hash chains or 0. */
 
+    uint32_t ins_h; /* hash index of string to be inserted */
+
     int block_start;
     /* Window position at the beginning of the current output block. Gets
      * negative when the window is moved backwards.

--- a/deflate.h
+++ b/deflate.h
@@ -99,8 +99,14 @@ typedef uint16_t Pos;
 /* A Pos is an index in the character window. We use short instead of int to
  * save space in the various tables.
  */
+/* Type definitions for hash callbacks */
+typedef struct internal_state deflate_state;
 
-typedef struct internal_state {
+typedef uint32_t (* update_hash_cb)        (deflate_state *const s, uint32_t h, uint32_t val);
+typedef void     (* insert_string_cb)      (deflate_state *const s, uint32_t str, uint32_t count);
+typedef Pos      (* quick_insert_string_cb)(deflate_state *const s, uint32_t str);
+
+struct internal_state {
     PREFIX3(stream)      *strm;            /* pointer back to this zlib stream */
     unsigned char        *pending_buf;     /* output still pending */
     unsigned char        *pending_out;     /* next pending byte to output to the stream */
@@ -188,6 +194,12 @@ typedef struct internal_state {
      * max_insert_length is used only for compression levels <= 3.
      */
 
+    update_hash_cb          update_hash;
+    insert_string_cb        insert_string;
+    quick_insert_string_cb  quick_insert_string;
+    /* Hash function callbacks that can be configured depending on the deflate
+     * algorithm being used */
+
     int level;    /* compression level (1..9) */
     int strategy; /* favor or force Huffman coding*/
 
@@ -269,7 +281,7 @@ typedef struct internal_state {
 
     /* Reserved for future use and alignment purposes */
     int32_t reserved[11];
-} ALIGNED_(8) deflate_state;
+} ALIGNED_(8);
 
 typedef enum {
     need_more,      /* block not completed, need more input or more output */

--- a/deflate_p.h
+++ b/deflate_p.h
@@ -108,4 +108,9 @@ static inline int zng_tr_tally_dist(deflate_state *s, uint32_t dist, uint32_t le
 /* Maximum stored block length in deflate format (not including header). */
 #define MAX_STORED 65535
 
+/* Compression function. Returns the block state after the call. */
+typedef block_state (*compress_func) (deflate_state *s, int flush);
+/* Match function. Returns the longest match. */
+typedef uint32_t    (*match_func)    (deflate_state *const s, Pos cur_match);
+
 #endif

--- a/deflate_slow.c
+++ b/deflate_slow.c
@@ -68,8 +68,8 @@ Z_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
         /* If there was a match at the previous step and the current
          * match is not better, output the previous match:
          */
-        if (s->prev_length >= WANT_MIN_MATCH && match_len <= s->prev_length) {
-            unsigned int max_insert = s->strstart + s->lookahead - WANT_MIN_MATCH;
+        if (s->prev_length >= STD_MIN_MATCH && match_len <= s->prev_length) {
+            unsigned int max_insert = s->strstart + s->lookahead - STD_MIN_MATCH;
             /* Do not insert strings in hash table beyond this. */
 
             check_match(s, s->strstart-1, s->prev_match, s->prev_length);

--- a/deflate_slow.c
+++ b/deflate_slow.c
@@ -41,7 +41,7 @@ Z_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
          */
         hash_head = 0;
         if (LIKELY(s->lookahead >= WANT_MIN_MATCH)) {
-            hash_head = functable.quick_insert_string(s, s->strstart);
+            hash_head = s->quick_insert_string(s, s->strstart);
         }
 
         /* Find the longest match, discarding those <= prev_length.
@@ -88,8 +88,7 @@ Z_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
                 unsigned int insert_cnt = mov_fwd;
                 if (UNLIKELY(insert_cnt > max_insert - s->strstart))
                     insert_cnt = max_insert - s->strstart;
-
-                functable.insert_string(s, s->strstart + 1, insert_cnt);
+                s->insert_string(s, s->strstart + 1, insert_cnt);
             }
             s->prev_length = 0;
             s->match_available = 0;

--- a/deflate_slow.c
+++ b/deflate_slow.c
@@ -19,6 +19,12 @@ Z_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
     int bflush;              /* set if current block must be flushed */
     int64_t dist;
     uint32_t match_len;
+    match_func longest_match;
+
+    if (s->max_chain_length <= 1024)
+        longest_match = functable.longest_match;
+    else
+        longest_match = functable.longest_match_slow;
 
     /* Process the input block. */
     for (;;) {
@@ -55,7 +61,7 @@ Z_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
              * of window index 0 (in particular we have to avoid a match
              * of the string with itself at the start of the input file).
              */
-            match_len = functable.longest_match_slow(s, hash_head);
+            match_len = longest_match(s, hash_head);
             /* longest_match() sets match_start */
 
             if (match_len <= 5 && (s->strategy == Z_FILTERED)) {

--- a/deflate_slow.c
+++ b/deflate_slow.c
@@ -55,7 +55,7 @@ Z_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
              * of window index 0 (in particular we have to avoid a match
              * of the string with itself at the start of the input file).
              */
-            match_len = functable.longest_match(s, hash_head);
+            match_len = functable.longest_match_slow(s, hash_head);
             /* longest_match() sets match_start */
 
             if (match_len <= 5 && (s->strategy == Z_FILTERED)) {

--- a/deflate_slow.c
+++ b/deflate_slow.c
@@ -81,9 +81,10 @@ Z_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
              * enough lookahead, the last two strings are not inserted in
              * the hash table.
              */
-            s->lookahead -= s->prev_length-1;
+            s->prev_length -= 1;
+            s->lookahead -= s->prev_length;
 
-            unsigned int mov_fwd = s->prev_length - 2;
+            unsigned int mov_fwd = s->prev_length - 1;
             if (max_insert > s->strstart) {
                 unsigned int insert_cnt = mov_fwd;
                 if (UNLIKELY(insert_cnt > max_insert - s->strstart))

--- a/functable.c
+++ b/functable.c
@@ -142,6 +142,22 @@ extern uint32_t longest_match_unaligned_avx2(deflate_state *const s, Pos cur_mat
 #endif
 #endif
 
+/* longest_match_slow */
+extern uint32_t longest_match_slow_c(deflate_state *const s, Pos cur_match);
+#ifdef UNALIGNED_OK
+extern uint32_t longest_match_slow_unaligned_16(deflate_state *const s, Pos cur_match);
+extern uint32_t longest_match_slow_unaligned_32(deflate_state *const s, Pos cur_match);
+#ifdef UNALIGNED64_OK
+extern uint32_t longest_match_slow_unaligned_64(deflate_state *const s, Pos cur_match);
+#endif
+#ifdef X86_SSE42_CMP_STR
+extern uint32_t longest_match_slow_unaligned_sse4(deflate_state *const s, Pos cur_match);
+#endif
+#if defined(X86_AVX2) && defined(HAVE_BUILTIN_CTZ)
+extern uint32_t longest_match_slow_unaligned_avx2(deflate_state *const s, Pos cur_match);
+#endif
+#endif
+
 Z_INTERNAL Z_TLS struct functable_s functable;
 
 Z_INTERNAL void cpu_check_features(void)
@@ -473,6 +489,31 @@ Z_INTERNAL uint32_t longest_match_stub(deflate_state *const s, Pos cur_match) {
     return functable.longest_match(s, cur_match);
 }
 
+Z_INTERNAL uint32_t longest_match_slow_stub(deflate_state *const s, Pos cur_match) {
+
+    functable.longest_match_slow = &longest_match_slow_c;
+
+#ifdef UNALIGNED_OK
+#  if defined(UNALIGNED64_OK) && defined(HAVE_BUILTIN_CTZLL)
+    functable.longest_match_slow = &longest_match_slow_unaligned_64;
+#  elif defined(HAVE_BUILTIN_CTZ)
+    functable.longest_match_slow = &longest_match_slow_unaligned_32;
+#  else
+    functable.longest_match_slow = &longest_match_slow_unaligned_16;
+#  endif
+#  ifdef X86_SSE42_CMP_STR
+    if (x86_cpu_has_sse42)
+        functable.longest_match_slow = &longest_match_slow_unaligned_sse4;
+#  endif
+#  if defined(X86_AVX2) && defined(HAVE_BUILTIN_CTZ)
+    if (x86_cpu_has_avx2)
+        functable.longest_match_slow = &longest_match_slow_unaligned_avx2;
+#  endif
+#endif
+
+    return functable.longest_match_slow(s, cur_match);
+}
+
 /* functable init */
 Z_INTERNAL Z_TLS struct functable_s functable = {
     update_hash_stub,
@@ -483,6 +524,7 @@ Z_INTERNAL Z_TLS struct functable_s functable = {
     slide_hash_stub,
     compare258_stub,
     longest_match_stub,
+    longest_match_slow_stub,
     chunksize_stub,
     chunkcopy_stub,
     chunkcopy_safe_stub,

--- a/functable.c
+++ b/functable.c
@@ -14,6 +14,14 @@
 #  include "fallback_builtins.h"
 #endif
 
+/* update_hash */
+extern uint32_t update_hash_c(deflate_state *const s, uint32_t h, uint32_t val);
+#ifdef X86_SSE42_CRC_HASH
+extern uint32_t update_hash_sse4(deflate_state *const s, uint32_t h, uint32_t val);
+#elif defined(ARM_ACLE_CRC_HASH)
+extern uint32_t update_hash_acle(deflate_state *const s, uint32_t h, uint32_t val);
+#endif
+
 /* insert_string */
 extern void insert_string_c(deflate_state *const s, const uint32_t str, uint32_t count);
 #ifdef X86_SSE42_CRC_HASH
@@ -152,7 +160,24 @@ Z_INTERNAL void cpu_check_features(void)
 }
 
 /* stub functions */
-Z_INTERNAL void insert_string_stub(deflate_state *const s, const uint32_t str, uint32_t count) {
+Z_INTERNAL uint32_t update_hash_stub(deflate_state *const s, uint32_t h, uint32_t val) {
+    // Initialize default
+
+    functable.update_hash = &update_hash_c;
+    cpu_check_features();
+
+#ifdef X86_SSE42_CRC_HASH
+    if (x86_cpu_has_sse42)
+        functable.update_hash = &update_hash_sse4;
+#elif defined(ARM_ACLE_CRC_HASH)
+    if (arm_cpu_has_crc32)
+        functable.update_hash = &update_hash_acle;
+#endif
+
+    return functable.update_hash(s, h, val);
+}
+
+Z_INTERNAL void insert_string_stub(deflate_state *const s, uint32_t str, uint32_t count) {
     // Initialize default
 
     functable.insert_string = &insert_string_c;
@@ -450,6 +475,7 @@ Z_INTERNAL uint32_t longest_match_stub(deflate_state *const s, Pos cur_match) {
 
 /* functable init */
 Z_INTERNAL Z_TLS struct functable_s functable = {
+    update_hash_stub,
     insert_string_stub,
     quick_insert_string_stub,
     adler32_stub,

--- a/functable.h
+++ b/functable.h
@@ -9,8 +9,9 @@
 #include "deflate.h"
 
 struct functable_s {
-    void     (* insert_string)      (deflate_state *const s, const uint32_t str, uint32_t count);
-    Pos      (* quick_insert_string)(deflate_state *const s, const uint32_t str);
+    uint32_t (* update_hash)        (deflate_state *const s, uint32_t h, uint32_t val);
+    void     (* insert_string)      (deflate_state *const s, uint32_t str, uint32_t count);
+    Pos      (* quick_insert_string)(deflate_state *const s, uint32_t str);
     uint32_t (* adler32)            (uint32_t adler, const unsigned char *buf, size_t len);
     uint32_t (* crc32)              (uint32_t crc, const unsigned char *buf, uint64_t len);
     void     (* slide_hash)         (deflate_state *s);

--- a/functable.h
+++ b/functable.h
@@ -17,6 +17,7 @@ struct functable_s {
     void     (* slide_hash)         (deflate_state *s);
     uint32_t (* compare258)         (const unsigned char *src0, const unsigned char *src1);
     uint32_t (* longest_match)      (deflate_state *const s, Pos cur_match);
+    uint32_t (* longest_match_slow) (deflate_state *const s, Pos cur_match);
     uint32_t (* chunksize)          (void);
     uint8_t* (* chunkcopy)          (uint8_t *out, uint8_t const *from, unsigned len);
     uint8_t* (* chunkcopy_safe)     (uint8_t *out, uint8_t const *from, unsigned len, uint8_t *safe);

--- a/insert_string.c
+++ b/insert_string.c
@@ -1,4 +1,4 @@
-/* insert_string_c -- insert_string variant for c
+/* insert_string.c -- insert_string integer hash variant
  *
  * Copyright (C) 1995-2013 Jean-loup Gailly and Mark Adler
  * For conditions of distribution and use, see copyright notice in zlib.h
@@ -8,18 +8,14 @@
 #include "zbuild.h"
 #include "deflate.h"
 
-/* ===========================================================================
- * Update a hash value with the given input byte
- * IN  assertion: all calls to to UPDATE_HASH are made with consecutive
- *    input characters, so that a running hash key can be computed from the
- *    previous key instead of complete recalculation each time.
- */
-#define HASH_SLIDE 16  // Number of bits to slide hash
+#define HASH_SLIDE           16
 
-#define UPDATE_HASH(s, h, val) \
-    h = ((val * 2654435761U) >> HASH_SLIDE);
+#define HASH_CALC(s, h, val) h = ((val * 2654435761U) >> HASH_SLIDE);
+#define HASH_CALC_VAR        h
+#define HASH_CALC_VAR_INIT   uint32_t h = 0
 
-#define INSERT_STRING       insert_string_c
-#define QUICK_INSERT_STRING quick_insert_string_c
+#define UPDATE_HASH          update_hash_c
+#define INSERT_STRING        insert_string_c
+#define QUICK_INSERT_STRING  quick_insert_string_c
 
 #include "insert_string_tpl.h"

--- a/insert_string_roll.c
+++ b/insert_string_roll.c
@@ -1,0 +1,24 @@
+/* insert_string_roll.c -- insert_string rolling hash variant
+ *
+ * Copyright (C) 1995-2013 Jean-loup Gailly and Mark Adler
+ * For conditions of distribution and use, see copyright notice in zlib.h
+ *
+ */
+
+#include "zbuild.h"
+#include "deflate.h"
+
+#define HASH_SLIDE           5
+
+#define HASH_CALC(s, h, val) h = ((h << HASH_SLIDE) ^ ((uint8_t)val))
+#define HASH_CALC_VAR        s->ins_h
+#define HASH_CALC_VAR_INIT
+#define HASH_CALC_READ       val = strstart[0]
+#define HASH_CALC_MASK       (32768u - 1u)
+#define HASH_CALC_OFFSET     (STD_MIN_MATCH-1)
+
+#define UPDATE_HASH          update_hash_roll
+#define INSERT_STRING        insert_string_roll
+#define QUICK_INSERT_STRING  quick_insert_string_roll
+
+#include "insert_string_tpl.h"

--- a/insert_string_tpl.h
+++ b/insert_string_tpl.h
@@ -42,6 +42,18 @@
 #endif
 
 /* ===========================================================================
+ * Update a hash value with the given input byte
+ * IN  assertion: all calls to to UPDATE_HASH are made with consecutive
+ *    input characters, so that a running hash key can be computed from the
+ *    previous key instead of complete recalculation each time.
+ */
+Z_INTERNAL uint32_t UPDATE_HASH(deflate_state *const s, uint32_t h, uint32_t val) {
+    (void)s;
+    HASH_CALC(s, h, val);
+    return h & HASH_CALC_MASK;
+}
+
+/* ===========================================================================
  * Quick insert string str in the dictionary and set match_head to the previous head
  * of the hash chain (the most recent string with same hash key). Return
  * the previous length of the hash chain.

--- a/match_tpl.h
+++ b/match_tpl.h
@@ -1,3 +1,12 @@
+/* match_tpl.h -- find longest match template for compare256 variants
+ *
+ * Copyright (C) 1995-2013 Jean-loup Gailly and Mark Adler
+ * For conditions of distribution and use, see copyright notice in zlib.h
+ *
+ * Portions copyright (C) 2014-2021 Konstantin Nosov
+ *  Fast-zlib optimized longest_match
+ *  https://github.com/gildor2/fast_zlib
+ */
 
 #include "zbuild.h"
 #include "deflate.h"
@@ -36,10 +45,12 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
     Z_REGISTER unsigned char *mbase_start = window;
     Z_REGISTER unsigned char *mbase_end;
     const Pos *prev = s->prev;
-    Pos limit;
+    Pos limit, limit_base;
     int32_t early_exit;
     uint32_t chain_length, nice_match, best_len, offset;
     uint32_t lookahead = s->lookahead;
+    Pos match_offset = 0;
+    int32_t rolling_hash;
     bestcmp_t scan_end;
 #ifndef UNALIGNED_OK
     bestcmp_t scan_end0;
@@ -55,7 +66,7 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
     /* The code is optimized for STD_MAX_MATCH-2 multiple of 16. */
     Assert(STD_MAX_MATCH == 258, "Code too clever");
 
-    best_len = s->prev_length ? s->prev_length : 1;
+    best_len = s->prev_length ? s->prev_length : STD_MIN_MATCH-1;
 
     /* Calculate read offset which should only extend an extra byte
      * to find the next best match length.
@@ -81,6 +92,7 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
 
     /* Do not waste too much time if we already have a good match */
     chain_length = s->max_chain_length;
+    rolling_hash = chain_length > 1024;
     early_exit = s->level < EARLY_EXIT_TRIGGER_LEVEL;
     if (best_len >= s->good_match)
         chain_length >>= 2;
@@ -89,7 +101,38 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
     /* Stop when cur_match becomes <= limit. To simplify the code,
      * we prevent matches with the string of window index 0
      */
-    limit = strstart > MAX_DIST(s) ? (Pos)(strstart - MAX_DIST(s)) : 0;
+    limit = limit_base = strstart > MAX_DIST(s) ? (Pos)(strstart - MAX_DIST(s)) : 0;
+
+    if (best_len >= STD_MIN_MATCH && rolling_hash) {
+        /* We're continuing search (lazy evaluation). */
+        uint32_t i, hash;
+        Pos pos;
+
+        /* Find a most distant chain starting from scan with index=1 (index=0 corresponds
+         * to cur_match). We cannot use s->prev[strstart+1,...] immediately, because
+         * these strings are not yet inserted into the hash table.
+         */
+        hash = s->update_hash(s, 0, scan[1]);
+        hash = s->update_hash(s, hash, scan[2]);
+
+        for (i = 3; i <= best_len; i++) {
+            hash = s->update_hash(s, hash, scan[i]);
+
+            /* If we're starting with best_len >= 3, we can use offset search. */
+            pos = s->head[hash];
+            if (pos < cur_match) {
+                match_offset = (Pos)(i - 2);
+                cur_match = pos;
+            }
+        }
+
+        /* Update offset-dependent variables */
+        limit = limit_base+match_offset;
+        if (cur_match <= limit)
+            goto break_matching;
+        mbase_start -= match_offset;
+        mbase_end -= match_offset;
+    }
 
     Assert((unsigned long)strstart <= s->window_size - MIN_LOOKAHEAD, "need lookahead");
     for (;;) {
@@ -140,7 +183,9 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
         Assert(scan+len <= window+(unsigned)(s->window_size-1), "wild scan");
 
         if (len > best_len) {
-            s->match_start = cur_match;
+            uint32_t match_start = cur_match - match_offset;
+            s->match_start = match_start;
+
             /* Do not look for matches beyond the end of the input. */
             if (len > lookahead)
                 return lookahead;
@@ -162,7 +207,56 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
 #ifndef UNALIGNED_OK
             scan_end0 = *(bestcmp_t *)(scan+offset+1);
 #endif
-            mbase_end = (mbase_start+offset);
+            /* Look for a better string offset */
+            if (len > STD_MIN_MATCH && match_start + len < strstart && rolling_hash) {
+                Pos pos, next_pos;
+                uint32_t i, hash;
+                unsigned char *scan_endstr;
+
+                /* Go back to offset 0 */
+                cur_match -= match_offset;
+                match_offset = 0;
+                next_pos = cur_match;
+                for (i = 0; i <= len - STD_MIN_MATCH; i++) {
+                    pos = prev[(cur_match + i) & wmask];
+                    if (pos < next_pos) {
+                        /* Hash chain is more distant, use it */
+                        if (pos <= limit_base + i)
+                            goto break_matching;
+                        next_pos = pos;
+                        match_offset = (Pos)i;
+                    }
+                }
+                /* Switch cur_match to next_pos chain */
+                cur_match = next_pos;
+
+                /* Try hash head at len-(STD_MIN_MATCH-1) position to see if we could get
+                 * a better cur_match at the end of string. Using (STD_MIN_MATCH-1) lets
+                 * us include one more byte into hash - the byte which will be checked
+                 * in main loop now, and which allows to grow match by 1.
+                 */
+                scan_endstr = scan + len - (STD_MIN_MATCH+1);
+
+                hash = s->update_hash(s, 0, scan_endstr[0]);
+                hash = s->update_hash(s, hash, scan_endstr[1]);
+                hash = s->update_hash(s, hash, scan_endstr[2]);
+
+                pos = s->head[hash];
+                if (pos < cur_match) {
+                    match_offset = (Pos)(len - (STD_MIN_MATCH+1));
+                    if (pos <= limit_base + match_offset)
+                        goto break_matching;
+                    cur_match = pos;
+                }
+
+                /* Update offset-dependent variables */
+                limit = limit_base+match_offset;
+                mbase_start = window-match_offset;
+                mbase_end = (mbase_start+offset);
+                continue;
+            } else {
+                mbase_end = (mbase_start+offset);
+            }
         } else if (UNLIKELY(early_exit)) {
             /* The probability of finding a match later if we here is pretty low, so for
              * performance it's best to outright stop here for the lower compression levels
@@ -171,8 +265,14 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
         }
         GOTO_NEXT_CHAIN;
     }
-
     return best_len;
+
+break_matching:
+
+    if (best_len < s->lookahead)
+        return best_len;
+
+    return s->lookahead;
 }
 
 #undef LONGEST_MATCH

--- a/match_tpl.h
+++ b/match_tpl.h
@@ -45,12 +45,16 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
     Z_REGISTER unsigned char *mbase_start = window;
     Z_REGISTER unsigned char *mbase_end;
     const Pos *prev = s->prev;
-    Pos limit, limit_base;
+    Pos limit;
+#ifdef LONGEST_MATCH_SLOW
+    Pos limit_base;
+    int32_t rolling_hash;
+#else
     int32_t early_exit;
+#endif
     uint32_t chain_length, nice_match, best_len, offset;
     uint32_t lookahead = s->lookahead;
     Pos match_offset = 0;
-    int32_t rolling_hash;
     bestcmp_t scan_end;
 #ifndef UNALIGNED_OK
     bestcmp_t scan_end0;
@@ -92,8 +96,11 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
 
     /* Do not waste too much time if we already have a good match */
     chain_length = s->max_chain_length;
+#ifdef LONGEST_MATCH_SLOW
     rolling_hash = chain_length > 1024;
+#else
     early_exit = s->level < EARLY_EXIT_TRIGGER_LEVEL;
+#endif
     if (best_len >= s->good_match)
         chain_length >>= 2;
     nice_match = (uint32_t)s->nice_match;
@@ -101,8 +108,9 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
     /* Stop when cur_match becomes <= limit. To simplify the code,
      * we prevent matches with the string of window index 0
      */
-    limit = limit_base = strstart > MAX_DIST(s) ? (Pos)(strstart - MAX_DIST(s)) : 0;
-
+    limit = strstart > MAX_DIST(s) ? (Pos)(strstart - MAX_DIST(s)) : 0;
+#ifdef LONGEST_MATCH_SLOW
+    limit_base = limit;
     if (best_len >= STD_MIN_MATCH && rolling_hash) {
         /* We're continuing search (lazy evaluation). */
         uint32_t i, hash;
@@ -133,7 +141,7 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
         mbase_start -= match_offset;
         mbase_end -= match_offset;
     }
-
+#endif
     Assert((unsigned long)strstart <= s->window_size - MIN_LOOKAHEAD, "need lookahead");
     for (;;) {
         if (cur_match >= strstart)
@@ -207,6 +215,7 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
 #ifndef UNALIGNED_OK
             scan_end0 = *(bestcmp_t *)(scan+offset+1);
 #endif
+#ifdef LONGEST_MATCH_SLOW
             /* Look for a better string offset */
             if (len > STD_MIN_MATCH && match_start + len < strstart && rolling_hash) {
                 Pos pos, next_pos;
@@ -254,27 +263,33 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
                 mbase_start = window-match_offset;
                 mbase_end = (mbase_start+offset);
                 continue;
-            } else {
-                mbase_end = (mbase_start+offset);
             }
-        } else if (UNLIKELY(early_exit)) {
+#endif
+            mbase_end = (mbase_start+offset);
+        }
+#ifndef LONGEST_MATCH_SLOW
+        else if (UNLIKELY(early_exit)) {
             /* The probability of finding a match later if we here is pretty low, so for
              * performance it's best to outright stop here for the lower compression levels
              */
             break;
         }
+#endif
         GOTO_NEXT_CHAIN;
     }
     return best_len;
 
+#ifdef LONGEST_MATCH_SLOW
 break_matching:
 
     if (best_len < s->lookahead)
         return best_len;
 
     return s->lookahead;
+#endif
 }
 
+#undef LONGEST_MATCH_SLOW
 #undef LONGEST_MATCH
 #undef COMPARE256
 #undef COMPARE258

--- a/match_tpl.h
+++ b/match_tpl.h
@@ -217,7 +217,7 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
 #endif
 #ifdef LONGEST_MATCH_SLOW
             /* Look for a better string offset */
-            if (len > STD_MIN_MATCH && match_start + len < strstart && rolling_hash) {
+            if (UNLIKELY(len > STD_MIN_MATCH && match_start + len < strstart && rolling_hash)) {
                 Pos pos, next_pos;
                 uint32_t i, hash;
                 unsigned char *scan_endstr;

--- a/win32/Makefile.a64
+++ b/win32/Makefile.a64
@@ -63,6 +63,7 @@ OBJS = \
 	inftrees.obj \
 	inffast.obj \
 	insert_string.obj \
+	insert_string_roll.obj \
 	trees.obj \
 	uncompr.obj \
 	zutil.obj \

--- a/win32/Makefile.arm
+++ b/win32/Makefile.arm
@@ -66,6 +66,7 @@ OBJS = \
 	inftrees.obj \
 	inffast.obj \
 	insert_string.obj \
+	insert_string_roll.obj \
 	trees.obj \
 	uncompr.obj \
 	zutil.obj \

--- a/win32/Makefile.msc
+++ b/win32/Makefile.msc
@@ -73,6 +73,7 @@ OBJS = \
 	inftrees.obj \
 	inffast.obj \
 	insert_string.obj \
+	insert_string_roll.obj \
 	insert_string_sse.obj \
 	slide_avx.obj \
 	slide_sse.obj \


### PR DESCRIPTION
This is a PR that seeks to incorporate the fast zlib changes mentioned in #97. Fast-zlib changes require rolling hash to be used. It also performs best when hash mask is 32k-1 instead of 64k-1 which is used for integer hashing method we currently use. 

I don't expect these changes to be incorporated into the first release. We might also decide to not incorporate them at all due to the added complexity. But this is the first step toward determining that. And in the future should anybody want to investigate this again they can use this PR as a starting base.

# Benchmarks

## MADLER

```
 Tool: minigzip-madler.exe Levels: 1-9
 Runs: 70         Trim worst: 40

 Level   Comp   Comptime min/avg/max/stddev  Decomptime min/avg/max/stddev  Compressed size
 1     36.448%      2.421/2.433/2.442/0.006        0.907/0.919/0.925/0.004       77,255,275
 2     35.381%      2.675/2.689/2.696/0.006        0.897/0.907/0.916/0.006       74,991,864
 3     34.426%      3.306/3.321/3.332/0.007        0.880/0.900/0.908/0.008       72,967,657
 4     33.498%      3.540/3.556/3.566/0.008        0.876/0.891/0.896/0.006       71,002,237
 5     32.627%      4.840/4.858/4.872/0.007        0.876/0.888/0.892/0.004       69,156,120
 6     32.188%      6.789/6.822/6.842/0.015        0.870/0.880/0.886/0.004       68,224,174
 7     32.051%      8.181/8.214/8.234/0.013        0.865/0.877/0.882/0.005       67,934,314
 8     31.935%   12.677/12.719/12.745/0.019        0.863/0.872/0.877/0.003       67,688,380
 9     31.916%   16.200/16.248/16.282/0.022        0.861/0.872/0.877/0.004       67,647,801

 avg1  33.385%                        6.762                          0.889
 tot                               1825.836                        240.135      636,867,822
 ```

 ## ZLIB-NG

 ```
 Tool: minigzip-ng.exe Levels: 1-9
 Runs: 70         Trim worst: 40

 Level   Comp   Comptime min/avg/max/stddev  Decomptime min/avg/max/stddev  Compressed size
 1     47.618%      1.840/1.859/1.865/0.006        0.681/0.688/0.693/0.003      100,930,315
 2     35.519%      2.050/2.065/2.074/0.007        0.703/0.715/0.719/0.005       75,286,316
 3     34.198%      2.424/2.435/2.442/0.005        0.686/0.699/0.704/0.004       72,485,932
 4     32.928%      2.849/2.866/2.874/0.006        0.674/0.681/0.687/0.004       69,794,199
 5     32.661%      3.049/3.059/3.064/0.004        0.667/0.678/0.683/0.004       69,226,720
 6     32.507%      3.475/3.493/3.502/0.007        0.670/0.678/0.682/0.003       68,902,076
 7     32.255%      4.448/4.468/4.480/0.008        0.666/0.676/0.681/0.004       68,366,763
 8     32.167%      6.652/6.671/6.683/0.009        0.666/0.675/0.679/0.003       68,180,782
 9     32.156%      9.090/9.109/9.124/0.010        0.667/0.674/0.678/0.003       68,156,152

 avg1  34.668%                        4.003                          0.685
 tot                               1080.764                        184.972      661,329,255
 ```

 ## FAST-ZLIB

 ```
  Tool: minigzip-fast-zlib.exe Levels: 1-9
 Runs: 70         Trim worst: 40

 Level   Comp   Comptime min/avg/max/stddev  Decomptime min/avg/max/stddev  Compressed size
 1     36.448%      2.325/2.350/2.359/0.008        0.908/0.918/0.926/0.005       77,255,275
 2     35.381%      2.517/2.535/2.543/0.006        0.889/0.909/0.917/0.008       74,991,864
 3     34.426%      3.072/3.087/3.097/0.008        0.893/0.901/0.908/0.005       72,967,657
 4     33.481%      3.359/3.377/3.386/0.007        0.874/0.891/0.896/0.005       70,966,161
 5     32.489%      4.366/4.377/4.387/0.006        0.870/0.882/0.887/0.005       68,863,411
 6     32.061%      5.148/5.173/5.188/0.011        0.865/0.878/0.882/0.004       67,955,060
 7     31.979%      5.433/5.459/5.474/0.011        0.868/0.875/0.879/0.003       67,782,174
 8     31.913%      5.889/5.909/5.921/0.010        0.863/0.872/0.878/0.004       67,641,467
 9     31.909%      6.116/6.155/6.174/0.014        0.865/0.872/0.876/0.003       67,634,262

 avg1  33.343%                        4.269                          0.889
 tot                               1152.638                        239.939      636,057,331
 ```

 ## ZLIB-NG-FAST

 ```
  Tool: minigzip-fast-ng.exe Levels: 1-9
 Runs: 70         Trim worst: 40

 Level   Comp   Comptime min/avg/max/stddev  Decomptime min/avg/max/stddev  Compressed size
 1     47.618%      1.853/1.864/1.870/0.005        0.681/0.690/0.694/0.004      100,930,315
 2     35.519%      2.062/2.078/2.086/0.008        0.705/0.715/0.721/0.004       75,286,316
 3     34.198%      2.435/2.451/2.462/0.008        0.693/0.700/0.705/0.003       72,485,932
 4     32.928%      2.870/2.889/2.899/0.007        0.675/0.682/0.688/0.004       69,794,199
 5     32.661%      3.062/3.075/3.086/0.007        0.673/0.680/0.685/0.003       69,226,720
 6     32.507%      3.490/3.513/3.522/0.008        0.668/0.678/0.683/0.004       68,902,076
 7     32.255%      4.488/4.516/4.525/0.008        0.669/0.677/0.682/0.003       68,366,763
 8     32.167%      6.708/6.723/6.735/0.008        0.661/0.676/0.680/0.005       68,180,782
 9     32.003%      8.272/8.302/8.321/0.015        0.677/0.686/0.689/0.003       67,831,961

 avg1  34.651%                        3.935                          0.687
 tot                               1062.329                        185.535      661,005,064
 ```