### PR TITLE
Alias ZEXTERN, ZEXPORT and ZEXPORTVA to Z_EXTERN, Z_EXPORT and Z_EXPORTVA respectively.

### DIFF
--- a/zconf.h.in
+++ b/zconf.h.in
@@ -102,6 +102,18 @@
 #  define Z_EXPORTVA
 #endif
 
+/* For backwards compatibility */
+
+#ifndef ZEXTERN
+#  define ZEXTERN Z_EXTERN
+#endif
+#ifndef ZEXPORT
+#  define ZEXPORT Z_EXPORT
+#endif
+#ifndef ZEXPORTVA
+#  define ZEXPORTVA Z_EXPORTVA
+#endif
+
 /* Fallback for something that includes us. */
 typedef unsigned char Byte;
 typedef Byte Bytef;


### PR DESCRIPTION
See #914.

I chained the defines so any changes to zlib-ng defines are mirrored to stock zlib defines if not overwritten.