### PR TITLE
Change compare258 to compare256

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -719,8 +719,8 @@ if(WITH_OPTIM)
                 add_feature_info(AVX2_SLIDEHASH 1 "Support AVX2 optimized slide_hash, using \"${AVX2FLAG}\"")
                 list(APPEND AVX2_SRCS ${ARCHDIR}/chunkset_avx.c)
                 add_feature_info(AVX_CHUNKSET 1 "Support AVX optimized chunkset, using \"${AVX2FLAG}\"")
-                list(APPEND AVX2_SRCS ${ARCHDIR}/compare258_avx2.c)
-                add_feature_info(AVX2_COMPARE258 1 "Support AVX2 optimized compare258, using \"${AVX2FLAG}\"")
+                list(APPEND AVX2_SRCS ${ARCHDIR}/compare256_avx2.c)
+                add_feature_info(AVX2_COMPARE256 1 "Support AVX2 optimized compare256, using \"${AVX2FLAG}\"")
                 list(APPEND AVX2_SRCS ${ARCHDIR}/adler32_avx2.c)
                 add_feature_info(AVX2_ADLER32 1 "Support AVX2-accelerated adler32, using \"${AVX2FLAG}\"")
                 list(APPEND ZLIB_ARCH_SRCS ${AVX2_SRCS})
@@ -782,8 +782,8 @@ if(WITH_OPTIM)
             endif()
             if(HAVE_SSE42CMPSTR_INTRIN)
                 add_definitions(-DX86_SSE42_CMP_STR)
-                set(SSE42_SRCS ${ARCHDIR}/compare258_sse42.c)
-                add_feature_info(SSE42_COMPARE258 1 "Support SSE4.2 optimized compare258, using \"${SSE42FLAG}\"")
+                set(SSE42_SRCS ${ARCHDIR}/compare256_sse42.c)
+                add_feature_info(SSE42_COMPARE256 1 "Support SSE4.2 optimized compare256, using \"${SSE42FLAG}\"")
                 list(APPEND ZLIB_ARCH_SRCS ${SSE42_SRCS})
                 set_property(SOURCE ${SSE42_SRCS} PROPERTY COMPILE_FLAGS "${SSE42FLAG} ${NOLTOFLAG}")
             endif()
