### PR TITLE
Move UNALIGNED_OK detection to compile time instead of configure time.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -51,10 +51,11 @@ jobs:
             codecov: ubuntu_gcc_osb
             cflags: -O1 -g3
 
-          - name: Ubuntu GCC -O3
+          - name: Ubuntu GCC -O3 No Unaligned
             os: ubuntu-latest
             compiler: gcc
             cxx-compiler: g++
+            cmake-args: -DWITH_UNALIGNED=OFF
             codecov: ubuntu_gcc_o3
             cflags: -O3
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -59,6 +59,14 @@ jobs:
             codecov: ubuntu_gcc_o3
             cflags: -O3
 
+          - name: Ubuntu GCC 32-bit
+            os: ubuntu-latest
+            compiler: gcc
+            cxx-compiler: g++
+            cmake-args: -DCMAKE_C_FLAGS=-m32 -DCMAKE_CXX_FLAGS=-m32 -DCMAKE_SHARED_LINKER_FLAGS=-m32 -DCMAKE_EXE_LINKER_FLAGS=-m32
+            packages: gcc-multilib g++-multilib
+            codecov: ubuntu_gcc_m32
+
           - name: Ubuntu GCC No CTZLL
             os: ubuntu-latest
             compiler: gcc

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -41,21 +41,20 @@ jobs:
             cmake-args: -DZLIB_COMPAT=ON -DZLIB_SYMBOL_PREFIX=zTest_
             codecov: ubuntu_gcc_compat_sprefix
 
-          - name: Ubuntu GCC OSB -O1 No Unaligned64 UBSAN
+          - name: Ubuntu GCC OSB -O1 UBSAN
             os: ubuntu-latest
             compiler: gcc
             cxx-compiler: g++
-            cmake-args: -DWITH_UNALIGNED=ON -DUNALIGNED64_OK=OFF -DWITH_SANITIZER=Undefined
+            cmake-args: -DWITH_SANITIZER=Undefined
             build-dir: ../build
             build-src-dir: ../zlib-ng
             codecov: ubuntu_gcc_osb
             cflags: -O1 -g3
 
-          - name: Ubuntu GCC -O3 No Unaligned
+          - name: Ubuntu GCC -O3
             os: ubuntu-latest
             compiler: gcc
             cxx-compiler: g++
-            cmake-args: -DWITH_UNALIGNED=OFF
             codecov: ubuntu_gcc_o3
             cflags: -O3
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ option(WITH_MAINTAINER_WARNINGS "Build with project maintainer warnings" OFF)
 option(WITH_CODE_COVERAGE "Enable code coverage reporting" OFF)
 option(WITH_INFLATE_STRICT "Build with strict inflate distance checking" OFF)
 option(WITH_INFLATE_ALLOW_INVALID_DIST "Build with zero fill for inflate invalid distances" OFF)
