### PR TITLE
Store result of early exit trigger at the top of longest_match.

### DIFF
--- a/match_tpl.h
+++ b/match_tpl.h
@@ -37,6 +37,7 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
     Z_REGISTER unsigned char *mbase_end;
     const Pos *prev = s->prev;
     Pos limit;
+    int32_t early_exit;
     uint32_t chain_length, nice_match, best_len, offset;
     uint32_t lookahead = s->lookahead;
     bestcmp_t scan_end;
@@ -80,6 +81,7 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
 
     /* Do not waste too much time if we already have a good match */
     chain_length = s->max_chain_length;
+    early_exit = s->level < EARLY_EXIT_TRIGGER_LEVEL;
     if (best_len >= s->good_match)
         chain_length >>= 2;
     nice_match = (uint32_t)s->nice_match;
@@ -161,7 +163,7 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
             scan_end0 = *(bestcmp_t *)(scan+offset+1);
 #endif
             mbase_end = (mbase_start+offset);
-        } else if (UNLIKELY(s->level < EARLY_EXIT_TRIGGER_LEVEL)) {
+        } else if (UNLIKELY(early_exit)) {
             /* The probability of finding a match later if we here is pretty low, so for
              * performance it's best to outright stop here for the lower compression levels
              */


### PR DESCRIPTION
In this PR we calculate the result of the early exit condition once at the top of the `longest_match` function, instead of each time through the loop.

 ## ZLIB-NG

 ```
Tool: minigzip-ng.exe Levels: 1-9
 Runs: 70         Trim worst: 40

 Level   Comp   Comptime min/avg/max/stddev  Decomptime min/avg/max/stddev  Compressed size
 1     47.618%      1.771/1.787/1.797/0.008        0.668/0.680/0.688/0.006      100,930,315
 2     35.519%      1.992/2.010/2.020/0.008        0.688/0.703/0.709/0.006       75,286,316
 3     34.198%      2.351/2.371/2.383/0.008        0.677/0.687/0.693/0.004       72,485,932
 4     32.928%      2.772/2.782/2.791/0.006        0.661/0.672/0.679/0.005       69,794,199
 5     32.661%      2.959/2.974/2.983/0.006        0.653/0.669/0.678/0.007       69,226,720
 6     32.507%      3.374/3.395/3.408/0.009        0.655/0.669/0.675/0.005       68,902,076
 7     32.255%      4.325/4.351/4.363/0.009        0.658/0.668/0.673/0.004       68,366,763
 8     32.167%      6.462/6.510/6.526/0.015        0.656/0.668/0.673/0.004       68,180,782
 9     32.156%      8.867/8.899/8.916/0.012        0.661/0.668/0.675/0.004       68,156,152

 avg1  34.668%                        3.898                          0.676
 tot                               1052.350                        182.513      661,329,255
 ```

 ## ZLIB-NG OPTIM

 ```
 Tool: minigzip-ng-optim.exe Levels: 1-9
 Runs: 70         Trim worst: 40

 Level   Comp   Comptime min/avg/max/stddev  Decomptime min/avg/max/stddev  Compressed size
 1     47.618%      0.940/0.951/0.958/0.005        0.637/0.652/0.660/0.006      100,930,174
 2     35.518%      1.573/1.592/1.604/0.009        0.657/0.671/0.676/0.005       75,282,951
 3     34.198%      1.904/1.927/1.943/0.011        0.645/0.655/0.663/0.005       72,485,720
 4     32.928%      2.298/2.317/2.327/0.007        0.624/0.636/0.643/0.006       69,793,995
 5     32.662%      2.482/2.498/2.510/0.008        0.624/0.636/0.642/0.004       69,228,861
 6     32.507%      2.892/2.911/2.921/0.008        0.620/0.632/0.637/0.004       68,901,208
 7     32.255%      3.876/3.889/3.897/0.006        0.624/0.632/0.637/0.004       68,366,778
 8     32.167%      6.048/6.081/6.098/0.014        0.624/0.634/0.640/0.004       68,180,776
 9     32.156%      8.448/8.475/8.492/0.013        0.624/0.634/0.639/0.004       68,156,160

 avg1  34.668%                        3.404                          0.642
 tot                                919.194                        173.462      661,326,623
 ```

## ZLIB-NG (STORE EARLY EXIT)

```
 Tool: minigzip-ng-see.exe Levels: 1-9
 Runs: 70         Trim worst: 40

 Level   Comp   Comptime min/avg/max/stddev  Decomptime min/avg/max/stddev  Compressed size
 1     47.618%      1.773/1.792/1.799/0.006        0.662/0.677/0.685/0.006      100,930,315
 2     35.519%      1.995/2.016/2.026/0.009        0.688/0.700/0.707/0.006       75,286,316
 3     34.198%      2.354/2.373/2.385/0.009        0.671/0.690/0.695/0.005       72,485,932
 4     32.928%      2.748/2.776/2.783/0.008        0.662/0.671/0.677/0.004       69,794,199
 5     32.661%      2.932/2.960/2.970/0.009        0.661/0.668/0.674/0.004       69,226,720
 6     32.507%      3.374/3.392/3.400/0.007        0.655/0.669/0.676/0.005       68,902,076
 7     32.255%      4.310/4.347/4.359/0.011        0.653/0.667/0.674/0.006       68,366,763
 8     32.167%      6.478/6.506/6.529/0.016        0.656/0.667/0.673/0.004       68,180,782
 9     32.156%      8.864/8.896/8.919/0.015        0.656/0.668/0.674/0.005       68,156,152

 avg1  34.668%                        3.895                          0.675
 tot                               1051.739                        182.320      661,329,255
```

## ZLIB-NG (STORE EARLY EXIT) OPTIM

```
 Tool: minigzip-ng-see-optim.exe Levels: 1-9
 Runs: 70         Trim worst: 40

 Level   Comp   Comptime min/avg/max/stddev  Decomptime min/avg/max/stddev  Compressed size
 1     47.618%      0.941/0.953/0.959/0.005        0.636/0.652/0.662/0.006      100,930,174
 2     35.518%      1.580/1.600/1.612/0.009        0.653/0.669/0.677/0.007       75,282,951
 3     34.198%      1.896/1.926/1.943/0.014        0.645/0.658/0.664/0.005       72,485,720
 4     32.928%      2.292/2.311/2.318/0.007        0.626/0.637/0.645/0.005       69,793,995
 5     32.662%      2.477/2.493/2.509/0.010        0.623/0.635/0.642/0.005       69,228,861
 6     32.507%      2.887/2.908/2.920/0.010        0.623/0.634/0.641/0.005       68,901,208
 7     32.255%      3.839/3.873/3.886/0.011        0.620/0.630/0.636/0.005       68,366,778
 8     32.167%      6.039/6.073/6.084/0.009        0.623/0.634/0.640/0.004       68,180,776
 9     32.156%      8.430/8.469/8.484/0.013        0.626/0.635/0.640/0.004       68,156,160

 avg1  34.668%                        3.401                          0.643
 tot                                918.154                        173.528      661,326,623
```
