### PR TITLE
Remove debug check for match beginning at zero.

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -1201,10 +1201,8 @@ void check_match(deflate_state *s, Pos start, Pos match, int length) {
         fprintf(stderr, " start %u, match %u, length %d\n", start, match, length);
         z_error("invalid match length");
     }
-    /* check that the match isn't at the beginning of the window and that it isn't at
-     * the same position as the start string
-     */
-    if (match == 0 || match == start) {
+    /* check that the match isn't at the same position as the start string */
+    if (match == start) {
         fprintf(stderr, " start %u, match %u, length %d\n", start, match, length);
         z_error("invalid match position");
     }


### PR DESCRIPTION
Debug CI has been failing since https://github.com/zlib-ng/zlib-ng/commit/f82f9ea86fa4cdda5038094bda33bc9ba63d3277. I also noticed this recently in #828. Perhaps I made some incorrect assumptions. I think if we check that atleast `match != start` that should be sufficient enough.