+option(WITH_UNALIGNED "Support unaligned reads on platforms that support it" ON)
 
 set(ZLIB_SYMBOL_PREFIX "" CACHE STRING "Give this prefix to all publicly exported symbols.
 Useful when embedding into a larger library.
@@ -137,6 +138,7 @@ mark_as_advanced(FORCE
     WITH_POWER8
     WITH_INFLATE_STRICT
     WITH_INFLATE_ALLOW_INVALID_DIST
+    WITH_UNALIGNED
     INSTALL_UTILS
     )
 
@@ -245,6 +247,12 @@ else()
         message(STATUS "Ignoring WITH_NATIVE_INSTRUCTIONS; not implemented yet on this configuration")
         set(WITH_NATIVE_INSTRUCTIONS OFF)
     endif()
+endif()
+
+# Set architecture alignment requirements
+if(NOT WITH_UNALIGNED)
+    add_definitions(-DNO_UNALIGNED)
+    message(STATUS "Unaligned reads manually disabled")
 endif()
 
 # Apply warning compiler flags

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,6 @@ option(WITH_MAINTAINER_WARNINGS "Build with project maintainer warnings" OFF)
 option(WITH_CODE_COVERAGE "Enable code coverage reporting" OFF)
 option(WITH_INFLATE_STRICT "Build with strict inflate distance checking" OFF)
 option(WITH_INFLATE_ALLOW_INVALID_DIST "Build with zero fill for inflate invalid distances" OFF)
-option(WITH_UNALIGNED "Support unaligned reads on platforms that support it" ON)
 
 set(ZLIB_SYMBOL_PREFIX "" CACHE STRING "Give this prefix to all publicly exported symbols.
 Useful when embedding into a larger library.
@@ -138,7 +137,6 @@ mark_as_advanced(FORCE
     WITH_POWER8
     WITH_INFLATE_STRICT
     WITH_INFLATE_ALLOW_INVALID_DIST
-    WITH_UNALIGNED
     INSTALL_UTILS
     )
 
@@ -247,46 +245,6 @@ else()
         message(STATUS "Ignoring WITH_NATIVE_INSTRUCTIONS; not implemented yet on this configuration")
         set(WITH_NATIVE_INSTRUCTIONS OFF)
     endif()
-endif()
-
-# Set architecture alignment requirements
-if(WITH_UNALIGNED)
-    if((BASEARCH_ARM_FOUND AND NOT "${ARCH}" MATCHES "armv[2-7]") OR (BASEARCH_PPC_FOUND AND "${ARCH}" MATCHES "powerpc64le") OR BASEARCH_X86_FOUND)
-        if(NOT DEFINED UNALIGNED_OK)
-            set(UNALIGNED_OK TRUE)
-        endif()
-    endif()
-    if(UNALIGNED_OK)
-        add_definitions(-DUNALIGNED_OK)
-        message(STATUS "Architecture supports unaligned reads")
-    endif()
-    if(BASEARCH_ARM_FOUND)
-        if(NOT DEFINED UNALIGNED64_OK)
-            if("${ARCH}" MATCHES "armv[2-7]")
-                set(UNALIGNED64_OK FALSE)
-            elseif("${ARCH}" MATCHES "(arm(v[8-9])?|aarch64)")
-                set(UNALIGNED64_OK TRUE)
-            endif()
-        endif()
-    endif()
-    if(BASEARCH_PPC_FOUND)
-        if(NOT DEFINED UNALIGNED64_OK)
-            if("${ARCH}" MATCHES "powerpc64le")
-                set(UNALIGNED64_OK TRUE)
-            endif()
-        endif()
-    endif()
-    if(BASEARCH_X86_FOUND)
-        if(NOT DEFINED UNALIGNED64_OK)
-            set(UNALIGNED64_OK TRUE)
-        endif()
-    endif()
-    if(UNALIGNED64_OK)
-        add_definitions(-DUNALIGNED64_OK)
-        message(STATUS "Architecture supports unaligned reads of > 4 bytes")
-    endif()
-else()
-    message(STATUS "Unaligned reads manually disabled")
 endif()
 
 # Apply warning compiler flags
@@ -1459,8 +1417,6 @@ add_feature_info(WITH_MAINTAINER_WARNINGS WITH_MAINTAINER_WARNINGS "Build with p
 add_feature_info(WITH_CODE_COVERAGE WITH_CODE_COVERAGE "Enable code coverage reporting")
 add_feature_info(WITH_INFLATE_STRICT WITH_INFLATE_STRICT "Build with strict inflate distance checking")
 add_feature_info(WITH_INFLATE_ALLOW_INVALID_DIST WITH_INFLATE_ALLOW_INVALID_DIST "Build with zero fill for inflate invalid distances")
-add_feature_info(WITH_UNALIGNED UNALIGNED_OK "Support unaligned reads on platforms that support it")
-add_feature_info(WITH_UNALIGNED64 UNALIGNED64_OK "Support unaligned 64-bit reads on platforms that support it")
 
 if(BASEARCH_ARM_FOUND)
     add_feature_info(WITH_ACLE WITH_ACLE "Build with ACLE")

--- a/README.md
+++ b/README.md
@@ -194,7 +194,6 @@ Advanced Build Options
 | CMake                           | configure             | Description                                                         | Default                |
 |:--------------------------------|:----------------------|:--------------------------------------------------------------------|------------------------|
 | ZLIB_DUAL_LINK                  |                       | Dual link tests with system zlib                                    | OFF                    |
-| UNALIGNED_OK                    |                       | Allow unaligned reads                                               | ON (x86, arm)          |
 | FORCE_SSE2                      | --force-sse2          | Skip runtime check for SSE2 instructions (Always on for x86_64)     | OFF (x86)              |
 | FORCE_TZCNT                     | --force-tzcnt         | Skip runtime check for TZCNT instructions                           | OFF                    |
 | WITH_AVX2                       |                       | Build with AVX2 intrinsics                                          | ON                     |
@@ -212,7 +211,6 @@ Advanced Build Options
 | WITH_CRC32_VX                   | --without-crc32-vx    | Build with vectorized CRC32 on IBM Z                                | ON                     |
 | WITH_DFLTCC_DEFLATE             | --with-dfltcc-deflate | Build with DFLTCC intrinsics for compression on IBM Z               | OFF                    |
 | WITH_DFLTCC_INFLATE             | --with-dfltcc-inflate | Build with DFLTCC intrinsics for decompression on IBM Z             | OFF                    |
-| WITH_UNALIGNED                  |                       | Allow optimizations that use unaligned reads if safe on current arch| ON                     |
 | WITH_INFLATE_STRICT             |                       | Build with strict inflate distance checking                         | OFF                    |
 | WITH_INFLATE_ALLOW_INVALID_DIST |                       | Build with zero fill for inflate invalid distances                  | OFF                    |
 | INSTALL_UTILS                   |                       | Copy minigzip and minideflate during install                        | OFF                    |

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Advanced Build Options
 | WITH_CRC32_VX                   | --without-crc32-vx    | Build with vectorized CRC32 on IBM Z                                | ON                     |
 | WITH_DFLTCC_DEFLATE             | --with-dfltcc-deflate | Build with DFLTCC intrinsics for compression on IBM Z               | OFF                    |
 | WITH_DFLTCC_INFLATE             | --with-dfltcc-inflate | Build with DFLTCC intrinsics for decompression on IBM Z             | OFF                    |
+| WITH_UNALIGNED                  | --without-unaligned   | Allow optimizations that use unaligned reads if safe on current arch| ON                     |
 | WITH_INFLATE_STRICT             |                       | Build with strict inflate distance checking                         | OFF                    |
 | WITH_INFLATE_ALLOW_INVALID_DIST |                       | Build with zero fill for inflate invalid distances                  | OFF                    |
 | INSTALL_UTILS                   |                       | Copy minigzip and minideflate during install                        | OFF                    |

--- a/arch/x86/compare256_avx2.c
+++ b/arch/x86/compare256_avx2.c
@@ -14,7 +14,7 @@
 #  include <nmmintrin.h>
 #endif
 
-/* UNALIGNED_OK, AVX2 intrinsic comparison */
+/* AVX2 unaligned intrinsic comparison */
 static inline uint32_t compare256_unaligned_avx2_static(const uint8_t *src0, const uint8_t *src1) {
     uint32_t len = 0;
 

--- a/compare256.c
+++ b/compare256.c
@@ -56,7 +56,7 @@ Z_INTERNAL uint32_t compare256_c(const uint8_t *src0, const uint8_t *src1) {
 #include "match_tpl.h"
 
 #ifdef UNALIGNED_OK
-/* UNALIGNED_OK, 16-bit integer comparison */
+/* 16-bit unaligned integer comparison */
 static inline uint32_t compare256_unaligned_16_static(const uint8_t *src0, const uint8_t *src1) {
     uint32_t len = 0;
 
@@ -94,7 +94,7 @@ Z_INTERNAL uint32_t compare256_unaligned_16(const uint8_t *src0, const uint8_t *
 #include "match_tpl.h"
 
 #ifdef HAVE_BUILTIN_CTZ
-/* UNALIGNED_OK, 32-bit integer comparison */
+/* 32-bit unaligned integer comparison */
 static inline uint32_t compare256_unaligned_32_static(const uint8_t *src0, const uint8_t *src1) {
     uint32_t len = 0;
 

--- a/configure
+++ b/configure
@@ -86,6 +86,7 @@ mandir=${mandir-'${prefix}/share/man'}
 shared_ext='.so'
 shared=1
 gzfileops=1
+unalignedok=1
 compat=0
 cover=0
 build32=0
@@ -162,7 +163,8 @@ case "$1" in
       echo '    [--warn]                    Enables extra compiler warnings' | tee -a configure.log
       echo '    [--debug]                   Enables extra debug prints during operation' | tee -a configure.log
       echo '    [--zlib-compat]             Compiles for zlib-compatible API instead of zlib-ng API' | tee -a configure.log
-      echo '    [--without-gzfileops]       Compiles with the gzfile parts of the API enabled' | tee -a configure.log
+      echo '    [--without-unaligned]       Compiles without fast unaligned access' | tee -a configure.log
+      echo '    [--without-gzfileops]       Compiles without the gzfile parts of the API enabled' | tee -a configure.log
       echo '    [--without-optimizations]   Compiles without support for optional instruction sets' | tee -a configure.log
       echo '    [--without-new-strategies]  Compiles without using new additional deflate strategies' | tee -a configure.log
       echo '    [--without-acle]            Compiles without ARM C Language Extensions' | tee -a configure.log
@@ -194,6 +196,7 @@ case "$1" in
     -s* | --shared | --enable-shared) shared=1; shift ;;
     -t | --static) shared=0; shift ;;
     --zlib-compat) compat=1; shift ;;
+    --without-unaligned) unalignedok=0; shift ;;
     --without-gzfileops) gzfileops=0; shift ;;
     --cover) cover=1; shift ;;
     -3* | --32) build32=1; shift ;;
@@ -908,6 +911,13 @@ if test $gzfileops -eq 1; then
   PIC_OBJC="${PIC_OBJC} \$(PIC_OBJG)"
 else
   PIC_TESTOBJG="\$(OBJG)"
+fi
+
+# set architecture alignment requirements
+if test $unalignedok -eq 0; then
+  CFLAGS="${CFLAGS} -DNO_UANLIGNED"
+  SFLAGS="${SFLAGS} -DNO_UNALIGNED"
+  echo "Unaligned reads manually disabled." | tee -a configure.log
 fi
 
 # enable reduced memory configuration

--- a/configure
+++ b/configure
@@ -1481,9 +1481,6 @@ case "${ARCH}" in
     i386 | i486 | i586 | i686 |x86_64)
         ARCHDIR=arch/x86
 
