### PR TITLE
Don't directly include asm/hwcap.h; fix compilation on musl aarch64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -640,6 +640,34 @@ endif()
 if(WITH_OPTIM)
     if(BASEARCH_ARM_FOUND)
         add_definitions(-DARM_FEATURES)
+        if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+            check_c_source_compiles(
+                "#include <sys/auxv.h>
+                int main() {
+                    return (getauxval(AT_HWCAP2) & HWCAP2_CRC32);
+                }"
+                ARM_AUXV_HAS_CRC32
+            )
+            if(ARM_AUXV_HAS_CRC32)
+                add_definitions(-DARM_AUXV_HAS_CRC32)
+            else()
+                message(STATUS "HWCAP2_CRC32 not present in sys/auxv.h; cannot detect support at runtime.")
+            endif()
+            if(NOT "${ARCH}" MATCHES "aarch64")
+                check_c_source_compiles(
+                    "#include <sys/auxv.h>
+                    int main() {
+                      return (getauxval(AT_HWCAP) & HWCAP_NEON);
+                    }"
+                    ARM_AUXV_HAS_NEON
+                )
+                if(ARM_AUXV_HAS_NEON)
+                    add_definitions(-DARM_AUXV_HAS_NEON)
+                else()
+                    message(STATUS "HWCAP_NEON not present in sys/auxv.h; cannot detect support at runtime.")
+                endif()
+            endif()
+        endif()
         list(APPEND ZLIB_ARCH_HDRS ${ARCHDIR}/arm.h)
         list(APPEND ZLIB_ARCH_SRCS ${ARCHDIR}/armfeature.c)
         if(WITH_ACLE AND NOT MSVC)

--- a/arch/arm/armfeature.c
+++ b/arch/arm/armfeature.c
@@ -2,7 +2,6 @@
 
 #if defined(__linux__)
 #  include <sys/auxv.h>
-#  include <asm/hwcap.h>
 #elif defined(__FreeBSD__) && defined(__aarch64__)
 #  include <machine/armreg.h>
 #  ifndef ID_AA64ISAR0_CRC32_VAL

--- a/arch/arm/armfeature.c
+++ b/arch/arm/armfeature.c
@@ -14,7 +14,7 @@
 #endif
 
 static int arm_has_crc32() {
-#if defined(__linux__) && defined(HWCAP2_CRC32)
+#if defined(__linux__) && defined(ARM_AUXV_HAS_CRC32)
     return (getauxval(AT_HWCAP2) & HWCAP2_CRC32) != 0 ? 1 : 0;
 #elif defined(__FreeBSD__) && defined(__aarch64__)
     return getenv("QEMU_EMULATING") == NULL
@@ -34,7 +34,7 @@ static int arm_has_crc32() {
 /* AArch64 has neon. */
 #if !defined(__aarch64__) && !defined(_M_ARM64)
 static inline int arm_has_neon() {
-#if defined(__linux__) && defined(HWCAP_NEON)
+#if defined(__linux__) && defined(ARM_AUXV_HAS_NEON)
     return (getauxval(AT_HWCAP) & HWCAP_NEON) != 0 ? 1 : 0;
 #elif defined(__APPLE__)
     int hasneon;

--- a/configure
+++ b/configure
@@ -522,6 +522,14 @@ else
   esac
 fi
 
+# Simplify some later conditionals
+case "$uname" in
+Linux* | linux*)
+  LINUX=1 ;;
+*)
+  LINUX=0 ;;
+esac
+
 # destination names for shared library if not defined above
 SHAREDLIB=${SHAREDLIB-"${LIBNAME}$shared_ext"}
 SHAREDLIBV=${SHAREDLIBV-"${LIBNAME}$shared_ext.$VER"}
@@ -1250,6 +1258,34 @@ case "${ARCH}" in
             SFLAGS="${SFLAGS} -DARM_FEATURES"
             ARCH_STATIC_OBJS="${ARCH_STATIC_OBJS} armfeature.o"
             ARCH_SHARED_OBJS="${ARCH_SHARED_OBJS} armfeature.lo"
+
+            if test $LINUX -eq 1; then
+                cat > $test.c <<EOF
+#include <sys/auxv.h>
+int main() {
+    return (getauxval(AT_HWCAP2) & HWCAP2_CRC32);
+}
+EOF
+                if try $CC -c $CFLAGS $test.c; then
+                    CFLAGS="${CFLAGS} -DARM_AUXV_HAS_CRC32"
+                    SFLAGS="${SFLAGS} -DARM_AUXV_HAS_CRC32"
+                else
+                    echo "HWCAP2_CRC32 not present in sys/auxv.h; cannot detect support at runtime." | tee -a configure.log
+                fi
+
+                cat > $test.c <<EOF
+#include <sys/auxv.h>
+int main() {
+    return (getauxval(AT_HWCAP) & HWCAP_NEON);
+}
+EOF
+                if try $CC -c $CFLAGS $test.c; then
+                    CFLAGS="${CFLAGS} -DARM_AUXV_HAS_NEON"
+                    SFLAGS="${SFLAGS} -DARM_AUXV_HAS_NEON"
+                else
+                    echo "HWCAP_NEON not present in sys/auxv.h; cannot detect support at runtime." | tee -a configure.log
+                fi
+            fi
         fi
 
         cat > $test.c << EOF
@@ -1389,6 +1425,21 @@ EOF
             SFLAGS="${SFLAGS} -DARM_FEATURES"
             ARCH_STATIC_OBJS="${ARCH_STATIC_OBJS} armfeature.o"
             ARCH_SHARED_OBJS="${ARCH_SHARED_OBJS} armfeature.lo"
+
+            if test $LINUX -eq 1; then
+                cat > $test.c <<EOF
+#include <sys/auxv.h>
+int main() {
+    return (getauxval(AT_HWCAP2) & HWCAP2_CRC32);
+}
+EOF
+                if try $CC -c $CFLAGS $test.c; then
+                    CFLAGS="${CFLAGS} -DARM_AUXV_HAS_CRC32"
+                    SFLAGS="${SFLAGS} -DARM_AUXV_HAS_CRC32"
+                else
+                    echo "HWCAP2_CRC32 not present in sys/auxv.h; cannot detect support at runtime." | tee -a configure.log
+                fi
+            fi
 
             if test $buildacle -eq 1; then
                 if test $native -eq 0; then


### PR DESCRIPTION
sys/auxv.h includes the appropriate headers to provide the HWCAP
constants, on both glibc and musl, which makes it unnecessary to include
asm/hwcap.h directly. And on musl, asm/hwcap.h doesn't exist.