### PR TITLE
Added preprocessor error guards to ensure proper library usage.

### DIFF
--- a/zlib-ng.h
+++ b/zlib-ng.h
@@ -29,8 +29,16 @@
   (zlib format), rfc1951 (deflate format) and rfc1952 (gzip format).
 */
 
+#ifdef ZLIB_H_
+#  error Include zlib-ng.h for zlib-ng API or zlib.h for zlib-compat API but not both
+#endif
+
 #include <stdint.h>
 #include "zconf-ng.h"
+
+#ifndef ZCONFNG_H
+#  error Missing zconf-ng.h add binary output directory to include directories
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/zlib.h
+++ b/zlib.h
@@ -30,9 +30,17 @@
   (zlib format), rfc1951 (deflate format) and rfc1952 (gzip format).
 */
 
+#ifdef ZNGLIB_H_
+#  error Include zlib-ng.h for zlib-ng API or zlib.h for zlib-compat API but not both
+#endif
+
 #include <stdint.h>
 #include <stdarg.h>
 #include "zconf.h"
+
+#ifndef ZCONF_H
+#  error Missing zconf.h add binary output directory to include directories
+#endif
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
This prevents including both zlib-ng.h and zlib.h and gives the developer some indication of the issue. It also checks to make sure that zconf.h or zconf-ng.h was found and included properly, I think sometimes compiler will ignore if it cannot find this include. 