### PR TITLE
Don't assign C versions of functions if we don't use them.

### DIFF
--- a/functable.c
+++ b/functable.c
@@ -315,31 +315,31 @@ Z_INTERNAL uint32_t adler32_stub(uint32_t adler, const unsigned char *buf, size_
 }
 
 Z_INTERNAL uint32_t crc32_fold_reset_stub(crc32_fold *crc) {
-    functable.crc32_fold_reset = crc32_fold_reset_c;
+    functable.crc32_fold_reset = &crc32_fold_reset_c;
     cpu_check_features();
 #ifdef X86_PCLMULQDQ_CRC
     if (x86_cpu_has_pclmulqdq)
-        functable.crc32_fold_reset = crc32_fold_reset_pclmulqdq;
+        functable.crc32_fold_reset = &crc32_fold_reset_pclmulqdq;
 #endif
     return functable.crc32_fold_reset(crc);
 }
 
 Z_INTERNAL void crc32_fold_copy_stub(crc32_fold *crc, uint8_t *dst, const uint8_t *src, size_t len) {
-    functable.crc32_fold_copy = crc32_fold_copy_c;
+    functable.crc32_fold_copy = &crc32_fold_copy_c;
     cpu_check_features();
 #ifdef X86_PCLMULQDQ_CRC
     if (x86_cpu_has_pclmulqdq)
-        functable.crc32_fold_copy = crc32_fold_copy_pclmulqdq;
+        functable.crc32_fold_copy = &crc32_fold_copy_pclmulqdq;
 #endif
     functable.crc32_fold_copy(crc, dst, src, len);
 }
 
 Z_INTERNAL uint32_t crc32_fold_final_stub(crc32_fold *crc) {
-    functable.crc32_fold_final = crc32_fold_final_c;
+    functable.crc32_fold_final = &crc32_fold_final_c;
     cpu_check_features();
 #ifdef X86_PCLMULQDQ_CRC
     if (x86_cpu_has_pclmulqdq)
-        functable.crc32_fold_final = crc32_fold_final_pclmulqdq;
+        functable.crc32_fold_final = &crc32_fold_final_pclmulqdq;
 #endif
     return functable.crc32_fold_final(crc);
 }
@@ -507,22 +507,22 @@ Z_INTERNAL uint32_t crc32_stub(uint32_t crc, const unsigned char *buf, uint64_t 
            "crc32_z takes size_t but internally we have a uint64_t len");
 
 #if BYTE_ORDER == LITTLE_ENDIAN
-    functable.crc32 = crc32_little;
+    functable.crc32 = &crc32_little;
 #elif BYTE_ORDER == BIG_ENDIAN
-    functable.crc32 = crc32_big;
+    functable.crc32 = &crc32_big;
 #else
     functable.crc32 = &crc32_generic;
 #endif
     cpu_check_features();
 #ifdef ARM_ACLE_CRC_HASH
     if (arm_cpu_has_crc32)
-        functable.crc32 = crc32_acle;
+        functable.crc32 = &crc32_acle;
 #elif defined(POWER8_VSX_CRC32)
     if (power_cpu_has_arch_2_07)
-        functable.crc32 = crc32_power8;
+        functable.crc32 = &crc32_power8;
 #elif defined(S390_CRC32_VX)
     if (s390_cpu_has_vx)
-        functable.crc32 = s390_crc32_vx;
+        functable.crc32 = &s390_crc32_vx;
 #endif
 
     return functable.crc32(crc, buf, len);

