### PR TITLE
Merge crc32_little and crc32_big

### DIFF
--- a/arch/s390/crc32-vx.c
+++ b/arch/s390/crc32-vx.c
@@ -202,12 +202,12 @@ uint32_t Z_INTERNAL s390_crc32_vx(uint32_t crc, const unsigned char *buf, uint64
     uint64_t prealign, aligned, remaining;
 
     if (len < VX_MIN_LEN + VX_ALIGN_MASK)
-        return crc32_big(crc, buf, len);
+        return crc32_byfour(crc, buf, len);
 
     if ((uintptr_t)buf & VX_ALIGN_MASK) {
         prealign = VX_ALIGNMENT - ((uintptr_t)buf & VX_ALIGN_MASK);
         len -= prealign;
-        crc = crc32_big(crc, buf, prealign);
+        crc = crc32_byfour(crc, buf, prealign);
         buf += prealign;
     }
     aligned = len & ~VX_ALIGN_MASK;
@@ -216,7 +216,7 @@ uint32_t Z_INTERNAL s390_crc32_vx(uint32_t crc, const unsigned char *buf, uint64
     crc = crc32_le_vgfm_16(crc ^ 0xffffffff, buf, (size_t)aligned) ^ 0xffffffff;
 
     if (remaining)
-        crc = crc32_big(crc, buf + aligned, remaining);
+        crc = crc32_byfour(crc, buf + aligned, remaining);
 
     return crc;
 }

--- a/crc32_p.h
+++ b/crc32_p.h
@@ -19,10 +19,6 @@ static inline uint32_t gf2_matrix_times(const uint32_t *mat, uint32_t vec) {
 }
 
 
-#if BYTE_ORDER == LITTLE_ENDIAN
-extern uint32_t crc32_little(uint32_t, const unsigned char *, uint64_t);
-#elif BYTE_ORDER == BIG_ENDIAN
-extern uint32_t crc32_big(uint32_t, const unsigned char *, uint64_t);
-#endif
+extern uint32_t crc32_byfour(uint32_t, const unsigned char *, uint64_t);
 
 #endif /* CRC32_P_H_ */

--- a/functable.c
+++ b/functable.c
@@ -528,13 +528,7 @@ Z_INTERNAL uint32_t crc32_stub(uint32_t crc, const unsigned char *buf, uint64_t 
     Assert(sizeof(uint64_t) >= sizeof(size_t),
            "crc32_z takes size_t but internally we have a uint64_t len");
 
-#if BYTE_ORDER == LITTLE_ENDIAN
-    functable.crc32 = &crc32_little;
-#elif BYTE_ORDER == BIG_ENDIAN
-    functable.crc32 = &crc32_big;
-#else
-    functable.crc32 = &crc32_generic;
-#endif
+    functable.crc32 = &crc32_byfour;
     cpu_check_features();
 #ifdef ARM_ACLE_CRC_HASH
     if (arm_cpu_has_crc32)


### PR DESCRIPTION
Just an idea I had about cleaning up the `crc32` endian variants. Instead of doing the endian check in `functable`, we do it in `crc32` function. And the preprocessor macros are defined different per endian. The remove `crc32_generic` because it is not used anywhere.