### PR TITLE
Fixed crc32_combine_gen declaration warning in zlib-ng API.

### DIFF
--- a/crc32_comb.c
+++ b/crc32_comb.c
@@ -18,7 +18,7 @@
 
 /* Local functions for crc concatenation */
 static uint32_t crc32_combine_(uint32_t crc1, uint32_t crc2, z_off64_t len2);
-static void crc32_combine_gen_(uint32_t *op, z_off64_t len2);
+static void crc32_combine_gen_(uint32_t op[GF2_DIM], z_off64_t len2);
 
 /* ========================================================================= */
 static uint32_t crc32_combine_(uint32_t crc1, uint32_t crc2, z_off64_t len2) {
@@ -49,7 +49,7 @@ uint32_t Z_EXPORT PREFIX4(crc32_combine)(uint32_t crc1, uint32_t crc2, z_off64_t
 
 /* ========================================================================= */
 
-static void crc32_combine_gen_(uint32_t *op, z_off64_t len2) {
+static void crc32_combine_gen_(uint32_t op[GF2_DIM], z_off64_t len2) {
     uint32_t row;
     int j;
     unsigned i;
@@ -96,11 +96,14 @@ static void crc32_combine_gen_(uint32_t *op, z_off64_t len2) {
 void Z_EXPORT PREFIX(crc32_combine_gen)(uint32_t *op, z_off_t len2) {
     crc32_combine_gen_(op, len2);
 }
-#endif
-
 void Z_EXPORT PREFIX4(crc32_combine_gen)(uint32_t *op, z_off64_t len2) {
     crc32_combine_gen_(op, len2);
 }
+#else
+void Z_EXPORT PREFIX4(crc32_combine_gen)(uint32_t op[GF2_DIM], z_off64_t len2) {
+    crc32_combine_gen_(op, len2);
+}
+#endif
 
 /* ========================================================================= */
 uint32_t Z_EXPORT PREFIX(crc32_combine_op)(uint32_t crc1, uint32_t crc2, const uint32_t *op) {


### PR DESCRIPTION
See #1077.