### PR TITLE
Fixed minideflate write buffers being overwritten.

### DIFF
--- a/test/minideflate.c
+++ b/test/minideflate.c
@@ -70,6 +70,8 @@ void deflate_params(FILE *fin, FILE *fout, int32_t read_buf_size, int32_t write_
     c_stream.opaque = (void *)0;
     c_stream.total_in = 0;
     c_stream.total_out = 0;
+    c_stream.next_out = write_buf;
+    c_stream.avail_out = write_buf_size;
 
     err = PREFIX(deflateInit2)(&c_stream, level, Z_DEFLATED, window_bits, mem_level, strategy);
     CHECK_ERR(err, "deflateInit2");
@@ -82,11 +84,9 @@ void deflate_params(FILE *fin, FILE *fout, int32_t read_buf_size, int32_t write_
             break;
 
         c_stream.next_in  = (z_const uint8_t *)read_buf;
-        c_stream.next_out = write_buf;
         c_stream.avail_in = read;
 
         do {
-            c_stream.avail_out = write_buf_size;
             err = PREFIX(deflate)(&c_stream, flush);
             if (err == Z_STREAM_END) break;
             CHECK_ERR(err, "deflate");
@@ -94,6 +94,7 @@ void deflate_params(FILE *fin, FILE *fout, int32_t read_buf_size, int32_t write_
             if (c_stream.next_out == write_buf + write_buf_size) {
                 fwrite(write_buf, 1, write_buf_size, fout);
                 c_stream.next_out = write_buf;
+                c_stream.avail_out = write_buf_size;
             }
         } while (c_stream.next_in < read_buf + read);
     } while (err == Z_OK);
@@ -105,9 +106,9 @@ void deflate_params(FILE *fin, FILE *fout, int32_t read_buf_size, int32_t write_
             if (c_stream.next_out == write_buf + write_buf_size) {
                 fwrite(write_buf, 1, write_buf_size, fout);
                 c_stream.next_out = write_buf;
+                c_stream.avail_out = write_buf_size;
             }
 
-            c_stream.avail_out = write_buf_size;
             err = PREFIX(deflate)(&c_stream, Z_FINISH);
             if (err == Z_STREAM_END) break;
             CHECK_ERR(err, "deflate");
@@ -155,6 +156,8 @@ void inflate_params(FILE *fin, FILE *fout, int32_t read_buf_size, int32_t write_
     d_stream.opaque = (void *)0;
     d_stream.total_in = 0;
     d_stream.total_out = 0;
+    d_stream.next_out = write_buf;
+    d_stream.avail_out = write_buf_size;
 
     err = PREFIX(inflateInit2)(&d_stream, window_bits);
     CHECK_ERR(err, "inflateInit2");
@@ -167,11 +170,9 @@ void inflate_params(FILE *fin, FILE *fout, int32_t read_buf_size, int32_t write_
             break;
 
         d_stream.next_in  = (z_const uint8_t *)read_buf;
-        d_stream.next_out = write_buf;
         d_stream.avail_in = read;
 
         do {
-            d_stream.avail_out = write_buf_size;
             err = PREFIX(inflate)(&d_stream, flush);
             if (err == Z_STREAM_END) break;
             CHECK_ERR(err, "deflate");
@@ -179,6 +180,7 @@ void inflate_params(FILE *fin, FILE *fout, int32_t read_buf_size, int32_t write_
             if (d_stream.next_out == write_buf + write_buf_size) {
                 fwrite(write_buf, 1, write_buf_size, fout);
                 d_stream.next_out = write_buf;
+                d_stream.avail_out = write_buf_size;
             }
         } while (d_stream.next_in < read_buf + read);
     } while (err == Z_OK);
@@ -190,9 +192,9 @@ void inflate_params(FILE *fin, FILE *fout, int32_t read_buf_size, int32_t write_
             if (d_stream.next_out == write_buf + write_buf_size) {
                 fwrite(write_buf, 1, write_buf_size, fout);
                 d_stream.next_out = write_buf;
+                d_stream.avail_out = write_buf_size;
             }
 
-            d_stream.avail_out = write_buf_size;
             err = PREFIX(inflate)(&d_stream, Z_FINISH);
             if (err == Z_STREAM_END) break;
             CHECK_ERR(err, "inflate");


### PR DESCRIPTION
See #1059 and #1053.  Certain stream info were not being set at the correct times on the stream, causing some data to be lost.