### PR TITLE
Remove gz_intmax

### DIFF
--- a/gzguts.h
+++ b/gzguts.h
@@ -144,11 +144,6 @@ void Z_INTERNAL gz_error(gz_state *, int, const char *);
 /* GT_OFF(x), where x is an unsigned value, is true if x > maximum z_off64_t
    value -- needed when comparing unsigned to z_off64_t, which is signed
    (possible z_off64_t types off_t, off64_t, and long are all signed) */
-#ifdef INT_MAX
-#  define GT_OFF(x) (sizeof(int) == sizeof(z_off64_t) && (x) > INT_MAX)
-#else
-unsigned Z_INTERNAL gz_intmax(void);
-#  define GT_OFF(x) (sizeof(int) == sizeof(z_off64_t) && (x) > gz_intmax())
-#endif
+#define GT_OFF(x) (sizeof(int) == sizeof(z_off64_t) && (x) > INT_MAX)
 
 #endif /* GZGUTS_H_ */

--- a/gzlib.c
+++ b/gzlib.c
@@ -523,21 +523,3 @@ void Z_INTERNAL gz_error(gz_state *state, int err, const char *msg) {
     }
     (void)snprintf(state->msg, strlen(state->path) + strlen(msg) + 3, "%s%s%s", state->path, ": ", msg);
 }
-
-#ifndef INT_MAX
-/* portably return maximum value for an int (when limits.h presumed not
-   available) -- we need to do this to cover cases where 2's complement not
-   used, since C standard permits 1's complement and sign-bit representations,
-   otherwise we could just use ((unsigned)-1) >> 1 */
-unsigned Z_INTERNAL gz_intmax() {
-    unsigned p, q;
-
-    p = 1;
-    do {
-        q = p;
-        p <<= 1;
-        p++;
-    } while (p > q);
-    return q >> 1;
-}
-#endif

--- a/zlib-ng.map
+++ b/zlib-ng.map
@@ -66,7 +66,6 @@ ZLIB_NG_2.0.0 {
     zng_zcfree;
     zng_z_errmsg;
     zng_gz_error;
-    zng_gz_intmax;
     _*;
 };
 

--- a/zlib.map
+++ b/zlib.map
@@ -15,7 +15,6 @@ ZLIB_1.2.0 {
     zcfree;
     z_errmsg;
     gz_error;
-    gz_intmax;
     _*;
 };
 

--- a/zlib_name_mangling-ng.h.in
+++ b/zlib_name_mangling-ng.h.in
@@ -48,7 +48,6 @@
 #define zng_get_crc_table         @ZLIB_SYMBOL_PREFIX@zng_get_crc_table
 #ifndef Z_SOLO
 #  define zng_gz_error              @ZLIB_SYMBOL_PREFIX@zng_gz_error
-#  define zng_gz_intmax             @ZLIB_SYMBOL_PREFIX@zng_gz_intmax
 #  define zng_gz_strwinerror        @ZLIB_SYMBOL_PREFIX@zng_gz_strwinerror
 #  define zng_gzbuffer              @ZLIB_SYMBOL_PREFIX@zng_gzbuffer
 #  define zng_gzclearerr            @ZLIB_SYMBOL_PREFIX@zng_gzclearerr

--- a/zlib_name_mangling.h.in
+++ b/zlib_name_mangling.h.in
@@ -48,7 +48,6 @@
 #define get_crc_table         @ZLIB_SYMBOL_PREFIX@get_crc_table
 #ifndef Z_SOLO
 #  define gz_error              @ZLIB_SYMBOL_PREFIX@gz_error
-#  define gz_intmax             @ZLIB_SYMBOL_PREFIX@gz_intmax
 #  define gz_strwinerror        @ZLIB_SYMBOL_PREFIX@gz_strwinerror
 #  define gzbuffer              @ZLIB_SYMBOL_PREFIX@gzbuffer
 #  define gzclearerr            @ZLIB_SYMBOL_PREFIX@gzclearerr


### PR DESCRIPTION
Remove gz_intmax implementation, since INT_MAX is always available in modern C implementations.