### PR TITLE
Fix MSVC warnings in deflate_quick_block_open

### DIFF
--- a/test/deflate_quick_block_open.c
+++ b/test/deflate_quick_block_open.c
@@ -59,7 +59,7 @@ int main() {
 
     strm.avail_in = sizeof(next_in);
     while (1) {
-        strm.avail_out = next_out + sizeof(next_out) - strm.next_out;
+        strm.avail_out = (uint32_t)(next_out + sizeof(next_out) - strm.next_out);
         if (strm.avail_out > 38)
             strm.avail_out = 38;
         ret = PREFIX(deflate)(&strm, Z_FINISH);
@@ -70,7 +70,7 @@ int main() {
             return EXIT_FAILURE;
         }
     }
-    uint32_t compressed_size = strm.next_out - next_out;
+    uint32_t compressed_size = (uint32_t)(strm.next_out - next_out);
 
     ret = PREFIX(deflateEnd)(&strm);
     if (ret != Z_OK) {


### PR DESCRIPTION
@nmoinvaz, could you please give it a try? I don't have MSVC.

---

Add casts in order to fix the following warnings [1]:

```
C:\Users\Nathan\Source\zlib-ng\test\deflate_quick_block_open.c(62,69): warning C4244: '=': conversion from '__int64' to
 'uint32_t', possible loss of data [C:\Users\Nathan\Source\zlib-ng\deflate_quick_block_open.vcxproj]
C:\Users\Nathan\Source\zlib-ng\test\deflate_quick_block_open.c(73,1): warning C4244: 'initializing': conversion from '_
_int64' to 'uint32_t', possible loss of data [C:\Users\Nathan\Source\zlib-ng\deflate_quick_block_open.vcxproj]
```

[1] https://github.com/zlib-ng/zlib-ng/pull/880#issuecomment-802432700