### PR TITLE
Disable homebrew auto cleanup on macOS CIs.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -329,6 +329,8 @@ jobs:
       if: runner.os == 'macOS'
       run: |
         brew install ninja ${{ matrix.packages }}
+      env:
+        HOMEBREW_NO_INSTALL_CLEANUP: 1
 
     - name: Install codecov.io tools
       if: matrix.codecov

--- a/.github/workflows/pkgcheck.yml
+++ b/.github/workflows/pkgcheck.yml
@@ -66,6 +66,8 @@ jobs:
       if: runner.os == 'macOS'
       run: |
         brew install ninja diffoscope ${{ matrix.packages }}
+      env:
+        HOMEBREW_NO_INSTALL_CLEANUP: 1
 
     - name: Compare builds
       run: |


### PR DESCRIPTION
I noticed homebrew was doing auto cleanup after install. This will prevent auto cleanup as it is useless for our purposes and only wastes time.
https://www.scivision.dev/macos-ci-homebrew-disable-cleanup/