### PR TITLE
Fix deflateBound for HASH_BITS > 15

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -644,7 +644,7 @@ unsigned long Z_EXPORT PREFIX(deflateBound)(PREFIX3(stream) *strm, unsigned long
 
     /* if not default parameters, return conservative bound */
     if (DEFLATE_NEED_CONSERVATIVE_BOUND(strm) ||  /* hook for IBM Z DFLTCC */
-            s->w_bits != 15 || HASH_BITS < 15)
+            s->w_bits != 15 || HASH_BITS != 15)
         return complen + wraplen;
 
     /* default settings: return tight bound for that case */


### PR DESCRIPTION
This check was changed from HASH_BITS != 15 to HASH_BITS < 15 in commit e7bb6db09a, leading zlib-ng to produce upper bounds that are too small in certain cases.