### PR TITLE
Install clang-6 package if it is not present on Ubuntu

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -250,7 +250,7 @@ jobs:
           - name: Ubuntu 16.04 Clang
             os: ubuntu-16.04
             compiler: clang-6.0
-            # note: github preinstalls compilers now, see https://github.com/actions/virtual-environments/pull/369/
+            packages: clang-6.0
 
           - name: Ubuntu Clang
             os: ubuntu-latest


### PR DESCRIPTION
I can only assume GitHub have changed things and don't install this by default anymore. Perhaps somebody changed it and changed it back. Let's just always try to install.