### PR TITLE
Cygwin fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -945,13 +945,13 @@ set(ZLIB_GZFILE_SRCS
     gzwrite.c
 )
 
-if(NOT MINGW AND NOT MSYS)
+if(NOT MINGW AND NOT MSYS AND NOT CYGWIN)
     set(ZLIB_DLL_SRCS
         win32/zlib${SUFFIX}1.rc # If present will override custom build rule below.
     )
 endif()
 
-if(MINGW OR MSYS)
+if(MINGW OR MSYS OR CYGWIN)
     # This gets us DLL resource information when compiling on MinGW.
     if(NOT CMAKE_RC_COMPILER)
         set(CMAKE_RC_COMPILER windres.exe)
@@ -1033,7 +1033,8 @@ if(NOT DEFINED BUILD_SHARED_LIBS OR BUILD_SHARED_LIBS)
             # Match configure/make's behavior (i.e. don't use @rpath on mac).
             set_target_properties(zlib PROPERTIES INSTALL_NAME_DIR "${LIB_INSTALL_DIR}")
         endif()
-    elseif(MSYS)
+    endif()
+    if(MSYS OR CYGWIN)
         # Suppress version number from shared library name
         set(CMAKE_SHARED_LIBRARY_NAME_WITH_VERSION 0)
     elseif(WIN32)

--- a/test/minideflate.c
+++ b/test/minideflate.c
@@ -3,6 +3,9 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
+#define _POSIX_SOURCE 1  /* This file needs POSIX for fileno(). */
+#define _POSIX_C_SOURCE 200112  /* For snprintf(). */
+
 #include <stdio.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/test/switchlevels.c
+++ b/test/switchlevels.c
@@ -2,6 +2,8 @@
  * Each chunk is compressed with a user-specified level.
  */
 
+#define _POSIX_SOURCE 1  /* This file needs POSIX for fileno(). */
+
 #include "zbuild.h"
 #ifdef ZLIB_COMPAT
 #  include "zlib.h"


### PR DESCRIPTION
* `GCC_WINDRES` is required under Cygwin version of windres.
* `_POSIX_SOURCE` is required for fileno()
* Suppress version number in filename

NOTE: MacOS requires defining either neither or both `_POSIX_SOURCE` and `_POSIX_C_SOURCE` for snprintf().

See #973.