### PR TITLE
Only perform auto-detection of floating point ABI on ARM arch.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,8 +205,8 @@ else()
     if(NOT NATIVEFLAG)
         if(__GNUC__)
             if(BASEARCH_ARM_FOUND)
-                if(NOT CMAKE_C_FLAGS MATCHES "-mfloat-abi")
-                    # Check support for ARM floating point
+                if("${ARCH}" MATCHES "arm" AND NOT CMAKE_C_FLAGS MATCHES "-mfloat-abi")
+                    # Check support for ARM floating point ABI
                     execute_process(COMMAND ${CMAKE_C_COMPILER} "-dumpmachine"
                                     OUTPUT_VARIABLE GCC_MACHINE)
                     if("${GCC_MACHINE}" MATCHES "gnueabihf")


### PR DESCRIPTION
`-mfloat-abi` does not apply to `aarch64` so we need to check for `arm` arch before doing auto-detection.