--- a/functable.c
+++ b/functable.c
@@ -508,31 +508,28 @@ Z_INTERNAL uint32_t crc32_stub(uint32_t crc, const unsigned char *buf, uint64_t 
 
     Assert(sizeof(uint64_t) >= sizeof(size_t),
            "crc32_z takes size_t but internally we have a uint64_t len");
-    /* return a function pointer for optimized arches here after a capability test */
-
-    functable.crc32 = &crc32_generic;
-    cpu_check_features();
 
     if (use_byfour) {
 #if BYTE_ORDER == LITTLE_ENDIAN
         functable.crc32 = crc32_little;
-#  if defined(ARM_ACLE_CRC_HASH)
-        if (arm_cpu_has_crc32)
-            functable.crc32 = crc32_acle;
-#  endif
 #elif BYTE_ORDER == BIG_ENDIAN
         functable.crc32 = crc32_big;
-#  if defined(S390_CRC32_VX)
-        if (s390_cpu_has_vx)
-            functable.crc32 = s390_crc32_vx;
-#  endif
 #else
 #  error No endian defined
 #endif
+    } else {
+        functable.crc32 = &crc32_generic;
     }
-#if defined(POWER8_VSX_CRC32)
+    cpu_check_features();
+#ifdef ARM_ACLE_CRC_HASH
+    if (arm_cpu_has_crc32)
+        functable.crc32 = crc32_acle;
+#elif defined(POWER8_VSX_CRC32)
     if (power_cpu_has_arch_2_07)
         functable.crc32 = crc32_power8;
+#elif defined(S390_CRC32_VX)
+    if (s390_cpu_has_vx)
+        functable.crc32 = s390_crc32_vx;
 #endif
 
     return functable.crc32(crc, buf, len);

--- a/functable.c
+++ b/functable.c
@@ -504,22 +504,16 @@ Z_INTERNAL uint8_t* chunkmemset_safe_stub(uint8_t *out, unsigned dist, unsigned 
 }
 
 Z_INTERNAL uint32_t crc32_stub(uint32_t crc, const unsigned char *buf, uint64_t len) {
-    int32_t use_byfour = sizeof(void *) == sizeof(ptrdiff_t);
-
     Assert(sizeof(uint64_t) >= sizeof(size_t),
            "crc32_z takes size_t but internally we have a uint64_t len");
 
-    if (use_byfour) {
 #if BYTE_ORDER == LITTLE_ENDIAN
-        functable.crc32 = crc32_little;
+    functable.crc32 = crc32_little;
 #elif BYTE_ORDER == BIG_ENDIAN
-        functable.crc32 = crc32_big;
+    functable.crc32 = crc32_big;
 #else
-#  error No endian defined
+    functable.crc32 = &crc32_generic;
 #endif
-    } else {
-        functable.crc32 = &crc32_generic;
-    }
     cpu_check_features();
 #ifdef ARM_ACLE_CRC_HASH
     if (arm_cpu_has_crc32)

--- a/functable.c
+++ b/functable.c
@@ -540,8 +540,6 @@ Z_INTERNAL uint32_t crc32_stub(uint32_t crc, const unsigned char *buf, uint64_t 
 
 Z_INTERNAL uint32_t compare258_stub(const unsigned char *src0, const unsigned char *src1) {
 
-    functable.compare258 = &compare258_c;
-
 #ifdef UNALIGNED_OK
 #  if defined(UNALIGNED64_OK) && defined(HAVE_BUILTIN_CTZLL)
     functable.compare258 = &compare258_unaligned_64;
@@ -558,14 +556,14 @@ Z_INTERNAL uint32_t compare258_stub(const unsigned char *src0, const unsigned ch
     if (x86_cpu_has_avx2)
         functable.compare258 = &compare258_unaligned_avx2;
 #  endif
+#else
+    functable.compare258 = &compare258_c;
 #endif
 
     return functable.compare258(src0, src1);
 }
 
 Z_INTERNAL uint32_t longest_match_stub(deflate_state *const s, Pos cur_match) {
-
-    functable.longest_match = &longest_match_c;
 
 #ifdef UNALIGNED_OK
 #  if defined(UNALIGNED64_OK) && defined(HAVE_BUILTIN_CTZLL)
@@ -583,14 +581,14 @@ Z_INTERNAL uint32_t longest_match_stub(deflate_state *const s, Pos cur_match) {
     if (x86_cpu_has_avx2)
         functable.longest_match = &longest_match_unaligned_avx2;
 #  endif
+#else
+    functable.longest_match = &longest_match_c;
 #endif
 
     return functable.longest_match(s, cur_match);
 }
 
 Z_INTERNAL uint32_t longest_match_slow_stub(deflate_state *const s, Pos cur_match) {
-
-    functable.longest_match_slow = &longest_match_slow_c;
 
 #ifdef UNALIGNED_OK
 #  if defined(UNALIGNED64_OK) && defined(HAVE_BUILTIN_CTZLL)
@@ -608,6 +606,8 @@ Z_INTERNAL uint32_t longest_match_slow_stub(deflate_state *const s, Pos cur_matc
     if (x86_cpu_has_avx2)
         functable.longest_match_slow = &longest_match_slow_unaligned_avx2;
 #  endif
+#else
+    functable.longest_match_slow = &longest_match_slow_c;
 #endif
 
     return functable.longest_match_slow(s, cur_match);

--- a/functable.c
+++ b/functable.c
@@ -131,8 +131,7 @@ Z_INTERNAL uint32_t crc32_generic(uint32_t, const unsigned char *, uint64_t);
 extern uint32_t crc32_acle(uint32_t, const unsigned char *, uint64_t);
 #elif defined(POWER8_VSX_CRC32)
 extern uint32_t crc32_power8(uint32_t, const unsigned char *, uint64_t);
-#endif
-#ifdef S390_CRC32_VX
+#elif defined(S390_CRC32_VX)
 extern uint32_t s390_crc32_vx(uint32_t, const unsigned char *, uint64_t);
 #endif
 


### PR DESCRIPTION
These two commits save an extra 236 bytes on MSVC. First commit saves 168, second one saves 68.