### PR TITLE
Memcpy/memcmp macros

### DIFF
--- a/arch/arm/chunkset_neon.c
+++ b/arch/arm/chunkset_neon.c
@@ -26,19 +26,19 @@ static inline void chunkmemset_1(uint8_t *from, chunk_t *chunk) {
 
 static inline void chunkmemset_2(uint8_t *from, chunk_t *chunk) {
     uint16_t tmp;
-    memcpy(&tmp, from, 2);
+    zmemcpy_2(&tmp, from);
     *chunk = vreinterpretq_u8_u16(vdupq_n_u16(tmp));
 }
 
 static inline void chunkmemset_4(uint8_t *from, chunk_t *chunk) {
     uint32_t tmp;
-    memcpy(&tmp, from, 4);
+    zmemcpy_4(&tmp, from);
     *chunk = vreinterpretq_u8_u32(vdupq_n_u32(tmp));
 }
 
 static inline void chunkmemset_8(uint8_t *from, chunk_t *chunk) {
     uint64_t tmp;
-    memcpy(&tmp, from, 8);
+    zmemcpy_8(&tmp, from);
     *chunk = vreinterpretq_u8_u64(vdupq_n_u64(tmp));
 }
 

--- a/arch/power/chunkset_power8.c
+++ b/arch/power/chunkset_power8.c
@@ -22,19 +22,19 @@ static inline void chunkmemset_1(uint8_t *from, chunk_t *chunk) {
 
 static inline void chunkmemset_2(uint8_t *from, chunk_t *chunk) {
     uint16_t tmp;
-    memcpy(&tmp, from, 2);
+    zmemcpy_2(&tmp, from);
     *chunk = (vector unsigned char)vec_splats(tmp);
 }
 
 static inline void chunkmemset_4(uint8_t *from, chunk_t *chunk) {
     uint32_t tmp;
-    memcpy(&tmp, from, 4);
+    zmemcpy_4(&tmp, from);
     *chunk = (vector unsigned char)vec_splats(tmp);
 }
 
 static inline void chunkmemset_8(uint8_t *from, chunk_t *chunk) {
     uint64_t tmp;
-    memcpy(&tmp, from, 8);
+    zmemcpy_8(&tmp, from);
     *chunk = (vector unsigned char)vec_splats(tmp);
 }
 

--- a/chunkset.c
+++ b/chunkset.c
@@ -18,20 +18,20 @@ static inline void chunkmemset_1(uint8_t *from, chunk_t *chunk) {
 
 static inline void chunkmemset_4(uint8_t *from, chunk_t *chunk) {
     uint8_t *dest = (uint8_t *)chunk;
-    memcpy(dest, from, sizeof(uint32_t));
-    memcpy(dest+4, from, sizeof(uint32_t));
+    zmemcpy_4(dest, from);
+    zmemcpy_4(dest+4, from);
 }
 
 static inline void chunkmemset_8(uint8_t *from, chunk_t *chunk) {
-    memcpy(chunk, from, sizeof(uint64_t));
+    zmemcpy_8(chunk, from);
 }
 
 static inline void loadchunk(uint8_t const *s, chunk_t *chunk) {
-    chunkmemset_8((uint8_t *)s, chunk);
+    zmemcpy_8(chunk, (uint8_t *)s);
 }
 
 static inline void storechunk(uint8_t *out, chunk_t *chunk) {
-    memcpy(out, chunk, sizeof(uint64_t));
+    zmemcpy_8(out, chunk);
 }
 
 #define CHUNKSIZE        chunksize_c

--- a/chunkset.c
+++ b/chunkset.c
@@ -4,14 +4,7 @@
 
 #include "zbuild.h"
 
-/* Define 8 byte chunks differently depending on unaligned support */
-#if defined(UNALIGNED64_OK)
 typedef uint64_t chunk_t;
-#elif defined(UNALIGNED_OK)
-typedef struct chunk_t { uint32_t u32[2]; } chunk_t;
-#else
-typedef struct chunk_t { uint8_t u8[8]; } chunk_t;
-#endif
 
 #define CHUNK_SIZE 8
 
@@ -20,38 +13,17 @@ typedef struct chunk_t { uint8_t u8[8]; } chunk_t;
 #define HAVE_CHUNKMEMSET_8
 
 static inline void chunkmemset_1(uint8_t *from, chunk_t *chunk) {
-#if defined(UNALIGNED64_OK)
-    *chunk = 0x0101010101010101 * (uint8_t)*from;
-#elif defined(UNALIGNED_OK)
-    chunk->u32[0] = 0x01010101 * (uint8_t)*from;
-    chunk->u32[1] = chunk->u32[0];
-#else
     memset(chunk, *from, sizeof(chunk_t));
-#endif
 }
 
 static inline void chunkmemset_4(uint8_t *from, chunk_t *chunk) {
-#if defined(UNALIGNED64_OK)
-    uint32_t half_chunk;
-    memcpy(&half_chunk, from, sizeof(half_chunk));
-    *chunk = 0x0000000100000001 * (uint64_t)half_chunk;
-#elif defined(UNALIGNED_OK)
-    memcpy(&chunk->u32[0], from, sizeof(chunk->u32[0]));
-    chunk->u32[1] = chunk->u32[0];
-#else
-    uint8_t *chunkptr = (uint8_t *)chunk;
-    memcpy(chunkptr, from, sizeof(uint32_t));
-    memcpy(chunkptr+4, from, sizeof(uint32_t));
-#endif
+    uint8_t *dest = (uint8_t *)chunk;
+    memcpy(dest, from, sizeof(uint32_t));
+    memcpy(dest+4, from, sizeof(uint32_t));
 }
 
 static inline void chunkmemset_8(uint8_t *from, chunk_t *chunk) {
-#if defined(UNALIGNED_OK) && !defined(UNALIGNED64_OK)
-    memcpy(&chunk->u32[0], from, sizeof(chunk->u32[0]));
-    memcpy(&chunk->u32[1], from+4, sizeof(chunk->u32[1]));
-#else
     memcpy(chunk, from, sizeof(uint64_t));
-#endif
 }
 
 static inline void loadchunk(uint8_t const *s, chunk_t *chunk) {

--- a/chunkset_tpl.h
+++ b/chunkset_tpl.h
@@ -60,20 +60,20 @@ Z_INTERNAL uint8_t* CHUNKCOPY_SAFE(uint8_t *out, uint8_t const *from, unsigned l
 #endif
 #if CHUNK_SIZE >= 8
     while (len >= 8) {
-        memcpy(out, from, 8);
+        zmemcpy_8(out, from);
         out += 8;
         from += 8;
         len -= 8;
     }
 #endif
     if (len >= 4) {
-        memcpy(out, from, 4);
+        zmemcpy_4(out, from);
         out += 4;
         from += 4;
         len -= 4;
     }
     if (len >= 2) {
-        memcpy(out, from, 2);
+        zmemcpy_2(out, from);
         out += 2;
         from += 2;
         len -= 2;

--- a/compare256.c
+++ b/compare256.c
@@ -101,8 +101,8 @@ static inline uint32_t compare256_unaligned_32_static(const uint8_t *src0, const
     do {
         uint32_t sv, mv, diff;
 
-        memcpy(&sv, src0, sizeof(sv));
-        memcpy(&mv, src1, sizeof(mv));
+        zmemcpy_4(&sv, src0);
+        zmemcpy_4(&mv, src1);
 
         diff = sv ^ mv;
         if (diff) {
@@ -141,8 +141,8 @@ static inline uint32_t compare256_unaligned_64_static(const uint8_t *src0, const
     do {
         uint64_t sv, mv, diff;
 
-        memcpy(&sv, src0, sizeof(sv));
-        memcpy(&mv, src1, sizeof(mv));
+        zmemcpy_8(&sv, src0);
+        zmemcpy_8(&mv, src1);
 
         diff = sv ^ mv;
         if (diff) {

--- a/deflate.h
+++ b/deflate.h
@@ -305,7 +305,7 @@ static inline void put_short(deflate_state *s, uint16_t w) {
 #if BYTE_ORDER == BIG_ENDIAN
     w = ZSWAP16(w);
 #endif
-    memcpy(&s->pending_buf[s->pending], &w, sizeof(w));
+    zmemcpy_2(&s->pending_buf[s->pending], &w);
     s->pending += 2;
 }
 
@@ -317,7 +317,7 @@ static inline void put_short_msb(deflate_state *s, uint16_t w) {
 #if BYTE_ORDER == LITTLE_ENDIAN
     w = ZSWAP16(w);
 #endif
-    memcpy(&s->pending_buf[s->pending], &w, sizeof(w));
+    zmemcpy_2(&s->pending_buf[s->pending], &w);
     s->pending += 2;
 }
 
@@ -329,7 +329,7 @@ static inline void put_uint32(deflate_state *s, uint32_t dw) {
 #if BYTE_ORDER == BIG_ENDIAN
     dw = ZSWAP32(dw);
 #endif
-    memcpy(&s->pending_buf[s->pending], &dw, sizeof(dw));
+    zmemcpy_4(&s->pending_buf[s->pending], &dw);
     s->pending += 4;
 }
 
@@ -341,7 +341,7 @@ static inline void put_uint32_msb(deflate_state *s, uint32_t dw) {
 #if BYTE_ORDER == LITTLE_ENDIAN
     dw = ZSWAP32(dw);
 #endif
-    memcpy(&s->pending_buf[s->pending], &dw, sizeof(dw));
+    zmemcpy_4(&s->pending_buf[s->pending], &dw);
     s->pending += 4;
 }
 
@@ -353,7 +353,7 @@ static inline void put_uint64(deflate_state *s, uint64_t lld) {
 #if BYTE_ORDER == BIG_ENDIAN
     lld = ZSWAP64(lld);
 #endif
-    memcpy(&s->pending_buf[s->pending], &lld, sizeof(lld));
+    zmemcpy_8(&s->pending_buf[s->pending], &lld);
     s->pending += 8;
 }
 

--- a/deflate_quick.c
+++ b/deflate_quick.c
@@ -92,7 +92,7 @@ Z_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
                 const uint8_t *str_start = s->window + s->strstart;
                 const uint8_t *match_start = s->window + hash_head;
 
-                if (*(uint16_t *)str_start == *(uint16_t *)match_start) {
+                if (zmemcmp_2(str_start, match_start) == 0) {
                     match_len = functable.compare256(str_start+2, match_start+2) + 2;
 
                     if (match_len >= WANT_MIN_MATCH) {

--- a/inffast.c
+++ b/inffast.c
@@ -15,7 +15,7 @@
 /* Load 64 bits from IN and place the bytes at offset BITS in the result. */
 static inline uint64_t load_64_bits(const unsigned char *in, unsigned bits) {
     uint64_t chunk;
-    memcpy(&chunk, in, sizeof(chunk));
+    zmemcpy_8(&chunk, in);
 
 #if BYTE_ORDER == LITTLE_ENDIAN
     return chunk << bits;

--- a/insert_string_tpl.h
+++ b/insert_string_tpl.h
@@ -29,9 +29,9 @@
 #  define HASH_CALC_MASK HASH_MASK
 #endif
 #ifndef HASH_CALC_READ
-#  ifdef UNALIGNED_OK
+#  if BYTE_ORDER == LITTLE_ENDIAN
 #    define HASH_CALC_READ \
-        memcpy(&val, strstart, sizeof(val));
+        zmemcpy_4(&val, strstart);
 #  else
 #    define HASH_CALC_READ \
         val  = ((uint32_t)(strstart[0])); \

--- a/match_tpl.h
+++ b/match_tpl.h
@@ -145,24 +145,24 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
 #ifdef UNALIGNED_OK
         if (best_len < sizeof(uint32_t)) {
             for (;;) {
-                if (*(uint16_t *)(mbase_end+cur_match) == *(uint16_t *)scan_end &&
-                    *(uint16_t *)(mbase_start+cur_match) == *(uint16_t *)scan_start)
+                if (zmemcmp_2(mbase_end+cur_match, scan_end) == 0 &&
+                    zmemcmp_2(mbase_start+cur_match, scan_start) == 0)
                     break;
                 GOTO_NEXT_CHAIN;
             }
 #  ifdef UNALIGNED64_OK
         } else if (best_len >= sizeof(uint64_t)) {
             for (;;) {
-                if (*(uint64_t *)(mbase_end+cur_match) == *(uint64_t *)scan_end &&
-                    *(uint64_t *)(mbase_start+cur_match) == *(uint64_t *)scan_start)
+                if (zmemcmp_8(mbase_end+cur_match, scan_end) == 0 &&
+                    zmemcmp_8(mbase_start+cur_match, scan_start) == 0)
                     break;
                 GOTO_NEXT_CHAIN;
             }
 #  endif
         } else {
             for (;;) {
-                if (*(uint32_t *)(mbase_end+cur_match) == *(uint32_t *)scan_end &&
-                    *(uint32_t *)(mbase_start+cur_match) == *(uint32_t *)scan_start)
+                if (zmemcmp_4(mbase_end+cur_match, scan_end) == 0 &&
+                    zmemcmp_4(mbase_start+cur_match, scan_start) == 0)
                     break;
                 GOTO_NEXT_CHAIN;
             }

--- a/match_tpl.h
+++ b/match_tpl.h
@@ -74,11 +74,11 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
 #endif
 
 #ifdef UNALIGNED64_OK
-    memcpy(scan_start, scan, sizeof(uint64_t));
-    memcpy(scan_end, scan+offset, sizeof(uint64_t));
+    zmemcpy_8(scan_start, scan);
+    zmemcpy_8(scan_end, scan+offset);
 #elif defined(UNALIGNED_OK)
-    memcpy(scan_start, scan, sizeof(uint32_t));
-    memcpy(scan_end, scan+offset, sizeof(uint32_t));
+    zmemcpy_4(scan_start, scan);
+    zmemcpy_4(scan_end, scan+offset);
 #else
     scan_end[0] = *(scan+offset);
     scan_end[1] = *(scan+offset+1);
@@ -201,9 +201,9 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
 #endif
 
 #ifdef UNALIGNED64_OK
-            memcpy(scan_end, scan+offset, sizeof(uint64_t));
+            zmemcpy_8(scan_end, scan+offset);
 #elif defined(UNALIGNED_OK)
-            memcpy(scan_end, scan+offset, sizeof(uint32_t));
+            zmemcpy_4(scan_end, scan+offset);
 #else
             scan_end[0] = *(scan+offset);
             scan_end[1] = *(scan+offset+1);

--- a/zbuild.h
+++ b/zbuild.h
@@ -194,19 +194,32 @@
 #  define Tracecv(c, x)
 #endif
 
+/* Force compiler to emit unaligned memory accesses if unaligned access is supported
+   on the architecture, otherwise don't assume unaligned access is supported. Older
+   compilers don't optimize memcpy and memcmp calls to unaligned access instructions
+   when it is supported on the architecture resulting in significant performance impact.
+   Newer compilers might optimize memcpy but not all optimize memcmp for all integer types. */
 #ifdef UNALIGNED_OK
-#  define zmemcpy_2(dest, src) *((uint16_t *)dest) = *((uint16_t *)src)
-#  define zmemcpy_4(dest, src) *((uint32_t *)dest) = *((uint32_t *)src)
+#  define zmemcpy_2(dest, src)    (*((uint16_t *)(dest)) = *((uint16_t *)(src)))
+#  define zmemcmp_2(str1, str2)   (*((uint16_t *)(str1)) != *((uint16_t *)(str2)))
+#  define zmemcpy_4(dest, src)    (*((uint32_t *)(dest)) = *((uint32_t *)(src)))
+#  define zmemcmp_4(str1, str2)   (*((uint32_t *)(str1)) != *((uint32_t *)(str2)))
 #  if UINTPTR_MAX == UINT64_MAX
-#    define zmemcpy_8(dest, src) *((uint64_t *)dest) = *((uint64_t *)src)
+#    define zmemcpy_8(dest, src)  (*((uint64_t *)(dest)) = *((uint64_t *)(src)))
+#    define zmemcmp_8(str1, str2) (*((uint64_t *)(str1)) != *((uint64_t *)(str2)))
 #  else
-#    define zmemcpy_8(dest, src) ((uint32_t *)dest)[0] = *((uint32_t *)src)[0] \
-                                 ((uint32_t *)dest)[1] = *((uint32_t *)src)[1]
+#    define zmemcpy_8(dest, src)  (((uint32_t *)(dest))[0] = ((uint32_t *)(src))[0], \
+                                   ((uint32_t *)(dest))[1] = ((uint32_t *)(src))[1])
+#    define zmemcmp_8(str1, str2) (((uint32_t *)(str1))[0] != ((uint32_t *)(str2))[0] || \
+                                   ((uint32_t *)(str1))[1] != ((uint32_t *)(str2))[1])
 #  endif
 #else
-#  define zmemcpy_2(dest, src) memcpy(dest, src, 2)
-#  define zmemcpy_4(dest, src) memcpy(dest, src, 4)
-#  define zmemcpy_8(dest, src) memcpy(dest, src, 8)
+#  define zmemcpy_2(dest, src)  memcpy(dest, src, 2)
+#  define zmemcmp_2(str1, str2) memcmp(str1, str2, 2)
+#  define zmemcpy_4(dest, src)  memcpy(dest, src, 4)
+#  define zmemcmp_4(str1, str2) memcmp(str1, str2, 4)
+#  define zmemcpy_8(dest, src)  memcpy(dest, src, 8)
+#  define zmemcmp_8(str1, str2) memcmp(str1, str2, 8)
 #endif
 
 #endif

--- a/zbuild.h
+++ b/zbuild.h
@@ -194,4 +194,19 @@
 #  define Tracecv(c, x)
 #endif
 
+#ifdef UNALIGNED_OK
+#  define zmemcpy_2(dest, src) *((uint16_t *)dest) = *((uint16_t *)src)
+#  define zmemcpy_4(dest, src) *((uint32_t *)dest) = *((uint32_t *)src)
+#  if UINTPTR_MAX == UINT64_MAX
+#    define zmemcpy_8(dest, src) *((uint64_t *)dest) = *((uint64_t *)src)
+#  else
+#    define zmemcpy_8(dest, src) ((uint32_t *)dest)[0] = *((uint32_t *)src)[0] \
+                                 ((uint32_t *)dest)[1] = *((uint32_t *)src)[1]
+#  endif
+#else
+#  define zmemcpy_2(dest, src) memcpy(dest, src, 2)
+#  define zmemcpy_4(dest, src) memcpy(dest, src, 4)
+#  define zmemcpy_8(dest, src) memcpy(dest, src, 8)
+#endif
+
 #endif


### PR DESCRIPTION
* Define preprocessor macros `zmemcpy/zmemcmp` that force unaligned access on supported architectures
* Use `zmemcpy/zmemcmp` in the code where necessary.


