### PR TITLE
Support for posix_memalign in FreeBSD 11. 

### DIFF
--- a/zutil_p.h
+++ b/zutil_p.h
@@ -7,13 +7,19 @@
 
 #ifdef __APPLE__
 #  include <stdlib.h>
+#elif defined(__FreeBSD__)
+#  include <stdlib.h>
+#  include <malloc_np.h>
 #else
 #  include <malloc.h>
 #endif
 
 /* Function to allocate 16 or 64-byte aligned memory */
 static inline void *zng_alloc(size_t size) {
-#if defined(_WIN32)
+#if defined(__FreeBSD__)
+    void *ptr;
+    return posix_memalign(&ptr, 64, size) ? NULL : ptr;
+#elif defined(_WIN32)
     return (void *)_aligned_malloc(size, 64);
 #elif defined(__APPLE__)
     return (void *)malloc(size);     /* MacOS always aligns to 16 bytes */


### PR DESCRIPTION
Minimum changes needed for FreeBSD 11 compilation based on #873. I tested this on FreeBSD 11.4.