### PR TITLE
Don't build DLL sources if BUILD_SHARED_LIBS=OFF.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -920,43 +920,45 @@ set(ZLIB_GZFILE_SRCS
     gzwrite.c
 )
 
-if(NOT MINGW AND NOT MSYS AND NOT CYGWIN)
-    set(ZLIB_DLL_SRCS
-        win32/zlib${SUFFIX}1.rc # If present will override custom build rule below.
-    )
-endif()
-
-if(MINGW OR MSYS OR CYGWIN)
-    # This gets us DLL resource information when compiling on MinGW.
-    if(NOT CMAKE_RC_COMPILER)
-        set(CMAKE_RC_COMPILER windres.exe)
-    endif()
-
-    add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj
-        COMMAND ${CMAKE_RC_COMPILER}
-            -D GCC_WINDRES
-            -I ${CMAKE_CURRENT_SOURCE_DIR}
-            -I ${CMAKE_CURRENT_BINARY_DIR}
-            -o ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj
-            -i ${CMAKE_CURRENT_SOURCE_DIR}/win32/zlib${SUFFIX}1.rc)
-    set(ZLIB_DLL_SRCS ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj)
-endif()
-
-set(ZLIB_ALL_SRCS ${ZLIB_SRCS} ${ZLIB_ARCH_HDRS} ${ZLIB_ARCH_SRCS} ${ZLIB_DLL_SRCS}
-    ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
+set(ZLIB_ALL_SRCS ${ZLIB_SRCS} ${ZLIB_ARCH_HDRS} ${ZLIB_ARCH_SRCS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
 if(WITH_GZFILEOP)
     list(APPEND ZLIB_ALL_SRCS ${ZLIB_GZFILE_PRIVATE_HDRS} ${ZLIB_GZFILE_SRCS})
 endif()
 
+if(NOT DEFINED BUILD_SHARED_LIBS OR BUILD_SHARED_LIBS)
+    if(NOT MINGW AND NOT MSYS AND NOT CYGWIN)
+        # If present will override custom build rule below.
+        set(ZLIB_DLL_SRCS win32/zlib${SUFFIX}1.rc)
+    endif()
+
+    if(MINGW OR MSYS OR CYGWIN)
+        # This gets us DLL resource information when compiling on MinGW.
+        if(NOT CMAKE_RC_COMPILER)
+            set(CMAKE_RC_COMPILER windres.exe)
+        endif()
+
+        add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj
+            COMMAND ${CMAKE_RC_COMPILER}
+                -D GCC_WINDRES
+                -I ${CMAKE_CURRENT_SOURCE_DIR}
+                -I ${CMAKE_CURRENT_BINARY_DIR}
+                -o ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj
+                -i ${CMAKE_CURRENT_SOURCE_DIR}/win32/zlib${SUFFIX}1.rc)
+        set(ZLIB_DLL_SRCS ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj)
+    endif()
+endif()
+
 if(NOT DEFINED BUILD_SHARED_LIBS)
-    add_library(zlib SHARED ${ZLIB_ALL_SRCS})
+    add_library(zlib SHARED ${ZLIB_ALL_SRCS} ${ZLIB_DLL_SRCS})
     add_library(zlibstatic STATIC ${ZLIB_ALL_SRCS})
 
     set(ZLIB_INSTALL_LIBRARIES zlib zlibstatic)
 else()
     add_library(zlib ${ZLIB_ALL_SRCS})
 
-    if(NOT BUILD_SHARED_LIBS)
+    if(BUILD_SHARED_LIBS)
+        target_sources(zlib PRIVATE ${ZLIB_DLL_SRCS})
+    else()
         add_library(zlibstatic ALIAS zlib)
     endif()
 


### PR DESCRIPTION
In this commit, we only add `ZLIB_DLL_SRCS` if `BUILD_SHARED_LIBS=ON` or not defined.