### PR TITLE
Add testing of minigzip/minideflate "--help" and invalid parameter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1198,6 +1198,9 @@ if(ZLIB_ENABLE_TESTS)
             -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/run-and-redirect.cmake)
     endforeach()
 
+    # Run tests targeting tools
+    include(cmake/test-tools.cmake)
+
     if(NOT WIN32 AND ZLIB_COMPAT)
         add_executable(CVE-2003-0107 test/CVE-2003-0107.c)
         target_link_libraries(CVE-2003-0107 zlib)

--- a/cmake/test-tools.cmake
+++ b/cmake/test-tools.cmake
@@ -1,0 +1,35 @@
+# test-tools.cmake -- Tests targeting tool coverage
+
+# Test --help and invalid parameters for our tools
+set(TEST_COMMAND ${MINIGZIP_COMMAND} "--help")
+add_test(NAME minigzip-help
+    COMMAND ${CMAKE_COMMAND}
+    "-DCOMMAND=${TEST_COMMAND}"
+    -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/run-and-redirect.cmake)
+
+set(TEST_COMMAND ${MINIGZIP_COMMAND} "--invalid")
+add_test(NAME minigzip-invalid
+    COMMAND ${CMAKE_COMMAND}
+    "-DCOMMAND=${TEST_COMMAND}"
+    -DSUCCESS_EXIT=64
+    -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/run-and-redirect.cmake)
+
+set(TEST_COMMAND ${MINIDEFLATE_COMMAND} "--help")
+add_test(NAME minideflate-help
+    COMMAND ${CMAKE_COMMAND}
+     "-DCOMMAND=${TEST_COMMAND}"
+     -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/run-and-redirect.cmake)
+
+set(TEST_COMMAND ${MINIDEFLATE_COMMAND} "--invalid")
+add_test(NAME minideflate-invalid
+    COMMAND ${CMAKE_COMMAND}
+    "-DCOMMAND=${TEST_COMMAND}"
+    -DSUCCESS_EXIT=64
+    -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/run-and-redirect.cmake)
+
+set(TEST_COMMAND ${SWITCHLEVELS_COMMAND} "--help")
+add_test(NAME switchlevels-help
+    COMMAND ${CMAKE_COMMAND}
+     "-DCOMMAND=${TEST_COMMAND}"
+     -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/run-and-redirect.cmake)
+


### PR DESCRIPTION
This adds some very basic testing of minigzip/minideflate and switchlevels.
Currently these tools pull down our average coverage numbers, so might as well get that up a bit.