### PR TITLE
[CHUNKCOPY_SAFE] Fix off-by-one error

### DIFF
--- a/chunkset_tpl.h
+++ b/chunkset_tpl.h
@@ -161,10 +161,11 @@ Z_INTERNAL uint8_t* CHUNKMEMSET(uint8_t *out, unsigned dist, unsigned len) {
 }
 
 Z_INTERNAL uint8_t* CHUNKMEMSET_SAFE(uint8_t *out, unsigned dist, unsigned len, unsigned left) {
+    len = MIN(len, left);
     if (left < (unsigned)(3 * sizeof(chunk_t))) {
+        uint8_t *from = out - dist;
         while (len > 0) {
-            *out = *(out - dist);
-            out++;
+            *out++ = *from++;
             --len;
         }
         return out;

--- a/chunkset_tpl.h
+++ b/chunkset_tpl.h
@@ -37,7 +37,8 @@ Z_INTERNAL uint8_t* CHUNKCOPY(uint8_t *out, uint8_t const *from, unsigned len) {
 
 /* Behave like chunkcopy, but avoid writing beyond of legal output. */
 Z_INTERNAL uint8_t* CHUNKCOPY_SAFE(uint8_t *out, uint8_t const *from, unsigned len, uint8_t *safe) {
-    if ((safe - out) < (ptrdiff_t)sizeof(chunk_t)) {
+    len = MIN(len, safe - out + 1);
+    if (len < sizeof(chunk_t)) {
         int32_t use_chunk16 = sizeof(chunk_t) > 16 && (len & 16);
         if (use_chunk16) {
             memcpy(out, from, 16);

--- a/inffast.c
+++ b/inffast.c
@@ -260,15 +260,11 @@ void Z_INTERNAL zng_inflate_fast(PREFIX3(stream) *strm, unsigned long start) {
                         out = functable.chunkcopy_safe(out, from, len, safe);
                     }
                 } else {
-                    /* Whole reference is in range of current output.  No range checks are
-                       necessary because we start with room for at least 258 bytes of output,
-                       so unroll and roundoff operations can write beyond `out+len` so long
-                       as they stay within 258 bytes of `out`.
-                    */
+                    /* Whole reference is in range of current output. */
                     if (dist >= len || dist >= state->chunksize)
-                        out = functable.chunkcopy(out, out - dist, len);
+                        out = functable.chunkcopy_safe(out, out - dist, len, safe);
                     else
-                        out = functable.chunkmemset(out, dist, len);
+                        out = functable.chunkmemset_safe(out, dist, len, safe - out + 1);
                 }
             } else if ((op & 64) == 0) {          /* 2nd level distance code */
                 here = dcode + here->val + BITS(op);


### PR DESCRIPTION
* When chunk size is more than 8 bytes, the comparison logic failed if remaining buffer length was one less than chunk size.

1. For example when using AVX2 with buffer length of 31 bytes, it would write past end of buffer.
2. When `len` is less than remaining buffer length, `CHUNKCOPY_SAFE` now uses smaller chunks to avoid writing past of end of buffer.