### PR TITLE
Reorganize inflate window layout

### DIFF
--- a/arch/s390/README.md
+++ b/arch/s390/README.md
@@ -66,11 +66,10 @@ buffer and a window. `ZALLOC_STATE()`, `ZFREE_STATE()`, `ZCOPY_STATE()`,
 details for the parameter block (which is allocated alongside zlib-ng
 state) and the window (which must be page-aligned).
 
-While inflate software and hardware window formats match, this is not
-the case for deflate. Therefore, `deflateSetDictionary()` and
-`deflateGetDictionary()` need special handling, which is triggered using
-`DEFLATE_SET_DICTIONARY_HOOK()` and `DEFLATE_GET_DICTIONARY_HOOK()`
-macros.
+Software and hardware deflate window formats don't match, therefore,
+`deflateSetDictionary()` and `deflateGetDictionary()` need special handling,
+which is triggered using `DEFLATE_SET_DICTIONARY_HOOK()` and
+`DEFLATE_GET_DICTIONARY_HOOK()` macros.
 
 `deflateResetKeep()` and `inflateResetKeep()` update the DFLTCC
 parameter block using `DEFLATE_RESET_KEEP_HOOK()` and
@@ -92,9 +91,14 @@ and `DEFLATE_NEED_CONSERVATIVE_BOUND()` macros make `deflateBound()`
 return the correct results for the hardware implementation.
 
 Actual compression and decompression are handled by `DEFLATE_HOOK()` and
-`INFLATE_TYPEDO_HOOK()` macros. Since inflation with DFLTCC manages the
-window on its own, calling `updatewindow()` is suppressed using
-`INFLATE_NEED_UPDATEWINDOW()` macro.
+`INFLATE_TYPEDO_HOOK()` macros.
+
+Software and hardware inflate window formats don't match, therefore,
+`inflateSetDictionary()` and `inflateGetDictionary()` need special handling,
+which is triggered using `INFLATE_SET_DICTIONARY_HOOK()` and
+`INFLATE_GET_DICTIONARY_HOOK()` macros. Furthermore, calling
+`window_output_flush()` is suppressed using
+`INFLATE_NEED_WINDOW_OUTPUT_FLUSH()` macro.
 
 In addition to compression, DFLTCC computes CRC-32 and Adler-32
 checksums, therefore, whenever it's used, software checksumming is

--- a/arch/s390/dfltcc_deflate.c
+++ b/arch/s390/dfltcc_deflate.c
@@ -343,46 +343,13 @@ int Z_INTERNAL dfltcc_can_set_reproducible(PREFIX3(streamp) strm, int reproducib
     return reproducible != state->reproducible && !dfltcc_was_deflate_used(strm);
 }
 
