### PR TITLE
Remove extra check that always is false in compare256_c_static.

### DIFF
--- a/compare258.c
+++ b/compare258.c
@@ -14,28 +14,28 @@ static inline uint32_t compare256_c_static(const unsigned char *src0, const unsi
 
     do {
         if (*src0 != *src1)
-            return len + (*src0 == *src1);
+            return len;
         src0 += 1, src1 += 1, len += 1;
         if (*src0 != *src1)
-            return len + (*src0 == *src1);
+            return len;
         src0 += 1, src1 += 1, len += 1;
         if (*src0 != *src1)
-            return len + (*src0 == *src1);
+            return len;
         src0 += 1, src1 += 1, len += 1;
         if (*src0 != *src1)
-            return len + (*src0 == *src1);
+            return len;
         src0 += 1, src1 += 1, len += 1;
         if (*src0 != *src1)
-            return len + (*src0 == *src1);
+            return len;
         src0 += 1, src1 += 1, len += 1;
         if (*src0 != *src1)
-            return len + (*src0 == *src1);
+            return len;
         src0 += 1, src1 += 1, len += 1;
         if (*src0 != *src1)
-            return len + (*src0 == *src1);
+            return len;
         src0 += 1, src1 += 1, len += 1;
         if (*src0 != *src1)
-            return len + (*src0 == *src1);
+            return len;
         src0 += 1, src1 += 1, len += 1;
     } while (len < 256);
 


### PR DESCRIPTION
This may have been a copy & paste artifact from `compare256_unaligned_16_static`. See #901.