### PR TITLE
Remove early exit for lower compression levels in longest_match

### DIFF
--- a/match_tpl.h
+++ b/match_tpl.h
@@ -16,8 +16,6 @@ typedef uint32_t        bestcmp_t;
 typedef uint8_t         bestcmp_t;
 #endif
 
-#define EARLY_EXIT_TRIGGER_LEVEL 5
-
 #endif
 
 /* Set match_start to the longest match starting at the given string and
@@ -161,11 +159,6 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
             scan_end0 = *(bestcmp_t *)(scan+offset+1);
 #endif
             mbase_end = (mbase_start+offset);
-        } else if (UNLIKELY(s->level < EARLY_EXIT_TRIGGER_LEVEL)) {
-            /* The probability of finding a match later if we here is pretty low, so for
-             * performance it's best to outright stop here for the lower compression levels
-             */
-            break;
         }
         GOTO_NEXT_CHAIN;
     }


### PR DESCRIPTION
I did a performance test to see if it still makes sense to do the early exit in `longest_match`:

## ZLIB-NG (EARLY-EXIT)
`-DWITH_OPTIM=OFF` (MSVC)
```

 Tool: minigzip-ng-early-exit.exe Levels: 1-9
 Runs: 70         Trim worst: 40

 Level   Comp   Comptime min/avg/max/stddev  Decomptime min/avg/max/stddev  Compressed size
 1     47.618%      1.784/1.804/1.817/0.008        0.666/0.674/0.679/0.003      100,930,315
 2     35.519%      2.003/2.012/2.018/0.004        0.688/0.697/0.701/0.004       75,286,316
 3     34.198%      2.365/2.384/2.394/0.008        0.670/0.683/0.690/0.005       72,485,932
 4     32.928%      2.790/2.809/2.820/0.008        0.658/0.667/0.674/0.005       69,794,199
 5     32.661%      2.979/3.001/3.014/0.009        0.649/0.662/0.669/0.005       69,226,720
 6     32.507%      3.400/3.433/3.445/0.010        0.656/0.663/0.668/0.004       68,902,076
 7     32.255%      4.381/4.410/4.423/0.012        0.653/0.662/0.668/0.004       68,366,763
 8     32.167%      6.558/6.599/6.615/0.015        0.646/0.664/0.669/0.005       68,180,782
 9     32.156%      9.010/9.033/9.055/0.014        0.660/0.667/0.673/0.004       68,156,152

 avg1  34.668%                        3.943                          0.671
 tot                               1064.517                        181.138      661,329,255
```

## ZLIB-NG (NO-EARLY-EXIT)
`-DWITH_OPTIM=OFF` (MSVC)
```
 Tool: minigzip-ng-no-early-exit.exe Levels: 1-9
 Runs: 70         Trim worst: 40

 Level   Comp   Comptime min/avg/max/stddev  Decomptime min/avg/max/stddev  Compressed size
 1     47.618%      1.791/1.804/1.812/0.006        0.662/0.670/0.676/0.004      100,930,315
 2     35.519%      1.988/2.005/2.014/0.006        0.685/0.695/0.701/0.004       75,286,316
 3     34.195%      2.357/2.379/2.391/0.008        0.670/0.680/0.687/0.005       72,478,755
 4     32.928%      2.779/2.800/2.811/0.007        0.655/0.665/0.672/0.005       69,794,199
 5     32.661%      2.977/2.995/3.004/0.008        0.652/0.661/0.667/0.004       69,226,720
 6     32.507%      3.394/3.416/3.432/0.012        0.651/0.661/0.668/0.005       68,902,076
 7     32.255%      4.359/4.393/4.404/0.008        0.649/0.664/0.668/0.004       68,366,763
 8     32.167%      6.545/6.576/6.589/0.012        0.656/0.664/0.668/0.003       68,180,782
 9     32.156%      8.971/9.006/9.019/0.014        0.662/0.667/0.670/0.002       68,156,152

 avg1  34.667%                        3.930                          0.670
 tot                               1061.207                        180.814      661,322,078
```

From this test run it appears that on all levels it only hurts performance.