### PR TITLE
Turn off reduced memory option in CMake by default

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -275,6 +275,14 @@ jobs:
             gcov-exec: llvm-cov-11 gcov
             codecov: ubuntu_clang_inflate_allow_invalid_dist
 
+          - name: Ubuntu Clang Reduced Memory
+            os: ubuntu-latest
+            compiler: clang-11
+            cmake-args: -DWITH_REDUCED_MEM=ON
+            packages: llvm-11-tools
+            gcov-exec: llvm-cov-11 gcov
+            codecov: ubuntu_clang_reduced_mem
+
           - name: Ubuntu Clang Memory Map
             os: ubuntu-latest
             compiler: clang-11

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ option(ZLIB_ENABLE_TESTS "Build test binaries" ON)
 option(ZLIB_DUAL_LINK "Dual link tests against system zlib" OFF)
 option(WITH_FUZZERS "Build test/fuzz" OFF)
 option(WITH_OPTIM "Build with optimisation" ON)
-option(WITH_REDUCED_MEM "Reduced memory usage for special cases (reduces performance)" ON)
+option(WITH_REDUCED_MEM "Reduced memory usage for special cases (reduces performance)" OFF)
 option(WITH_NEW_STRATEGIES "Use new strategies" ON)
 option(WITH_NATIVE_INSTRUCTIONS
     "Instruct the compiler to use the full instruction set on this host (gcc/clang -march=native)" OFF)

--- a/deflate.h
+++ b/deflate.h
@@ -65,7 +65,9 @@
 /* Stream status */
 
 #define HASH_BITS    16u           /* log2(HASH_SIZE) */
-#define HASH_SIZE 65536u           /* number of elements in hash table */
+#ifndef HASH_SIZE
+#  define HASH_SIZE 65536u         /* number of elements in hash table */
+#endif
 #define HASH_MASK (HASH_SIZE - 1u) /* HASH_SIZE-1 */
 
 


### PR DESCRIPTION
I have also added a new cmake CI job with reduced memory. I think it is important to make sure tests pass under such conditions because they could reveal an unknown problem with algos.