### PR TITLE
Improvements to minigzip fuzzer coverage

### DIFF
--- a/test/fuzz/minigzip_fuzzer.c
+++ b/test/fuzz/minigzip_fuzzer.c
@@ -271,7 +271,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t dataLen) {
     /* Compression level: [0..9]. */
     outmode[2] = data[0] % 10;
 
-    switch (data[0] % 4) {
+    switch (data[dataLen-1] % 4) {
     default:
     case 0:
         outmode[3] = 0;

--- a/test/fuzz/minigzip_fuzzer.c
+++ b/test/fuzz/minigzip_fuzzer.c
@@ -271,7 +271,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t dataLen) {
     /* Compression level: [0..9]. */
     outmode[2] = data[0] % 10;
 
-    switch (data[dataLen-1] % 4) {
+    switch (data[dataLen-1] % 6) {
     default:
     case 0:
         outmode[3] = 0;
@@ -287,6 +287,14 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t dataLen) {
     case 3:
         /* compress with Z_RLE */
         outmode[3] = 'R';
+        break;
+    case 4:
+        /* compress with Z_FIXED */
+        outmode[3] = 'F';
+        break;
+    case 5:
+        /* direct */
+        outmode[3] = 'T';
         break;
     }
 


### PR DESCRIPTION
The first commit I double checked my assumptions here:
https://jsfiddle.net/use0f6yv/
But using the same random input value to determine both values will miss some combinations.