-        CFLAGS="${CFLAGS} -DUNALIGNED_OK -DUNALIGNED64_OK"
-        SFLAGS="${SFLAGS} -DUNALIGNED_OK -DUNALIGNED64_OK"
-
         # Enable arch-specific optimizations
         if test $without_optimizations -eq 0; then
             CFLAGS="${CFLAGS} -DX86_FEATURES"
@@ -1704,9 +1701,6 @@ EOF
                 fi
             ;;
             armv6l | armv6hl)
-                CFLAGS="${CFLAGS} -DUNALIGNED_OK"
-                SFLAGS="${SFLAGS} -DUNALIGNED_OK"
-
                 if test $without_optimizations -eq 0; then
                     if test $buildacle -eq 1; then
                         echo ACLE support not available
@@ -1718,9 +1712,6 @@ EOF
                 fi
             ;;
             arm | armv7*)
-                CFLAGS="${CFLAGS} -DUNALIGNED_OK"
-                SFLAGS="${SFLAGS} -DUNALIGNED_OK"
-
                 if test $without_optimizations -eq 0; then
                     if test $buildacle -eq 1; then
                         echo ACLE support not available
@@ -1745,9 +1736,6 @@ EOF
                 fi
             ;;
             armv8-a | armv8-a+simd)
-                CFLAGS="${CFLAGS} -DUNALIGNED_OK -DUNALIGNED64_OK"
-                SFLAGS="${SFLAGS} -DUNALIGNED_OK -DUNALIGNED64_OK"
-
                 if test $without_optimizations -eq 0; then
                     if test $buildacle -eq 1; then
                         echo ACLE support not available
