### PR TITLE
Some improvements to fuzzers

### DIFF
--- a/test/fuzz/example_dict_fuzzer.c
+++ b/test/fuzz/example_dict_fuzzer.c
@@ -42,13 +42,13 @@ void test_dict_deflate(unsigned char **compr, size_t *comprLen) {
 
     int method = Z_DEFLATED; /* The deflate compression method (the only one
                                 supported in this version) */
-    int windowBits = 8 + data[0] % 8; /* The windowBits parameter is the base
+    int windowBits = 8 + data[(dataLen > 1) ? 1:0] % 8; /* The windowBits parameter is the base
       two logarithm of the window size (the size of the history buffer).  It
       should be in the range 8..15 for this version of the library. */
-    int memLevel = 1 + data[0] % 9;   /* memLevel=1 uses minimum memory but is
+    int memLevel = 1 + data[(dataLen > 2) ? 2:0] % 9;   /* memLevel=1 uses minimum memory but is
       slow and reduces compression ratio; memLevel=9 uses maximum memory for
       optimal speed. */
-    int strategy = data[0] % 5;       /* [0..4]
+    int strategy = data[(dataLen > 3) ? 3:0] % 5;       /* [0..4]
       #define Z_FILTERED            1
       #define Z_HUFFMAN_ONLY        2
       #define Z_RLE                 3

--- a/test/fuzz/minigzip_fuzzer.c
+++ b/test/fuzz/minigzip_fuzzer.c
@@ -295,7 +295,12 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t dataLen) {
     }
 
     file_compress(inFileName, outmode);
-    file_uncompress(outFileName);
+
+    /* gzopen does not support reading in direct mode */
+    if (outmode[3] == 'T')
+        inFileName = outFileName;
+    else
+        file_uncompress(outFileName);
 
     /* Check that the uncompressed file matches the input data. */
     in = fopen(inFileName, "rb");

--- a/test/fuzz/minigzip_fuzzer.c
+++ b/test/fuzz/minigzip_fuzzer.c
@@ -265,7 +265,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t dataLen) {
     snprintf(outmode, sizeof(outmode), "%s", "wb");
 
     /* Compression level: [0..9]. */
-    outmode[2] = data[0] % 10;
+    outmode[2] = '0' + (data[0] % 10);
 
     switch (data[dataLen-1] % 6) {
     default:


### PR DESCRIPTION
* Use different fuzzer bits in `example_dict_fuzzer` for more input value combinations.
  *  This is similar to changes made in #929 but for `example_dict_fuzzer` instead of `minigzip_fuzzer`.
* Fixed gz mode for compression level not using ascii numeric value.
  *  This is a bug in `minigzip_fuzzer` writing the gz mode. Previously `minigzip_fuzzer` wouldn't have been testing all compression levels.
* Fixed trying to uncompress after compressing in gzip direct mode which is not supported by gz functions.
  * Changes made by #929 caused this issue. This should fix OSS-Fuzz issue https://oss-fuzz.com/testcase-detail/6194422837542912.