-/*
-   Preloading history.
-*/
-static void append_history(struct dfltcc_param_v0 *param, unsigned char *history, const unsigned char *buf, uInt count) {
-    size_t offset;
-    size_t n;
-
-    /* Do not use more than 32K */
-    if (count > HB_SIZE) {
-        buf += count - HB_SIZE;
-        count = HB_SIZE;
-    }
-    offset = (param->ho + param->hl) % HB_SIZE;
-    if (offset + count <= HB_SIZE)
-        /* Circular history buffer does not wrap - copy one chunk */
-        memcpy(history + offset, buf, count);
-    else {
-        /* Circular history buffer wraps - copy two chunks */
-        n = HB_SIZE - offset;
-        memcpy(history + offset, buf, n);
-        memcpy(history, buf + n, count - n);
-    }
-    n = param->hl + count;
-    if (n <= HB_SIZE)
-        /* All history fits into buffer - no need to discard anything */
-        param->hl = n;
-    else {
-        /* History does not fit into buffer - discard extra bytes */
-        param->ho = (param->ho + (n - HB_SIZE)) % HB_SIZE;
-        param->hl = HB_SIZE;
-    }
-}
-
 int Z_INTERNAL dfltcc_deflate_set_dictionary(PREFIX3(streamp) strm,
                                                 const unsigned char *dictionary, uInt dict_length) {
     deflate_state *state = (deflate_state *)strm->state;
     struct dfltcc_state *dfltcc_state = GET_DFLTCC_STATE(state);
     struct dfltcc_param_v0 *param = &dfltcc_state->param;
 
-    append_history(param, state->window, dictionary, dict_length);
+    dfltcc_append_history(param, state->window, dictionary, dict_length);
     state->strstart = 1; /* Add FDICT to zlib header */
     state->block_start = state->strstart; /* Make deflate_stored happy */
     return Z_OK;
@@ -393,17 +360,6 @@ int Z_INTERNAL dfltcc_deflate_get_dictionary(PREFIX3(streamp) strm, unsigned cha
     struct dfltcc_state *dfltcc_state = GET_DFLTCC_STATE(state);
     struct dfltcc_param_v0 *param = &dfltcc_state->param;
 
-    if (dictionary) {
-        if (param->ho + param->hl <= HB_SIZE)
-            /* Circular history buffer does not wrap - copy one chunk */
-            memcpy(dictionary, state->window + param->ho, param->hl);
-        else {
-            /* Circular history buffer wraps - copy two chunks */
-            memcpy(dictionary, state->window + param->ho, HB_SIZE - param->ho);
-            memcpy(dictionary + HB_SIZE - param->ho, state->window, param->ho + param->hl - HB_SIZE);
-        }
-    }
-    if (dict_length)
-        *dict_length = param->hl;
+    dfltcc_get_history(param, state->window, dictionary, dict_length);
     return Z_OK;
 }

--- a/arch/s390/dfltcc_detail.h
+++ b/arch/s390/dfltcc_detail.h
@@ -197,3 +197,50 @@ struct dfltcc_state {
 #define ALIGN_UP(p, size) (__typeof__(p))(((uintptr_t)(p) + ((size) - 1)) & ~((size) - 1))
 
 #define GET_DFLTCC_STATE(state) ((struct dfltcc_state *)((char *)(state) + ALIGN_UP(sizeof(*state), 8)))
+
+static inline void dfltcc_get_history(struct dfltcc_param_v0 *param, const unsigned char *history,
+                                         unsigned char *buf, uInt *count) {
+    if (buf) {
+        if (param->ho + param->hl <= HB_SIZE)
+            /* Circular history buffer does not wrap - copy one chunk */
+            memcpy(buf, history + param->ho, param->hl);
+        else {
+            /* Circular history buffer wraps - copy two chunks */
+            memcpy(buf, history + param->ho, HB_SIZE - param->ho);
+            memcpy(buf + HB_SIZE - param->ho, history, param->ho + param->hl - HB_SIZE);
+        }
+    }
+    if (count)
+        *count = param->hl;
+}
+
+static inline void dfltcc_append_history(struct dfltcc_param_v0 *param, unsigned char *history,
+                                            const unsigned char *buf, uInt count) {
+    size_t offset;
+    size_t n;
+
+    /* Do not use more than 32K */
+    if (count > HB_SIZE) {
+        buf += count - HB_SIZE;
+        count = HB_SIZE;
+    }
+    offset = (param->ho + param->hl) % HB_SIZE;
+    if (offset + count <= HB_SIZE)
+        /* Circular history buffer does not wrap - copy one chunk */
+        memcpy(history + offset, buf, count);
+    else {
+        /* Circular history buffer wraps - copy two chunks */
+        n = HB_SIZE - offset;
+        memcpy(history + offset, buf, n);
+        memcpy(history, buf + n, count - n);
+    }
+    n = param->hl + count;
+    if (n <= HB_SIZE)
+        /* All history fits into buffer - no need to discard anything */
+        param->hl = n;
+    else {
+        /* History does not fit into buffer - discard extra bytes */
+        param->ho = (param->ho + (n - HB_SIZE)) % HB_SIZE;
+        param->hl = HB_SIZE;
+    }
+}

--- a/arch/s390/dfltcc_inflate.c
+++ b/arch/s390/dfltcc_inflate.c
@@ -83,8 +83,6 @@ dfltcc_inflate_action Z_INTERNAL dfltcc_inflate(PREFIX3(streamp) strm, int flush
     /* Translate stream to parameter block */
     param->cvt = state->flags ? CVT_CRC32 : CVT_ADLER32;
     param->sbb = state->bits;
-    param->hl = state->whave; /* Software and hardware history formats match */
-    param->ho = (state->wnext - state->whave) & ((1 << HB_BITS) - 1);
     if (param->hl)
         param->nt = 0; /* Honor history for the first block */
     param->cv = state->flags ? ZSWAP32(state->check) : state->check;
@@ -98,8 +96,6 @@ dfltcc_inflate_action Z_INTERNAL dfltcc_inflate(PREFIX3(streamp) strm, int flush
     strm->msg = oesc_msg(dfltcc_state->msg, param->oesc);
     state->last = cc == DFLTCC_CC_OK;
     state->bits = param->sbb;
-    state->whave = param->hl;
-    state->wnext = (param->ho + param->hl) & ((1 << HB_BITS) - 1);
     state->check = state->flags ? ZSWAP32(param->cv) : param->cv;
     if (cc == DFLTCC_CC_OP2_CORRUPT && param->oesc != 0) {
         /* Report an error if stream is corrupted */
@@ -122,6 +118,8 @@ int Z_INTERNAL dfltcc_was_inflate_used(PREFIX3(streamp) strm) {
 int Z_INTERNAL dfltcc_inflate_disable(PREFIX3(streamp) strm) {
     struct inflate_state *state = (struct inflate_state *)strm->state;
     struct dfltcc_state *dfltcc_state = GET_DFLTCC_STATE(state);
+    struct dfltcc_param_v0 *param = &dfltcc_state->param;
+    uInt count;
 
     if (!dfltcc_can_inflate(strm))
         return 0;
@@ -133,5 +131,29 @@ int Z_INTERNAL dfltcc_inflate_disable(PREFIX3(streamp) strm) {
         return 1;
     /* DFLTCC was not used yet - decompress in software */
     memset(&dfltcc_state->af, 0, sizeof(dfltcc_state->af));
+    /* Convert window from hardware to software format. Use its second part as scratch space. */
+    dfltcc_get_history(param, state->window, state->window + state->wsize, &count);
+    state->whave = count;
+    state->wnext = 0;
+    memcpy(state->window + state->wsize - state->whave, state->window + state->wsize, state->whave);
     return 0;
+}
+
+int Z_INTERNAL dfltcc_inflate_set_dictionary(PREFIX3(streamp) strm, const unsigned char *dictionary, uInt dict_length) {
+    struct inflate_state *state = (struct inflate_state *)strm->state;
+    struct dfltcc_state *dfltcc_state = GET_DFLTCC_STATE(state);
+    struct dfltcc_param_v0 *param = &dfltcc_state->param;
+
+    dfltcc_append_history(param, state->window, dictionary, dict_length);
+    state->havedict = 1;
+    return Z_OK;
+}
+
+int Z_INTERNAL dfltcc_inflate_get_dictionary(PREFIX3(streamp) strm, unsigned char *dictionary, uInt *dict_length) {
+    struct inflate_state *state = (struct inflate_state *)strm->state;
+    struct dfltcc_state *dfltcc_state = GET_DFLTCC_STATE(state);
+    struct dfltcc_param_v0 *param = &dfltcc_state->param;
+
+    dfltcc_get_history(param, state->window, dictionary, dict_length);
+    return Z_OK;
 }

--- a/arch/s390/dfltcc_inflate.h
+++ b/arch/s390/dfltcc_inflate.h
@@ -12,6 +12,8 @@ typedef enum {
 dfltcc_inflate_action Z_INTERNAL dfltcc_inflate(PREFIX3(streamp) strm, int flush, int *ret);
 int Z_INTERNAL dfltcc_was_inflate_used(PREFIX3(streamp) strm);
 int Z_INTERNAL dfltcc_inflate_disable(PREFIX3(streamp) strm);
+int Z_INTERNAL dfltcc_inflate_set_dictionary(PREFIX3(streamp) strm, const unsigned char *dictionary, uInt dict_length);
+int Z_INTERNAL dfltcc_inflate_get_dictionary(PREFIX3(streamp) strm, unsigned char *dictionary, uInt* dict_length);
 
 #define INFLATE_RESET_KEEP_HOOK(strm) \
     dfltcc_reset((strm), sizeof(struct inflate_state))
@@ -34,7 +36,7 @@ int Z_INTERNAL dfltcc_inflate_disable(PREFIX3(streamp) strm);
 
 #define INFLATE_NEED_CHECKSUM(strm) (!dfltcc_can_inflate((strm)))
 
-#define INFLATE_NEED_UPDATEWINDOW(strm) (!dfltcc_can_inflate((strm)))
+#define INFLATE_NEED_WINDOW_OUTPUT_FLUSH(strm) (!dfltcc_can_inflate((strm)))
 
 #define INFLATE_MARK_HOOK(strm) \
     do { \
@@ -44,6 +46,18 @@ int Z_INTERNAL dfltcc_inflate_disable(PREFIX3(streamp) strm);
 #define INFLATE_SYNC_POINT_HOOK(strm) \
     do { \
         if (dfltcc_was_inflate_used((strm))) return Z_STREAM_ERROR; \
+    } while (0)
+
+#define INFLATE_SET_DICTIONARY_HOOK(strm, dict, dict_len) \
+    do { \
+        if (dfltcc_can_inflate((strm))) \
+            return dfltcc_inflate_set_dictionary((strm), (dict), (dict_len)); \
+    } while (0)
+
+#define INFLATE_GET_DICTIONARY_HOOK(strm, dict, dict_len) \
+    do { \
+        if (dfltcc_can_inflate((strm))) \
+            return dfltcc_inflate_get_dictionary((strm), (dict), (dict_len)); \
     } while (0)
 
 #endif

--- a/deflate.c
+++ b/deflate.c
@@ -82,7 +82,7 @@ const char PREFIX(deflate_copyright)[] = " deflate 1.2.11.f Copyright 1995-2016 
 /* Invoked at the beginning of deflateParams(). Useful for updating arch-specific compression parameters. */
 #  define DEFLATE_PARAMS_HOOK(strm, level, strategy, hook_flush) do {} while (0)
 /* Returns whether the last deflate(flush) operation did everything it's supposed to do. */
-# define DEFLATE_DONE(strm, flush) 1
+#  define DEFLATE_DONE(strm, flush) 1
 /* Adjusts the upper bound on compressed data length based on compression parameters and uncompressed data length.
  * Useful when arch-specific deflation code behaves differently than regular zlib-ng algorithms. */
 #  define DEFLATE_BOUND_ADJUST_COMPLEN(strm, complen, sourceLen) do {} while (0)

--- a/infback.c
+++ b/infback.c
@@ -40,7 +40,7 @@ int32_t Z_EXPORT PREFIX(inflateBackInit_)(PREFIX3(stream) *strm, int32_t windowB
     }
     if (strm->zfree == NULL)
         strm->zfree = zng_cfree;
-    state = (struct inflate_state *) ZALLOC(strm, 1, sizeof(struct inflate_state));
+    state = (struct inflate_state *)ZALLOC_STATE(strm, 1, sizeof(struct inflate_state));
     if (state == NULL)
         return Z_MEM_ERROR;
     Tracev((stderr, "inflate: allocated\n"));
@@ -338,17 +338,6 @@ int32_t Z_EXPORT PREFIX(inflateBack)(PREFIX3(stream) *strm, in_func in, void *in
             state->mode = LEN;
 
         case LEN:
-            /* use inflate_fast() if we have enough input and output */
-            if (have >= INFLATE_FAST_MIN_HAVE &&
-                left >= INFLATE_FAST_MIN_LEFT) {
-                RESTORE();
-                if (state->whave < state->wsize)
-                    state->whave = state->wsize - left;
-                zng_inflate_fast(strm, state->wsize);
-                LOAD();
-                break;
-            }
-
             /* get a literal, length, or end-of-block code */
             for (;;) {
                 here = state->lencode[BITS(state->lenbits)];
@@ -490,7 +479,7 @@ int32_t Z_EXPORT PREFIX(inflateBack)(PREFIX3(stream) *strm, in_func in, void *in
 int32_t Z_EXPORT PREFIX(inflateBackEnd)(PREFIX3(stream) *strm) {
     if (strm == NULL || strm->state == NULL || strm->zfree == NULL)
         return Z_STREAM_ERROR;
-    ZFREE(strm, strm->state);
+    ZFREE_STATE(strm, strm->state);
     strm->state = NULL;
     Tracev((stderr, "inflate: end\n"));
     return Z_OK;

--- a/infback.c
+++ b/infback.c
@@ -338,6 +338,17 @@ int32_t Z_EXPORT PREFIX(inflateBack)(PREFIX3(stream) *strm, in_func in, void *in
             state->mode = LEN;
 
         case LEN:
+            /* use inflate_fast() if we have enough input and output */
+            if (have >= INFLATE_FAST_MIN_HAVE &&
+                left >= INFLATE_FAST_MIN_LEFT) {
+                RESTORE_BACK();
+                if (state->whave < state->wsize)
+                    state->whave = state->wsize - left;
+                zng_inflate_fast_back(strm, state->wsize);
+                LOAD_BACK();
+                break;
+            }
+
             /* get a literal, length, or end-of-block code */
             for (;;) {
                 here = state->lencode[BITS(state->lenbits)];

--- a/inffast.c
+++ b/inffast.c
@@ -250,6 +250,258 @@ void Z_INTERNAL zng_inflate_fast(PREFIX3(stream) *strm) {
     state->bits = bits;
     return;
 }
+void Z_INTERNAL zng_inflate_fast_back(PREFIX3(stream) *strm, unsigned long start) {
+    /* start: inflate()'s starting value for strm->avail_out */
+    struct inflate_state *state;
+    z_const unsigned char *in;  /* local strm->next_in */
+    const unsigned char *last;  /* have enough input while in < last */
+    unsigned char *out;         /* local strm->next_out */
+    unsigned char *beg;         /* inflate()'s initial strm->next_out */
+    unsigned char *end;         /* while out < end, enough space available */
+    unsigned char *safe;        /* can use chunkcopy provided out < safe */
+#ifdef INFLATE_STRICT
+    unsigned dmax;              /* maximum distance from zlib header */
+#endif
+    unsigned wsize;             /* window size or zero if not using window */
+    unsigned whave;             /* valid bytes in the window */
+    unsigned wnext;             /* window write index */
+    unsigned char *window;      /* allocated sliding window, if wsize != 0 */
+
+    /* hold is a local copy of strm->hold. By default, hold satisfies the same
+       invariants that strm->hold does, namely that (hold >> bits) == 0. This
+       invariant is kept by loading bits into hold one byte at a time, like:
+       hold |= next_byte_of_input << bits; in++; bits += 8;
+       If we need to ensure that bits >= 15 then this code snippet is simply
+       repeated. Over one iteration of the outermost do/while loop, this
+       happens up to six times (48 bits of input), as described in the NOTES
+       above.
+       However, on some little endian architectures, it can be significantly
+       faster to load 64 bits once instead of 8 bits six times:
+       if (bits <= 16) {
+         hold |= next_8_bytes_of_input << bits; in += 6; bits += 48;
+       }
+       Unlike the simpler one byte load, shifting the next_8_bytes_of_input
+       by bits will overflow and lose those high bits, up to 2 bytes' worth.
+       The conservative estimate is therefore that we have read only 6 bytes
+       (48 bits). Again, as per the NOTES above, 48 bits is sufficient for the
+       rest of the iteration, and we will not need to load another 8 bytes.
+       Inside this function, we no longer satisfy (hold >> bits) == 0, but
+       this is not problematic, even if that overflow does not land on an 8 bit
+       byte boundary. Those excess bits will eventually shift down lower as the
+       Huffman decoder consumes input, and when new input bits need to be loaded
+       into the bits variable, the same input bits will be or'ed over those
+       existing bits. A bitwise or is idempotent: (a | b | b) equals (a | b).
+       Note that we therefore write that load operation as "hold |= etc" and not
+       "hold += etc".
+       Outside that loop, at the end of the function, hold is bitwise and'ed
+       with (1<<bits)-1 to drop those excess bits so that, on function exit, we
+       keep the invariant that (state->hold >> state->bits) == 0.
+    */
+    uint64_t hold;              /* local strm->hold */
+    unsigned bits;              /* local strm->bits */
+    code const *lcode;          /* local strm->lencode */
+    code const *dcode;          /* local strm->distcode */
+    unsigned lmask;             /* mask for first level of length codes */
+    unsigned dmask;             /* mask for first level of distance codes */
+    const code *here;           /* retrieved table entry */
+    unsigned op;                /* code bits, operation, extra bits, or */
+                                /*  window position, window bytes to copy */
+    unsigned len;               /* match length, unused bytes */
+    unsigned dist;              /* match distance */
+    unsigned char *from;        /* where to copy match from */
+    unsigned extra_safe;        /* copy chunks safely in all cases */
+
+    /* copy state to local variables */
+    state = (struct inflate_state *)strm->state;
+    in = strm->next_in;
+    last = in + (strm->avail_in - (INFLATE_FAST_MIN_HAVE - 1));
+    out = strm->next_out;
+    beg = out - (start - strm->avail_out);
+    end = out + (strm->avail_out - (INFLATE_FAST_MIN_LEFT - 1));
+    safe = out + strm->avail_out;
+#ifdef INFLATE_STRICT
+    dmax = state->dmax;
+#endif
+    wsize = state->wsize;
+    whave = state->whave;
+    wnext = state->wnext;
+    window = state->window;
+    hold = state->hold;
+    bits = state->bits;
+    lcode = state->lencode;
+    dcode = state->distcode;
+    lmask = (1U << state->lenbits) - 1;
+    dmask = (1U << state->distbits) - 1;
+
+    /* Detect if out and window point to the same memory allocation. In this instance it is
+       necessary to use safe chunk copy functions to prevent overwriting the window. If the
+       window is overwritten then future matches with far distances will fail to copy correctly. */
+    extra_safe = (wsize != 0 && out >= window && out + INFLATE_FAST_MIN_LEFT <= window + wsize);
+
+    /* decode literals and length/distances until end-of-block or not enough
+       input data or output space */
+    do {
+        if (bits < 15) {
+            hold |= load_64_bits(in, bits);
+            in += 6;
+            bits += 48;
+        }
+        here = lcode + (hold & lmask);
+      dolen:
+        DROPBITS(here->bits);
+        op = here->op;
+        if (op == 0) {                          /* literal */
+            Tracevv((stderr, here->val >= 0x20 && here->val < 0x7f ?
+                    "inflate:         literal '%c'\n" :
+                    "inflate:         literal 0x%02x\n", here->val));
+            *out++ = (unsigned char)(here->val);
+        } else if (op & 16) {                     /* length base */
+            len = here->val;
+            op &= 15;                           /* number of extra bits */
+            if (bits < op) {
+                hold |= load_64_bits(in, bits);
+                in += 6;
+                bits += 48;
+            }
+            len += BITS(op);
+            DROPBITS(op);
+            Tracevv((stderr, "inflate:         length %u\n", len));
+            if (bits < 15) {
+                hold |= load_64_bits(in, bits);
+                in += 6;
+                bits += 48;
+            }
+            here = dcode + (hold & dmask);
+          dodist:
+            DROPBITS(here->bits);
+            op = here->op;
+            if (op & 16) {                      /* distance base */
+                dist = here->val;
+                op &= 15;                       /* number of extra bits */
+                if (bits < op) {
+                    hold |= load_64_bits(in, bits);
+                    in += 6;
+                    bits += 48;
+                }
+                dist += BITS(op);
+#ifdef INFLATE_STRICT
+                if (dist > dmax) {
+                    SET_BAD("invalid distance too far back");
+                    break;
+                }
+#endif
+                DROPBITS(op);
+                Tracevv((stderr, "inflate:         distance %u\n", dist));
+                op = (unsigned)(out - beg);     /* max distance in output */
+                if (dist > op) {                /* see if copy from window */
+                    op = dist - op;             /* distance back in window */
+                    if (op > whave) {
+                        if (state->sane) {
+                            SET_BAD("invalid distance too far back");
+                            break;
+                        }
+#ifdef INFLATE_ALLOW_INVALID_DISTANCE_TOOFAR_ARRR
+                        if (len <= op - whave) {
+                            do {
+                                *out++ = 0;
+                            } while (--len);
+                            continue;
+                        }
+                        len -= op - whave;
+                        do {
+                            *out++ = 0;
+                        } while (--op > whave);
+                        if (op == 0) {
+                            from = out - dist;
+                            do {
+                                *out++ = *from++;
+                            } while (--len);
+                            continue;
+                        }
+#endif
+                    }
+                    from = window;
+                    if (wnext == 0) {           /* very common case */
+                        from += wsize - op;
+                    } else if (wnext >= op) {   /* contiguous in window */
+                        from += wnext - op;
+                    } else {                    /* wrap around window */
+                        op -= wnext;
+                        from += wsize - op;
+                        if (op < len) {         /* some from end of window */
+                            len -= op;
+                            out = functable.chunkcopy_safe(out, from, op, safe);
+                            from = window;      /* more from start of window */
+                            op = wnext;
+                            /* This (rare) case can create a situation where
+                               the first chunkcopy below must be checked.
+                             */
+                        }
+                    }
+                    if (op < len) {             /* still need some from output */
+                        len -= op;
+                        out = functable.chunkcopy_safe(out, from, op, safe);
+                        out = functable.chunkunroll(out, &dist, &len);
+                        out = functable.chunkcopy_safe(out, out - dist, len, safe);
+                    } else {
+                        out = functable.chunkcopy_safe(out, from, len, safe);
+                    }
+                } else if (extra_safe) {
+                    /* Whole reference is in range of current output. */
+                    if (dist >= len || dist >= state->chunksize)
+                        out = functable.chunkcopy_safe(out, out - dist, len, safe);
+                    else
+                        out = functable.chunkmemset_safe(out, dist, len, (unsigned)((safe - out) + 1));
+                } else {
+                    /* Whole reference is in range of current output.  No range checks are
+                       necessary because we start with room for at least 258 bytes of output,
+                       so unroll and roundoff operations can write beyond `out+len` so long
+                       as they stay within 258 bytes of `out`.
+                    */
+                    if (dist >= len || dist >= state->chunksize)
+                        out = functable.chunkcopy(out, out - dist, len);
+                    else
+                        out = functable.chunkmemset(out, dist, len);
+                }
+            } else if ((op & 64) == 0) {          /* 2nd level distance code */
+                here = dcode + here->val + BITS(op);
+                goto dodist;
+            } else {
+                SET_BAD("invalid distance code");
+                break;
+            }
+        } else if ((op & 64) == 0) {              /* 2nd level length code */
+            here = lcode + here->val + BITS(op);
+            goto dolen;
+        } else if (op & 32) {                     /* end-of-block */
+            Tracevv((stderr, "inflate:         end of block\n"));
+            state->mode = TYPE;
+            break;
+        } else {
+            SET_BAD("invalid literal/length code");
+            break;
+        }
+    } while (in < last && out < end);
+
+    /* return unused bytes (on entry, bits < 8, so in won't go too far back) */
+    len = bits >> 3;
+    in -= len;
+    bits -= len << 3;
+    hold &= (UINT64_C(1) << bits) - 1;
+
+    /* update state and return */
+    strm->next_in = in;
+    strm->next_out = out;
+    strm->avail_in = (unsigned)(in < last ? (INFLATE_FAST_MIN_HAVE - 1) + (last - in)
+                                          : (INFLATE_FAST_MIN_HAVE - 1) - (in - last));
+    strm->avail_out = (unsigned)(out < end ? (INFLATE_FAST_MIN_LEFT - 1) + (end - out)
+                                           : (INFLATE_FAST_MIN_LEFT - 1) - (out - end));
+
+    Assert(bits <= 32, "Remaining bits greater than 32");
+    state->hold = (uint32_t)hold;
+    state->bits = bits;
+    return;
+}
 
 /*
    inflate_fast() speedups that turned out slower (on a PowerPC G3 750CXe):

--- a/inffast.h
+++ b/inffast.h
@@ -10,7 +10,7 @@
    subject to change. Applications should only use zlib.h.
  */
 
-void Z_INTERNAL zng_inflate_fast(PREFIX3(stream) *strm, unsigned long start);
+void Z_INTERNAL zng_inflate_fast(PREFIX3(stream) *strm);
 
 #define INFLATE_FAST_MIN_HAVE 8
 #define INFLATE_FAST_MIN_LEFT 258

--- a/inffast.h
+++ b/inffast.h
@@ -11,6 +11,7 @@
  */
 
 void Z_INTERNAL zng_inflate_fast(PREFIX3(stream) *strm);
+void Z_INTERNAL zng_inflate_fast_back(PREFIX3(stream) *strm, unsigned long start);
 
 #define INFLATE_FAST_MIN_HAVE 8
 #define INFLATE_FAST_MIN_LEFT 258

--- a/inflate.h
+++ b/inflate.h
@@ -11,6 +11,8 @@
 #ifndef INFLATE_H_
 #define INFLATE_H_
 
+#include "crc32_fold.h"
+
 /* define NO_GZIP when compiling if you want to disable gzip header and trailer decoding by inflate().
    NO_GZIP would be used to avoid linking in the crc code when it is not needed.
    For shared libraries, gzip decoding should be left enabled. */
@@ -100,6 +102,9 @@ struct inflate_state {
     uint32_t whave;             /* valid bytes in the window */
     uint32_t wnext;             /* window write index */
     unsigned char *window;      /* allocated sliding window, if needed */
+
+    crc32_fold ALIGNED_(16) crc_fold;
+
         /* bit accumulator */
     uint32_t hold;              /* input bit accumulator */
     unsigned bits;              /* number of bits in "in" */

--- a/inflate_p.h
+++ b/inflate_p.h
@@ -27,12 +27,17 @@
 #  define INFLATE_TYPEDO_HOOK(strm, flush) do {} while (0)
 /* Returns whether zlib-ng should compute a checksum. Set to 0 if arch-specific inflation code already does that. */
 #  define INFLATE_NEED_CHECKSUM(strm) 1
-/* Returns whether zlib-ng should update a window. Set to 0 if arch-specific inflation code already does that. */
-#  define INFLATE_NEED_UPDATEWINDOW(strm) 1
+/* Returns whether zlib-ng should flush the window to the output buffer.
+   Set to 0 if arch-specific inflation code already does that. */
+#  define INFLATE_NEED_WINDOW_OUTPUT_FLUSH(strm) 1
 /* Invoked at the beginning of inflateMark(). Useful for updating arch-specific pointers and offsets. */
 #  define INFLATE_MARK_HOOK(strm) do {} while (0)
 /* Invoked at the beginning of inflateSyncPoint(). Useful for performing arch-specific state checks. */
-#define INFLATE_SYNC_POINT_HOOK(strm) do {} while (0)
+#  define INFLATE_SYNC_POINT_HOOK(strm) do {} while (0)
+/* Invoked at the beginning of inflateSetDictionary(). Useful for checking arch-specific window data. */
+#  define INFLATE_SET_DICTIONARY_HOOK(strm, dict, dict_len) do {} while (0)
+/* Invoked at the beginning of inflateGetDictionary(). Useful for adjusting arch-specific window data. */
+#  define INFLATE_GET_DICTIONARY_HOOK(strm, dict, dict_len) do {} while (0)
 #endif
 
 

--- a/inflate_p.h
+++ b/inflate_p.h
@@ -70,10 +70,32 @@
         bits = state->bits; \
     } while (0)
 
+/* Load registers with state in inflateBack() for speed */
+#define LOAD_BACK() \
+    do { \
+        put = strm->next_out; \
+        left = strm->avail_out; \
+        next = strm->next_in; \
+        have = strm->avail_in; \
+        hold = state->hold; \
+        bits = state->bits; \
+    } while (0)
+
 /* Restore state from registers in inflate() */
 #define RESTORE() \
     do { \
         state->wnext = (uint32_t)(put - (state->window + state->wsize)); \
+        strm->avail_out = left; \
+        strm->next_in = (z_const unsigned char *)next; \
+        strm->avail_in = have; \
+        state->hold = hold; \
+        state->bits = bits; \
+    } while (0)
+
+/* Restore state from registers in inflateBack() */
+#define RESTORE_BACK() \
+    do { \
+        strm->next_out = put; \
         strm->avail_out = left; \
         strm->next_in = (z_const unsigned char *)next; \
         strm->avail_in = have; \

--- a/inflate_p.h
+++ b/inflate_p.h
@@ -5,17 +5,40 @@
 #ifndef INFLATE_P_H
 #define INFLATE_P_H
 
+#include "zbuild.h"
+#include "functable.h"
+
+/* Architecture-specific hooks. */
+#ifdef S390_DFLTCC_INFLATE
+#  include "arch/s390/dfltcc_inflate.h"
+#else
+/* Memory management for the inflate state. Useful for allocating arch-specific extension blocks. */
+#  define ZALLOC_STATE(strm, items, size) ZALLOC(strm, items, size)
+#  define ZFREE_STATE(strm, addr) ZFREE(strm, addr)
+#  define ZCOPY_STATE(dst, src, size) memcpy(dst, src, size)
+/* Memory management for the window. Useful for allocation the aligned window. */
+#  define ZALLOC_WINDOW(strm, items, size) ZALLOC(strm, items, size)
+#  define ZFREE_WINDOW(strm, addr) ZFREE(strm, addr)
+/* Invoked at the end of inflateResetKeep(). Useful for initializing arch-specific extension blocks. */
+#  define INFLATE_RESET_KEEP_HOOK(strm) do {} while (0)
+/* Invoked at the beginning of inflatePrime(). Useful for updating arch-specific buffers. */
+#  define INFLATE_PRIME_HOOK(strm, bits, value) do {} while (0)
+/* Invoked at the beginning of each block. Useful for plugging arch-specific inflation code. */
+#  define INFLATE_TYPEDO_HOOK(strm, flush) do {} while (0)
+/* Returns whether zlib-ng should compute a checksum. Set to 0 if arch-specific inflation code already does that. */
+#  define INFLATE_NEED_CHECKSUM(strm) 1
+/* Returns whether zlib-ng should update a window. Set to 0 if arch-specific inflation code already does that. */
+#  define INFLATE_NEED_UPDATEWINDOW(strm) 1
+/* Invoked at the beginning of inflateMark(). Useful for updating arch-specific pointers and offsets. */
+#  define INFLATE_MARK_HOOK(strm) do {} while (0)
+/* Invoked at the beginning of inflateSyncPoint(). Useful for performing arch-specific state checks. */
+#define INFLATE_SYNC_POINT_HOOK(strm) do {} while (0)
+#endif
+
+
 /*
  *   Macros shared by inflate() and inflateBack()
  */
-
-/* check function to use adler32() for zlib or crc32() for gzip */
-#ifdef GUNZIP
-#  define UPDATE(check, buf, len) \
-    (state->flags ? PREFIX(crc32)(check, buf, len) : functable.adler32(check, buf, len))
-#else
-#  define UPDATE(check, buf, len) functable.adler32(check, buf, len)
-#endif
 
 /* check macros for header crc */
 #ifdef GUNZIP
@@ -39,7 +62,7 @@
 /* Load registers with state in inflate() for speed */
 #define LOAD() \
     do { \
-        put = strm->next_out; \
+        put = state->window + state->wsize + state->wnext; \
         left = strm->avail_out; \
         next = strm->next_in; \
         have = strm->avail_in; \
@@ -50,7 +73,7 @@
 /* Restore state from registers in inflate() */
 #define RESTORE() \
     do { \
-        strm->next_out = put; \
+        state->wnext = (uint32_t)(put - (state->window + state->wsize)); \
         strm->avail_out = left; \
         strm->next_in = (z_const unsigned char *)next; \
         strm->avail_in = have; \
@@ -99,3 +122,60 @@
         state->mode = BAD; \
         strm->msg = (char *)errmsg; \
     } while (0)
+
+
+static inline void inf_crc_copy(PREFIX3(stream) *strm, unsigned char *const dst,
+        const unsigned char *const src, size_t len) {
+    struct inflate_state *const state = (struct inflate_state *const)strm->state;
+
+    if (!INFLATE_NEED_CHECKSUM(strm))
+        return;
+
+    /* check function to use adler32() for zlib or crc32() for gzip */
+#ifdef GUNZIP
+    if (state->flags)
+        functable.crc32_fold_copy(&state->crc_fold, dst, src, len);
+    else
+#endif
+    {
+        memcpy(dst, src, len);
+        strm->adler = state->check = functable.adler32(state->check, dst, len);
+    }
+}
+
+static inline void window_output_flush(PREFIX3(stream) *strm) {
+    struct inflate_state *const state = (struct inflate_state *const)strm->state;
+    size_t write_offset, read_offset, copy_size;
+    uint32_t out_bytes;
+
+    if (state->wnext > strm->avail_out) {
+        out_bytes = strm->avail_out;
+        copy_size = state->wnext - out_bytes;
+    } else {
+        out_bytes = state->wnext;
+        copy_size = 0;
+    }
+
+    /* Copy from pending buffer to stream output */
+    inf_crc_copy(strm, strm->next_out, state->window + state->wsize, out_bytes);
+
+    strm->avail_out -= out_bytes;
+    strm->next_out += out_bytes;
+
+    /* Discard bytes in sliding window */
+    if (state->whave + out_bytes > state->wsize) {
+        write_offset = 0;
+        read_offset = out_bytes;
+        copy_size += state->wsize;
+    } else {
+        read_offset = state->wsize - state->whave;
+        write_offset = read_offset - out_bytes;
+        copy_size += state->whave + out_bytes;
+    }
+
+    memmove(state->window + write_offset, state->window + read_offset, copy_size);
+
+    state->wnext -= out_bytes;
+    state->whave += out_bytes;
+    state->whave = MIN(state->whave, state->wsize);
+}

--- a/test/example.c
+++ b/test/example.c
@@ -551,7 +551,7 @@ void test_dict_inflate(unsigned char *compr, size_t comprLen, unsigned char *unc
     err = PREFIX(inflateGetDictionary)(&d_stream, NULL, &check_dictionary_len);
     CHECK_ERR(err, "inflateGetDictionary");
 #ifndef S390_DFLTCC_INFLATE
-    if (check_dictionary_len != sizeof(dictionary))
+    if (check_dictionary_len < sizeof(dictionary))
         error("bad dictionary length\n");
 #endif
     


### PR DESCRIPTION
This commit merges in the Intel inflate changes for crc32 pclmulqdq:
https://github.com/jtkukunas/zlib/commit/62b7616b0bad4ff088f1a73d0fa11159b6925fbb

Here is Jim Kukunas original notes from the commit:

> This commit significantly improves inflate performance by reorganizing the window buffer into a contiguous window and pending output buffer. The goal of this layout is to reduce branching, improve cache locality, and enable for the use of crc folding with gzip input.

> The window buffer is allocated as a multiple of the user-selected window size. In this commit, a factor of 2 is utilized.

> The layout of the window buffer is divided into two sections. The first section, window offset [0, wsize), is reserved for history that has already been output. The second section, window offset [wsize, 2 * wsize), is reserved for buffering pending output that hasn't been flushed to the user's output buffer yet.

> The history section grows downwards, towards the window offset of 0. The pending output section grows upwards, towards the end of the buffer. As a result, all of the possible distance/length data that may need to be copied is contiguous. This removes the need to stitch together output from 2 separate buffers.

> In the case of gzip input, crc folding is used to copy the pending output to the user's buffers.

The downsides:

* inflate uses ~~64kb of memory~~ twice as much window memory. If window is 32k, it uses 64k.
* ~~inflateBack no longer uses inflate_fast. With inflateBack you specify the window buffer and size which is different than what this commit does in that it uses a single memory allocation for window buffer and pending output buffer similar to deflate. We could possibly use a separate inflate_fast function or with separate parameters for inflateBack.~~
* For inflateBack we had to create a separate `zng_inflate_fast_back` function to preserve speed improvements when all we are supplied with is a buffer allocation only intended for use as the window.

Todo:

* ~~Make all CI work~~
* ~~Newer benchmarks~~
* ~~See if we can overcome inflateBack issue.~~

Old Benchmarks:

### ZLIB-NG
```
 Tool: minigzip-ng-develop.exe Levels: 1-9
 Runs: 70         Trim worst: 40

 Level   Comp   Comptime min/avg/max/stddev  Decomptime min/avg/max/stddev  Compressed size
 1     44.809%      1.015/1.022/1.030/0.005        0.660/0.670/0.674/0.003      104,067,822
 2     35.391%      1.678/1.700/1.710/0.009        0.673/0.686/0.692/0.005       82,195,416
 3     33.698%      2.320/2.338/2.348/0.009        0.655/0.661/0.666/0.003       78,262,436
 4     32.989%      2.618/2.639/2.649/0.007        0.637/0.648/0.654/0.005       76,616,183
 5     32.483%      2.781/2.803/2.815/0.009        0.638/0.644/0.649/0.004       75,441,984
 6     32.318%      3.392/3.414/3.425/0.009        0.632/0.640/0.645/0.004       75,058,801
 7     32.061%      4.654/4.675/4.688/0.010        0.633/0.644/0.650/0.005       74,461,300
 8     31.978%      7.149/7.192/7.212/0.014        0.635/0.643/0.650/0.005       74,269,032
 9     31.961%      9.729/9.761/9.784/0.016        0.638/0.645/0.650/0.003       74,230,342

 avg1  34.188%                        3.949                          0.654
 tot                               1066.332                        176.447      714,603,316
```
### ZLIB-NG (With inflate changes)
```
 Tool: minigzip-ng-infcrc.exe Levels: 1-9
 Runs: 70         Trim worst: 40

 Level   Comp   Comptime min/avg/max/stddev  Decomptime min/avg/max/stddev  Compressed size
 1     44.807%      1.149/1.166/1.177/0.007        0.550/0.558/0.566/0.004      104,063,993
 2     35.391%      1.805/1.828/1.838/0.010        0.553/0.563/0.569/0.004       82,195,416
 3     33.698%      2.438/2.456/2.469/0.009        0.534/0.543/0.550/0.004       78,262,436
 4     32.989%      2.732/2.757/2.771/0.010        0.522/0.527/0.532/0.003       76,616,183
 5     32.484%      2.905/2.926/2.948/0.013        0.513/0.523/0.529/0.004       75,443,521
 6     32.318%      3.515/3.530/3.540/0.007        0.511/0.520/0.525/0.004       75,057,363
 7     32.061%      4.737/4.755/4.768/0.008        0.511/0.523/0.529/0.005       74,461,300
 8     31.978%      7.241/7.264/7.279/0.010        0.513/0.521/0.527/0.004       74,269,032
 9     31.961%      9.807/9.835/9.849/0.011        0.514/0.523/0.531/0.005       74,230,342

 avg1  34.187%                        4.057                          0.534
 tot                               1095.468                        144.062      714,599,586
```
Shows it is possible to get %18 improvement in decompression. 