@@ -1772,9 +1760,6 @@ EOF
                 fi
             ;;
             armv8-a+crc | armv8-a+crc+simd | armv8.[1234]-a | armv8.[1234]-a+simd)
-                CFLAGS="${CFLAGS} -DUNALIGNED_OK -DUNALIGNED64_OK"
-                SFLAGS="${SFLAGS} -DUNALIGNED_OK -DUNALIGNED64_OK"
-
                 acleflag="-march=${ARCH}"
 
                 if test $without_optimizations -eq 0; then
@@ -1869,9 +1854,6 @@ EOF
 
         neonflag="-march=${ARCH}"
         acleflag="-march=${ARCH}"
-
-        CFLAGS="${CFLAGS} -DUNALIGNED_OK -DUNALIGNED64_OK"
-        SFLAGS="${SFLAGS} -DUNALIGNED_OK -DUNALIGNED64_OK"
     ;;
     powerpc*)
         case "${ARCH}" in
@@ -1883,8 +1865,6 @@ EOF
             ;;
             powerpc64le)
                 [ ! -z $CROSS_PREFIX ] && QEMU_ARCH=ppc64le
-                CFLAGS="${CFLAGS} -DUNALIGNED_OK -DUNALIGNED64_OK"
-                SFLAGS="${SFLAGS} -DUNALIGNED_OK -DUNALIGNED64_OK"
             ;;
         esac
 

