### PR TITLE
Decompress gzip compressed archive to a separate file to prevent corruption issues on macOS.

### DIFF
--- a/cmake/test-compress.cmake
+++ b/cmake/test-compress.cmake
@@ -185,7 +185,7 @@ if(GZIP_VERIFY AND NOT "${COMPRESS_ARGS}" MATCHES "-T")
 
         if(NOT EXISTS ${OUTPUT_BASE}.gz)
             cleanup()
-            message(FATAL_ERROR "Cannot find minigzip decompress input: ${OUTPUT_BASE}.gzip.gz")
+            message(FATAL_ERROR "Cannot find decompress gzip input: ${OUTPUT_BASE}.gzip.gz")
         endif()
 
         # Check decompress target can handle gzip compressed output
@@ -199,7 +199,7 @@ if(GZIP_VERIFY AND NOT "${COMPRESS_ARGS}" MATCHES "-T")
 
         if(CMD_RESULT)
             cleanup()
-            message(FATAL_ERROR "Minigzip decompress gzip failed: ${CMD_RESULT}")
+            message(FATAL_ERROR "Decompress gzip failed: ${CMD_RESULT}")
         endif()
 
         if(COMPARE)
@@ -210,7 +210,7 @@ if(GZIP_VERIFY AND NOT "${COMPRESS_ARGS}" MATCHES "-T")
 
             if(CMD_RESULT)
                 cleanup()
-                message(FATAL_ERROR "Compare minigzip decompress gzip failed: ${CMD_RESULT}")
+                message(FATAL_ERROR "Compare decompress gzip failed: ${CMD_RESULT}")
             endif()
         endif()
     endif()

--- a/cmake/test-compress.cmake
+++ b/cmake/test-compress.cmake
@@ -183,7 +183,7 @@ if(GZIP_VERIFY AND NOT "${COMPRESS_ARGS}" MATCHES "-T")
             message(FATAL_ERROR "Gzip compress failed: ${CMD_RESULT}")
         endif()
 
-        if(NOT EXISTS ${OUTPUT_BASE}.gz)
+        if(NOT EXISTS ${OUTPUT_BASE}.gzip.gz)
             cleanup()
             message(FATAL_ERROR "Cannot find decompress gzip input: ${OUTPUT_BASE}.gzip.gz")
         endif()

--- a/cmake/test-compress.cmake
+++ b/cmake/test-compress.cmake
@@ -65,10 +65,13 @@ get_filename_component(OUTPUT_DIR "${OUTPUT_BASE}" DIRECTORY)
 file(MAKE_DIRECTORY "${OUTPUT_DIR}")
 
 macro(cleanup)
-    # Cleanup temporary mingizip files
-    file(REMOVE ${OUTPUT_BASE}.gz ${OUTPUT_BASE}.out)
-    # Cleanup temporary gzip files
-    file(REMOVE ${OUTPUT_BASE}.gzip.gz ${OUTPUT_BASE}.gzip.out)
+    # Cleanup temporary files
+    file(REMOVE
+        ${OUTPUT_BASE}.gz
+        ${OUTPUT_BASE}.out
+        ${OUTPUT_BASE}.gzip
+        ${OUTPUT_BASE}.gzip.gz
+        ${OUTPUT_BASE}.gzip.out)
 endmacro()
 
 # Compress input file
@@ -189,7 +192,7 @@ if(GZIP_VERIFY AND NOT "${COMPRESS_ARGS}" MATCHES "-T")
         execute_process(COMMAND ${CMAKE_COMMAND}
             "-DCOMMAND=${DECOMPRESS_COMMAND}"
             -DINPUT=${OUTPUT_BASE}.gzip.gz
-            -DOUTPUT=${OUTPUT_BASE}.gzip.out
+            -DOUTPUT=${OUTPUT_BASE}.gzip
             "-DSUCCESS_EXIT=${SUCCESS_EXIT}"
             -P ${CMAKE_CURRENT_LIST_DIR}/run-and-redirect.cmake
             RESULT_VARIABLE CMD_RESULT)
@@ -202,7 +205,7 @@ if(GZIP_VERIFY AND NOT "${COMPRESS_ARGS}" MATCHES "-T")
         if(COMPARE)
             # Compare original input file with gzip decompressed output
             execute_process(COMMAND ${CMAKE_COMMAND}
-                -E compare_files ${INPUT} ${OUTPUT_BASE}.gzip.out
+                -E compare_files ${INPUT} ${OUTPUT_BASE}.gzip
                 RESULT_VARIABLE CMD_RESULT)
 
             if(CMD_RESULT)


### PR DESCRIPTION
I'm not 100% sure why this works but it appears to on over 40,000 runs. The steps are run sequential but some how on macOS writing to the same content to the same filename gets corrupted.