### PR TITLE
Use __attribute__ (constructor) for platform check features

### DIFF
--- a/arch/arm/arm.h
+++ b/arch/arm/arm.h
@@ -8,6 +8,4 @@
 extern int arm_cpu_has_neon;
 extern int arm_cpu_has_crc32;
 
-void Z_INTERNAL arm_check_features(void);
-
 #endif /* ARM_H_ */

--- a/arch/arm/armfeature.c
+++ b/arch/arm/armfeature.c
@@ -59,7 +59,7 @@ static inline int arm_has_neon() {
 Z_INTERNAL int arm_cpu_has_neon;
 Z_INTERNAL int arm_cpu_has_crc32;
 
-void Z_INTERNAL arm_check_features(void) {
+static void __attribute__((constructor)) arm_check_features(void) {
 #if defined(__aarch64__) || defined(_M_ARM64)
     arm_cpu_has_neon = 1; /* always available */
 #else

--- a/arch/power/power.c
+++ b/arch/power/power.c
@@ -8,7 +8,7 @@
 
 Z_INTERNAL int power_cpu_has_arch_2_07;
 
-void Z_INTERNAL power_check_features(void) {
+static void __attribute__((constructor)) power_check_features(void) {
     unsigned long hwcap2;
     hwcap2 = getauxval(AT_HWCAP2);
 

--- a/arch/power/power.h
+++ b/arch/power/power.h
@@ -8,6 +8,4 @@
 
 extern int power_cpu_has_arch_2_07;
 
-void Z_INTERNAL power_check_features(void);
-
 #endif /* POWER_H_ */

--- a/arch/x86/x86.c
+++ b/arch/x86/x86.c
@@ -52,7 +52,7 @@ static void cpuidex(int info, int subinfo, unsigned* eax, unsigned* ebx, unsigne
 #endif
 }
 
-void Z_INTERNAL x86_check_features(void) {
+static void __attribute__((constructor)) x86_check_features(void) {
     unsigned eax, ebx, ecx, edx;
     unsigned maxbasic;
 

--- a/arch/x86/x86.h
+++ b/arch/x86/x86.h
@@ -13,6 +13,4 @@ extern int x86_cpu_has_sse42;
 extern int x86_cpu_has_pclmulqdq;
 extern int x86_cpu_has_tzcnt;
 
-void Z_INTERNAL x86_check_features(void);
-
 #endif /* CPU_H_ */

--- a/crc32.c
+++ b/crc32.c
@@ -181,7 +181,6 @@ Z_INTERNAL void crc_finalize(deflate_state *const s) {
 
 Z_INTERNAL void crc_reset(deflate_state *const s) {
 #ifdef X86_PCLMULQDQ_CRC
-    x86_check_features();
     if (x86_cpu_has_pclmulqdq) {
         crc_fold_init(s);
         return;

--- a/deflate.c
+++ b/deflate.c
@@ -259,12 +259,6 @@ int32_t Z_EXPORT PREFIX(deflateInit2_)(PREFIX3(stream) *strm, int32_t level, int
     int wrap = 1;
     static const char my_version[] = PREFIX2(VERSION);
 
-#if defined(X86_FEATURES)
-    x86_check_features();
-#elif defined(ARM_FEATURES)
-    arm_check_features();
-#endif
-
     if (version == NULL || version[0] != my_version[0] || stream_size != sizeof(PREFIX3(stream))) {
         return Z_VERSION_ERROR;
     }

--- a/functable.c
+++ b/functable.c
@@ -136,27 +136,11 @@ extern uint32_t longest_match_unaligned_avx2(deflate_state *const s, Pos cur_mat
 
 Z_INTERNAL Z_TLS struct functable_s functable;
 
-Z_INTERNAL void cpu_check_features(void)
-{
-    static int features_checked = 0;
-    if (features_checked)
-        return;
-#if defined(X86_FEATURES)
-    x86_check_features();
-#elif defined(ARM_FEATURES)
-    arm_check_features();
-#elif defined(POWER_FEATURES)
-    power_check_features();
-#endif
-    features_checked = 1;
-}
-
 /* stub functions */
 Z_INTERNAL void insert_string_stub(deflate_state *const s, const uint32_t str, uint32_t count) {
     // Initialize default
 
     functable.insert_string = &insert_string_c;
-    cpu_check_features();
 
 #ifdef X86_SSE42_CRC_HASH
     if (x86_cpu_has_sse42)
@@ -186,7 +170,6 @@ Z_INTERNAL Pos quick_insert_string_stub(deflate_state *const s, const uint32_t s
 Z_INTERNAL void slide_hash_stub(deflate_state *s) {
 
     functable.slide_hash = &slide_hash_c;
-    cpu_check_features();
 
 #ifdef X86_SSE2
 #  if !defined(__x86_64__) && !defined(_M_X64) && !defined(X86_NOCHECK_SSE2)
@@ -214,7 +197,6 @@ Z_INTERNAL void slide_hash_stub(deflate_state *s) {
 Z_INTERNAL uint32_t adler32_stub(uint32_t adler, const unsigned char *buf, size_t len) {
     // Initialize default
     functable.adler32 = &adler32_c;
-    cpu_check_features();
 
 #ifdef ARM_NEON_ADLER32
 #  ifndef ARM_NOCHECK_NEON
@@ -376,8 +358,6 @@ Z_INTERNAL uint32_t crc32_stub(uint32_t crc, const unsigned char *buf, uint64_t 
     Assert(sizeof(uint64_t) >= sizeof(size_t),
            "crc32_z takes size_t but internally we have a uint64_t len");
     /* return a function pointer for optimized arches here after a capability test */
-
-    cpu_check_features();
 
     if (use_byfour) {
 #if BYTE_ORDER == LITTLE_ENDIAN

--- a/inflate.c
+++ b/inflate.c
@@ -132,12 +132,6 @@ int32_t Z_EXPORT PREFIX(inflateInit2_)(PREFIX3(stream) *strm, int32_t windowBits
     int32_t ret;
     struct inflate_state *state;
 
-#if defined(X86_FEATURES)
-    x86_check_features();
-#elif defined(ARM_FEATURES)
-    arm_check_features();
-#endif
-
     if (version == NULL || version[0] != PREFIX2(VERSION)[0] || stream_size != (int)(sizeof(PREFIX3(stream))))
         return Z_VERSION_ERROR;
     if (strm == NULL)


### PR DESCRIPTION
Currently calls to check_features are not thread safe, they produce errors under thread sanitizer. Use __attribute__ (constructor) for platform check features. 