### PR TITLE
Separate MIN_MATCH into properly separated values.

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -443,7 +443,7 @@ int32_t Z_EXPORT PREFIX(deflateSetDictionary)(PREFIX3(stream) *strm, const uint8
     s->block_start = (int)s->strstart;
     s->insert = s->lookahead;
     s->lookahead = 0;
-    s->prev_length = STD_MIN_MATCH - 1;
+    s->prev_length = 0;
     s->match_available = 0;
     strm->next_in = (z_const unsigned char *)next;
     strm->avail_in = avail;
@@ -1160,7 +1160,7 @@ static void lm_init(deflate_state *s) {
     s->block_start = 0;
     s->lookahead = 0;
     s->insert = 0;
-    s->prev_length = STD_MIN_MATCH - 1;
+    s->prev_length = 0;
     s->match_available = 0;
     s->match_start = 0;
 }

--- a/deflate.c
+++ b/deflate.c
@@ -1228,15 +1228,6 @@ void Z_INTERNAL fill_window(deflate_state *s) {
             unsigned int str = s->strstart - s->insert;
             if (str >= 1)
                 functable.quick_insert_string(s, str + 2 - STD_MIN_MATCH);
-#if STD_MIN_MATCH != 3
-            while (s->insert) {
-                functable.quick_insert_string(s, str);
-                str++;
-                s->insert--;
-                if (s->lookahead + s->insert < STD_MIN_MATCH)
-                    break;
-            }
-#else
             unsigned int count;
             if (UNLIKELY(s->lookahead == 1)) {
                 count = s->insert - 1;
@@ -1247,7 +1238,6 @@ void Z_INTERNAL fill_window(deflate_state *s) {
                 functable.insert_string(s, str, count);
                 s->insert -= count;
             }
-#endif
         }
         /* If the whole input has less than STD_MIN_MATCH bytes, ins_h is garbage,
          * but this is not important since only literal bytes will be emitted.

--- a/deflate.c
+++ b/deflate.c
@@ -433,17 +433,17 @@ int32_t Z_EXPORT PREFIX(deflateSetDictionary)(PREFIX3(stream) *strm, const uint8
     fill_window(s);
     while (s->lookahead >= STD_MIN_MATCH) {
         str = s->strstart;
-        n = s->lookahead - (STD_MIN_MATCH-1);
+        n = s->lookahead - (STD_MIN_MATCH - 1);
         functable.insert_string(s, str, n);
         s->strstart = str + n;
-        s->lookahead = STD_MIN_MATCH-1;
+        s->lookahead = STD_MIN_MATCH - 1;
         fill_window(s);
     }
     s->strstart += s->lookahead;
     s->block_start = (int)s->strstart;
     s->insert = s->lookahead;
     s->lookahead = 0;
-    s->prev_length = STD_MIN_MATCH-1;
+    s->prev_length = STD_MIN_MATCH - 1;
     s->match_available = 0;
     strm->next_in = (z_const unsigned char *)next;
     strm->avail_in = avail;
@@ -1160,7 +1160,7 @@ static void lm_init(deflate_state *s) {
     s->block_start = 0;
     s->lookahead = 0;
     s->insert = 0;
-    s->prev_length = STD_MIN_MATCH-1;
+    s->prev_length = STD_MIN_MATCH - 1;
     s->match_available = 0;
     s->match_start = 0;
 }

--- a/deflate.h
+++ b/deflate.h
@@ -141,7 +141,7 @@ typedef struct internal_state {
     /* Sliding window. Input bytes are read into the second half of the window,
      * and move to the first half later to keep a dictionary of at least wSize
      * bytes. With this organization, matches are limited to a distance of
-     * wSize-MAX_MATCH bytes, but this ensures that IO is always
+     * wSize-STD_MAX_MATCH bytes, but this ensures that IO is always
      * performed with a length multiple of the block size. Also, it limits
      * the window size to 64K, which is quite useful on MSDOS.
      * To do: use the user input buffer as sliding window.
@@ -363,17 +363,17 @@ static inline void put_uint64(deflate_state *s, uint64_t lld) {
 #endif
 }
 
-#define MIN_LOOKAHEAD (MAX_MATCH+MIN_MATCH+1)
+#define MIN_LOOKAHEAD (STD_MAX_MATCH + STD_MIN_MATCH + 1)
 /* Minimum amount of lookahead, except at the end of the input file.
- * See deflate.c for comments about the MIN_MATCH+1.
+ * See deflate.c for comments about the STD_MIN_MATCH+1.
  */
 
-#define MAX_DIST(s)  ((s)->w_size-MIN_LOOKAHEAD)
+#define MAX_DIST(s)  ((s)->w_size - MIN_LOOKAHEAD)
 /* In order to simplify the code, particularly on 16 bit machines, match
  * distances are limited to MAX_DIST instead of WSIZE.
  */
 
-#define WIN_INIT MAX_MATCH
+#define WIN_INIT STD_MAX_MATCH
 /* Number of bytes after end of data in window to initialize in order to avoid
    memory checker errors from longest match routines */
 

--- a/deflate_fast.c
+++ b/deflate_fast.c
@@ -76,11 +76,8 @@ Z_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
                 s->strstart += match_len;
             } else {
                 s->strstart += match_len;
-#if STD_MIN_MATCH != 3
-                functable.insert_string(s, s->strstart + 2 - STD_MIN_MATCH, STD_MIN_MATCH - 2);
-#else
                 functable.quick_insert_string(s, s->strstart + 2 - STD_MIN_MATCH);
-#endif
+
                 /* If lookahead < STD_MIN_MATCH, ins_h is garbage, but it does not
                  * matter since it will be recomputed at next deflate call.
                  */

--- a/deflate_fast.c
+++ b/deflate_fast.c
@@ -95,7 +95,7 @@ Z_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
         if (UNLIKELY(bflush))
             FLUSH_BLOCK(s, 0);
     }
-    s->insert = s->strstart < STD_MIN_MATCH-1 ? s->strstart : STD_MIN_MATCH-1;
+    s->insert = s->strstart < (STD_MIN_MATCH - 1) ? s->strstart : (STD_MIN_MATCH - 1);
     if (UNLIKELY(flush == Z_FINISH)) {
         FLUSH_BLOCK(s, 1);
         return finish_done;

--- a/deflate_fast.c
+++ b/deflate_fast.c
@@ -24,8 +24,8 @@ Z_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
 
     for (;;) {
         /* Make sure that we always have enough lookahead, except
-         * at the end of the input file. We need MAX_MATCH bytes
-         * for the next match, plus MIN_MATCH bytes to insert the
+         * at the end of the input file. We need STD_MAX_MATCH bytes
+         * for the next match, plus WANT_MIN_MATCH bytes to insert the
          * string following the next match.
          */
         if (s->lookahead < MIN_LOOKAHEAD) {
@@ -40,14 +40,14 @@ Z_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
         /* Insert the string window[strstart .. strstart+2] in the
          * dictionary, and set hash_head to the head of the hash chain:
          */
-        if (s->lookahead >= MIN_MATCH) {
+        if (s->lookahead >= WANT_MIN_MATCH) {
             hash_head = functable.quick_insert_string(s, s->strstart);
             dist = (int64_t)s->strstart - hash_head;
 
             /* Find the longest match, discarding those <= prev_length.
-             * At this point we have always match length < MIN_MATCH
+             * At this point we have always match length < WANT_MIN_MATCH
              */
-            
+
             if (dist <= MAX_DIST(s) && dist > 0 && hash_head != 0) {
                 /* To simplify the code, we prevent matches with the string
                  * of window index 0 (in particular we have to avoid a match
@@ -58,17 +58,17 @@ Z_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
             }
         }
 
-        if (match_len >= MIN_MATCH) {
+        if (match_len >= WANT_MIN_MATCH) {
             check_match(s, s->strstart, s->match_start, match_len);
 
-            bflush = zng_tr_tally_dist(s, s->strstart - s->match_start, match_len - MIN_MATCH);
+            bflush = zng_tr_tally_dist(s, s->strstart - s->match_start, match_len - STD_MIN_MATCH);
 
             s->lookahead -= match_len;
 
             /* Insert new strings in the hash table only if the match length
              * is not too large. This saves time but degrades compression.
              */
-            if (match_len <= s->max_insert_length && s->lookahead >= MIN_MATCH) {
+            if (match_len <= s->max_insert_length && s->lookahead >= WANT_MIN_MATCH) {
                 match_len--; /* string at strstart already in table */
                 s->strstart++;
 
@@ -76,12 +76,12 @@ Z_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
                 s->strstart += match_len;
             } else {
                 s->strstart += match_len;
-#if MIN_MATCH != 3
-                functable.insert_string(s, s->strstart + 2 - MIN_MATCH, MIN_MATCH - 2);
+#if STD_MIN_MATCH != 3
+                functable.insert_string(s, s->strstart + 2 - STD_MIN_MATCH, STD_MIN_MATCH - 2);
 #else
-                functable.quick_insert_string(s, s->strstart + 2 - MIN_MATCH);
+                functable.quick_insert_string(s, s->strstart + 2 - STD_MIN_MATCH);
 #endif
-                /* If lookahead < MIN_MATCH, ins_h is garbage, but it does not
+                /* If lookahead < STD_MIN_MATCH, ins_h is garbage, but it does not
                  * matter since it will be recomputed at next deflate call.
                  */
             }
@@ -95,7 +95,7 @@ Z_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
         if (UNLIKELY(bflush))
             FLUSH_BLOCK(s, 0);
     }
-    s->insert = s->strstart < MIN_MATCH-1 ? s->strstart : MIN_MATCH-1;
+    s->insert = s->strstart < STD_MIN_MATCH-1 ? s->strstart : STD_MIN_MATCH-1;
     if (UNLIKELY(flush == Z_FINISH)) {
         FLUSH_BLOCK(s, 1);
         return finish_done;

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -85,12 +85,10 @@ static void insert_match(deflate_state *s, struct match match) {
     } else {
         match.strstart += match.match_length;
         match.match_length = 0;
+
         if (match.strstart >= (STD_MIN_MATCH - 2))
-#if STD_MIN_MATCH != 3
-            functable.insert_string(s, match.strstart + 2 - STD_MIN_MATCH, STD_MIN_MATCH - 2);
-#else
             functable.quick_insert_string(s, match.strstart + 2 - STD_MIN_MATCH);
-#endif
+
         /* If lookahead < WANT_MIN_MATCH, ins_h is garbage, but it does not
          * matter since it will be recomputed at next deflate call.
          */

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -67,7 +67,7 @@ static void insert_match(deflate_state *s, struct match match) {
     /* Insert new strings in the hash table only if the match length
      * is not too large. This saves time but degrades compression.
      */
-    if (match.match_length <= 16* s->max_insert_length && s->lookahead >= WANT_MIN_MATCH) {
+    if (match.match_length <= 16 * s->max_insert_length && s->lookahead >= WANT_MIN_MATCH) {
         match.match_length--; /* string at strstart already in table */
         match.strstart++;
 
@@ -283,7 +283,7 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
         if (UNLIKELY(bflush))
             FLUSH_BLOCK(s, 0);
     }
-    s->insert = s->strstart < STD_MIN_MATCH-1 ? s->strstart : STD_MIN_MATCH-1;
+    s->insert = s->strstart < (STD_MIN_MATCH - 1) ? s->strstart : (STD_MIN_MATCH - 1);
     if (flush == Z_FINISH) {
         FLUSH_BLOCK(s, 1);
         return finish_done;

--- a/deflate_p.h
+++ b/deflate_p.h
@@ -17,7 +17,7 @@
  */
 static inline void check_match(deflate_state *s, Pos start, Pos match, int length) {
     /* check that the match length is valid*/
-    if (length < MIN_MATCH || length > MAX_MATCH) {
+    if (length < STD_MIN_MATCH || length > STD_MAX_MATCH) {
         fprintf(stderr, " start %u, match %u, length %d\n", start, match, length);
         z_error("invalid match length");
     }
@@ -65,13 +65,13 @@ static inline int zng_tr_tally_lit(deflate_state *s, unsigned char c) {
     s->sym_buf[s->sym_next++] = c;
     s->dyn_ltree[c].Freq++;
     Tracevv((stderr, "%c", c));
-    Assert(c <= (MAX_MATCH-MIN_MATCH), "zng_tr_tally: bad literal");
+    Assert(c <= (STD_MAX_MATCH-STD_MIN_MATCH), "zng_tr_tally: bad literal");
     return (s->sym_next == s->sym_end);
 }
 
 static inline int zng_tr_tally_dist(deflate_state *s, uint32_t dist, uint32_t len) {
     /* dist: distance of matched string */
-    /* len: match length-MIN_MATCH */
+    /* len: match length-STD_MIN_MATCH */
     s->sym_buf[s->sym_next++] = (uint8_t)(dist);
     s->sym_buf[s->sym_next++] = (uint8_t)(dist >> 8);
     s->sym_buf[s->sym_next++] = (uint8_t)len;

--- a/deflate_quick.c
+++ b/deflate_quick.c
@@ -110,7 +110,7 @@ Z_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
         s->lookahead--;
     }
 
-    s->insert = s->strstart < STD_MIN_MATCH-1 ? s->strstart : STD_MIN_MATCH-1;
+    s->insert = s->strstart < (STD_MIN_MATCH - 1) ? s->strstart : (STD_MIN_MATCH - 1);
     if (UNLIKELY(last)) {
         QUICK_END_BLOCK(s, 1);
         return finish_done;

--- a/deflate_quick.c
+++ b/deflate_quick.c
@@ -84,20 +84,20 @@ Z_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
             }
         }
 
-        if (LIKELY(s->lookahead >= MIN_MATCH)) {
+        if (LIKELY(s->lookahead >= WANT_MIN_MATCH)) {
             hash_head = functable.quick_insert_string(s, s->strstart);
             dist = (int64_t)s->strstart - hash_head;
 
             if (dist <= MAX_DIST(s) && dist > 0) {
                 match_len = functable.compare258(s->window + s->strstart, s->window + hash_head);
 
-                if (match_len >= MIN_MATCH) {
+                if (match_len >= WANT_MIN_MATCH) {
                     if (UNLIKELY(match_len > s->lookahead))
                         match_len = s->lookahead;
 
                     check_match(s, s->strstart, hash_head, match_len);
 
-                    zng_tr_emit_dist(s, static_ltree, static_dtree, match_len - MIN_MATCH, (uint32_t)dist);
+                    zng_tr_emit_dist(s, static_ltree, static_dtree, match_len - STD_MIN_MATCH, (uint32_t)dist);
                     s->lookahead -= match_len;
                     s->strstart += match_len;
                     continue;
@@ -110,7 +110,7 @@ Z_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
         s->lookahead--;
     }
 
-    s->insert = s->strstart < MIN_MATCH-1 ? s->strstart : MIN_MATCH-1;
+    s->insert = s->strstart < STD_MIN_MATCH-1 ? s->strstart : STD_MIN_MATCH-1;
     if (UNLIKELY(last)) {
         QUICK_END_BLOCK(s, 1);
         return finish_done;

--- a/deflate_rle.c
+++ b/deflate_rle.c
@@ -22,40 +22,40 @@ Z_INTERNAL block_state deflate_rle(deflate_state *s, int flush) {
 
     for (;;) {
         /* Make sure that we always have enough lookahead, except
-         * at the end of the input file. We need MAX_MATCH bytes
+         * at the end of the input file. We need STD_MAX_MATCH bytes
          * for the longest run, plus one for the unrolled loop.
          */
-        if (s->lookahead <= MAX_MATCH) {
+        if (s->lookahead <= STD_MAX_MATCH) {
             fill_window(s);
-            if (s->lookahead <= MAX_MATCH && flush == Z_NO_FLUSH)
+            if (s->lookahead <= STD_MAX_MATCH && flush == Z_NO_FLUSH)
                 return need_more;
             if (s->lookahead == 0)
                 break; /* flush the current block */
         }
 
         /* See how many times the previous byte repeats */
-        if (s->lookahead >= MIN_MATCH && s->strstart > 0) {
+        if (s->lookahead >= STD_MIN_MATCH && s->strstart > 0) {
             scan = s->window + s->strstart - 1;
             prev = *scan;
             if (prev == *++scan && prev == *++scan && prev == *++scan) {
-                strend = s->window + s->strstart + MAX_MATCH;
+                strend = s->window + s->strstart + STD_MAX_MATCH;
                 do {
                 } while (prev == *++scan && prev == *++scan &&
                          prev == *++scan && prev == *++scan &&
                          prev == *++scan && prev == *++scan &&
                          prev == *++scan && prev == *++scan &&
                          scan < strend);
-                match_len = MAX_MATCH - (unsigned int)(strend - scan);
+                match_len = STD_MAX_MATCH - (unsigned int)(strend - scan);
                 match_len = MIN(match_len, s->lookahead);
             }
             Assert(scan <= s->window + s->window_size - 1, "wild scan");
         }
 
-        /* Emit match if have run of MIN_MATCH or longer, else emit literal */
-        if (match_len >= MIN_MATCH) {
+        /* Emit match if have run of STD_MIN_MATCH or longer, else emit literal */
+        if (match_len >= STD_MIN_MATCH) {
             check_match(s, s->strstart, s->strstart - 1, match_len);
 
-            bflush = zng_tr_tally_dist(s, 1, match_len - MIN_MATCH);
+            bflush = zng_tr_tally_dist(s, 1, match_len - STD_MIN_MATCH);
 
             s->lookahead -= match_len;
             s->strstart += match_len;

--- a/deflate_slow.c
+++ b/deflate_slow.c
@@ -47,7 +47,7 @@ Z_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
         /* Find the longest match, discarding those <= prev_length.
          */
         s->prev_match = (Pos)s->match_start;
-        match_len = STD_MIN_MATCH-1;
+        match_len = STD_MIN_MATCH - 1;
         dist = (int64_t)s->strstart - hash_head;
 
         if (dist <= MAX_DIST(s) && dist > 0 && s->prev_length < s->max_lazy_match && hash_head != 0) {
@@ -62,7 +62,7 @@ Z_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
                 /* If prev_match is also WANT_MIN_MATCH, match_start is garbage
                  * but we will ignore the current match anyway.
                  */
-                match_len = STD_MIN_MATCH-1;
+                match_len = STD_MIN_MATCH - 1;
             }
         }
         /* If there was a match at the previous step and the current
@@ -126,7 +126,7 @@ Z_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
         (void) zng_tr_tally_lit(s, s->window[s->strstart-1]);
         s->match_available = 0;
     }
-    s->insert = s->strstart < STD_MIN_MATCH-1 ? s->strstart : STD_MIN_MATCH-1;
+    s->insert = s->strstart < (STD_MIN_MATCH - 1) ? s->strstart : (STD_MIN_MATCH - 1);
     if (UNLIKELY(flush == Z_FINISH)) {
         FLUSH_BLOCK(s, 1);
         return finish_done;

--- a/insert_string_tpl.h
+++ b/insert_string_tpl.h
@@ -57,8 +57,8 @@ Z_INTERNAL Pos QUICK_INSERT_STRING(deflate_state *const s, const uint32_t str) {
  * of the hash chain (the most recent string with same hash key). Return
  * the previous length of the hash chain.
  * IN  assertion: all calls to to INSERT_STRING are made with consecutive
- *    input characters and the first MIN_MATCH bytes of str are valid
- *    (except for the last MIN_MATCH-1 bytes of the input file).
+ *    input characters and the first STD_MIN_MATCH bytes of str are valid
+ *    (except for the last STD_MIN_MATCH-1 bytes of the input file).
  */
 Z_INTERNAL void INSERT_STRING(deflate_state *const s, const uint32_t str, uint32_t count) {
     uint8_t *strstart = s->window + str;

--- a/match_tpl.h
+++ b/match_tpl.h
@@ -52,8 +52,8 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
         continue; \
     return best_len;
 
-    /* The code is optimized for MAX_MATCH-2 multiple of 16. */
-    Assert(MAX_MATCH == 258, "Code too clever");
+    /* The code is optimized for STD_MAX_MATCH-2 multiple of 16. */
+    Assert(STD_MAX_MATCH == 258, "Code too clever");
 
     best_len = s->prev_length ? s->prev_length : 1;
 

--- a/tools/maketrees.c
+++ b/tools/maketrees.c
@@ -23,11 +23,11 @@ static unsigned char dist_code[DIST_CODE_LEN];
  * the last 256 values correspond to the top 8 bits of the 15 bit distances.
  */
 
-static unsigned char length_code[MAX_MATCH-MIN_MATCH+1];
-/* length code for each normalized match length (0 == MIN_MATCH) */
+static unsigned char length_code[STD_MAX_MATCH-STD_MIN_MATCH+1];
+/* length code for each normalized match length (0 == STD_MIN_MATCH) */
 
 static int base_length[LENGTH_CODES];
-/* First normalized length for each code (0 = MIN_MATCH) */
+/* First normalized length for each code (0 = STD_MIN_MATCH) */
 
 static int base_dist[D_CODES];
 /* First normalized distance for each code (0 = distance of 1) */
@@ -121,9 +121,9 @@ static void gen_trees_header() {
         printf("%2u%s", dist_code[i], SEPARATOR(i, DIST_CODE_LEN-1, 20));
     }
 
-    printf("const unsigned char Z_INTERNAL zng_length_code[MAX_MATCH-MIN_MATCH+1] = {\n");
-    for (i = 0; i < MAX_MATCH-MIN_MATCH+1; i++) {
-        printf("%2u%s", length_code[i], SEPARATOR(i, MAX_MATCH-MIN_MATCH, 20));
+    printf("const unsigned char Z_INTERNAL zng_length_code[STD_MAX_MATCH-STD_MIN_MATCH+1] = {\n");
+    for (i = 0; i < STD_MAX_MATCH-STD_MIN_MATCH+1; i++) {
+        printf("%2u%s", length_code[i], SEPARATOR(i, STD_MAX_MATCH-STD_MIN_MATCH, 20));
     }
 
     printf("Z_INTERNAL const int base_length[LENGTH_CODES] = {\n");

--- a/trees_emit.h
+++ b/trees_emit.h
@@ -16,7 +16,7 @@ extern Z_INTERNAL const ct_data static_ltree[L_CODES+2];
 extern Z_INTERNAL const ct_data static_dtree[D_CODES];
 
 extern const unsigned char Z_INTERNAL zng_dist_code[DIST_CODE_LEN];
-extern const unsigned char Z_INTERNAL zng_length_code[MAX_MATCH-MIN_MATCH+1];
+extern const unsigned char Z_INTERNAL zng_length_code[STD_MAX_MATCH-STD_MIN_MATCH+1];
 
 extern Z_INTERNAL const int base_length[LENGTH_CODES];
 extern Z_INTERNAL const int base_dist[D_CODES];
@@ -126,7 +126,7 @@ static inline uint32_t zng_emit_dist(deflate_state *s, const ct_data *ltree, con
     uint32_t bi_valid = s->bi_valid;
     uint64_t bi_buf = s->bi_buf;
 
-    /* Send the length code, len is the match length - MIN_MATCH */
+    /* Send the length code, len is the match length - STD_MIN_MATCH */
     code = zng_length_code[lc];
     c = code+LITERALS+1;
     Assert(c < L_CODES, "bad l_code");

--- a/trees_tbl.h
+++ b/trees_tbl.h
@@ -102,7 +102,7 @@ const unsigned char Z_INTERNAL zng_dist_code[DIST_CODE_LEN] = {
 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29
 };
 
-const unsigned char Z_INTERNAL zng_length_code[MAX_MATCH-MIN_MATCH+1] = {
+const unsigned char Z_INTERNAL zng_length_code[STD_MAX_MATCH-STD_MIN_MATCH+1] = {
  0,  1,  2,  3,  4,  5,  6,  7,  8,  8,  9,  9, 10, 10, 11, 11, 12, 12, 12, 12,
 13, 13, 13, 13, 14, 14, 14, 14, 15, 15, 15, 15, 16, 16, 16, 16, 16, 16, 16, 16,
 17, 17, 17, 17, 17, 17, 17, 17, 18, 18, 18, 18, 18, 18, 18, 18, 19, 19, 19, 19,

--- a/zutil.h
+++ b/zutil.h
@@ -70,9 +70,12 @@ extern z_const char * const PREFIX(z_errmsg)[10]; /* indexed by 2-zlib_error */
 #define DYN_TREES    2
 /* The three kinds of block type */
 
-#define MIN_MATCH  3
-#define MAX_MATCH  258
-/* The minimum and maximum match lengths */
+#define STD_MIN_MATCH  3
+#define STD_MAX_MATCH  258
+/* The minimum and maximum match lengths mandated by the deflate standard */
+
+#define WANT_MIN_MATCH  4
+/* The minimum wanted match length, affects deflate_quick, deflate_fast, deflate_medium and deflate_slow  */
 
 #define PRESET_DICT 0x20 /* preset dictionary flag in zlib header */
 


### PR DESCRIPTION
- STD_MIN_MATCH is 3, and is used to stay compatible with the deflate standards.
- WANT_MIN_MATCH is set to 4, and is used to indicate to the code what the minimum match length we intend to accept is.

Having WAN_MIN_MATCH set to 4 also means that we now skip the last round of longest_match in the sliding window. This is good because we currently hash 4 bytes, so checking for a match when there is only 3 bytes left is pointless.

The performance difference with this PR appears to be better (as it should), but the difference is slight (around +0.05-0.10% faster), so it is within the margin of error.

This PR also removes the partial, dead, broken and untested support for STD_MIN_MATCH != 3.
As far as I understand, setting this to something else would cause the output data to deviate from the deflate standard and produce an incompatible output stream, unless the tree tables are also regenerated to match the changed offset. And STD_MAX_MATCH would probably have to be reduced by the same number as well. I am not 100% certain of this, but I think it is easier to experiment with this kind of thing now that the variables are split.

I am not 100% certain about the correctness, but the current iteration makes sense to me and the compressed output is identical to pre-PR in my tests.
