### PR TITLE
Use a version of Xcode that supports ZERO_AR_DATE.

### DIFF
--- a/.github/workflows/pkgcheck.yml
+++ b/.github/workflows/pkgcheck.yml
@@ -67,6 +67,15 @@ jobs:
       run: |
         brew install ninja diffoscope ${{ matrix.packages }}
 
+    - name: Select Xcode version (macOS)
+      # Use a version of Xcode that supports ZERO_AR_DATE until CMake supports
+      # AppleClang linking with libtool using -D argument
+      # https://gitlab.kitware.com/cmake/cmake/-/issues/19852
+      if: runner.os == 'macOS'
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: '12.1.1'
+
     - name: Compare builds
       run: |
         sh test/pkgcheck.sh


### PR DESCRIPTION
This should fix CI issues with macOS pkgcheck builds. We have to use an older version of Xcode for now with CMake. I think in Xcode 12.2 Apple made a change to how deterministic builds should be created by removed `ZERO_AR_DATE` environment variable from `AppleClang` and requiring the use of `libtool -D`. Our problem is that CMake does not have good support for using `libtool` as of 3.19.

I've tried the methods mentioned in the article below, but the only one that worked was changing the version of Xcode.
https://gitlab.kitware.com/cmake/cmake/-/issues/19852