### PR TITLE
use memcpy/memcmp for unaligned reads

### DIFF
--- a/chunkset.c
+++ b/chunkset.c
@@ -6,9 +6,9 @@
 #include "zutil.h"
 
 // We need sizeof(chunk_t) to be 8, no matter what.
-#if defined(UNALIGNED64_OK)
+#if defined(UNALIGNED64_OK) && defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 8
 typedef uint64_t chunk_t;
-#elif defined(UNALIGNED_OK)
+#elif defined(UNALIGNED_OK) && defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 8
 typedef struct chunk_t { uint32_t u32[2]; } chunk_t;
 #else
 typedef struct chunk_t { uint8_t u8[8]; } chunk_t;
@@ -21,9 +21,9 @@ typedef struct chunk_t { uint8_t u8[8]; } chunk_t;
 #define HAVE_CHUNKMEMSET_8
 
 static inline void chunkmemset_1(uint8_t *from, chunk_t *chunk) {
-#if defined(UNALIGNED64_OK)
+#if defined(UNALIGNED64_OK) && defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 8
     *chunk = 0x0101010101010101 * (uint8_t)*from;
-#elif defined(UNALIGNED_OK)
+#elif defined(UNALIGNED_OK) && defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 8
     chunk->u32[0] = 0x01010101 * (uint8_t)*from;
     chunk->u32[1] = chunk->u32[0];
 #else
@@ -32,11 +32,11 @@ static inline void chunkmemset_1(uint8_t *from, chunk_t *chunk) {
 }
 
 static inline void chunkmemset_4(uint8_t *from, chunk_t *chunk) {
-#if defined(UNALIGNED64_OK)
+#if defined(UNALIGNED64_OK) && defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 8
     uint32_t half_chunk;
     half_chunk = *(uint32_t *)from;
     *chunk = 0x0000000100000001 * (uint64_t)half_chunk;
-#elif defined(UNALIGNED_OK)
+#elif defined(UNALIGNED_OK) && defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 8
     chunk->u32[0] = *(uint32_t *)from;
     chunk->u32[1] = chunk->u32[0];
 #else
@@ -47,9 +47,9 @@ static inline void chunkmemset_4(uint8_t *from, chunk_t *chunk) {
 }
 
 static inline void chunkmemset_8(uint8_t *from, chunk_t *chunk) {
-#if defined(UNALIGNED64_OK)
+#if defined(UNALIGNED64_OK) && defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 8
     *chunk = *(uint64_t *)from;
-#elif defined(UNALIGNED_OK)
+#elif defined(UNALIGNED_OK) && defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 8
     uint32_t* p = (uint32_t *)from;
     chunk->u32[0] = p[0];
     chunk->u32[1] = p[1];
@@ -63,9 +63,9 @@ static inline void loadchunk(uint8_t const *s, chunk_t *chunk) {
 }
 
 static inline void storechunk(uint8_t *out, chunk_t *chunk) {
-#if defined(UNALIGNED64_OK)
+#if defined(UNALIGNED64_OK) && defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 8
     *(uint64_t *)out = *chunk;
-#elif defined(UNALIGNED_OK)
+#elif defined(UNALIGNED_OK) && defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 8
     ((uint32_t *)out)[0] = chunk->u32[0];
     ((uint32_t *)out)[1] = chunk->u32[1];
 #else

--- a/compare258.c
+++ b/compare258.c
@@ -76,16 +76,32 @@ static inline uint32_t compare256_unaligned_16_static(const unsigned char *src0,
     uint32_t len = 0;
 
     do {
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 8
         if (*(uint16_t *)src0 != *(uint16_t *)src1)
+#else
+        if (memcmp(src0, src1, 2))
+#endif
             return len + (*src0 == *src1);
         src0 += 2, src1 += 2, len += 2;
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 8
         if (*(uint16_t *)src0 != *(uint16_t *)src1)
+#else
+        if (memcmp(src0, src1, 2))
+#endif
             return len + (*src0 == *src1);
         src0 += 2, src1 += 2, len += 2;
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 8
         if (*(uint16_t *)src0 != *(uint16_t *)src1)
+#else
+        if (memcmp(src0, src1, 2))
+#endif
             return len + (*src0 == *src1);
         src0 += 2, src1 += 2, len += 2;
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 8
         if (*(uint16_t *)src0 != *(uint16_t *)src1)
+#else
+        if (memcmp(src0, src1, 2))
+#endif
             return len + (*src0 == *src1);
         src0 += 2, src1 += 2, len += 2;
     } while (len < 256);
@@ -94,7 +110,11 @@ static inline uint32_t compare256_unaligned_16_static(const unsigned char *src0,
 }
 
 static inline uint32_t compare258_unaligned_16_static(const unsigned char *src0, const unsigned char *src1) {
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 8
     if (*(uint16_t *)src0 != *(uint16_t *)src1)
+#else
+    if (memcmp(src0, src1, 2))
+#endif
         return (*src0 == *src1);
 
     return compare256_unaligned_16_static(src0+2, src1+2) + 2;
@@ -123,8 +143,14 @@ static inline uint32_t compare256_unaligned_32_static(const unsigned char *src0,
     uint32_t len = 0;
 
     do {
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 8
         uint32_t sv = *(uint32_t *)src0;
         uint32_t mv = *(uint32_t *)src1;
+#else
+        uint32_t sv, mv;
+        memcpy(&sv, src0, 4);
+        memcpy(&mv, src1, 4);
+#endif
         uint32_t diff = sv ^ mv;
 
         if (diff) {
@@ -139,7 +165,11 @@ static inline uint32_t compare256_unaligned_32_static(const unsigned char *src0,
 }
 
 static inline uint32_t compare258_unaligned_32_static(const unsigned char *src0, const unsigned char *src1) {
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 8
     if (*(uint16_t *)src0 != *(uint16_t *)src1)
+#else
+    if (memcmp(src0, src1, 2))
+#endif
         return (*src0 == *src1);
 
     return compare256_unaligned_32_static(src0+2, src1+2) + 2;
@@ -170,8 +200,14 @@ static inline uint32_t compare256_unaligned_64_static(const unsigned char *src0,
     uint32_t len = 0;
 
     do {
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 8
         uint64_t sv = *(uint64_t *)src0;
         uint64_t mv = *(uint64_t *)src1;
+#else
+        uint64_t sv, mv;
+        memcpy(&sv, src0, 8);
+        memcpy(&mv, src1, 8);
+#endif
         uint64_t diff = sv ^ mv;
 
         if (diff) {
@@ -186,7 +222,11 @@ static inline uint32_t compare256_unaligned_64_static(const unsigned char *src0,
 }
 
 static inline uint32_t compare258_unaligned_64_static(const unsigned char *src0, const unsigned char *src1) {
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 8
     if (*(uint16_t *)src0 != *(uint16_t *)src1)
+#else
+    if (memcmp(src0, src1, 2))
+#endif
         return (*src0 == *src1);
 
     return compare256_unaligned_64_static(src0+2, src1+2) + 2;

--- a/insert_string_tpl.h
+++ b/insert_string_tpl.h
@@ -29,9 +29,14 @@
 #  define HASH_CALC_MASK HASH_MASK
 #endif
 #ifndef HASH_CALC_READ
-#  ifdef UNALIGNED_OK
+#  if BYTE_ORDER == LITTLE_ENDIAN
+#   if UNALIGNED_OK && defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 8
 #    define HASH_CALC_READ \
         val = *(uint32_t *)(strstart);
+#   else
+#    define HASH_CALC_READ \
+        memcpy(&val, strstart, 4);
+#   endif
 #  else
 #    define HASH_CALC_READ \
         val  = ((uint32_t)(strstart[0])); \


### PR DESCRIPTION
that way any future optimizers won't make false
assumptions that those reads are actually aligned

compiler optimizes out memcpy/memcmp calls so
generated assembly code remains identical