### PR TITLE
Workaround for installation failure of wine32.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -408,6 +408,7 @@ jobs:
       if: runner.os == 'Linux' && matrix.packages
       run: |
         sudo dpkg --add-architecture i386 # Required for wine32
+        sudo apt-add-repository ppa:ondrej/php -y
         sudo apt-get update
         sudo apt-get install -y ${{ matrix.packages }}
 


### PR DESCRIPTION
Fixes version mismatch between i386 and amd64 packages of dependencies.