### PR TITLE
Fix deflateBound and compressBound returning very small size estimates.

### DIFF
--- a/compress.c
+++ b/compress.c
@@ -91,10 +91,11 @@ z_size_t Z_EXPORT PREFIX(compressBound)(z_size_t sourceLen) {
         return complen + ZLIB_WRAPLEN;
 
 #ifndef NO_QUICK_STRATEGY
-    /* Quick deflate strategy worse case is 9 bits per literal, rounded to nearest byte,
-       plus the size of block & gzip headers and footers */
-    return sourceLen + ((sourceLen + 13 + 7) >> 3) + 18;
+    return sourceLen                       /* The source size itself */
+      + DEFLATE_QUICK_OVERHEAD(sourceLen)  /* Source encoding overhead, padded to next full byte */
+      + DEFLATE_BLOCK_OVERHEAD             /* Deflate block overhead bytes */
+      + ZLIB_WRAPLEN;                      /* zlib wrapper */
 #else
-    return sourceLen + (sourceLen >> 12) + (sourceLen >> 14) + (sourceLen >> 25) + 13;
+    return sourceLen + (sourceLen >> 4) + 7 + ZLIB_WRAPLEN;
 #endif
 }

--- a/deflate.c
+++ b/deflate.c
@@ -611,11 +611,11 @@ unsigned long Z_EXPORT PREFIX(deflateBound)(PREFIX3(stream) *strm, unsigned long
         wraplen = 0;
         break;
     case 1:                                 /* zlib wrapper */
-        wraplen = 6 + (s->strstart ? 4 : 0);
+        wraplen = ZLIB_WRAPLEN + (s->strstart ? 4 : 0);
         break;
 #ifdef GZIP
     case 2:                                 /* gzip wrapper */
-        wraplen = 18;
+        wraplen = GZIP_WRAPLEN;
         if (s->gzhead != NULL) {            /* user-supplied gzip header */
             unsigned char *str;
             if (s->gzhead->extra != NULL) {
@@ -639,7 +639,7 @@ unsigned long Z_EXPORT PREFIX(deflateBound)(PREFIX3(stream) *strm, unsigned long
         break;
 #endif
     default:                                /* for compiler happiness */
-        wraplen = 6;
+        wraplen = ZLIB_WRAPLEN;
     }
 
     /* if not default parameters, return conservative bound */
@@ -647,8 +647,14 @@ unsigned long Z_EXPORT PREFIX(deflateBound)(PREFIX3(stream) *strm, unsigned long
             s->w_bits != 15 || HASH_BITS < 15)
         return complen + wraplen;
 
-    /* default settings: return tight bound for that case */
-    return sourceLen + (sourceLen >> 12) + (sourceLen >> 14) + (sourceLen >> 25) + 13 - 6 + wraplen;
+#ifndef NO_QUICK_STRATEGY
+    return sourceLen                       /* The source size itself */
+      + DEFLATE_QUICK_OVERHEAD(sourceLen)  /* Source encoding overhead, padded to next full byte */
+      + DEFLATE_BLOCK_OVERHEAD             /* Deflate block overhead bytes */
+      + wraplen;                           /* none, zlib or gzip wrapper */
+#else
+    return sourceLen + (sourceLen >> 4) + 7 + wraplen;
+#endif
 }
 
 /* =========================================================================

--- a/test/switchlevels.c
+++ b/test/switchlevels.c
@@ -68,7 +68,7 @@ static int compress_chunk(PREFIX3(stream) *strm, int level, int size, int last) 
         goto done;
     }
 
-    compsize = 100 + 2 * PREFIX(deflateBound)(strm, size);
+    compsize = PREFIX(deflateBound)(strm, size);
     buf = malloc(size + compsize);
     if (buf == NULL) {
         fprintf(stderr, "Out of memory\n");

--- a/zutil.h
+++ b/zutil.h
@@ -78,7 +78,19 @@ extern z_const char * const PREFIX(z_errmsg)[10]; /* indexed by 2-zlib_error */
 #define ADLER32_INITIAL_VALUE 1 /* initial adler-32 hash value */
 #define CRC32_INITIAL_VALUE   0 /* initial crc-32 hash value */
 
-#define ZLIB_WRAPLEN 6 /* zlib format overhead */
+#define ZLIB_WRAPLEN 6      /* zlib format overhead */
+#define GZIP_WRAPLEN 18     /* gzip format overhead */
+
+#define DEFLATE_HEADER_BITS 3
+#define DEFLATE_EOBS_BITS   15
+#define DEFLATE_PAD_BITS    6
+#define DEFLATE_BLOCK_OVERHEAD ((DEFLATE_HEADER_BITS + DEFLATE_EOBS_BITS + DEFLATE_PAD_BITS) >> 3)
+/* deflate block overhead: 3 bits for block start + 15 bits for block end + padding to nearest byte */
+
+#define DEFLATE_QUICK_LIT_MAX_BITS 9
+#define DEFLATE_QUICK_OVERHEAD(x) ((x * (DEFLATE_QUICK_LIT_MAX_BITS - 8) + 7) >> 3)
+/* deflate_quick worst-case overhead: 9 bits per literal, round up to next byte (+7) */
+
 
         /* target dependencies */
 


### PR DESCRIPTION
Fixes deflateBound and compressBound returning very small size estimates.
Remove workaround in switchlevels.c, so we do actual testing of this.

I also made a few of the magic numbers more understandable by using defines,
I would have liked to do so with the rest too.

##
I reasoned that the `+ 13` comes from compressBound, and thus includes zlib header size (6 bytes).
That seems to be the reason why it was `+13 - 6` in deflateBound, since we do not always want to use the zlib header type there.
The remaining 7 bytes I am unsure about, raw deflate block headers? I was unable to find any documentation saying more than 2-3 bytes for that though, so I left that as a 7.

Also not sure why the `((sourceLen + 13 + 7) >> 3)` is used for deflate_quick, it kind of looks like those additions should have been outside of the bitshifting, but without any comments those are just magic numbers. They also fail to add enough when the buffer size is 1 byte for example, thus the reason for adding the `+1`.

##
With these changes, the buffer size ends up being a lot bigger, but several of the changes we have made have affected the worst case compressed size. Deflate_quick is a big one for example, possibly we could investigate why level 1 becomes bigger than level 0 for random data, but I suspect it has to do with skipping extra checks for raw speed.
Also since hash_bits is now a define and not set depending on wsize, the check on hash_bits no longer checks wsize, and thus we need to be more pessimistic. (unless we add window_bits to the state struct so we can verify that is actually 15)

I also considered using the DFLTCC calculation, but that thing is calculating around 2x the size of the input buffer. Is that a mistake, or does the hardware compression worst case actually become that big? @iii-i 

Resolves the problem reported in #1039