### PR TITLE
Change to C11 and add TLS support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,11 +8,11 @@ message(STATUS "Using CMake version ${CMAKE_VERSION}")
 
 set(CMAKE_MACOSX_RPATH 1)
 
-# If not specified on the command line, enable C99 as the default
+# If not specified on the command line, enable C11 as the default
 # Configuration items that affect the global compiler environment standards
 # should be issued before the "project" command.
 if(NOT CMAKE_C_STANDARD)
-    set(CMAKE_C_STANDARD 99)          # The C standard whose features are requested to build this target
+    set(CMAKE_C_STANDARD 11)          # The C standard whose features are requested to build this target
 endif()
 if(NOT CMAKE_C_STANDARD_REQUIRED)
     set(CMAKE_C_STANDARD_REQUIRED ON) # Boolean describing whether the value of C_STANDARD is a requirement
@@ -22,7 +22,7 @@ if(NOT CMAKE_C_EXTENSIONS)
 endif()
 set(VALID_C_STANDARDS "99" "11")
 if(NOT CMAKE_C_STANDARD IN_LIST VALID_C_STANDARDS)
-    MESSAGE(FATAL_ERROR "CMAKE_C_STANDARD:STRING=${CMAKE_C_STANDARD} not in know standards list\n ${VALID_C_STANDARDS}")
+    MESSAGE(FATAL_ERROR "CMAKE_C_STANDARD:STRING=${CMAKE_C_STANDARD} not in known standards list\n ${VALID_C_STANDARDS}")
 endif()
 
 # Parse the full version number from zlib.h and include in ZLIB_FULL_VERSION

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Features
 
 * Zlib compatible API with support for dual-linking
 * Modernized native API based on zlib API for ease of porting
-* Modern C99 syntax and a clean code layout
+* Modern C11 syntax and a clean code layout
 * Deflate medium and quick algorithms based on Intels zlib fork
 * Support for CPU intrinsics when available
   * Adler32 implementation using SSSE3, AVX2, Neon & VSX

--- a/configure
+++ b/configure
@@ -283,7 +283,7 @@ show $cc -c $test.c
 if test "$gcc" -eq 1 && ($cc $CFLAGS -c $test.c) >> configure.log 2>&1; then
   echo "$cc" | tee -a configure.log
   CC="$cc"
-  CFLAGS="${CFLAGS} -std=c99"
+  CFLAGS="${CFLAGS} -std=c11"
 
   # Re-check ARCH if the compiler is a cross-compiler.
   if $CC -print-multiarch 1> /dev/null 2>&1 && test -n "$($CC -print-multiarch)" 1> /dev/null 2>&1; then

--- a/zbuild.h
+++ b/zbuild.h
@@ -15,6 +15,20 @@
 #  endif
 #endif
 
+/* Determine compiler support for TLS */
+#ifndef Z_TLS
+#  if __STDC_VERSION__ >= 201112 && !defined __STDC_NO_THREADS__
+#    define Z_TLS _Thread_local
+#  elif defined(__GNUC__) || defined(__SUNPRO_C)
+#    define Z_TLS __thread
+#  elif defined(_WIN32) && (defined(_MSC_VER) || defined(__ICL))
+#    define Z_TLS __declspec(thread)
+#  else
+#    warning Unable to detect Thread Local Storage support.
+#    define Z_TLS
+#  endif
+#endif
+
 /* This has to be first include that defines any types */
 #if defined(_MSC_VER)
 #  if defined(_WIN64)

--- a/zbuild.h
+++ b/zbuild.h
@@ -1,6 +1,20 @@
 #ifndef _ZBUILD_H
 #define _ZBUILD_H
 
+/* Determine compiler version of C Standard */
+#ifdef __STDC_VERSION__
+#  if __STDC_VERSION__ >= 199901L
+#    ifndef STDC99
+#      define STDC99
+#    endif
+#  endif
+#  if __STDC_VERSION__ >= 201112L
+#    ifndef STDC11
+#      define STDC11
+#    endif
+#  endif
+#endif
+
 /* This has to be first include that defines any types */
 #if defined(_MSC_VER)
 #  if defined(_WIN64)

--- a/zconf-ng.h.in
+++ b/zconf-ng.h.in
@@ -10,14 +10,6 @@
 #  define _WIN32
 #endif
 
-#ifdef __STDC_VERSION__
-#  if __STDC_VERSION__ >= 199901L
-#    ifndef STDC99
-#      define STDC99
-#    endif
-#  endif
-#endif
-
 /* Clang macro for detecting declspec support
  * https://clang.llvm.org/docs/LanguageExtensions.html#has-declspec-attribute
  */

--- a/zconf.h.in
+++ b/zconf.h.in
@@ -10,14 +10,6 @@
 #  define _WIN32
 #endif
 
-#ifdef __STDC_VERSION__
-#  if __STDC_VERSION__ >= 199901L
-#    ifndef STDC99
-#      define STDC99
-#    endif
-#  endif
-#endif
-
 /* Clang macro for detecting declspec support
  * https://clang.llvm.org/docs/LanguageExtensions.html#has-declspec-attribute
  */

--- a/zutil.h
+++ b/zutil.h
@@ -24,10 +24,6 @@
 #  define Z_REGISTER
 #endif
 
-#ifndef Z_TLS
-#  define Z_TLS
-#endif
-
 #include <stddef.h>
 #include <string.h>
 #include <stdlib.h>


### PR DESCRIPTION
In order to ensure functable consistency we need support for Thread Local Storage, C11 provides this but it is optional.
This PR adds detection of C11 and detection of a few of the most common types of defining TLS support for a variable.