### PR TITLE
[ARM] Try to compile test for float-abi detection code.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,15 +197,24 @@ elseif(CMAKE_C_COMPILER_ID MATCHES "GNU" OR CMAKE_C_COMPILER_ID MATCHES "Clang")
         if(BASEARCH_ARM_FOUND)
             if("${ARCH}" MATCHES "arm" AND NOT CMAKE_C_FLAGS MATCHES "-mfloat-abi")
                 # Auto-detect support for ARM floating point ABI
-                check_c_compiler_flag(-mfloat-abi=softfp HAVE_FLOATABI_SOFTFP)
+                set(CMAKE_REQUIRED_FLAGS "-mfloat-abi=softfp")
+                check_c_source_compiles(
+                    "#include <features.h>
+                    int main() { return 0; }"
+                    HAVE_FLOATABI_SOFTFP)
                 if(HAVE_FLOATABI_SOFTFP)
                     set(FLOATABI "-mfloat-abi=softfp")
                 else()
-                    check_c_compiler_flag(-mfloat-abi=hard HAVE_FLOATABI_HARD)
+                    set(CMAKE_REQUIRED_FLAGS "-mfloat-abi=hard")
+                    check_c_source_compiles(
+                        "#include <features.h>
+                        int main() { return 0; }"
+                        HAVE_FLOATABI_HARD)
                     if(HAVE_FLOATABI_HARD)
                         set(FLOATABI "-mfloat-abi=hard")
                     endif()
                 endif()
+                set(CMAKE_REQUIRED_FLAGS)
                 if(FLOATABI)
                     message(STATUS "ARM floating point arch: ${FLOATABI}")
                     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FLOATABI}")


### PR DESCRIPTION
Some ARM toolchains support both software and hardware floating-point ABI depending on the targeted processor...
We need to test compiling using either software or hardware ABI by including `<features.h>` which will try to include the correct stub header depending on the requested ABI.