### PR TITLE
Fixed crc32 assembly not returning hash value to correct variable.

### DIFF
--- a/arch/x86/insert_string_sse.c
+++ b/arch/x86/insert_string_sse.c
@@ -26,7 +26,7 @@
         __asm mov edx, h\
         __asm mov eax, val\
         __asm crc32 eax, edx\
-        __asm mov val, eax\
+        __asm mov h, eax\
     }
 #  else
 #    define HASH_CALC(s, h, val) \

--- a/cmake/detect-intrinsics.cmake
+++ b/cmake/detect-intrinsics.cmake
@@ -230,7 +230,7 @@ macro(check_sse4_intrinsics)
         "int main(void) {
             unsigned val = 0, h = 0;
         #if defined(_MSC_VER)
-            { __asm mov edx, h __asm mov eax, val __asm crc32 eax, edx __asm mov val, eax }
+            { __asm mov edx, h __asm mov eax, val __asm crc32 eax, edx __asm mov h, eax }
         #else
             __asm__ __volatile__ ( \"crc32 %1,%0\" : \"+r\" (h) : \"r\" (val) );
         #endif


### PR DESCRIPTION
Discovered while benchmarking #1086.