### PR TITLE
Fixed undefined behavior of isgraph when passing integer

### DIFF
--- a/trees.c
+++ b/trees.c
@@ -308,7 +308,7 @@ Z_INTERNAL void gen_codes(ct_data *tree, int max_code, uint16_t *bl_count) {
         tree[n].Code = bi_reverse(next_code[len]++, len);
 
         Tracecv(tree != static_ltree, (stderr, "\nn %3d %c l %2d c %4x (%x) ",
-             n, (isgraph(n) ? n : ' '), len, tree[n].Code, next_code[len]-1));
+             n, (isgraph(n & 0xff) ? n : ' '), len, tree[n].Code, next_code[len]-1));
     }
 }
 

--- a/trees_emit.h
+++ b/trees_emit.h
@@ -109,7 +109,7 @@ static inline uint32_t zng_emit_lit(deflate_state *s, const ct_data *ltree, unsi
     s->bi_valid = bi_valid;
     s->bi_buf = bi_buf;
 
-    Tracecv(isgraph(c), (stderr, " '%c' ", c));
+    Tracecv(isgraph(c & 0xff), (stderr, " '%c' ", c));
 
     return ltree[c].Len;
 }


### PR DESCRIPTION
https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/isgraph-iswgraph-isgraph-l-iswgraph-l?view=msvc-160

> The behavior of isgraph and _isgraph_l is undefined if c is not EOF or in the range 0 through 0xFF, inclusive. **When a debug CRT library is used and c is not one of these values, the functions raise an assertion.**