### PR TITLE
IBM Z: Run DFLTCC tests on the self-hosted builder

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -253,23 +253,17 @@ jobs:
             codecov: ubuntu_gcc_s390x
 
           - name: Ubuntu GCC S390X DFLTCC
-            os: ubuntu-latest
-            compiler: s390x-linux-gnu-gcc
-            cmake-args: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-s390x.cmake -DWITH_DFLTCC_DEFLATE=ON -DWITH_DFLTCC_INFLATE=ON -DWITH_SANITIZER=Address
+            os: z15
+            compiler: gcc
+            cmake-args: -DWITH_DFLTCC_DEFLATE=ON -DWITH_DFLTCC_INFLATE=ON -DWITH_SANITIZER=Address
             asan-options: detect_leaks=0
-            packages: qemu qemu-user gcc-s390x-linux-gnu libc-dev-s390x-cross
-            qemu-run: qemu-s390x
-            ldflags: -static
             codecov: ubuntu_gcc_s390x
 
           - name: Ubuntu GCC S390X DFLTCC Compat
-            os: ubuntu-latest
-            compiler: s390x-linux-gnu-gcc
-            cmake-args: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-s390x.cmake -DZLIB_COMPAT=ON -DWITH_DFLTCC_DEFLATE=ON -DWITH_DFLTCC_INFLATE=ON -DWITH_SANITIZER=Undefined
+            os: z15
+            compiler: gcc
+            cmake-args: -DZLIB_COMPAT=ON -DWITH_DFLTCC_DEFLATE=ON -DWITH_DFLTCC_INFLATE=ON -DWITH_SANITIZER=Undefined
             asan-options: detect_leaks=0
-            packages: qemu qemu-user gcc-s390x-linux-gnu libc-dev-s390x-cross
-            qemu-run: qemu-s390x
-            ldflags: -static
             codecov: ubuntu_gcc_s390x
 
           - name: Ubuntu MinGW i686
@@ -432,7 +426,7 @@ jobs:
     - name: Install codecov.io tools
       if: matrix.codecov
       run: |
-        python -u -m pip install codecov
+        python -u -m pip install --user codecov
 
     - name: Initialize Wine
       # Prevent parallel test jobs from initializing Wine at the same time

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -167,24 +167,14 @@ jobs:
             ldflags: -static
 
           - name: Ubuntu GCC S390X DFLTCC
-            os: ubuntu-latest
-            compiler: s390x-linux-gnu-gcc
+            os: z15
+            compiler: gcc
             configure-args: --warn --static --with-dfltcc-deflate --with-dfltcc-inflate
-            chost: s390x-linux-gnu
-            packages: qemu qemu-user gcc-s390x-linux-gnu libc-dev-s390x-cross
-            qemu-run: qemu-s390x
-            cflags: -static
-            ldflags: -static
 
           - name: Ubuntu GCC S390X DFLTCC Compat
-            os: ubuntu-latest
-            compiler: s390x-linux-gnu-gcc
+            os: z15
+            compiler: gcc
             configure-args: --warn --zlib-compat --static --with-dfltcc-deflate --with-dfltcc-inflate
-            chost: s390x-linux-gnu
-            packages: qemu qemu-user gcc-s390x-linux-gnu libc-dev-s390x-cross
-            qemu-run: qemu-s390x
-            cflags: -static
-            ldflags: -static
 
           - name: macOS GCC symbol prefix
             os: macOS-latest
@@ -203,7 +193,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Install packages (Ubuntu)
       if: runner.os == 'Linux' && matrix.packages

--- a/arch/s390/README.md
+++ b/arch/s390/README.md
@@ -212,5 +212,72 @@ access to an IBM z15+ VM or LPAR in order to test DFLTCC support. Since
 DFLTCC is a non-privileged instruction, neither special VM/LPAR
 configuration nor root are required.
 
