### PR TITLE
Remove unnecessary malloc.h header include

### DIFF
--- a/test/fuzz/minigzip_fuzzer.c
+++ b/test/fuzz/minigzip_fuzzer.c
@@ -32,10 +32,6 @@
 #  include <sys/stat.h>
 #endif
 
-#ifndef UNALIGNED_OK
-#  include <malloc.h>
-#endif
-
 #if defined(_WIN32) || defined(__CYGWIN__)
 #  include <fcntl.h>
 #  include <io.h>

--- a/test/minigzip.c
+++ b/test/minigzip.c
@@ -32,10 +32,6 @@
 #  include <sys/stat.h>
 #endif
 
-#ifndef UNALIGNED_OK
-#  include <malloc.h>
-#endif
-
 #if defined(_WIN32) || defined(__CYGWIN__)
 #  include <fcntl.h>
 #  include <io.h>


### PR DESCRIPTION
This comes out of the discussion from [#766](https://github.com/zlib-ng/zlib-ng/pull/766/files), where we discovered it doesn't make sense to have wrapped malloc.h include in `ifndef UNALIGNED_OK`. `malloc()` is already included from `stdlib.h` include.