### PR TITLE
Added Z_UNUSED define for ignore unused variables.

### DIFF
--- a/deflate.h
+++ b/deflate.h
@@ -402,9 +402,9 @@ void Z_INTERNAL flush_pending(PREFIX3(streamp) strm);
 #  define sent_bits_add(s, bits)    s->bits_sent += (bits)
 #  define sent_bits_align(s)        s->bits_sent = (s->bits_sent + 7) & ~7L
 #else
-#  define cmpr_bits_add(s, len)     (void)(len)
+#  define cmpr_bits_add(s, len)     Z_UNUSED(len)
 #  define cmpr_bits_align(s)
-#  define sent_bits_add(s, bits)    (void)(bits)
+#  define sent_bits_add(s, bits)    Z_UNUSED(bits)
 #  define sent_bits_align(s)
 #endif
 

--- a/inflate.c
+++ b/inflate.c
@@ -1283,7 +1283,7 @@ int32_t Z_EXPORT PREFIX(inflateUndermine)(PREFIX3(stream) *strm, int32_t subvert
     state->sane = !subvert;
     return Z_OK;
 #else
-    (void)subvert;
+    Z_UNUSED(subvert);
     state->sane = 1;
     return Z_DATA_ERROR;
 #endif

--- a/test/example.c
+++ b/test/example.c
@@ -229,7 +229,7 @@ void test_gzio(const char *fname, unsigned char *uncompr, z_size_t uncomprLen) {
         fprintf(stderr, "gzclose unexpected return when handle null\n");
         exit(1);
     }
-    (void)read;
+    Z_UNUSED(read);
 #endif
 }
 

--- a/test/fuzz/checksum_fuzzer.c
+++ b/test/fuzz/checksum_fuzzer.c
@@ -42,16 +42,16 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t dataLen) {
         uint32_t crc4 = PREFIX(crc32_combine_op)(crc1, crc3, op);
         crc1 = PREFIX(crc32_z)(crc1, data + offset, buffSize);
         assert(crc1 == crc4);
-        (void)crc1;
-        (void)crc4;
+        Z_UNUSED(crc1);
+        Z_UNUSED(crc4);
     }
     crc1 = PREFIX(crc32_z)(crc1, data + offset, dataLen % buffSize);
 
     crc2 = PREFIX(crc32_z)(crc2, data, dataLen);
 
     assert(crc1 == crc2);
-    (void)crc1;
-    (void)crc2;
+    Z_UNUSED(crc1);
+    Z_UNUSED(crc2);
     combine1 = PREFIX(crc32_combine)(crc1, crc2, (z_off_t)dataLen);
     combine2 = PREFIX(crc32_combine)(crc1, crc1, (z_off_t)dataLen);
     assert(combine1 == combine2);
