### PR TITLE
Minor changes to chunk copy functions

### DIFF
--- a/chunkset_tpl.h
+++ b/chunkset_tpl.h
@@ -37,9 +37,8 @@ Z_INTERNAL uint8_t* CHUNKCOPY(uint8_t *out, uint8_t const *from, unsigned len) {
 }
 
 /* Behave like chunkcopy, but avoid writing beyond of legal output. */
-Z_INTERNAL uint8_t* CHUNKCOPY_SAFE(uint8_t *out, uint8_t const *from, unsigned len, uint8_t *safe) {
-    unsigned safelen = (unsigned)((safe - out) + 1);
-    len = MIN(len, safelen);
+Z_INTERNAL uint8_t* CHUNKCOPY_SAFE(uint8_t *out, uint8_t const *from, unsigned len, unsigned left) {
+    len = MIN(len, left);
 #if CHUNK_SIZE >= 32
     while (len >= 32) {
         memcpy(out, from, 32);
@@ -144,13 +143,12 @@ Z_INTERNAL uint8_t* CHUNKMEMSET(uint8_t *out, unsigned dist, unsigned len) {
     if (dist == sz) {
         loadchunk(from, &chunk);
     } else if (dist < sz) {
-        unsigned char *end = out + len - 1;
         while (len > dist) {
-            out = CHUNKCOPY_SAFE(out, from, dist, end);
+            out = CHUNKCOPY_SAFE(out, from, dist, dist);
             len -= dist;
         }
         if (len > 0) {
-            out = CHUNKCOPY_SAFE(out, from, len, end);
+            out = CHUNKCOPY_SAFE(out, from, len, len);
         }
         return out;
     } else {

--- a/functable.c
+++ b/functable.c
@@ -68,14 +68,14 @@ extern uint32_t adler32_power8(uint32_t adler, const unsigned char* buf, size_t 
 /* memory chunking */
 extern uint32_t chunksize_c(void);
 extern uint8_t* chunkcopy_c(uint8_t *out, uint8_t const *from, unsigned len);
-extern uint8_t* chunkcopy_safe_c(uint8_t *out, uint8_t const *from, unsigned len, uint8_t *safe);
+extern uint8_t* chunkcopy_safe_c(uint8_t *out, uint8_t const *from, unsigned len, unsigned left);
 extern uint8_t* chunkunroll_c(uint8_t *out, unsigned *dist, unsigned *len);
 extern uint8_t* chunkmemset_c(uint8_t *out, unsigned dist, unsigned len);
 extern uint8_t* chunkmemset_safe_c(uint8_t *out, unsigned dist, unsigned len, unsigned left);
 #ifdef X86_SSE2_CHUNKSET
 extern uint32_t chunksize_sse2(void);
 extern uint8_t* chunkcopy_sse2(uint8_t *out, uint8_t const *from, unsigned len);
-extern uint8_t* chunkcopy_safe_sse2(uint8_t *out, uint8_t const *from, unsigned len, uint8_t *safe);
+extern uint8_t* chunkcopy_safe_sse2(uint8_t *out, uint8_t const *from, unsigned len, unsigned left);
 extern uint8_t* chunkunroll_sse2(uint8_t *out, unsigned *dist, unsigned *len);
 extern uint8_t* chunkmemset_sse2(uint8_t *out, unsigned dist, unsigned len);
 extern uint8_t* chunkmemset_safe_sse2(uint8_t *out, unsigned dist, unsigned len, unsigned left);
@@ -83,7 +83,7 @@ extern uint8_t* chunkmemset_safe_sse2(uint8_t *out, unsigned dist, unsigned len,
 #ifdef X86_AVX_CHUNKSET
 extern uint32_t chunksize_avx(void);
 extern uint8_t* chunkcopy_avx(uint8_t *out, uint8_t const *from, unsigned len);
-extern uint8_t* chunkcopy_safe_avx(uint8_t *out, uint8_t const *from, unsigned len, uint8_t *safe);
+extern uint8_t* chunkcopy_safe_avx(uint8_t *out, uint8_t const *from, unsigned len, unsigned left);
 extern uint8_t* chunkunroll_avx(uint8_t *out, unsigned *dist, unsigned *len);
 extern uint8_t* chunkmemset_avx(uint8_t *out, unsigned dist, unsigned len);
 extern uint8_t* chunkmemset_safe_avx(uint8_t *out, unsigned dist, unsigned len, unsigned left);
@@ -91,7 +91,7 @@ extern uint8_t* chunkmemset_safe_avx(uint8_t *out, unsigned dist, unsigned len, 
 #ifdef ARM_NEON_CHUNKSET
 extern uint32_t chunksize_neon(void);
 extern uint8_t* chunkcopy_neon(uint8_t *out, uint8_t const *from, unsigned len);
-extern uint8_t* chunkcopy_safe_neon(uint8_t *out, uint8_t const *from, unsigned len, uint8_t *safe);
+extern uint8_t* chunkcopy_safe_neon(uint8_t *out, uint8_t const *from, unsigned len, unsigned left);
 extern uint8_t* chunkunroll_neon(uint8_t *out, unsigned *dist, unsigned *len);
 extern uint8_t* chunkmemset_neon(uint8_t *out, unsigned dist, unsigned len);
 extern uint8_t* chunkmemset_safe_neon(uint8_t *out, unsigned dist, unsigned len, unsigned left);
@@ -340,7 +340,7 @@ Z_INTERNAL uint8_t* chunkcopy_stub(uint8_t *out, uint8_t const *from, unsigned l
     return functable.chunkcopy(out, from, len);
 }
 
-Z_INTERNAL uint8_t* chunkcopy_safe_stub(uint8_t *out, uint8_t const *from, unsigned len, uint8_t *safe) {
+Z_INTERNAL uint8_t* chunkcopy_safe_stub(uint8_t *out, uint8_t const *from, unsigned len, unsigned left) {
     // Initialize default
     functable.chunkcopy_safe = &chunkcopy_safe_c;
 
@@ -363,7 +363,7 @@ Z_INTERNAL uint8_t* chunkcopy_safe_stub(uint8_t *out, uint8_t const *from, unsig
         functable.chunkcopy_safe = &chunkcopy_safe_power8;
 #endif
 
-    return functable.chunkcopy_safe(out, from, len, safe);
+    return functable.chunkcopy_safe(out, from, len, left);
 }
 
 Z_INTERNAL uint8_t* chunkunroll_stub(uint8_t *out, unsigned *dist, unsigned *len) {

--- a/functable.c
+++ b/functable.c
@@ -67,34 +67,34 @@ extern uint32_t adler32_power8(uint32_t adler, const unsigned char* buf, size_t 
 
 /* memory chunking */
 extern uint32_t chunksize_c(void);
-extern uint8_t* chunkcopy_c(uint8_t *out, uint8_t const *from, unsigned len);
-extern uint8_t* chunkcopy_safe_c(uint8_t *out, uint8_t const *from, unsigned len, unsigned left);
-extern uint8_t* chunkunroll_c(uint8_t *out, unsigned *dist, unsigned *len);
-extern uint8_t* chunkmemset_c(uint8_t *out, unsigned dist, unsigned len);
-extern uint8_t* chunkmemset_safe_c(uint8_t *out, unsigned dist, unsigned len, unsigned left);
+extern uint8_t* chunkcopy_c(uint8_t *out, uint8_t const *from, uint32_t len);
+extern uint8_t* chunkcopy_safe_c(uint8_t *out, uint8_t const *from, uint32_t len, uint32_t left);
+extern uint8_t* chunkunroll_c(uint8_t *out, uint32_t *dist, uint32_t *len);
+extern uint8_t* chunkmemset_c(uint8_t *out, uint32_t dist, uint32_t len);
+extern uint8_t* chunkmemset_safe_c(uint8_t *out, uint32_t dist, uint32_t len, uint32_t left);
 #ifdef X86_SSE2_CHUNKSET
 extern uint32_t chunksize_sse2(void);
-extern uint8_t* chunkcopy_sse2(uint8_t *out, uint8_t const *from, unsigned len);
-extern uint8_t* chunkcopy_safe_sse2(uint8_t *out, uint8_t const *from, unsigned len, unsigned left);
-extern uint8_t* chunkunroll_sse2(uint8_t *out, unsigned *dist, unsigned *len);
-extern uint8_t* chunkmemset_sse2(uint8_t *out, unsigned dist, unsigned len);
-extern uint8_t* chunkmemset_safe_sse2(uint8_t *out, unsigned dist, unsigned len, unsigned left);
+extern uint8_t* chunkcopy_sse2(uint8_t *out, uint8_t const *from, uint32_t len);
+extern uint8_t* chunkcopy_safe_sse2(uint8_t *out, uint8_t const *from, uint32_t len, uint32_t left);
+extern uint8_t* chunkunroll_sse2(uint8_t *out, uint32_t *dist, uint32_t *len);
+extern uint8_t* chunkmemset_sse2(uint8_t *out, uint32_t dist, uint32_t len);
+extern uint8_t* chunkmemset_safe_sse2(uint8_t *out, uint32_t dist, uint32_t len, uint32_t left);
 #endif
 #ifdef X86_AVX_CHUNKSET
 extern uint32_t chunksize_avx(void);
-extern uint8_t* chunkcopy_avx(uint8_t *out, uint8_t const *from, unsigned len);
-extern uint8_t* chunkcopy_safe_avx(uint8_t *out, uint8_t const *from, unsigned len, unsigned left);
-extern uint8_t* chunkunroll_avx(uint8_t *out, unsigned *dist, unsigned *len);
-extern uint8_t* chunkmemset_avx(uint8_t *out, unsigned dist, unsigned len);
-extern uint8_t* chunkmemset_safe_avx(uint8_t *out, unsigned dist, unsigned len, unsigned left);
+extern uint8_t* chunkcopy_avx(uint8_t *out, uint8_t const *from, uint32_t len);
+extern uint8_t* chunkcopy_safe_avx(uint8_t *out, uint8_t const *from, uint32_t len, uint32_t left);
+extern uint8_t* chunkunroll_avx(uint8_t *out, uint32_t *dist, uint32_t *len);
+extern uint8_t* chunkmemset_avx(uint8_t *out, uint32_t dist, uint32_t len);
+extern uint8_t* chunkmemset_safe_avx(uint8_t *out, uint32_t dist, uint32_t len, uint32_t left);
 #endif
 #ifdef ARM_NEON_CHUNKSET
 extern uint32_t chunksize_neon(void);
-extern uint8_t* chunkcopy_neon(uint8_t *out, uint8_t const *from, unsigned len);
-extern uint8_t* chunkcopy_safe_neon(uint8_t *out, uint8_t const *from, unsigned len, unsigned left);
-extern uint8_t* chunkunroll_neon(uint8_t *out, unsigned *dist, unsigned *len);
-extern uint8_t* chunkmemset_neon(uint8_t *out, unsigned dist, unsigned len);
-extern uint8_t* chunkmemset_safe_neon(uint8_t *out, unsigned dist, unsigned len, unsigned left);
+extern uint8_t* chunkcopy_neon(uint8_t *out, uint8_t const *from, uint32_t len);
+extern uint8_t* chunkcopy_safe_neon(uint8_t *out, uint8_t const *from, uint32_t len, uint32_t left);
+extern uint8_t* chunkunroll_neon(uint8_t *out, uint32_t *dist, uint32_t *len);
+extern uint8_t* chunkmemset_neon(uint8_t *out, uint32_t dist, uint32_t len);
+extern uint8_t* chunkmemset_safe_neon(uint8_t *out, uint32_t dist, uint32_t len, uint32_t left);
 #endif
 #ifdef POWER8_VSX_CHUNKSET
 extern uint32_t chunksize_power8(void);
@@ -314,7 +314,7 @@ Z_INTERNAL uint32_t chunksize_stub(void) {
     return functable.chunksize();
 }
 
-Z_INTERNAL uint8_t* chunkcopy_stub(uint8_t *out, uint8_t const *from, unsigned len) {
+Z_INTERNAL uint8_t* chunkcopy_stub(uint8_t *out, uint8_t const *from, uint32_t len) {
     // Initialize default
     functable.chunkcopy = &chunkcopy_c;
 
@@ -340,7 +340,7 @@ Z_INTERNAL uint8_t* chunkcopy_stub(uint8_t *out, uint8_t const *from, unsigned l
     return functable.chunkcopy(out, from, len);
 }
 
-Z_INTERNAL uint8_t* chunkcopy_safe_stub(uint8_t *out, uint8_t const *from, unsigned len, unsigned left) {
+Z_INTERNAL uint8_t* chunkcopy_safe_stub(uint8_t *out, uint8_t const *from, uint32_t len, uint32_t left) {
     // Initialize default
     functable.chunkcopy_safe = &chunkcopy_safe_c;
 
@@ -366,7 +366,7 @@ Z_INTERNAL uint8_t* chunkcopy_safe_stub(uint8_t *out, uint8_t const *from, unsig
     return functable.chunkcopy_safe(out, from, len, left);
 }
 
-Z_INTERNAL uint8_t* chunkunroll_stub(uint8_t *out, unsigned *dist, unsigned *len) {
+Z_INTERNAL uint8_t* chunkunroll_stub(uint8_t *out, uint32_t *dist, uint32_t *len) {
     // Initialize default
     functable.chunkunroll = &chunkunroll_c;
 
@@ -392,7 +392,7 @@ Z_INTERNAL uint8_t* chunkunroll_stub(uint8_t *out, unsigned *dist, unsigned *len
     return functable.chunkunroll(out, dist, len);
 }
 
-Z_INTERNAL uint8_t* chunkmemset_stub(uint8_t *out, unsigned dist, unsigned len) {
+Z_INTERNAL uint8_t* chunkmemset_stub(uint8_t *out, uint32_t dist, uint32_t len) {
     // Initialize default
     functable.chunkmemset = &chunkmemset_c;
 
@@ -419,7 +419,7 @@ Z_INTERNAL uint8_t* chunkmemset_stub(uint8_t *out, unsigned dist, unsigned len) 
     return functable.chunkmemset(out, dist, len);
 }
 
-Z_INTERNAL uint8_t* chunkmemset_safe_stub(uint8_t *out, unsigned dist, unsigned len, unsigned left) {
+Z_INTERNAL uint8_t* chunkmemset_safe_stub(uint8_t *out, uint32_t dist, uint32_t len, uint32_t left) {
     // Initialize default
     functable.chunkmemset_safe = &chunkmemset_safe_c;
 

--- a/functable.h
+++ b/functable.h
@@ -20,7 +20,7 @@ struct functable_s {
     uint32_t (* longest_match_slow) (deflate_state *const s, Pos cur_match);
     uint32_t (* chunksize)          (void);
     uint8_t* (* chunkcopy)          (uint8_t *out, uint8_t const *from, unsigned len);
-    uint8_t* (* chunkcopy_safe)     (uint8_t *out, uint8_t const *from, unsigned len, uint8_t *safe);
+    uint8_t* (* chunkcopy_safe)     (uint8_t *out, uint8_t const *from, unsigned len, unsigned left);
     uint8_t* (* chunkunroll)        (uint8_t *out, unsigned *dist, unsigned *len);
     uint8_t* (* chunkmemset)        (uint8_t *out, unsigned dist, unsigned len);
     uint8_t* (* chunkmemset_safe)   (uint8_t *out, unsigned dist, unsigned len, unsigned left);

--- a/functable.h
+++ b/functable.h
@@ -19,11 +19,11 @@ struct functable_s {
     uint32_t (* longest_match)      (deflate_state *const s, Pos cur_match);
     uint32_t (* longest_match_slow) (deflate_state *const s, Pos cur_match);
     uint32_t (* chunksize)          (void);
-    uint8_t* (* chunkcopy)          (uint8_t *out, uint8_t const *from, unsigned len);
-    uint8_t* (* chunkcopy_safe)     (uint8_t *out, uint8_t const *from, unsigned len, unsigned left);
-    uint8_t* (* chunkunroll)        (uint8_t *out, unsigned *dist, unsigned *len);
-    uint8_t* (* chunkmemset)        (uint8_t *out, unsigned dist, unsigned len);
-    uint8_t* (* chunkmemset_safe)   (uint8_t *out, unsigned dist, unsigned len, unsigned left);
+    uint8_t* (* chunkcopy)          (uint8_t *out, uint8_t const *from, uint32_t len);
+    uint8_t* (* chunkcopy_safe)     (uint8_t *out, uint8_t const *from, uint32_t len, uint32_t left);
+    uint8_t* (* chunkunroll)        (uint8_t *out, uint32_t *dist, uint32_t *len);
+    uint8_t* (* chunkmemset)        (uint8_t *out, uint32_t dist, uint32_t len);
+    uint8_t* (* chunkmemset_safe)   (uint8_t *out, uint32_t dist, uint32_t len, uint32_t left);
 };
 
 Z_INTERNAL extern Z_TLS struct functable_s functable;

--- a/inffast.c
+++ b/inffast.c
@@ -249,7 +249,7 @@ void Z_INTERNAL zng_inflate_fast(PREFIX3(stream) *strm, unsigned long start) {
                         from += wsize - op;
                         if (op < len) {         /* some from end of window */
                             len -= op;
-                            out = functable.chunkcopy_safe(out, from, op, (unsigned)((safe - out) + 1));
+                            out = functable.chunkcopy_safe(out, from, op, (uint32_t)((safe - out) + 1));
                             from = window;      /* more from start of window */
                             op = wnext;
                             /* This (rare) case can create a situation where
@@ -259,18 +259,18 @@ void Z_INTERNAL zng_inflate_fast(PREFIX3(stream) *strm, unsigned long start) {
                     }
                     if (op < len) {             /* still need some from output */
                         len -= op;
-                        out = functable.chunkcopy_safe(out, from, op, (unsigned)((safe - out) + 1));
+                        out = functable.chunkcopy_safe(out, from, op, (uint32_t)((safe - out) + 1));
                         out = functable.chunkunroll(out, &dist, &len);
-                        out = functable.chunkcopy_safe(out, out - dist, len, (unsigned)((safe - out) + 1));
+                        out = functable.chunkcopy_safe(out, out - dist, len, (uint32_t)((safe - out) + 1));
                     } else {
-                        out = functable.chunkcopy_safe(out, from, len, (unsigned)((safe - out) + 1));
+                        out = functable.chunkcopy_safe(out, from, len, (uint32_t)((safe - out) + 1));
                     }
                 } else if (extra_safe) {
                     /* Whole reference is in range of current output. */
                     if (dist >= len || dist >= state->chunksize)
-                        out = functable.chunkcopy_safe(out, out - dist, len, (unsigned)((safe - out) + 1));
+                        out = functable.chunkcopy_safe(out, out - dist, len, (uint32_t)((safe - out) + 1));
                     else
-                        out = functable.chunkmemset_safe(out, dist, len, (unsigned)((safe - out) + 1));
+                        out = functable.chunkmemset_safe(out, dist, len, (uint32_t)(safe - out) + 1);
                 } else {
                     /* Whole reference is in range of current output.  No range checks are
                        necessary because we start with room for at least 258 bytes of output,

--- a/inffast.c
+++ b/inffast.c
@@ -249,7 +249,7 @@ void Z_INTERNAL zng_inflate_fast(PREFIX3(stream) *strm, unsigned long start) {
                         from += wsize - op;
                         if (op < len) {         /* some from end of window */
                             len -= op;
-                            out = functable.chunkcopy_safe(out, from, op, safe);
+                            out = functable.chunkcopy_safe(out, from, op, (unsigned)((safe - out) + 1));
                             from = window;      /* more from start of window */
                             op = wnext;
                             /* This (rare) case can create a situation where
@@ -259,16 +259,16 @@ void Z_INTERNAL zng_inflate_fast(PREFIX3(stream) *strm, unsigned long start) {
                     }
                     if (op < len) {             /* still need some from output */
                         len -= op;
-                        out = functable.chunkcopy_safe(out, from, op, safe);
+                        out = functable.chunkcopy_safe(out, from, op, (unsigned)((safe - out) + 1));
                         out = functable.chunkunroll(out, &dist, &len);
-                        out = functable.chunkcopy_safe(out, out - dist, len, safe);
+                        out = functable.chunkcopy_safe(out, out - dist, len, (unsigned)((safe - out) + 1));
                     } else {
-                        out = functable.chunkcopy_safe(out, from, len, safe);
+                        out = functable.chunkcopy_safe(out, from, len, (unsigned)((safe - out) + 1));
                     }
                 } else if (extra_safe) {
                     /* Whole reference is in range of current output. */
                     if (dist >= len || dist >= state->chunksize)
-                        out = functable.chunkcopy_safe(out, out - dist, len, safe);
+                        out = functable.chunkcopy_safe(out, out - dist, len, (unsigned)((safe - out) + 1));
                     else
                         out = functable.chunkmemset_safe(out, dist, len, (unsigned)((safe - out) + 1));
                 } else {

--- a/inflate.c
+++ b/inflate.c
@@ -949,7 +949,7 @@ int32_t Z_EXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int32_t flush) {
                 copy = MIN(copy, state->length);
                 copy = MIN(copy, left);
 
-                put = functable.chunkcopy_safe(put, from, copy, put + left);
+                put = functable.chunkcopy_safe(put, from, copy, left);
             } else {                             /* copy from output */
                 copy = MIN(state->length, left);
 


### PR DESCRIPTION
Code size reduction from 274610 to 272554 (MSVC). Fewer operations having to be done inside the multiple chunk function variants.

These are my last two relevant check-ins from #987.