@@ -946,7 +946,7 @@ set(ZLIB_PRIVATE_HDRS
 set(ZLIB_SRCS
     adler32.c
     chunkset.c
-    compare258.c
+    compare256.c
     compress.c
     crc32.c
     crc32_comb.c

--- a/Makefile.in
+++ b/Makefile.in
@@ -76,7 +76,7 @@ pkgconfigdir = ${libdir}/pkgconfig
 OBJZ = \
 	adler32.o \
 	chunkset.o \
-	compare258.o \
+	compare256.o \
 	compress.o \
 	crc32.o \
 	crc32_comb.o \
@@ -112,7 +112,7 @@ OBJC = $(OBJZ) $(OBJG)
 PIC_OBJZ = \
 	adler32.lo \
 	chunkset.lo \
-	compare258.lo \
+	compare256.lo \
 	compress.lo \
 	crc32.lo \
 	crc32_comb.lo \

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Features
   * CRC32-B implementation using PCLMULQDQ, VPCLMULQDQ, & ACLE
   * Hash table implementation using CRC32-C intrinsics on x86 and ARM
   * Slide hash implementations using SSE2, AVX2, Neon, VMX & VSX
-  * Compare256/258 implementations using SSE4.2 & AVX2
+  * Compare256 implementations using SSE4.2 & AVX2
   * Inflate chunk copying using SSE2, AVX2, Neon & VSX
   * CRC32 implementation using IBM Z vector instructions
   * Support for hardware-accelerated deflate using IBM Z DFLTCC

--- a/arch/x86/Makefile.in
+++ b/arch/x86/Makefile.in
@@ -32,8 +32,8 @@ all: \
 	adler32_ssse3.o adler32_ssse3.lo \
 	chunkset_avx.o chunkset_avx.lo \
 	chunkset_sse2.o chunkset_sse2.lo \
-	compare258_avx2.o compare258_avx2.lo \
-	compare258_sse42.o compare258_sse42.lo \
+	compare256_avx2.o compare256_avx2.lo \
+	compare256_sse42.o compare256_sse42.lo \
 	insert_string_sse42.o insert_string_sse42.lo \
 	crc32_fold_pclmulqdq.o crc32_fold_pclmulqdq.lo \
 	crc32_fold_vpclmulqdq.o crc32_fold_vpclmulqdq.lo \
@@ -58,17 +58,17 @@ chunkset_sse2.o:
 chunkset_sse2.lo:
 	$(CC) $(SFLAGS) $(SSE2FLAG) $(NOLTOFLAG) -DPIC $(INCLUDES) -c -o $@ $(SRCDIR)/chunkset_sse2.c
 
-compare258_avx2.o:
-	$(CC) $(CFLAGS) $(AVX2FLAG) $(NOLTOFLAG) $(INCLUDES) -c -o $@ $(SRCDIR)/compare258_avx2.c
+compare256_avx2.o:
+	$(CC) $(CFLAGS) $(AVX2FLAG) $(NOLTOFLAG) $(INCLUDES) -c -o $@ $(SRCDIR)/compare256_avx2.c
 
-compare258_avx2.lo:
-	$(CC) $(SFLAGS) $(AVX2FLAG) $(NOLTOFLAG) -DPIC $(INCLUDES) -c -o $@ $(SRCDIR)/compare258_avx2.c
+compare256_avx2.lo:
+	$(CC) $(SFLAGS) $(AVX2FLAG) $(NOLTOFLAG) -DPIC $(INCLUDES) -c -o $@ $(SRCDIR)/compare256_avx2.c
 
-compare258_sse42.o:
-	$(CC) $(CFLAGS) $(SSE42FLAG) $(NOLTOFLAG) $(INCLUDES) -c -o $@ $(SRCDIR)/compare258_sse42.c
+compare256_sse42.o:
+	$(CC) $(CFLAGS) $(SSE42FLAG) $(NOLTOFLAG) $(INCLUDES) -c -o $@ $(SRCDIR)/compare256_sse42.c
 
-compare258_sse42.lo:
-	$(CC) $(SFLAGS) $(SSE42FLAG) $(NOLTOFLAG) -DPIC $(INCLUDES) -c -o $@ $(SRCDIR)/compare258_sse42.c
+compare256_sse42.lo:
+	$(CC) $(SFLAGS) $(SSE42FLAG) $(NOLTOFLAG) -DPIC $(INCLUDES) -c -o $@ $(SRCDIR)/compare256_sse42.c
 
 insert_string_sse42.o:
 	$(CC) $(CFLAGS) $(SSE42FLAG) $(NOLTOFLAG) $(INCLUDES) -c -o $@ $(SRCDIR)/insert_string_sse42.c

--- a/arch/x86/compare256_avx2.c
+++ b/arch/x86/compare256_avx2.c
@@ -1,4 +1,4 @@
-/* compare258_avx2.c -- AVX2 version of compare258
+/* compare256_avx2.c -- AVX2 version of compare256
  * Copyright Mika T. Lindqvist  <postmaster@raasu.org>
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
@@ -47,15 +47,8 @@ static inline uint32_t compare256_unaligned_avx2_static(const unsigned char *src
     return 256;
 }
 
-static inline uint32_t compare258_unaligned_avx2_static(const unsigned char *src0, const unsigned char *src1) {
-    if (*(uint16_t *)src0 != *(uint16_t *)src1)
-        return (*src0 == *src1);
-
-    return compare256_unaligned_avx2_static(src0+2, src1+2) + 2;
-}
-
-Z_INTERNAL uint32_t compare258_unaligned_avx2(const unsigned char *src0, const unsigned char *src1) {
-    return compare258_unaligned_avx2_static(src0, src1);
+Z_INTERNAL uint32_t compare256_unaligned_avx2(const unsigned char *src0, const unsigned char *src1) {
+    return compare256_unaligned_avx2_static(src0, src1);
 }
 
 #define LONGEST_MATCH       longest_match_unaligned_avx2

--- a/arch/x86/compare256_sse42.c
+++ b/arch/x86/compare256_sse42.c
@@ -1,4 +1,4 @@
-/* compare258_sse42.c -- SSE4.2 version of compare258
+/* compare256_sse42.c -- SSE4.2 version of compare256
  *
  * Copyright (C) 2013 Intel Corporation. All rights reserved.
  * Authors:
@@ -54,15 +54,8 @@ static inline uint32_t compare256_unaligned_sse4_static(const unsigned char *src
     return 256;
 }
 
-static inline uint32_t compare258_unaligned_sse4_static(const unsigned char *src0, const unsigned char *src1) {
-    if (*(uint16_t *)src0 != *(uint16_t *)src1)
-        return (*src0 == *src1);
-
-    return compare256_unaligned_sse4_static(src0+2, src1+2) + 2;
-}
-
-Z_INTERNAL uint32_t compare258_unaligned_sse4(const unsigned char *src0, const unsigned char *src1) {
-    return compare258_unaligned_sse4_static(src0, src1);
+Z_INTERNAL uint32_t compare256_unaligned_sse4(const unsigned char *src0, const unsigned char *src1) {
+    return compare256_unaligned_sse4_static(src0, src1);
 }
 
 #define LONGEST_MATCH       longest_match_unaligned_sse4

--- a/compare256.c
+++ b/compare256.c
@@ -1,4 +1,4 @@
-/* compare258.c -- aligned and unaligned versions of compare258
+/* compare256.c -- 256 byte memory comparison with match length return
  * Copyright (C) 2020 Nathan Moinvaziri
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
@@ -42,19 +42,8 @@ static inline uint32_t compare256_c_static(const unsigned char *src0, const unsi
     return 256;
 }
 
-static inline uint32_t compare258_c_static(const unsigned char *src0, const unsigned char *src1) {
-    if (*src0 != *src1)
-        return 0;
-    src0 += 1, src1 += 1;
-    if (*src0 != *src1)
-        return 1;
-    src0 += 1, src1 += 1;
-
-    return compare256_c_static(src0, src1) + 2;
-}
-
-Z_INTERNAL uint32_t compare258_c(const unsigned char *src0, const unsigned char *src1) {
-    return compare258_c_static(src0, src1);
+Z_INTERNAL uint32_t compare256_c(const unsigned char *src0, const unsigned char *src1) {
+    return compare256_c_static(src0, src1);
 }
 
 #define LONGEST_MATCH       longest_match_c
@@ -91,15 +80,8 @@ static inline uint32_t compare256_unaligned_16_static(const unsigned char *src0,
     return 256;
 }
 
-static inline uint32_t compare258_unaligned_16_static(const unsigned char *src0, const unsigned char *src1) {
-    if (*(uint16_t *)src0 != *(uint16_t *)src1)
-        return (*src0 == *src1);
-
-    return compare256_unaligned_16_static(src0+2, src1+2) + 2;
-}
-
-Z_INTERNAL uint32_t compare258_unaligned_16(const unsigned char *src0, const unsigned char *src1) {
-    return compare258_unaligned_16_static(src0, src1);
+Z_INTERNAL uint32_t compare256_unaligned_16(const unsigned char *src0, const unsigned char *src1) {
+    return compare256_unaligned_16_static(src0, src1);
 }
 
 #define LONGEST_MATCH       longest_match_unaligned_16
@@ -136,15 +118,8 @@ static inline uint32_t compare256_unaligned_32_static(const unsigned char *src0,
     return 256;
 }
 
-static inline uint32_t compare258_unaligned_32_static(const unsigned char *src0, const unsigned char *src1) {
-    if (*(uint16_t *)src0 != *(uint16_t *)src1)
-        return (*src0 == *src1);
-
-    return compare256_unaligned_32_static(src0+2, src1+2) + 2;
-}
-
-Z_INTERNAL uint32_t compare258_unaligned_32(const unsigned char *src0, const unsigned char *src1) {
-    return compare258_unaligned_32_static(src0, src1);
+Z_INTERNAL uint32_t compare256_unaligned_32(const unsigned char *src0, const unsigned char *src1) {
+    return compare256_unaligned_32_static(src0, src1);
 }
 
 #define LONGEST_MATCH       longest_match_unaligned_32
@@ -183,15 +158,8 @@ static inline uint32_t compare256_unaligned_64_static(const unsigned char *src0,
     return 256;
 }
 
-static inline uint32_t compare258_unaligned_64_static(const unsigned char *src0, const unsigned char *src1) {
-    if (*(uint16_t *)src0 != *(uint16_t *)src1)
-        return (*src0 == *src1);
-
-    return compare256_unaligned_64_static(src0+2, src1+2) + 2;
-}
-
-Z_INTERNAL uint32_t compare258_unaligned_64(const unsigned char *src0, const unsigned char *src1) {
-    return compare258_unaligned_64_static(src0, src1);
+Z_INTERNAL uint32_t compare256_unaligned_64(const unsigned char *src0, const unsigned char *src1) {
+    return compare256_unaligned_64_static(src0, src1);
 }
 
 #define LONGEST_MATCH       longest_match_unaligned_64

--- a/configure
+++ b/configure
@@ -1438,8 +1438,8 @@ case "${ARCH}" in
             if test ${HAVE_AVX2_INTRIN} -eq 1; then
                 CFLAGS="${CFLAGS} -DX86_AVX2 -DX86_AVX2_ADLER32 -DX86_AVX_CHUNKSET"
                 SFLAGS="${SFLAGS} -DX86_AVX2 -DX86_AVX2_ADLER32 -DX86_AVX_CHUNKSET"
-                ARCH_STATIC_OBJS="${ARCH_STATIC_OBJS} slide_hash_avx2.o chunkset_avx.o compare258_avx2.o adler32_avx2.o"
-                ARCH_SHARED_OBJS="${ARCH_SHARED_OBJS} slide_hash_avx2.lo chunkset_avx.lo compare258_avx2.lo adler32_avx2.lo"
+                ARCH_STATIC_OBJS="${ARCH_STATIC_OBJS} slide_hash_avx2.o chunkset_avx.o compare256_avx2.o adler32_avx2.o"
+                ARCH_SHARED_OBJS="${ARCH_SHARED_OBJS} slide_hash_avx2.lo chunkset_avx.lo compare256_avx2.lo adler32_avx2.lo"
             fi
 
             check_avx512_intrinsics
@@ -1495,8 +1495,8 @@ case "${ARCH}" in
                 CFLAGS="${CFLAGS} -DX86_SSE42_CMP_STR"
                 SFLAGS="${SFLAGS} -DX86_SSE42_CMP_STR"
 
-                ARCH_STATIC_OBJS="${ARCH_STATIC_OBJS} compare258_sse42.o"
-                ARCH_SHARED_OBJS="${ARCH_SHARED_OBJS} compare258_sse42.lo"
+                ARCH_STATIC_OBJS="${ARCH_STATIC_OBJS} compare256_sse42.o"
+                ARCH_SHARED_OBJS="${ARCH_SHARED_OBJS} compare256_sse42.lo"
             fi
 
             check_sse2_intrinsics

--- a/functable.c
+++ b/functable.c
@@ -144,19 +144,19 @@ extern uint32_t crc32_power8(uint32_t, const unsigned char *, uint64_t);
 extern uint32_t s390_crc32_vx(uint32_t, const unsigned char *, uint64_t);
 #endif
 
-/* compare258 */
-extern uint32_t compare258_c(const unsigned char *src0, const unsigned char *src1);
+/* compare256 */
+extern uint32_t compare256_c(const unsigned char *src0, const unsigned char *src1);
 #ifdef UNALIGNED_OK
-extern uint32_t compare258_unaligned_16(const unsigned char *src0, const unsigned char *src1);
-extern uint32_t compare258_unaligned_32(const unsigned char *src0, const unsigned char *src1);
+extern uint32_t compare256_unaligned_16(const unsigned char *src0, const unsigned char *src1);
+extern uint32_t compare256_unaligned_32(const unsigned char *src0, const unsigned char *src1);
 #ifdef UNALIGNED64_OK
-extern uint32_t compare258_unaligned_64(const unsigned char *src0, const unsigned char *src1);
+extern uint32_t compare256_unaligned_64(const unsigned char *src0, const unsigned char *src1);
 #endif
 #ifdef X86_SSE42_CMP_STR
-extern uint32_t compare258_unaligned_sse4(const unsigned char *src0, const unsigned char *src1);
+extern uint32_t compare256_unaligned_sse4(const unsigned char *src0, const unsigned char *src1);
 #endif
 #if defined(X86_AVX2) && defined(HAVE_BUILTIN_CTZ)
-extern uint32_t compare258_unaligned_avx2(const unsigned char *src0, const unsigned char *src1);
+extern uint32_t compare256_unaligned_avx2(const unsigned char *src0, const unsigned char *src1);
 #endif
 #endif
 
@@ -550,29 +550,29 @@ Z_INTERNAL uint32_t crc32_stub(uint32_t crc, const unsigned char *buf, uint64_t 
     return functable.crc32(crc, buf, len);
 }
 
-Z_INTERNAL uint32_t compare258_stub(const unsigned char *src0, const unsigned char *src1) {
+Z_INTERNAL uint32_t compare256_stub(const unsigned char *src0, const unsigned char *src1) {
 
 #ifdef UNALIGNED_OK
 #  if defined(UNALIGNED64_OK) && defined(HAVE_BUILTIN_CTZLL)
-    functable.compare258 = &compare258_unaligned_64;
+    functable.compare256 = &compare256_unaligned_64;
 #  elif defined(HAVE_BUILTIN_CTZ)
-    functable.compare258 = &compare258_unaligned_32;
+    functable.compare256 = &compare256_unaligned_32;
 #  else
-    functable.compare258 = &compare258_unaligned_16;
+    functable.compare256 = &compare256_unaligned_16;
 #  endif
 #  ifdef X86_SSE42_CMP_STR
     if (x86_cpu_has_sse42)
-        functable.compare258 = &compare258_unaligned_sse4;
+        functable.compare256 = &compare256_unaligned_sse4;
 #  endif
 #  if defined(X86_AVX2) && defined(HAVE_BUILTIN_CTZ)
     if (x86_cpu_has_avx2)
-        functable.compare258 = &compare258_unaligned_avx2;
+        functable.compare256 = &compare256_unaligned_avx2;
 #  endif
 #else
-    functable.compare258 = &compare258_c;
+    functable.compare256 = &compare256_c;
 #endif
 
-    return functable.compare258(src0, src1);
+    return functable.compare256(src0, src1);
 }
 
 Z_INTERNAL uint32_t longest_match_stub(deflate_state *const s, Pos cur_match) {
@@ -636,7 +636,7 @@ Z_INTERNAL Z_TLS struct functable_s functable = {
     crc32_fold_copy_stub,
     crc32_fold_final_stub,
     slide_hash_stub,
-    compare258_stub,
+    compare256_stub,
     longest_match_stub,
     longest_match_slow_stub,
     chunksize_stub,

--- a/functable.h
+++ b/functable.h
@@ -19,7 +19,7 @@ struct functable_s {
     void     (* crc32_fold_copy)    (crc32_fold *crc, uint8_t *dst, const uint8_t *src, size_t len);
     uint32_t (* crc32_fold_final)   (crc32_fold *crc);
     void     (* slide_hash)         (deflate_state *s);
-    uint32_t (* compare258)         (const unsigned char *src0, const unsigned char *src1);
+    uint32_t (* compare256)         (const unsigned char *src0, const unsigned char *src1);
     uint32_t (* longest_match)      (deflate_state *const s, Pos cur_match);
     uint32_t (* longest_match_slow) (deflate_state *const s, Pos cur_match);
     uint32_t (* chunksize)          (void);

--- a/win32/Makefile.a64
+++ b/win32/Makefile.a64
@@ -46,7 +46,7 @@ OBJS = \
 	adler32.obj \
 	armfeature.obj \
 	chunkset.obj \
-	compare258.obj \
+	compare256.obj \
 	compress.obj \
 	crc32.obj \
 	crc32_comb.obj \

--- a/win32/Makefile.arm
+++ b/win32/Makefile.arm
@@ -49,7 +49,7 @@ OBJS = \
 	adler32.obj \
 	armfeature.obj \
 	chunkset.obj \
-	compare258.obj \
+	compare256.obj \
 	compress.obj \
 	crc32.obj \
 	crc32_comb.obj \

--- a/win32/Makefile.msc
+++ b/win32/Makefile.msc
@@ -53,9 +53,9 @@ OBJS = \
 	chunkset.obj \
 	chunkset_avx.obj \
 	chunkset_sse2.obj \
-	compare258.obj \
-	compare258_avx2.obj \
-	compare258_sse42.obj \
+	compare256.obj \
+	compare256_avx2.obj \
+	compare256_sse42.obj \
 	compress.obj \
 	crc32.obj \
 	crc32_comb.obj \


### PR DESCRIPTION
Requires PR #1095. Should reduce code size by around 1700 bytes (MSVC). We move the 2 byte check from `compare258` to `deflate_quick` where it is used then only need `compare256` everywhere. 

## Benchmarks

### DEVELOP https://github.com/zlib-ng/zlib-ng/commit/49d1704a1800c0b01241f13dee1dafe2961d1541
```
 Tool: ../zlib-ng/build/Release/minigzip-develop.exe Levels: 1-9
 Runs: 70         Trim worst: 40

 Level   Comp   Comptime min/avg/max/stddev  Decomptime min/avg/max/stddev  Compressed size
 1     54.166%      0.099/0.102/0.107/0.002        0.050/0.051/0.053/0.001        8,523,732
 2     43.871%      0.163/0.168/0.173/0.003        0.051/0.054/0.055/0.001        6,903,609
 3     42.387%      0.223/0.229/0.237/0.004        0.050/0.053/0.055/0.001        6,670,099
 4     41.647%      0.243/0.251/0.259/0.005        0.048/0.051/0.053/0.001        6,553,723
 5     41.216%      0.252/0.264/0.272/0.005        0.048/0.051/0.054/0.002        6,485,938
 6     41.037%      0.290/0.302/0.310/0.006        0.047/0.050/0.052/0.001        6,457,776
 7     40.778%      0.367/0.385/0.393/0.006        0.046/0.051/0.053/0.002        6,416,919
 8     40.704%      0.474/0.486/0.493/0.005        0.047/0.050/0.053/0.001        6,405,244
 9     40.409%      0.551/0.575/0.587/0.009        0.048/0.051/0.054/0.002        6,358,951

 avg1  42.913%                        0.307                          0.051
 tot                                 82.885                         13.851       60,775,991
```
### PR https://github.com/zlib-ng/zlib-ng/commit/e275c3aea793a602ab5b38891cc15488158fb4cb
```
 Tool: ../zlib-ng/build/Release/minigzip-compare256.exe Levels: 1-9
 Runs: 70         Trim worst: 40

 Level   Comp   Comptime min/avg/max/stddev  Decomptime min/avg/max/stddev  Compressed size
 1     54.166%      0.096/0.098/0.101/0.001        0.048/0.052/0.053/0.001        8,523,732
 2     43.871%      0.160/0.165/0.167/0.003        0.051/0.053/0.055/0.001        6,903,609
 3     42.387%      0.217/0.226/0.231/0.004        0.050/0.052/0.054/0.001        6,670,099
 4     41.647%      0.239/0.248/0.252/0.003        0.048/0.051/0.053/0.001        6,553,723
 5     41.216%      0.248/0.257/0.262/0.004        0.048/0.050/0.052/0.001        6,485,938
 6     41.037%      0.287/0.297/0.305/0.005        0.047/0.050/0.051/0.001        6,457,776
 7     40.778%      0.366/0.376/0.385/0.005        0.048/0.050/0.052/0.001        6,416,919
 8     40.704%      0.470/0.480/0.489/0.005        0.048/0.050/0.051/0.001        6,405,244
 9     40.409%      0.564/0.574/0.581/0.005        0.048/0.051/0.054/0.001        6,358,951

 avg1  42.913%                        0.302                          0.051
 tot                                 81.645                         13.778       60,775,991
```