### PR TITLE
Use latest version of llvm-cov to prevent code coverage version mismatch

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -255,39 +255,39 @@ jobs:
           - name: Ubuntu Clang
             os: ubuntu-latest
             compiler: clang
-            packages: llvm-6.0
-            gcov-exec: llvm-cov-6.0 gcov
+            packages: llvm-11-tools
+            gcov-exec: llvm-cov-11 gcov
             codecov: ubuntu_clang
 
           - name: Ubuntu Clang Inflate Strict
             os: ubuntu-latest
             compiler: clang
             cmake-args: -DWITH_INFLATE_STRICT=ON
-            packages: llvm-6.0
-            gcov-exec: llvm-cov-6.0 gcov
+            packages: llvm-11-tools
+            gcov-exec: llvm-cov-11 gcov
             codecov: ubuntu_clang_inflate_strict
 
           - name: Ubuntu Clang Inflate Allow Invalid Dist
             os: ubuntu-latest
             compiler: clang
             cmake-args: -DWITH_INFLATE_ALLOW_INVALID_DIST=ON
-            packages: llvm-6.0
-            gcov-exec: llvm-cov-6.0 gcov
+            packages: llvm-11-tools
+            gcov-exec: llvm-cov-11 gcov
             codecov: ubuntu_clang_inflate_allow_invalid_dist
 
           - name: Ubuntu Clang Memory Map
             os: ubuntu-latest
             compiler: clang
             cflags: -DUSE_MMAP
-            packages: llvm-6.0
-            gcov-exec: llvm-cov-6.0 gcov
+            packages: llvm-11-tools
+            gcov-exec: llvm-cov-11 gcov
             codecov: ubuntu_clang_mmap
 
           - name: Ubuntu Clang Debug
             os: ubuntu-latest
             compiler: clang
-            packages: llvm-6.0
-            gcov-exec: llvm-cov-6.0 gcov
+            packages: llvm-11-tools
+            gcov-exec: llvm-cov-11 gcov
             codecov: ubuntu_clang_debug
             build-config: Debug
 
@@ -295,8 +295,8 @@ jobs:
             os: ubuntu-latest
             compiler: clang
             cmake-args: -GNinja -DWITH_SANITIZER=Memory
-            packages:  ninja-build llvm-6.0
-            gcov-exec: llvm-cov-6.0 gcov
+            packages:  ninja-build llvm-11-tools
+            gcov-exec: llvm-cov-11 gcov
             cflags: -g3 -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize-memory-track-origins
             codecov: ubuntu_clang_msan
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -254,14 +254,14 @@ jobs:
 
           - name: Ubuntu Clang
             os: ubuntu-latest
-            compiler: clang
+            compiler: clang-11
             packages: llvm-11-tools
             gcov-exec: llvm-cov-11 gcov
             codecov: ubuntu_clang
 
           - name: Ubuntu Clang Inflate Strict
             os: ubuntu-latest
-            compiler: clang
+            compiler: clang-11
             cmake-args: -DWITH_INFLATE_STRICT=ON
             packages: llvm-11-tools
             gcov-exec: llvm-cov-11 gcov
@@ -269,7 +269,7 @@ jobs:
 
           - name: Ubuntu Clang Inflate Allow Invalid Dist
             os: ubuntu-latest
-            compiler: clang
+            compiler: clang-11
             cmake-args: -DWITH_INFLATE_ALLOW_INVALID_DIST=ON
             packages: llvm-11-tools
             gcov-exec: llvm-cov-11 gcov
@@ -277,7 +277,7 @@ jobs:
 
           - name: Ubuntu Clang Memory Map
             os: ubuntu-latest
-            compiler: clang
+            compiler: clang-11
             cflags: -DUSE_MMAP
             packages: llvm-11-tools
             gcov-exec: llvm-cov-11 gcov
@@ -285,7 +285,7 @@ jobs:
 
           - name: Ubuntu Clang Debug
             os: ubuntu-latest
-            compiler: clang
+            compiler: clang-11
             packages: llvm-11-tools
             gcov-exec: llvm-cov-11 gcov
             codecov: ubuntu_clang_debug
@@ -293,7 +293,7 @@ jobs:
 
           - name: Ubuntu Clang MSAN
             os: ubuntu-latest
-            compiler: clang
+            compiler: clang-11
             cmake-args: -GNinja -DWITH_SANITIZER=Memory
             packages:  ninja-build llvm-11-tools
             gcov-exec: llvm-cov-11 gcov


### PR DESCRIPTION
See #977.
```
Unexpected version: *804.
Invalid .gcno File!
```