### PR TITLE
.github: Test with old gcc and clang on oldest supported ubuntu

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -8,6 +8,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - name: Ubuntu 16.04 GCC
+            os: ubuntu-16.04
+            compiler: gcc
+
           - name: Ubuntu GCC
             os: ubuntu-latest
             compiler: gcc
@@ -242,6 +246,11 @@ jobs:
             codecov: ubuntu_gcc_mingw_x86_64
              # Limit parallel test jobs to prevent wine errors
             parallels-jobs: 3
+
+          - name: Ubuntu 16.04 Clang
+            os: ubuntu-16.04
+            compiler: clang-6.0
+            # note: github preinstalls compilers now, see https://github.com/actions/virtual-environments/pull/369/
 
           - name: Ubuntu Clang
             os: ubuntu-latest

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -13,6 +13,11 @@ jobs:
             compiler: gcc
             configure-args: --warn
 
+          - name: Ubuntu 16.04 GCC
+            os: ubuntu-16.04
+            compiler: gcc
+            configure-args: --warn
+
           - name: Ubuntu GCC OSB
             os: ubuntu-latest
             compiler: gcc


### PR DESCRIPTION
That's ubuntu 16.04 (earliest version on github), gcc-5.5, and clang-6.0.

Would like to show compiler version at the beginning of the "generate project files" step, but couldn't figure out how to do it without errors on windows.

FIXME: github actions doesn't support ubuntu 12.04 directly, so for now, use 16.04.
A future pull request should probably add 12.04 via qemu or the like.