### PR TITLE
[WIP] Use portable code for aligned memory allocation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ include(FeatureSummary)
 
 include(cmake/detect-arch.cmake)
 include(cmake/detect-coverage.cmake)
+include(cmake/detect-malloc.cmake)
 include(cmake/detect-sanitizer.cmake)
 
 if(CMAKE_TOOLCHAIN_FILE)

--- a/cmake/detect-malloc.cmake
+++ b/cmake/detect-malloc.cmake
@@ -1,0 +1,32 @@
+# Neither Windows nor macOS support ISO C11 `aligned_alloc`.
+#  https://social.msdn.microsoft.com/Forums/vstudio/4617cd56-4c8d-4717-a96b-348ad3b2f149
+#  https://developer.apple.com/forums/thread/81413
+# macOS supports POSIX.1-2001 `posix_memalign`.
+#  https://opensource.apple.com/source/Libc/Libc-825.25/gen/posix_memalign.3.auto.html
+# Android supports `aligned_alloc` from API 28.
+#  https://github.com/aosp-mirror/platform_bionic/commit/cae21a9b53a10f0cba79bf6783c4a5af16228fed
+# Android supports `posix_memalign` from API 17 (but is available on API 16 via
+# libandroid_support.a, which is linked by default when targeting API 16).
+#  https://github.com/aosp-mirror/platform_bionic/commit/85aad909560508410101c18c6ecc6633df39c596
+#  https://github.com/aosp-mirror/platform_bionic/commit/e219cefc173bf93b8ff710431784e5de30ffab8f
+if(WIN32)
+    return()
+elseif(APPLE)
+    add_definitions(-D MAL_IMPL=1)
+elseif(ANDROID)
+    # TODO: if API level >= 28, MAL_IMPL=2
+    # TODO: elif API level >= 17, MAL_IMPL=1
+    # TODO: else, MAL_IMPL=0
+elseif(NOT CMAKE_C_STANDARD EQUAL 99)
+    return()
+endif()
+
+include(CMakePushCheckState)
+
+cmake_push_check_state(RESET)
+set(CMAKE_REQUIRED_DEFINITIONS -D _POSIX_C_SOURCE=200112L)
+check_function_exists(posix_memalign HAVE_POSIX_MEMALIGN)
+if(HAVE_POSIX_MEMALIGN)
+    add_definitions(-D _POSIX_C_SOURCE=200112L)
+endif()
+cmake_pop_check_state()

--- a/configure
+++ b/configure
@@ -732,7 +732,24 @@ EOF
     echo "Checking for fseeko... No." | tee -a configure.log
   fi
 fi
+echo >> configure.log
 
+cat > $test.c <<EOF
+#define _POSIX_C_SOURCE 200112L
+#include <stdlib.h>
+int main(void) {
+  void *ptr;
+  posix_memalign(&ptr, 64, 10);
+  return EXIT_SUCCESS;
+}
+EOF
+if try $CC $CFLAGS -o $test $test.c $LDSHAREDLIBC; then
+  echo "Checking for posix_memalign... Yes." | tee -a configure.log
+  CFLAGS="${CFLAGS} -D _POSIX_C_SOURCE=200112L"
+  SFLAGS="${SFLAGS} -D _POSIX_C_SOURCE=200112L"
+else
+  echo "Checking for posix_memalign... No." | tee -a configure.log
+fi
 echo >> configure.log
 
 # check for strerror() for use by gz* functions

--- a/test/minigzip.c
+++ b/test/minigzip.c
@@ -12,8 +12,9 @@
  * real thing.
  */
 
-#define _POSIX_SOURCE 1  /* This file needs POSIX for fdopen(). */
-#define _POSIX_C_SOURCE 200112  /* For snprintf(). */
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200112L /* fdopen, snprintf */
+#endif
 
 #include "zbuild.h"
 #ifdef ZLIB_COMPAT

--- a/zutil_p.h
+++ b/zutil_p.h
@@ -5,20 +5,34 @@
 #ifndef ZUTIL_P_H
 #define ZUTIL_P_H
 
-#ifdef __APPLE__
-#  include <stdlib.h>
-#else
-#  include <malloc.h>
+#if !defined(MAL_IMPL) && !defined(_WIN32)
+#  if __STDC_VERSION__+0 >= 201112L
+#    define MAL_IMPL 2 /* ISO C11 `aligned_alloc` */
+#  elif _POSIX_C_SOURCE+0 >= 200112L
+#    define MAL_IMPL 1 /* POSIX.1-2001 optional `posix_memalign` */
+#  else
+#    pragma message("No portable function for aligned memory allocation found, defaulting to memalign()")
+#  endif
 #endif
 
-/* Function to allocate 16 or 64-byte aligned memory */
+#include <stddef.h> /* NULL, size_t */
+#if MAL_IMPL+0 != 0
+#  include <stdlib.h> /* aligned_alloc, free, posix_memalign */
+#else
+#  include <malloc.h> /* _aligned_malloc, _aligned_free, free, memalign */
+#endif
+
+/* Function to allocate 64-byte aligned memory */
 static inline void *zng_alloc(size_t size) {
 #if defined(_WIN32)
-    return (void *)_aligned_malloc(size, 64);
-#elif defined(__APPLE__)
-    return (void *)malloc(size);     /* MacOS always aligns to 16 bytes */
+    return _aligned_malloc(size, 64);
+#elif MAL_IMPL == 2
+    return aligned_alloc(64, size);
+#elif MAL_IMPL == 1
+    void *ptr;
+    return posix_memalign(&ptr, 64, size) ? NULL : ptr;
 #else
-    return (void *)memalign(64, size);
+    return memalign(64, size);
 #endif
 }
 


### PR DESCRIPTION
This is a quick reborn of https://github.com/zlib-ng/zlib-ng/issues/766.
@Dead2, can you review this approach? I focused on standards instead of operating systems.
It should probably fix https://github.com/zlib-ng/zlib-ng/issues/873, will see.

We now have two standard “backends” and a fallback one:
 - Set C standard to 11 for [`aligned_alloc`](https://en.cppreference.com/w/c/memory/aligned_alloc);
 - Set POSIX to 2001 (`-D _POSIX_C_SOURCE=200112L`) for [`posix_memalign`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_memalign.html);
 - Otherwise fallback to non-standard `memalign`;