### PR TITLE
Only set CPU feature flags in configure script if not using native instructions

### DIFF
--- a/.github/workflows/pkgcheck.yml
+++ b/.github/workflows/pkgcheck.yml
@@ -86,6 +86,7 @@ jobs:
         CFLAGS: ${{ matrix.cflags }}
         CHOST: ${{ matrix.chost }}
         CMAKE_ARGS: ${{ matrix.cmake-args }}
+        CONFIGURE_ARGS: ${{ matrix.configure-args }}
         LDFLAGS: ${{ matrix.ldflags }}
 
     - name: Compare builds (compat)
@@ -96,6 +97,7 @@ jobs:
         CFLAGS: ${{ matrix.cflags }}
         CHOST: ${{ matrix.chost }}
         CMAKE_ARGS: ${{ matrix.cmake-args }}
+        CONFIGURE_ARGS: ${{ matrix.configure-args }}
         LDFLAGS: ${{ matrix.ldflags }}
 
     - name: Check ABI
@@ -107,6 +109,8 @@ jobs:
         CC: ${{ matrix.compiler }}
         CFLAGS: ${{ matrix.cflags }}
         CHOST: ${{ matrix.chost }}
+        CMAKE_ARGS: ${{ matrix.cmake-args }}
+        CONFIGURE_ARGS: ${{ matrix.configure-args }}
         LDFLAGS: ${{ matrix.ldflags }}
 
     - name: Check ABI (compat)
@@ -118,4 +122,6 @@ jobs:
         CC: ${{ matrix.compiler }}
         CFLAGS: ${{ matrix.cflags }}
         CHOST: ${{ matrix.chost }}
+        CMAKE_ARGS: ${{ matrix.cmake-args }}
+        CONFIGURE_ARGS: ${{ matrix.configure-args }}
         LDFLAGS: ${{ matrix.ldflags }}

--- a/.github/workflows/pkgcheck.yml
+++ b/.github/workflows/pkgcheck.yml
@@ -52,6 +52,12 @@ jobs:
             os: macOS-latest
             compiler: clang
 
+          - name: macOS Clang Native
+            os: macOS-latest
+            compiler: clang
+            cmake-args: -DWITH_NATIVE_INSTRUCTIONS=ON
+            configure-args: --native
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v1

--- a/.github/workflows/pkgcheck.yml
+++ b/.github/workflows/pkgcheck.yml
@@ -131,3 +131,17 @@ jobs:
         CMAKE_ARGS: ${{ matrix.cmake-args }}
         CONFIGURE_ARGS: ${{ matrix.configure-args }}
         LDFLAGS: ${{ matrix.ldflags }}
+
+    - name: Upload build errors
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: ${{ matrix.name }}
+        path: |
+          btmp1/configure.log
+          btmp1/CMakeFiles/CMakeOutput.log
+          btmp1/CMakeFiles/CMakeError.log
+          btmp2/configure.log
+          btmp2/CMakeFiles/CMakeOutput.log
+          btmp2/CMakeFiles/CMakeError.log
+        retention-days: 30

--- a/configure
+++ b/configure
@@ -232,6 +232,15 @@ case `$cc -v 2>&1` in
   *clang*) gcc=1 ;;
 esac
 
+if test $native -eq 1; then
+  avx2flag=""
+  sse2flag=""
+  ssse3flag=""
+  sse4flag=""
+  sse42flag=""
+  pclmulflag=""
+fi
+
 if test $build32 -eq 1; then
   CFLAGS="${CFLAGS} -m32"
   SFLAGS="${SFLAGS} -m32"


### PR DESCRIPTION
macOS dylib was not bit identical when using configure script with `-native` flag and cmake script with `-DWITH_NATIVE_INSTRUCTIONS=ON`. 

This was due to the fact that configure script would use `-mnative -maxv2` for compile checks while cmake would use only `-mnative`. I have also added a CI test for this case and now upload build errors for this workflow. 

See #697 for more background info.