--- a/win32/Makefile.a64
+++ b/win32/Makefile.a64
@@ -30,8 +30,6 @@ WFLAGS  = \
 	-D_CRT_NONSTDC_NO_DEPRECATE \
 	-DARM_NEON_HASLD4 \
 	-DARM_FEATURES \
-	-DUNALIGNED_OK \
-	-DUNALIGNED64_OK \
 	#
 LDFLAGS = -nologo -debug -incremental:no -opt:ref -manifest
 ARFLAGS = -nologo

--- a/win32/Makefile.arm
+++ b/win32/Makefile.arm
@@ -30,7 +30,6 @@ WFLAGS  = \
 	-D_CRT_NONSTDC_NO_DEPRECATE \
 	-DARM_FEATURES \
 	-DARM_NEON_HASLD4 \
-	-DUNALIGNED_OK \
 	#
 LDFLAGS = -nologo -debug -incremental:no -opt:ref -manifest
 ARFLAGS = -nologo

--- a/win32/Makefile.msc
+++ b/win32/Makefile.msc
@@ -35,8 +35,6 @@ WFLAGS  = \
 	-DX86_AVX2 \
 	-DX86_AVX_CHUNKSET \
 	-DX86_SSE2_CHUNKSET \
-	-DUNALIGNED_OK \
-	-DUNALIGNED64_OK \
 	#
 LDFLAGS = -nologo -debug -incremental:no -opt:ref -manifest
 ARFLAGS = -nologo

--- a/zbuild.h
+++ b/zbuild.h
@@ -228,7 +228,7 @@
 #  define zmemcmp_2(str1, str2)   (*((uint16_t *)(str1)) != *((uint16_t *)(str2)))
 #  define zmemcpy_4(dest, src)    (*((uint32_t *)(dest)) = *((uint32_t *)(src)))
 #  define zmemcmp_4(str1, str2)   (*((uint32_t *)(str1)) != *((uint32_t *)(str2)))
-#  if UINTPTR_MAX == UINT64_MAX
+#  if defined(UNALIGNED64_OK) && (UINTPTR_MAX == UINT64_MAX)
 #    define zmemcpy_8(dest, src)  (*((uint64_t *)(dest)) = *((uint64_t *)(src)))
 #    define zmemcmp_8(str1, str2) (*((uint64_t *)(str1)) != *((uint64_t *)(str2)))
 #  else

