### PR TITLE
build: fix check for SSSE3 compiler support when using Emscripten

### DIFF
--- a/configure
+++ b/configure
@@ -1315,7 +1315,7 @@ EOF
 check_ssse3_intrinsics() {
     # Check whether compiler supports SSSE3 intrinsics
     cat > $test.c << EOF
-#include <x86intrin.h>
+#include <immintrin.h>
 int main(void)
 {
     __m128i u, v, w;


### PR DESCRIPTION
The check for SSSE3 compiler support in `configure` includes the `x86intrin.h` header instead of `immintrin.h` which makes the check return false when using Emscripten, it also deviates from the check in https://github.com/zlib-ng/zlib-ng/blob/5ef8e3b979065c04b863b71065323c2635cdbf02/cmake/detect-intrinsics.cmake#L281-L294
