### PR TITLE
ENH: Transition to Ubuntu 18.04 in `GitHub` actions workflows

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -8,8 +8,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Ubuntu 16.04 GCC
-            os: ubuntu-16.04
+          - name: Ubuntu 18.04 GCC
+            os: ubuntu-18.04
             compiler: gcc
 
           - name: Ubuntu GCC
@@ -290,8 +290,8 @@ jobs:
              # Limit parallel test jobs to prevent wine errors
             parallels-jobs: 1
 
-          - name: Ubuntu 16.04 Clang
-            os: ubuntu-16.04
+          - name: Ubuntu 18.04 Clang
+            os: ubuntu-18.04
             compiler: clang-6.0
             packages: clang-6.0
 

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -13,8 +13,8 @@ jobs:
             compiler: gcc
             configure-args: --warn
 
-          - name: Ubuntu 16.04 GCC
-            os: ubuntu-16.04
+          - name: Ubuntu 18.04 GCC
+            os: ubuntu-18.04
             compiler: gcc
             configure-args: --warn
 


### PR DESCRIPTION
Transition to Ubuntu 18.04 in `GitHub` actions workflows.

Fixes:
```
Ubuntu 16.04 Clang
This request was automatically failed because there were no enabled runners online to process the request for more than 1 days.

Ubuntu 16.04 GCC
This request was automatically failed because there were no enabled runners online to process the request for more than 1 days.
```

reported for example at:
https://github.com/zlib-ng/zlib-ng/actions/runs/1326434358

Official `GitHub` notice related to the removal of the 16.04 virtual
environments:
https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/