### PR TITLE
Fix defining HAVE_SYS_SDT_H with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,13 +314,16 @@ if(WITH_NATIVE_INSTRUCTIONS AND DEFINED NATIVEFLAG)
 endif()
 
 #
-# Check for stndard/system includes
+# Check for standard/system includes
 #
 check_include_file(sys/types.h HAVE_SYS_TYPES_H)
 check_include_file(stdarg.h    HAVE_STDARG_H)
 check_include_file(stdint.h    HAVE_STDINT_H)
 check_include_file(stddef.h    HAVE_STDDEF_H)
 check_include_file(sys/sdt.h   HAVE_SYS_SDT_H)
+if(HAVE_SYS_SDT_H)
+    add_definitions(-DHAVE_SYS_SDT_H)
+endif()
 check_include_file(unistd.h    HAVE_UNISTD_H)
 
 #


### PR DESCRIPTION
DFLTCC probe points are never activated when compiling with CMake. This
is because check_include_file() only sets an internal CMake variable,
but not a C define [1].

Fix as the link suggests - by adding an explicit add_definitions.

[1] https://cmake.org/pipermail/cmake/2015-June/060830.html