-Still, zlib-ng CI has a few QEMU TCG-based configurations that check
-whether fallback to software is working.
+zlib-ng CI uses an IBM-provided z15 self-hosted builder for the DFLTCC
+testing. There are no IBM Z builds of GitHub Actions runner, and
+stable qemu-user has problems with .NET apps, so the builder runs the
+x86_64 runner version with qemu-user built from the master branch.
+
+## Configuring the builder.
+
+### Install prerequisites.
+
+```
+$ sudo dnf install docker
+```
+
+### Add services.
+
+```
+$ sudo cp self-hosted-builder/*.service /etc/systemd/system/
+$ sudo systemctl daemon-reload
+```
+
+### Create a config file.
+
+```
+$ sudo tee /etc/actions-runner
+repo=<owner>/<name>
+access_token=<ghp_***>
+```
+
+Access token should have the repo scope, consult
+https://docs.github.com/en/rest/reference/actions#create-a-registration-token-for-a-repository
+for details.
+
+### Autostart the x86_64 emulation support.
+
+```
+$ sudo systemctl enable --now qemu-user-static
+```
+
+### Autostart the runner.
+
+```
+$ sudo systemctl enable --now actions-runner
+```
+
+## Rebuilding the image
+
+In order to update the `iiilinuxibmcom/actions-runner` image, e.g. to get the
+latest OS security fixes, use the following commands:
+
+```
+$ sudo docker build \
+      --pull \
+      -f self-hosted-builder/actions-runner.Dockerfile \
+      -t iiilinuxibmcom/actions-runner
+$ sudo systemctl restart actions-runner
+```
+
+## Removing persistent data
+
+The `actions-runner` service stores various temporary data, such as runner
+registration information, work directories and logs, in the `actions-runner`
+volume. In order to remove it and start from scratch, e.g. when switching the
+runner to a different repository, use the following commands:
+
+```
+$ sudo systemctl stop actions-runner
+$ sudo docker rm -f actions-runner
+$ sudo docker volume rm actions-runner
+```

--- a/arch/s390/self-hosted-builder/actions-runner.Dockerfile
+++ b/arch/s390/self-hosted-builder/actions-runner.Dockerfile
@@ -1,0 +1,40 @@
+# Self-Hosted IBM Z Github Actions Runner.
+
+# Temporary image: amd64 dependencies.
+FROM amd64/ubuntu:20.04 as ld-prefix
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get -y install ca-certificates libicu66 libssl1.1
+
+# Main image.
+FROM s390x/ubuntu:20.04
+
+# Packages for zlib-ng testing.
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get -y install \
+        cmake \
+        curl \
+        gcc \
+        git \
+        jq \
+        ninja-build \
+        python-is-python3 \
+        python3 \
+        python3-pip
+
+# amd64 dependencies.
+COPY --from=ld-prefix / /usr/x86_64-linux-gnu/
+RUN ln -fs ../lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 /usr/x86_64-linux-gnu/lib64/
+RUN ln -fs /etc/resolv.conf /usr/x86_64-linux-gnu/etc/
+ENV QEMU_LD_PREFIX=/usr/x86_64-linux-gnu
+
+# amd64 Github Actions Runner.
+RUN useradd -m actions-runner
+USER actions-runner
+WORKDIR /home/actions-runner
+RUN curl -L https://github.com/actions/runner/releases/download/v2.283.2/actions-runner-linux-x64-2.283.2.tar.gz | tar -xz
+VOLUME /home/actions-runner
+
+# Scripts.
+COPY fs/ /
+ENTRYPOINT ["/usr/bin/entrypoint"]
+CMD ["/usr/bin/actions-runner"]

--- a/arch/s390/self-hosted-builder/actions-runner.service
+++ b/arch/s390/self-hosted-builder/actions-runner.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Self-Hosted IBM Z Github Actions Runner
+Wants=qemu-user-static
+After=qemu-user-static
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+Restart=always
+ExecStart=/usr/bin/docker run \
+              --env-file=/etc/actions-runner \
+              --init \
+              --interactive \
+              --name=actions-runner \
+              --rm \
+              --volume=actions-runner:/home/actions-runner \
+              iiilinuxibmcom/actions-runner
+ExecStop=/bin/sh -c "docker exec actions-runner kill -INT -- -1"
+ExecStop=/bin/sh -c "docker wait actions-runner"
+ExecStop=/bin/sh -c "docker rm actions-runner"
+
+[Install]
+WantedBy=multi-user.target

