### PR TITLE
Include win directory in pigz even if not using threads.

### DIFF
--- a/test/pigz/CMakeLists.txt
+++ b/test/pigz/CMakeLists.txt
@@ -6,6 +6,9 @@
 # By default pigz will be linked against the system zlib and
 # pthread libraries if installed.
 
+# For compilation on Windows download and use shim:
+#  https://github.com/zlib-ng/pigzbench/tree/master/pigz/win
+
 # Optional Variables
 #   WITH_CODE_COVERAGE  - Enable code coverage reporting
 #   WITH_THREADS        - Enable threading support
@@ -69,6 +72,9 @@ set(PIGZ_HDRS
 
 add_executable(${PROJECT_NAME} ${PIGZ_SRCS} ${PIGZ_HDRS})
 add_definitions(-DNOZOPFLI)
+if(WIN32)
+    target_include_directories(${PROJECT_NAME} PRIVATE win)
+endif()
 
 # Find and link against pthreads or pthreads4w
 if(WITH_THREADS)
@@ -79,7 +85,7 @@ if(WITH_THREADS)
 
             add_subdirectory(${PTHREADS4W_ROOT} ${PTHREADS4W_ROOT} EXCLUDE_FROM_ALL)
             target_link_libraries(${PROJECT_NAME} pthreadVC3)
-            target_include_directories(${PROJECT_NAME} PRIVATE win ${PTHREADS4W_ROOT})
+            target_include_directories(${PROJECT_NAME} PRIVATE ${PTHREADS4W_ROOT})
         else()
             message(WARNING "Missing pthreads4w root directory")
             set(WITH_THREADS OFF)


### PR DESCRIPTION
This PR always includes `win` directory in pigz when on Windows even if not using pthreads. This `win` directory contains source code the mimic the necessary linux functions. https://github.com/zlib-ng/pigzbench/tree/master/pigz/win
By not compiling with pthreads on Windows we can get to compiling pigz quicker for testing functional issues unrelated to threading.