### PR TITLE
Fixed duplicate symbols in infcover when not building shared libs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1158,7 +1158,9 @@ if(ZLIB_ENABLE_TESTS)
     target_link_libraries(switchlevels zlib)
 
     add_simple_test_executable(infcover)
-    target_sources(infcover PRIVATE inftrees.c)
+    if(NOT BUILD_SHARED_LIBS)
+        target_sources(infcover PRIVATE inftrees.c)
+    endif()
 
     add_executable(makefixed tools/makefixed.c inftrees.c)
     target_include_directories(makefixed PUBLIC


### PR DESCRIPTION
CMake commands to reproduce:
```
cmake .. -DBUILD_SHARED_LIBS=OFF -T ClangCl -A Win32
cmake --build . --verbose --config Debug
```
Error output:
```
lld-link : error : duplicate symbol: _zng_inflate_table [C:\Users\Nathan\Source\zlib-ng\build-cl\infcover.vcxproj]
  >>> defined at C:\Users\Nathan\Source\zlib-ng\inftrees.c:33
  >>>            infcover.dir\Debug\inftrees.obj
  >>> defined at zlibstatic-ngd.lib(inftrees.obj)

lld-link : error : duplicate symbol: _zng_inflate_copyright [C:\Users\Nathan\Source\zlib-ng\build-cl\infcover.vcxproj
]
  >>> defined at infcover.dir\Debug\inftrees.obj
  >>> defined at zlibstatic-ngd.lib(inftrees.obj)
```