--- a/arch/s390/self-hosted-builder/fs/usr/bin/actions-runner
+++ b/arch/s390/self-hosted-builder/fs/usr/bin/actions-runner
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+#
+# Ephemeral runner startup script.
+#
+# Expects the following environment variables:
+#
+# - repo=<owner>/<name>
+# - access_token=<ghp_***>
+#
+
+set -e -u
+
+# Check the cached registration token.
+token_file=registration-token.json
+set +e
+expires_at=$(jq --raw-output .expires_at "$token_file" 2>/dev/null)
+status=$?
+set -e
+if [[ $status -ne 0 || $(date +%s) -ge $(date -d "$expires_at" +%s) ]]; then
+    # Refresh the cached registration token.
+    curl \
+        -X POST \
+        -H "Accept: application/vnd.github.v3+json" \
+        -H "Authorization: token $access_token" \
+        "https://api.github.com/repos/$repo/actions/runners/registration-token" \
+        -o "$token_file"
+fi
+
+# (Re-)register the runner.
+registration_token=$(jq --raw-output .token "$token_file")
+./config.sh remove --token "$registration_token" || true
+./config.sh \
+    --url "https://github.com/$repo" \
+    --token "$registration_token" \
+    --labels z15 \
+    --ephemeral
+
+# Run one job.
+./run.sh

--- a/arch/s390/self-hosted-builder/fs/usr/bin/entrypoint
+++ b/arch/s390/self-hosted-builder/fs/usr/bin/entrypoint
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+#
+# Container entrypoint that waits for all spawned processes.
+#
+
+set -e -u
+
+# Create a FIFO and start reading from its read end.
+tempdir=$(mktemp -d "/tmp/done.XXXXXXXXXX")
+trap 'rm -r "$tempdir"' EXIT
+done="$tempdir/pipe"
+mkfifo "$done"
+cat "$done" & waiter=$!
+
+# Start the workload. Its descendants will inherit the FIFO's write end.
+status=0
+if [ "$#" -eq 0 ]; then
+    bash 9>"$done" || status=$?
+else
+    "$@" 9>"$done" || status=$?
+fi
+
+# When the workload and all of its descendants exit, the FIFO's write end will
+# be closed and `cat "$done"` will exit. Wait until it happens. This is needed
+# in order to handle SelfUpdater, which the workload may start in background
+# before exiting.
+wait "$waiter"
+
+exit "$status"

--- a/arch/s390/self-hosted-builder/qemu-user-static.service
+++ b/arch/s390/self-hosted-builder/qemu-user-static.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Support for transparent execution of non-native binaries with QEMU user emulation
+
+[Service]
+Type=oneshot
+# The source code for iiilinuxibmcom/qemu-user-static is at https://github.com/iii-i/qemu-user-static/tree/v6.1.0-1
+# TODO: replace it with multiarch/qemu-user-static once version >6.1 is available
+ExecStart=/usr/bin/docker run --rm --interactive --privileged iiilinuxibmcom/qemu-user-static --reset -p yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Hello,

I've installed Github Actions Runner on the `zlib-ng01` z15 VM. Currently it points to [my zlib-ng fork](https://github.com/iii-i/zlib-ng/pull/3), but you should be able to easily reconfigure it to point to zlib-ng itself using the instructions that are part of this PR. With this in place, we'll have better coverage of DFLTCC code in zlib-ng CI.

Best regards,
Ilya

---

* Use the self-hosted builder instead of ubuntu-latest.
* Drop qemu-related settings from DFLTCC configurations.
* Install codecov only for the current user, since the self-hosted
  builder runs under a restricted non-root account.
* Use actions/checkout@v2 for configure checks, since for some reason
  actions/checkout@v1 cannot find git on the self-hosted builder.
* Update the testing section of the DFLTCC README.
* Add the infrastructure code for the self-hosted builder.