### PR TITLE
Fix warnings when compiling with Visual C++

### DIFF
--- a/chunkset_tpl.h
+++ b/chunkset_tpl.h
@@ -38,7 +38,8 @@ Z_INTERNAL uint8_t* CHUNKCOPY(uint8_t *out, uint8_t const *from, unsigned len) {
 
 /* Behave like chunkcopy, but avoid writing beyond of legal output. */
 Z_INTERNAL uint8_t* CHUNKCOPY_SAFE(uint8_t *out, uint8_t const *from, unsigned len, uint8_t *safe) {
-    len = MIN(len, safe - out + 1);
+    unsigned safelen = (unsigned)((safe - out) + 1);
+    len = MIN(len, safelen);
 #if CHUNK_SIZE >= 32
     while (len >= 32) {
         memcpy(out, from, 32);

--- a/inffast.c
+++ b/inffast.c
@@ -270,7 +270,7 @@ void Z_INTERNAL zng_inflate_fast(PREFIX3(stream) *strm, unsigned long start) {
                     if (dist >= len || dist >= state->chunksize)
                         out = functable.chunkcopy_safe(out, out - dist, len, safe);
                     else
-                        out = functable.chunkmemset_safe(out, dist, len, safe - out + 1);
+                        out = functable.chunkmemset_safe(out, dist, len, (unsigned)((safe - out) + 1));
                 } else {
                     /* Whole reference is in range of current output.  No range checks are
                        necessary because we start with room for at least 258 bytes of output,

--- a/win32/Makefile.msc
+++ b/win32/Makefile.msc
@@ -114,7 +114,7 @@ $(IMPLIB): $(SHAREDLIB)
 
 $(SHAREDLIB): zconf $(TOP)/win32/$(DEFFILE) $(OBJS) $(RESFILE)
 	$(LD) $(LDFLAGS) -def:$(TOP)/win32/$(DEFFILE) -dll -implib:$(IMPLIB) \
-	  -out:$@ -base:0x5A4C0000 $(OBJS) $(RESFILE)
+	  -out:$@ $(OBJS) $(RESFILE)
 	if exist $@.manifest \
 	  mt -nologo -manifest $@.manifest -outputresource:$@;2
 


### PR DESCRIPTION
* When comparing two pointers, the result is signed integer, but `len` is unsigned integer
* Remove base address when linking Windows dynamic library, as it has to be different for 32-bit and 64-bit versions

Fixes #1012.