### PR TITLE
[CMake] Add `zlibstatic` target alias when `BUILD_SHARED_LIBS` is "OFF"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -900,6 +900,10 @@ if(NOT DEFINED BUILD_SHARED_LIBS)
 else()
     add_library(zlib ${ZLIB_ALL_SRCS})
 
+    if(NOT BUILD_SHARED_LIBS)
+        add_library(zlibstatic ALIAS zlib)
+    endif()
+
     set(ZLIB_INSTALL_LIBRARIES zlib)
 endif()
 


### PR DESCRIPTION
Add `zlibstatic` alias when `BUILD_SHARED_LIBS` is "OFF".

IMO, a matter of debate / preference whether this is desirable for inclusion. Figured I'd offer it up for consideration.