### PR TITLE
Replace CMAKE_CURRENT_SOURCE_DIR to CMAKE_CURRENT_LIST_DIR

### DIFF
--- a/cmake/detect-arch.cmake
+++ b/cmake/detect-arch.cmake
@@ -25,7 +25,7 @@ else()
         run_result_unused
         compile_result_unused
         ${CMAKE_CURRENT_BINARY_DIR}
-        ${CMAKE_CURRENT_SOURCE_DIR}/cmake/detect-arch.c
+        ${CMAKE_CURRENT_LIST_DIR}/detect-arch.c
         COMPILE_OUTPUT_VARIABLE RAWOUTPUT
         CMAKE_FLAGS CMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES}
     )


### PR DESCRIPTION
Replace ```CMAKE_CURRENT_SOURCE_DIR``` to ```CMAKE_CURRENT_LIST_DIR``` to allow reuse script ```cmake/detect-arch.cmake``` in parent CMake project.