### PR TITLE
deflate_medium: avoid emitting a suboptimal literal in the restart case

### DIFF
--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -203,6 +203,9 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
                 hash_head = functable.quick_insert_string(s, s->strstart);
             }
 
+            if (hash_head && hash_head == s->strstart)
+                hash_head--;
+
             current_match.strstart = (uint16_t)s->strstart;
             current_match.orgstart = current_match.strstart;
 
@@ -237,6 +240,9 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
         if (LIKELY(!early_exit && s->lookahead > MIN_LOOKAHEAD && (uint32_t)(current_match.strstart + current_match.match_length) < (s->window_size - MIN_LOOKAHEAD))) {
             s->strstart = current_match.strstart + current_match.match_length;
             hash_head = functable.quick_insert_string(s, s->strstart);
+
+            if (hash_head && hash_head == s->strstart)
+                hash_head--;
 
             next_match.strstart = (uint16_t)s->strstart;
             next_match.orgstart = next_match.strstart;


### PR DESCRIPTION
Import external patch to deflate_medium, improving compression very slightly:
##

deflate_medium: avoid emitting a suboptimal literal in the restart case
When we load new data into the window, we invalidate the next match, in
case the match would improve. In this case, the hash has already been
updated with this data, so when we look for a new match it will point
it back at itself. As a result, a literal is generated even when a
better match is available.

This avoids that by catching this case and ensuring we're looking at the
past.