### PR TITLE
Change bi_reverse to use a much faster bit manipulation implementation.

### DIFF
--- a/deflate.h
+++ b/deflate.h
@@ -387,7 +387,7 @@ void Z_INTERNAL zng_tr_flush_block(deflate_state *s, char *buf, uint32_t stored_
 void Z_INTERNAL zng_tr_flush_bits(deflate_state *s);
 void Z_INTERNAL zng_tr_align(deflate_state *s);
 void Z_INTERNAL zng_tr_stored_block(deflate_state *s, char *buf, uint32_t stored_len, int last);
-unsigned Z_INTERNAL bi_reverse(unsigned code, int len);
+uint16_t Z_INTERNAL bi_reverse(unsigned code, int len);
 void Z_INTERNAL flush_pending(PREFIX3(streamp) strm);
 #define d_code(dist) ((dist) < 256 ? zng_dist_code[dist] : zng_dist_code[256+((dist)>>7)])
 /* Mapping from a distance to a distance code. dist is the distance - 1 and

--- a/tools/maketrees.c
+++ b/tools/maketrees.c
@@ -90,7 +90,7 @@ static void tr_static_init(void) {
     /* The static distance tree is trivial: */
     for (n = 0; n < D_CODES; n++) {
         static_dtree[n].Len = 5;
-        static_dtree[n].Code = (uint16_t)bi_reverse((unsigned)n, 5);
+        static_dtree[n].Code = bi_reverse((unsigned)n, 5);
     }
 }
 

--- a/trees.c
+++ b/trees.c
@@ -305,7 +305,7 @@ Z_INTERNAL void gen_codes(ct_data *tree, int max_code, uint16_t *bl_count) {
         if (len == 0)
             continue;
         /* Now reverse the bits */
-        tree[n].Code = (uint16_t)bi_reverse(next_code[len]++, len);
+        tree[n].Code = bi_reverse(next_code[len]++, len);
 
         Tracecv(tree != static_ltree, (stderr, "\nn %3d %c l %2d c %4x (%x) ",
              n, (isgraph(n) ? n : ' '), len, tree[n].Code, next_code[len]-1));
@@ -806,17 +806,13 @@ static void bi_flush(deflate_state *s) {
 }
 
 /* ===========================================================================
- * Reverse the first len bits of a code, using straightforward code (a faster
- * method would use a table)
- * IN assertion: 1 <= len <= 15
+ * Reverse the first len bits of a code using bit manipulation
  */
-Z_INTERNAL unsigned bi_reverse(unsigned code, int len) {
+Z_INTERNAL uint16_t bi_reverse(unsigned code, int len) {
     /* code: the value to invert */
     /* len: its bit length */
-    Z_REGISTER unsigned res = 0;
-    do {
-        res |= code & 1;
-        code >>= 1, res <<= 1;
-    } while (--len > 0);
-    return res >> 1;
+    Assert(len >= 1 && len <= 15, "code length must be 1-15");
+#define bitrev8(b) \
+    (uint8_t)((((uint8_t)(b) * 0x80200802ULL) & 0x0884422110ULL) * 0x0101010101ULL >> 32)
+    return (bitrev8(code >> 8) | (uint16_t)bitrev8(code) << 8) >> (16 - len);
 }


### PR DESCRIPTION
bi_reverse old versus new table method sees 240x improvement according to Quick C++ Benchmark. You can see minor improvements to both speed and size to the library itself. Two benchmark runs included below.

## ZLIB-NG (DEVELOP)

```
 Tool: minigzip-ng.exe Levels: 1-9
 Runs: 70         Trim worst: 40

 Level   Comp   Comptime min/avg/max/stddev   Compressed size
 1     48.014%      1.106/1.125/1.135/0.008       111,512,026
 2     35.391%      1.812/1.840/1.851/0.009        82,195,416
 3     34.039%      2.243/2.260/2.271/0.008        79,055,001
 4     32.751%      2.662/2.691/2.704/0.011        76,065,070
 5     32.484%      2.892/2.911/2.921/0.008        75,443,521
 6     32.318%      3.496/3.526/3.544/0.013        75,057,363
 7     32.061%      4.727/4.743/4.753/0.007        74,461,300
 8     31.978%      7.225/7.259/7.279/0.014        74,269,032
 9     31.961%      9.807/9.843/9.867/0.015        74,230,342

 avg1  34.555%                        4.022
 tot                               1085.923       722,289,071

 Tool: minigzip-ng.exe Levels: 1-9
 Runs: 70         Trim worst: 40

 Level   Comp   Comptime min/avg/max/stddev   Compressed size
 1     48.014%      1.066/1.078/1.095/0.009       111,512,026
 2     35.391%      1.786/1.816/1.833/0.012        82,195,416
 3     34.039%      2.217/2.237/2.260/0.011        79,055,001
 4     32.751%      2.642/2.675/2.694/0.014        76,065,070
 5     32.484%      2.855/2.893/2.918/0.015        75,443,521
 6     32.318%      3.472/3.500/3.529/0.017        75,057,363
 7     32.061%      4.685/4.728/4.751/0.018        74,461,300
 8     31.978%      7.209/7.243/7.290/0.023        74,269,032
 9     31.961%      9.777/9.825/9.889/0.035        74,230,342

 avg1  34.555%                        3.999
 tot                               1079.856       722,289,071
```

## ZLIB-NG (BI-REVERSE)

```
 Runs: 70         Trim worst: 40

 Level   Comp   Comptime min/avg/max/stddev   Compressed size
 1     48.014%      1.128/1.144/1.153/0.007       111,512,026
 2     35.391%      1.779/1.798/1.813/0.009        82,195,418
 3     34.039%      2.192/2.211/2.226/0.007        79,055,000
 4     32.751%      2.618/2.638/2.658/0.012        76,065,071
 5     32.484%      2.823/2.854/2.872/0.011        75,443,519
 6     32.318%      3.435/3.459/3.476/0.010        75,057,362
 7     32.061%      4.746/4.773/4.788/0.012        74,461,288
 8     31.978%      7.257/7.291/7.307/0.012        74,268,981
 9     31.961%      9.846/9.872/9.894/0.014        74,230,313

 avg1  34.555%                        4.005
 tot                               1081.243       722,288,978

 Tool: minigzip-ng-bi-reverse.exe Levels: 1-9
 Runs: 70         Trim worst: 40

 Level   Comp   Comptime min/avg/max/stddev   Compressed size
 1     48.014%      1.095/1.109/1.116/0.005       111,512,026
 2     35.391%      1.773/1.785/1.794/0.007        82,195,418
 3     34.039%      2.186/2.196/2.203/0.005        79,055,000
 4     32.751%      2.598/2.612/2.621/0.007        76,065,071
 5     32.484%      2.809/2.826/2.835/0.007        75,443,519
 6     32.318%      3.419/3.435/3.443/0.006        75,057,362
 7     32.061%      4.735/4.747/4.757/0.007        74,461,288
 8     31.978%      7.242/7.264/7.276/0.011        74,268,981
 9     31.961%      9.811/9.840/9.852/0.011        74,230,313

 avg1  34.555%                        3.979
 tot                               1074.405       722,288,978
```