### PR TITLE
Various improvements to test-compress cmake script.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -441,4 +441,9 @@ jobs:
         path: |
           ${{ matrix.build-dir || '.' }}/CMakeFiles/CMakeOutput.log
           ${{ matrix.build-dir || '.' }}/CMakeFiles/CMakeError.log
+          ${{ matrix.build-dir || '.' }}/Testing/Temporary/*.log
+          ${{ matrix.build-dir || '.' }}/test/**/*.diff
+          ${{ matrix.build-dir || '.' }}/test/**/*.hex
+          ${{ matrix.build-dir || '.' }}/test/**/*.gz*
+          ${{ matrix.build-dir || '.' }}/test/**/*.out
         retention-days: 30

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -441,9 +441,5 @@ jobs:
         path: |
           ${{ matrix.build-dir || '.' }}/CMakeFiles/CMakeOutput.log
           ${{ matrix.build-dir || '.' }}/CMakeFiles/CMakeError.log
-          ${{ matrix.build-dir || '.' }}/Testing/Temporary/*.log
-          ${{ matrix.build-dir || '.' }}/test/**/*.diff
-          ${{ matrix.build-dir || '.' }}/test/**/*.hex
-          ${{ matrix.build-dir || '.' }}/test/**/*.gz*
-          ${{ matrix.build-dir || '.' }}/test/**/*.out
+          ${{ matrix.build-dir || '.' }}/Testing/Temporary/*
         retention-days: 30

--- a/cmake/test-compress.cmake
+++ b/cmake/test-compress.cmake
@@ -58,7 +58,7 @@ endif()
 # Generate unique output path so multiple tests can be executed at the same time
 string(RANDOM LENGTH 6 UNIQUE_ID)
 string(REPLACE "." "-" TEST_NAME "${TEST_NAME}")
-set(OUTPUT_BASE "${CMAKE_CURRENT_BINARY_DIR}/test/${TEST_NAME}-${UNIQUE_ID}")
+set(OUTPUT_BASE "${CMAKE_CURRENT_BINARY_DIR}/Testing/Temporary/${TEST_NAME}-${UNIQUE_ID}")
 
 # Ensure directory exists for output files
 get_filename_component(OUTPUT_DIR "${OUTPUT_BASE}" DIRECTORY)

--- a/cmake/test-compress.cmake
+++ b/cmake/test-compress.cmake
@@ -65,14 +65,14 @@ get_filename_component(OUTPUT_DIR "${OUTPUT_BASE}" DIRECTORY)
 file(MAKE_DIRECTORY "${OUTPUT_DIR}")
 
 # Cleanup temporary files
+macro(cleanup_always)
+    file(GLOB TEMP_FILES ${OUTPUT_BASE}*)
+    file(REMOVE ${TEMP_FILES})
+endmacro()
+# Clean up temporary files if not on CI
 macro(cleanup)
     if(NOT DEFINED ENV{CI})
-        file(REMOVE
-            ${OUTPUT_BASE}.gz
-            ${OUTPUT_BASE}.out
-            ${OUTPUT_BASE}.gzip
-            ${OUTPUT_BASE}.gzip.gz
-            ${OUTPUT_BASE}.gzip.out)
+        cleanup_always()
     endif()
 endmacro()
 
@@ -246,4 +246,5 @@ if(GZIP_VERIFY AND NOT "${COMPRESS_ARGS}" MATCHES "-T")
     endif()
 endif()
 
-cleanup()
+
+cleanup_always()


### PR DESCRIPTION
PR #939 should be merged first. 

This adds writing of file differences using `diff` tool.
Added status messages to the script.
Write all temporary files to CMake's Testing/Temporary directory.