--- a/zbuild.h
+++ b/zbuild.h
@@ -194,6 +194,28 @@
 #  define Tracecv(c, x)
 #endif
 
+#if defined(__x86_64__) || defined(_M_X64) || defined(__amd64__) || defined(_M_AMD64)
+#  define UNALIGNED_OK
+#  define UNALIGNED64_OK
+#elif defined(__i386__) || defined(__i486__) || defined(__i586__) || \
+      defined(__i686__) || defined(_X86_) || defined(_M_IX86)
+#  define UNALIGNED_OK
+#elif defined(__aarch64__) || defined(_M_ARM64)
+#  if (defined(__GNUC__) && defined(__ARM_FEATURE_UNALIGNED)) || !defined(__GNUC__)
+#    define UNALIGNED_OK
+#    define UNALIGNED64_OK
+#  endif
+#elif defined(__arm__) || (_M_ARM >= 7)
+#  if (defined(__GNUC__) && defined(__ARM_FEATURE_UNALIGNED)) || !defined(__GNUC__)
+#    define UNALIGNED_OK
+#  endif
+#elif defined(__powerpc64__) || defined(__ppc64__)
+#  if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#    define UNALIGNED_OK
+#    define UNALIGNED64_OK
+#  endif
+#endif
+
 /* Force compiler to emit unaligned memory accesses if unaligned access is supported
    on the architecture, otherwise don't assume unaligned access is supported. Older
    compilers don't optimize memcpy and memcmp calls to unaligned access instructions

--- a/zbuild.h
+++ b/zbuild.h
@@ -194,25 +194,27 @@
 #  define Tracecv(c, x)
 #endif
 
-#if defined(__x86_64__) || defined(_M_X64) || defined(__amd64__) || defined(_M_AMD64)
-#  define UNALIGNED_OK
-#  define UNALIGNED64_OK
-#elif defined(__i386__) || defined(__i486__) || defined(__i586__) || \
-      defined(__i686__) || defined(_X86_) || defined(_M_IX86)
-#  define UNALIGNED_OK
-#elif defined(__aarch64__) || defined(_M_ARM64)
-#  if (defined(__GNUC__) && defined(__ARM_FEATURE_UNALIGNED)) || !defined(__GNUC__)
+#ifndef NO_UNALIGNED
+#  if defined(__x86_64__) || defined(_M_X64) || defined(__amd64__) || defined(_M_AMD64)
 #    define UNALIGNED_OK
 #    define UNALIGNED64_OK
-#  endif
-#elif defined(__arm__) || (_M_ARM >= 7)
-#  if (defined(__GNUC__) && defined(__ARM_FEATURE_UNALIGNED)) || !defined(__GNUC__)
+#  elif defined(__i386__) || defined(__i486__) || defined(__i586__) || \
+        defined(__i686__) || defined(_X86_) || defined(_M_IX86)
 #    define UNALIGNED_OK
-#  endif
-#elif defined(__powerpc64__) || defined(__ppc64__)
-#  if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-#    define UNALIGNED_OK
-#    define UNALIGNED64_OK
+#  elif defined(__aarch64__) || defined(_M_ARM64)
+#    if (defined(__GNUC__) && defined(__ARM_FEATURE_UNALIGNED)) || !defined(__GNUC__)
+#      define UNALIGNED_OK
+#      define UNALIGNED64_OK
+#    endif
+#  elif defined(__arm__) || (_M_ARM >= 7)
+#    if (defined(__GNUC__) && defined(__ARM_FEATURE_UNALIGNED)) || !defined(__GNUC__)
+#      define UNALIGNED_OK
+#    endif
+#  elif defined(__powerpc64__) || defined(__ppc64__)
+#    if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#      define UNALIGNED_OK
+#      define UNALIGNED64_OK
+#    endif
 #  endif
 #endif
 


### PR DESCRIPTION
Pros: 
* It moves detection to one place instead of duplicating similar logic in both build scripts.