### PR TITLE
Fix compilation with clang-cl on windows

### DIFF
--- a/zlib-ng.h.in
+++ b/zlib-ng.h.in
@@ -33,6 +33,7 @@
 #  error Include zlib-ng.h for zlib-ng API or zlib.h for zlib-compat API but not both
 #endif
 
+#ifndef RC_INVOKED
 #include "zconf-ng.h"
 
 #include <stdint.h>
@@ -40,6 +41,7 @@
 #ifndef ZCONFNG_H
 #  error Missing zconf-ng.h add binary output directory to include directories
 #endif
+#endif  /* RC_INVOKED */
 
 #ifdef __cplusplus
 extern "C" {

--- a/zlib.h.in
+++ b/zlib.h.in
@@ -34,6 +34,7 @@
 #  error Include zlib-ng.h for zlib-ng API or zlib.h for zlib-compat API but not both
 #endif
 
+#ifndef RC_INVOKED
 #include "zconf.h"
 
 #include <stdint.h>
@@ -42,6 +43,7 @@
 #ifndef ZCONF_H
 #  error Missing zconf.h add binary output directory to include directories
 #endif
+#endif  /* RC_INVOKED */
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
When compiling with Visual Studio using `clang-cl` compiler the resource-compiler of MSVC will still be used. However, it trips over some clang-specific things in the C standard headers of `libc++` which come with `clang-cl`.

With the changes introduced in this PR the resource-compiler will no longer see these problematic headers etc.