### PR TITLE
Fixed warnings when compiling for ClangCl

### DIFF
--- a/arch/x86/crc32_fold_pclmulqdq.c
+++ b/arch/x86/crc32_fold_pclmulqdq.c
@@ -22,6 +22,7 @@
 #include <stdint.h>
 #include <immintrin.h>
 #include <wmmintrin.h>
+#include <smmintrin.h> // _mm_extract_epi32
 
 #include "../../crc32_fold.h"
 

--- a/cmake/detect-intrinsics.cmake
+++ b/cmake/detect-intrinsics.cmake
@@ -221,7 +221,7 @@ macro(check_sse4_intrinsics)
         endif()
     elseif(CMAKE_C_COMPILER_ID MATCHES "GNU" OR CMAKE_C_COMPILER_ID MATCHES "Clang")
         if(NOT NATIVEFLAG)
-            set(SSE4FLAG "-msse4")
+            set(SSE4FLAG "-msse4.2")
         endif()
     endif()
     # Check whether compiler supports SSE4 CRC inline asm

--- a/zlib-ng.h.in
+++ b/zlib-ng.h.in
@@ -33,8 +33,9 @@
 #  error Include zlib-ng.h for zlib-ng API or zlib.h for zlib-compat API but not both
 #endif
 
-#include <stdint.h>
 #include "zconf-ng.h"
+
+#include <stdint.h>
 
 #ifndef ZCONFNG_H
 #  error Missing zconf-ng.h add binary output directory to include directories

--- a/zlib.h.in
+++ b/zlib.h.in
@@ -34,9 +34,10 @@
 #  error Include zlib-ng.h for zlib-ng API or zlib.h for zlib-compat API but not both
 #endif
 
+#include "zconf.h"
+
 #include <stdint.h>
 #include <stdarg.h>
-#include "zconf.h"
 
 #ifndef ZCONF_H
 #  error Missing zconf.h add binary output directory to include directories

--- a/zutil.h
+++ b/zutil.h
@@ -253,12 +253,10 @@ void Z_INTERNAL   zng_cfree(void *opaque, void *ptr);
 #  define PREFETCH_RW(addr)     addr
 #endif /* (un)likely */
 
-#if defined(_MSC_VER)
+#if defined(__clang__) || defined(__GNUC__)
+#  define ALIGNED_(x) __attribute__ ((aligned(x)))
+#elif defined(_MSC_VER)
 #  define ALIGNED_(x) __declspec(align(x))
-#else
-#  if defined(__GNUC__)
-#    define ALIGNED_(x) __attribute__ ((aligned(x)))
-#  endif
 #endif
 
 #if defined(X86_FEATURES)


### PR DESCRIPTION
Similar to #1082 but covers issues mentioned in the log.