### PR TITLE
Remove unmaintained index markdown in arch/x86.

### DIFF
--- a/arch/x86/INDEX.md
+++ b/arch/x86/INDEX.md
@@ -1,9 +1,0 @@
-Contents
---------
-
-|Name|Description|
-|:-|:-|
-|deflate_quick.c|SSE4 optimized deflate strategy for use as level 1|
-|crc32_fold_pclmulqdq.c|SSE4 + PCLMULQDQ optimized CRC folding implementation|
-|crc32_fold_vpclmulqdq.c|VPCLMULQDQ optimized CRC folding implementation|
-|slide_hash_sse2.c|SSE2 optimized slide_hash|


### PR DESCRIPTION
- x86 arch directory is the only arch directory that contains such an index.
- It is not necessary anymore since each header file contains info about its contents in the comment at the top of the files