@@ -73,13 +73,13 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t dataLen) {
     adler2 = PREFIX(adler32_z)(adler2, data, dataLen);
 
     assert(adler1 == adler2);
-    (void)adler1;
-    (void)adler2;
+    Z_UNUSED(adler1);
+    Z_UNUSED(adler2);
     combine1 = PREFIX(adler32_combine)(adler1, adler2, (z_off_t)dataLen);
     combine2 = PREFIX(adler32_combine)(adler1, adler1, (z_off_t)dataLen);
     assert(combine1 == combine2);
-    (void)combine1;
-    (void)combine2;
+    Z_UNUSED(combine1);
+    Z_UNUSED(combine2);
 
     /* This function must return 0. */
     return 0;

--- a/test/fuzz/standalone_fuzz_target_runner.c
+++ b/test/fuzz/standalone_fuzz_target_runner.c
@@ -2,6 +2,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "zbuild.h"
+
 extern int LLVMFuzzerTestOneInput(const unsigned char *data, size_t size);
 
 int main(int argc, char **argv) {
@@ -28,7 +30,7 @@ int main(int argc, char **argv) {
         free(buf);
         err = fclose(f);
         assert(err == 0);
-        (void)err;
+        Z_UNUSED(err);
         fprintf(stderr, "Done:    %s: (%d bytes)\n", argv[i], (int)n_read);
     }
 

--- a/test/infcover.c
+++ b/test/infcover.c
@@ -348,7 +348,7 @@ static void inf(char *hex, char *what, unsigned step, int win, unsigned len, int
     ret = PREFIX(inflateReset2)(&strm, -8);     assert(ret == Z_OK);
     ret = PREFIX(inflateEnd)(&strm);            assert(ret == Z_OK);
     mem_done(&strm, what);
-    (void)err;
+    Z_UNUSED(err);
 }
 
 /* cover all of the lines in inflate.c up to inflate() */
@@ -386,7 +386,7 @@ static void cover_support(void) {
     ret = PREFIX(inflateInit)(&strm);           assert(ret == Z_OK);
     ret = PREFIX(inflateEnd)(&strm);            assert(ret == Z_OK);
     fputs("inflate built-in memory routines\n", stderr);
-    (void)ret;
+    Z_UNUSED(ret);
 }
 
 /* cover all inflate() header and trailer cases and code after inflate() */
@@ -470,7 +470,7 @@ static unsigned pull(void *desc, z_const unsigned char **buf) {
 
 static int push(void *desc, unsigned char *buf, unsigned len) {
     buf += len;
-    (void)buf;
+    Z_UNUSED(buf);
     return desc != NULL;        /* force error if desc not null */
 }
 
@@ -511,7 +511,7 @@ static void cover_back(void) {
                                                 assert(ret == Z_OK);
     ret = PREFIX(inflateBackEnd)(&strm);        assert(ret == Z_OK);
     fputs("inflateBack built-in memory routines\n", stderr);
-    (void)ret;
+    Z_UNUSED(ret);
 }
 
 /* do a raw inflate of data in hexadecimal with both inflate and inflateBack */
@@ -647,7 +647,7 @@ static void cover_trees(void) {
     ret = zng_inflate_table(DISTS, lens, 16, &next, &bits, work);
                                                 assert(ret == 1);
     fputs("inflate_table not enough errors\n", stderr);
-    (void)ret;
+    Z_UNUSED(ret);
 }
 
 /* cover remaining inffast.c decoding and window copying */

--- a/trees_emit.h
+++ b/trees_emit.h
@@ -175,7 +175,7 @@ static inline void zng_emit_end_block(deflate_state *s, const ct_data *ltree, co
     s->bi_buf = bi_buf;
     Tracev((stderr, "\n+++ Emit End Block: Last: %u Pending: %u Total Out: %" PRIu64 "\n",
         last, s->pending, (uint64_t)s->strm->total_out));
-    (void)last;
+    Z_UNUSED(last);
 }
 
 /* ===========================================================================

--- a/zbuild.h
+++ b/zbuild.h
@@ -30,5 +30,7 @@
 #define MIN(a, b) ((a) > (b) ? (b) : (a))
 /* Maximum of a and b. */
 #define MAX(a, b) ((a) < (b) ? (b) : (a))
+/* Ignore unused variable warning */
+#define Z_UNUSED(var) (void)(var)
 
 #endif

--- a/zutil.c
+++ b/zutil.c
@@ -101,11 +101,11 @@ const char * Z_EXPORT PREFIX(zError)(int err) {
 }
 
 void Z_INTERNAL *zng_calloc(void *opaque, unsigned items, unsigned size) {
-    (void)opaque;
+    Z_UNUSED(opaque);
     return zng_alloc((size_t)items * (size_t)size);
 }
 
 void Z_INTERNAL zng_cfree(void *opaque, void *ptr) {
-    (void)opaque;
+    Z_UNUSED(opaque);
     zng_free(ptr);
 }


### PR DESCRIPTION
Previously mentioned in #418.
![image](https://user-images.githubusercontent.com/1364432/121823490-5d566c80-cc5a-11eb-9786-15957c8bb12d.png)

I have put it in zbuild.h for now and if we want to it can be moved. I can also rename it to `UNUSED()` if `Z_UNUSED` is not good name for zbuild.h.