### PR TITLE
Fixed crc32_fold alignment when deflate and inflate structures are not aligned.

### DIFF
--- a/test/test_aligned_alloc.cc
+++ b/test/test_aligned_alloc.cc
@@ -1,0 +1,44 @@
+/* test_aligned_alloc.cc - Test zng_calloc_aligned and zng_cfree_aligned */
+
+#include <stdlib.h>
+#include <errno.h>
+#include <stdio.h>
+
+extern "C" {
+#  include "zbuild.h"
+#  include "zutil.h"
+}
+
+#include <gtest/gtest.h>
+
+void *zng_calloc_unaligned(void *opaque, unsigned items, unsigned size) {
+    uint8_t *pointer = (uint8_t *)calloc(1, (items * size) + 2);
+    if (pointer == NULL)
+        return pointer;
+    /* Store whether or not our allocation is aligned */
+    *pointer = ((uint64_t)(intptr_t)pointer + 1) % 2 == 0;
+    pointer++;
+    if (*pointer) {
+        /* Return pointer that is off by one */
+        pointer++;
+    }
+    return (void *)pointer;
+}
+
+void zng_cfree_unaligned(void *opaque, void *ptr) {
+    uint8_t *pointer = (uint8_t *)ptr;
+    pointer--;
+    /* Get whether or not our original memory pointer was aligned */
+    if (*pointer) {
+        /* Return original aligned pointer to free() */
+        pointer--;
+    }
+    free(pointer);
+}
+
+TEST(zalloc, aligned_64) {
+    void *return_ptr = zng_calloc_aligned(zng_calloc_unaligned, 0, 1, 100, 64);
+    ASSERT_TRUE(return_ptr != NULL);
+    EXPECT_EQ((intptr_t)return_ptr % 64, 0);
+    zng_cfree_aligned(zng_cfree_unaligned, 0, return_ptr);
+}

--- a/zutil.c
+++ b/zutil.c
@@ -117,6 +117,10 @@ void Z_INTERNAL *zng_calloc_aligned(zng_calloc_func zalloc, void *opaque, unsign
     int32_t alloc_size, align_diff;
     void *ptr;
 
+    /* If no custom calloc function used then call zlib-ng's aligned calloc */
+    if (zalloc == zng_calloc)
+        return zng_calloc(opaque, items, size);
+
     /* Allocate enough memory for proper alignment and to store the original memory pointer */
     alloc_size = sizeof(void *) + (items * size) + align;
     ptr = zalloc(opaque, 1, alloc_size);
@@ -138,6 +142,11 @@ void Z_INTERNAL *zng_calloc_aligned(zng_calloc_func zalloc, void *opaque, unsign
 }
 
 void Z_INTERNAL zng_cfree_aligned(zng_cfree_func zfree, void *opaque, void *ptr) {
+    /* If no custom cfree function used then call zlib-ng's aligned cfree */
+    if (zfree == zng_cfree) {
+        zng_cfree(opaque, ptr);
+        return;
+    }
     if (!ptr)
         return;
 

--- a/zutil.h
+++ b/zutil.h
@@ -125,8 +125,15 @@ extern z_const char * const PREFIX(z_errmsg)[10]; /* indexed by 2-zlib_error */
 void Z_INTERNAL *zng_calloc(void *opaque, unsigned items, unsigned size);
 void Z_INTERNAL   zng_cfree(void *opaque, void *ptr);
 
-#define ZALLOC(strm, items, size) (*((strm)->zalloc))((strm)->opaque, (items), (size))
-#define ZFREE(strm, addr)         (*((strm)->zfree))((strm)->opaque, (void *)(addr))
+typedef void *zng_calloc_func(void *opaque, unsigned items, unsigned size);
+typedef void  zng_cfree_func(void *opaque, void *ptr);
+
+void Z_INTERNAL *zng_calloc_aligned(zng_calloc_func zalloc, void *opaque, unsigned items, unsigned size, unsigned align);
+void Z_INTERNAL  zng_cfree_aligned(zng_cfree_func zfree, void *opaque, void *ptr);
+
+#define ZALLOC(strm, items, size) zng_calloc_aligned((strm)->zalloc, (strm)->opaque, (items), (size), 64)
+#define ZFREE(strm, addr)         zng_cfree_aligned((strm)->zfree, (strm)->opaque, (void *)(addr))
+
 #define TRY_FREE(s, p)            {if (p) ZFREE(s, p);}
 
 #endif /* ZUTIL_H_ */


### PR DESCRIPTION
See #1088.

It is possible for an implementation to use their own custom allocators which don't allocate memory on alignment we are expecting. In this case, crc32_fold does not get aligned on 16-byte boundary. This fixes the problem by assigning `fold` to `buffer` on 16-byte alignment.