### PR TITLE
Move MIN() macro to zbuild.h

### DIFF
--- a/deflate_p.h
+++ b/deflate_p.h
@@ -76,7 +76,4 @@ static inline int zng_tr_tally_dist(deflate_state *s, uint32_t dist, uint32_t le
 /* Maximum stored block length in deflate format (not including header). */
 #define MAX_STORED 65535
 
-/* Minimum of a and b. */
-#define MIN(a, b) ((a) > (b) ? (b) : (a))
-
 #endif

--- a/zbuild.h
+++ b/zbuild.h
@@ -26,4 +26,7 @@
 #  define z_size_t size_t
 #endif
 
+/* Minimum of a and b. */
+#define MIN(a, b) ((a) > (b) ? (b) : (a))
+
 #endif


### PR DESCRIPTION
Separated from #982 so MIN() macro can be used outside deflate code.