### PR TITLE
[MacOS] Downgrade to XCode 11.7.0 for pkgcheck.

### DIFF
--- a/.github/workflows/pkgcheck.yml
+++ b/.github/workflows/pkgcheck.yml
@@ -88,7 +88,7 @@ jobs:
       if: runner.os == 'macOS'
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '12.1.1'
+        xcode-version: '11.7.0'
 
     - name: Compare builds
       run: |


### PR DESCRIPTION
XCode 12.1.1 was removed from CI, so pkgcheck tests started to fail. We need older version, because support for `ZERO_AR_DATE` variable was removed in more recent versions.