### PR TITLE
CPU features cleanup

### DIFF
--- a/arch/x86/compare256_avx2.c
+++ b/arch/x86/compare256_avx2.c
@@ -16,7 +16,7 @@
 #endif
 
 /* UNALIGNED_OK, AVX2 intrinsic comparison */
-static inline uint32_t compare256_unaligned_avx2_static(const unsigned char *src0, const unsigned char *src1) {
+static inline uint32_t compare256_unaligned_avx2_static(const uint8_t *src0, const uint8_t *src1) {
     uint32_t len = 0;
 
     do {
@@ -47,7 +47,7 @@ static inline uint32_t compare256_unaligned_avx2_static(const unsigned char *src
     return 256;
 }
 
-Z_INTERNAL uint32_t compare256_unaligned_avx2(const unsigned char *src0, const unsigned char *src1) {
+Z_INTERNAL uint32_t compare256_unaligned_avx2(const uint8_t *src0, const uint8_t *src1) {
     return compare256_unaligned_avx2_static(src0, src1);
 }
 

--- a/arch/x86/compare256_sse42.c
+++ b/arch/x86/compare256_sse42.c
@@ -26,7 +26,7 @@
 #endif
 
 /* UNALIGNED_OK, SSE4.2 intrinsic comparison */
-static inline uint32_t compare256_unaligned_sse4_static(const unsigned char *src0, const unsigned char *src1) {
+static inline uint32_t compare256_unaligned_sse4_static(const uint8_t *src0, const uint8_t *src1) {
     uint32_t len = 0;
 
     do {
@@ -54,7 +54,7 @@ static inline uint32_t compare256_unaligned_sse4_static(const unsigned char *src
     return 256;
 }
 
-Z_INTERNAL uint32_t compare256_unaligned_sse4(const unsigned char *src0, const unsigned char *src1) {
+Z_INTERNAL uint32_t compare256_unaligned_sse4(const uint8_t *src0, const uint8_t *src1) {
     return compare256_unaligned_sse4_static(src0, src1);
 }
 

--- a/arch/x86/crc32_fold_pclmulqdq.c
+++ b/arch/x86/crc32_fold_pclmulqdq.c
@@ -24,6 +24,8 @@
 #include <wmmintrin.h>
 #include <smmintrin.h> // _mm_extract_epi32
 
+#include "x86.h"
+
 #include "../../crc32_fold.h"
 
 #ifdef X86_VPCLMULQDQ_CRC

--- a/compare256.c
+++ b/compare256.c
@@ -9,7 +9,7 @@
 #include "fallback_builtins.h"
 
 /* ALIGNED, byte comparison */
-static inline uint32_t compare256_c_static(const unsigned char *src0, const unsigned char *src1) {
+static inline uint32_t compare256_c_static(const uint8_t *src0, const uint8_t *src1) {
     uint32_t len = 0;
 
     do {
@@ -42,7 +42,7 @@ static inline uint32_t compare256_c_static(const unsigned char *src0, const unsi
     return 256;
 }
 
-Z_INTERNAL uint32_t compare256_c(const unsigned char *src0, const unsigned char *src1) {
+Z_INTERNAL uint32_t compare256_c(const uint8_t *src0, const uint8_t *src1) {
     return compare256_c_static(src0, src1);
 }
 
@@ -59,7 +59,7 @@ Z_INTERNAL uint32_t compare256_c(const unsigned char *src0, const unsigned char 
 
 #ifdef UNALIGNED_OK
 /* UNALIGNED_OK, 16-bit integer comparison */
-static inline uint32_t compare256_unaligned_16_static(const unsigned char *src0, const unsigned char *src1) {
+static inline uint32_t compare256_unaligned_16_static(const uint8_t *src0, const uint8_t *src1) {
     uint32_t len = 0;
 
     do {
@@ -80,7 +80,7 @@ static inline uint32_t compare256_unaligned_16_static(const unsigned char *src0,
     return 256;
 }
 
-Z_INTERNAL uint32_t compare256_unaligned_16(const unsigned char *src0, const unsigned char *src1) {
+Z_INTERNAL uint32_t compare256_unaligned_16(const uint8_t *src0, const uint8_t *src1) {
     return compare256_unaligned_16_static(src0, src1);
 }
 
@@ -97,7 +97,7 @@ Z_INTERNAL uint32_t compare256_unaligned_16(const unsigned char *src0, const uns
 
 #ifdef HAVE_BUILTIN_CTZ
 /* UNALIGNED_OK, 32-bit integer comparison */
-static inline uint32_t compare256_unaligned_32_static(const unsigned char *src0, const unsigned char *src1) {
+static inline uint32_t compare256_unaligned_32_static(const uint8_t *src0, const uint8_t *src1) {
     uint32_t len = 0;
 
     do {
@@ -118,7 +118,7 @@ static inline uint32_t compare256_unaligned_32_static(const unsigned char *src0,
     return 256;
 }
 
-Z_INTERNAL uint32_t compare256_unaligned_32(const unsigned char *src0, const unsigned char *src1) {
+Z_INTERNAL uint32_t compare256_unaligned_32(const uint8_t *src0, const uint8_t *src1) {
     return compare256_unaligned_32_static(src0, src1);
 }
 
@@ -137,7 +137,7 @@ Z_INTERNAL uint32_t compare256_unaligned_32(const unsigned char *src0, const uns
 
 #if defined(UNALIGNED64_OK) && defined(HAVE_BUILTIN_CTZLL)
 /* UNALIGNED64_OK, 64-bit integer comparison */
-static inline uint32_t compare256_unaligned_64_static(const unsigned char *src0, const unsigned char *src1) {
+static inline uint32_t compare256_unaligned_64_static(const uint8_t *src0, const uint8_t *src1) {
     uint32_t len = 0;
 
     do {
@@ -158,7 +158,7 @@ static inline uint32_t compare256_unaligned_64_static(const unsigned char *src0,
     return 256;
 }
 
-Z_INTERNAL uint32_t compare256_unaligned_64(const unsigned char *src0, const unsigned char *src1) {
+Z_INTERNAL uint32_t compare256_unaligned_64(const uint8_t *src0, const uint8_t *src1) {
     return compare256_unaligned_64_static(src0, src1);
 }
 

--- a/cpu_features.c
+++ b/cpu_features.c
@@ -4,7 +4,8 @@
  */
 
 #include "zbuild.h"
-#include "zutil.h"
+
+#include "cpu_features.h"
 
 Z_INTERNAL void cpu_check_features(void) {
     static int features_checked = 0;

--- a/cpu_features.h
+++ b/cpu_features.h
@@ -172,18 +172,18 @@ extern Pos quick_insert_string_acle(deflate_state *const s, const uint32_t str);
 
 /* slide_hash */
 #ifdef X86_SSE2
-void slide_hash_sse2(deflate_state *s);
+extern void slide_hash_sse2(deflate_state *s);
 #elif defined(ARM_NEON_SLIDEHASH)
-void slide_hash_neon(deflate_state *s);
+extern void slide_hash_neon(deflate_state *s);
 #endif
 #if defined(PPC_VMX_SLIDEHASH)
-void slide_hash_vmx(deflate_state *s);
+extern void slide_hash_vmx(deflate_state *s);
 #endif
 #if defined(POWER8_VSX_SLIDEHASH)
-void slide_hash_power8(deflate_state *s);
+extern void slide_hash_power8(deflate_state *s);
 #endif
 #ifdef X86_AVX2
-void slide_hash_avx2(deflate_state *s);
+extern void slide_hash_avx2(deflate_state *s);
 #endif
 
 /* update_hash */

--- a/cpu_features.h
+++ b/cpu_features.h
@@ -9,8 +9,15 @@
 #include "deflate.h"
 #include "crc32_fold.h"
 
-#ifdef X86_FEATURES
+#if defined(X86_FEATURES)
+#  include "arch/x86/x86.h"
 #  include "fallback_builtins.h"
+#elif defined(ARM_FEATURES)
+#  include "arch/arm/arm.h"
+#elif defined(PPC_FEATURES) || defined(POWER_FEATURES)
+#  include "arch/power/power.h"
+#elif defined(S390_FEATURES)
+#  include "arch/s390/s390.h"
 #endif
 
 extern void cpu_check_features();

--- a/cpu_features.h
+++ b/cpu_features.h
@@ -22,46 +22,6 @@
 
 extern void cpu_check_features();
 
-/* update_hash */
-extern uint32_t update_hash_c(deflate_state *const s, uint32_t h, uint32_t val);
-#ifdef X86_SSE42_CRC_HASH
-extern uint32_t update_hash_sse4(deflate_state *const s, uint32_t h, uint32_t val);
-#elif defined(ARM_ACLE_CRC_HASH)
-extern uint32_t update_hash_acle(deflate_state *const s, uint32_t h, uint32_t val);
-#endif
-
-/* insert_string */
-extern void insert_string_c(deflate_state *const s, const uint32_t str, uint32_t count);
-#ifdef X86_SSE42_CRC_HASH
-extern void insert_string_sse4(deflate_state *const s, const uint32_t str, uint32_t count);
-#elif defined(ARM_ACLE_CRC_HASH)
-extern void insert_string_acle(deflate_state *const s, const uint32_t str, uint32_t count);
-#endif
-
-/* quick_insert_string */
-extern Pos quick_insert_string_c(deflate_state *const s, const uint32_t str);
-#ifdef X86_SSE42_CRC_HASH
-extern Pos quick_insert_string_sse4(deflate_state *const s, const uint32_t str);
-#elif defined(ARM_ACLE_CRC_HASH)
-extern Pos quick_insert_string_acle(deflate_state *const s, const uint32_t str);
-#endif
-
-/* slide_hash */
-#ifdef X86_SSE2
-void slide_hash_sse2(deflate_state *s);
-#elif defined(ARM_NEON_SLIDEHASH)
-void slide_hash_neon(deflate_state *s);
-#endif
-#if defined(PPC_VMX_SLIDEHASH)
-void slide_hash_vmx(deflate_state *s);
-#endif
-#if defined(POWER8_VSX_SLIDEHASH)
-void slide_hash_power8(deflate_state *s);
-#endif
-#ifdef X86_AVX2
-void slide_hash_avx2(deflate_state *s);
-#endif
-
 /* adler32 */
 extern uint32_t adler32_c(uint32_t adler, const unsigned char *buf, size_t len);
 #ifdef ARM_NEON_ADLER32
@@ -162,6 +122,14 @@ extern uint32_t compare256_unaligned_avx2(const uint8_t *src0, const uint8_t *sr
 #endif
 #endif
 
+/* insert_string */
+extern void insert_string_c(deflate_state *const s, const uint32_t str, uint32_t count);
+#ifdef X86_SSE42_CRC_HASH
+extern void insert_string_sse4(deflate_state *const s, const uint32_t str, uint32_t count);
+#elif defined(ARM_ACLE_CRC_HASH)
+extern void insert_string_acle(deflate_state *const s, const uint32_t str, uint32_t count);
+#endif
+
 /* longest_match */
 extern uint32_t longest_match_c(deflate_state *const s, Pos cur_match);
 #ifdef UNALIGNED_OK
@@ -192,6 +160,38 @@ extern uint32_t longest_match_slow_unaligned_sse4(deflate_state *const s, Pos cu
 #if defined(X86_AVX2) && defined(HAVE_BUILTIN_CTZ)
 extern uint32_t longest_match_slow_unaligned_avx2(deflate_state *const s, Pos cur_match);
 #endif
+#endif
+
+/* quick_insert_string */
+extern Pos quick_insert_string_c(deflate_state *const s, const uint32_t str);
+#ifdef X86_SSE42_CRC_HASH
+extern Pos quick_insert_string_sse4(deflate_state *const s, const uint32_t str);
+#elif defined(ARM_ACLE_CRC_HASH)
+extern Pos quick_insert_string_acle(deflate_state *const s, const uint32_t str);
+#endif
+
+/* slide_hash */
+#ifdef X86_SSE2
+void slide_hash_sse2(deflate_state *s);
+#elif defined(ARM_NEON_SLIDEHASH)
+void slide_hash_neon(deflate_state *s);
+#endif
+#if defined(PPC_VMX_SLIDEHASH)
+void slide_hash_vmx(deflate_state *s);
+#endif
+#if defined(POWER8_VSX_SLIDEHASH)
+void slide_hash_power8(deflate_state *s);
+#endif
+#ifdef X86_AVX2
+void slide_hash_avx2(deflate_state *s);
+#endif
+
+/* update_hash */
+extern uint32_t update_hash_c(deflate_state *const s, uint32_t h, uint32_t val);
+#ifdef X86_SSE42_CRC_HASH
+extern uint32_t update_hash_sse4(deflate_state *const s, uint32_t h, uint32_t val);
+#elif defined(ARM_ACLE_CRC_HASH)
+extern uint32_t update_hash_acle(deflate_state *const s, uint32_t h, uint32_t val);
 #endif
 
 #endif

--- a/cpu_features.h
+++ b/cpu_features.h
@@ -23,6 +23,8 @@
 extern void cpu_check_features();
 
 /* adler32 */
+typedef uint32_t (*adler32_func)(uint32_t adler, const unsigned char *buf, size_t len);
+
 extern uint32_t adler32_c(uint32_t adler, const unsigned char *buf, size_t len);
 #ifdef ARM_NEON_ADLER32
 extern uint32_t adler32_neon(uint32_t adler, const unsigned char *buf, size_t len);
@@ -97,6 +99,8 @@ extern uint8_t* chunkmemset_safe_power8(uint8_t *out, unsigned dist, unsigned le
 #endif
 
 /* CRC32 */
+typedef uint32_t (*crc32_func)(uint32_t crc32, const unsigned char * buf, uint64_t len);
+
 extern uint32_t crc32_byfour(uint32_t crc, const unsigned char *buf, uint64_t len);
 #ifdef ARM_ACLE_CRC_HASH
 extern uint32_t crc32_acle(uint32_t crc, const unsigned char *buf, uint64_t len);
@@ -107,6 +111,8 @@ extern uint32_t s390_crc32_vx(uint32_t crc, const unsigned char *buf, uint64_t l
 #endif
 
 /* compare256 */
+typedef uint32_t (*compare256_func)(const uint8_t *src0, const uint8_t *src1);
+
 extern uint32_t compare256_c(const uint8_t *src0, const uint8_t *src1);
 #ifdef UNALIGNED_OK
 extern uint32_t compare256_unaligned_16(const uint8_t *src0, const uint8_t *src1);
@@ -171,6 +177,8 @@ extern Pos quick_insert_string_acle(deflate_state *const s, const uint32_t str);
 #endif
 
 /* slide_hash */
+typedef void (*slide_hash_func)(deflate_state *s);
+
 #ifdef X86_SSE2
 extern void slide_hash_sse2(deflate_state *s);
 #elif defined(ARM_NEON_SLIDEHASH)

--- a/cpu_features.h
+++ b/cpu_features.h
@@ -140,18 +140,18 @@ extern uint32_t s390_crc32_vx(uint32_t crc, const unsigned char *buf, uint64_t l
 #endif
 
 /* compare256 */
-extern uint32_t compare256_c(const unsigned char *src0, const unsigned char *src1);
+extern uint32_t compare256_c(const uint8_t *src0, const uint8_t *src1);
 #ifdef UNALIGNED_OK
-extern uint32_t compare256_unaligned_16(const unsigned char *src0, const unsigned char *src1);
-extern uint32_t compare256_unaligned_32(const unsigned char *src0, const unsigned char *src1);
+extern uint32_t compare256_unaligned_16(const uint8_t *src0, const uint8_t *src1);
+extern uint32_t compare256_unaligned_32(const uint8_t *src0, const uint8_t *src1);
 #ifdef UNALIGNED64_OK
-extern uint32_t compare256_unaligned_64(const unsigned char *src0, const unsigned char *src1);
+extern uint32_t compare256_unaligned_64(const uint8_t *src0, const uint8_t *src1);
 #endif
 #ifdef X86_SSE42_CMP_STR
-extern uint32_t compare256_unaligned_sse4(const unsigned char *src0, const unsigned char *src1);
+extern uint32_t compare256_unaligned_sse4(const uint8_t *src0, const uint8_t *src1);
 #endif
 #if defined(X86_AVX2) && defined(HAVE_BUILTIN_CTZ)
-extern uint32_t compare256_unaligned_avx2(const unsigned char *src0, const unsigned char *src1);
+extern uint32_t compare256_unaligned_avx2(const uint8_t *src0, const uint8_t *src1);
 #endif
 #endif
 

--- a/deflate.c
+++ b/deflate.c
@@ -48,6 +48,7 @@
  */
 
 #include "zbuild.h"
+#include "cpu_features.h"
 #include "deflate.h"
 #include "deflate_p.h"
 #include "functable.h"

--- a/deflate.c
+++ b/deflate.c
@@ -194,11 +194,7 @@ int32_t Z_EXPORT PREFIX(deflateInit2_)(PREFIX3(stream) *strm, int32_t level, int
     int wrap = 1;
     static const char my_version[] = PREFIX2(VERSION);
 
-#if defined(X86_FEATURES)
-    x86_check_features();
-#elif defined(ARM_FEATURES)
-    arm_check_features();
-#endif
+    cpu_check_features();
 
     if (version == NULL || version[0] != my_version[0] || stream_size != sizeof(PREFIX3(stream))) {
         return Z_VERSION_ERROR;

--- a/functable.c
+++ b/functable.c
@@ -348,7 +348,7 @@ Z_INTERNAL uint32_t crc32_stub(uint32_t crc, const unsigned char *buf, uint64_t 
     return functable.crc32(crc, buf, len);
 }
 
-Z_INTERNAL uint32_t compare256_stub(const unsigned char *src0, const unsigned char *src1) {
+Z_INTERNAL uint32_t compare256_stub(const uint8_t *src0, const uint8_t *src1) {
 
 #ifdef UNALIGNED_OK
 #  if defined(UNALIGNED64_OK) && defined(HAVE_BUILTIN_CTZLL)

--- a/functable.h
+++ b/functable.h
@@ -19,7 +19,7 @@ struct functable_s {
     void     (* crc32_fold_copy)    (crc32_fold *crc, uint8_t *dst, const uint8_t *src, size_t len);
     uint32_t (* crc32_fold_final)   (crc32_fold *crc);
     void     (* slide_hash)         (deflate_state *s);
-    uint32_t (* compare256)         (const unsigned char *src0, const unsigned char *src1);
+    uint32_t (* compare256)         (const uint8_t *src0, const uint8_t *src1);
     uint32_t (* longest_match)      (deflate_state *const s, Pos cur_match);
     uint32_t (* longest_match_slow) (deflate_state *const s, Pos cur_match);
     uint32_t (* chunksize)          (void);

--- a/functable.h
+++ b/functable.h
@@ -10,24 +10,24 @@
 #include "crc32_fold.h"
 
 struct functable_s {
-    uint32_t (* update_hash)        (deflate_state *const s, uint32_t h, uint32_t val);
-    void     (* insert_string)      (deflate_state *const s, uint32_t str, uint32_t count);
-    Pos      (* quick_insert_string)(deflate_state *const s, uint32_t str);
     uint32_t (* adler32)            (uint32_t adler, const unsigned char *buf, size_t len);
     uint32_t (* crc32)              (uint32_t crc, const unsigned char *buf, uint64_t len);
     uint32_t (* crc32_fold_reset)   (crc32_fold *crc);
     void     (* crc32_fold_copy)    (crc32_fold *crc, uint8_t *dst, const uint8_t *src, size_t len);
     uint32_t (* crc32_fold_final)   (crc32_fold *crc);
-    void     (* slide_hash)         (deflate_state *s);
     uint32_t (* compare256)         (const uint8_t *src0, const uint8_t *src1);
-    uint32_t (* longest_match)      (deflate_state *const s, Pos cur_match);
-    uint32_t (* longest_match_slow) (deflate_state *const s, Pos cur_match);
     uint32_t (* chunksize)          (void);
     uint8_t* (* chunkcopy)          (uint8_t *out, uint8_t const *from, unsigned len);
     uint8_t* (* chunkcopy_safe)     (uint8_t *out, uint8_t const *from, unsigned len, uint8_t *safe);
     uint8_t* (* chunkunroll)        (uint8_t *out, unsigned *dist, unsigned *len);
     uint8_t* (* chunkmemset)        (uint8_t *out, unsigned dist, unsigned len);
     uint8_t* (* chunkmemset_safe)   (uint8_t *out, unsigned dist, unsigned len, unsigned left);
+    void     (* insert_string)      (deflate_state *const s, uint32_t str, uint32_t count);
+    uint32_t (* longest_match)      (deflate_state *const s, Pos cur_match);
+    uint32_t (* longest_match_slow) (deflate_state *const s, Pos cur_match);
+    Pos      (* quick_insert_string)(deflate_state *const s, uint32_t str);
+    void     (* slide_hash)         (deflate_state *s);
+    uint32_t (* update_hash)        (deflate_state *const s, uint32_t h, uint32_t val);
 };
 
 Z_INTERNAL extern Z_TLS struct functable_s functable;

--- a/inflate.c
+++ b/inflate.c
@@ -5,6 +5,7 @@
 
 #include "zbuild.h"
 #include "zutil.h"
+#include "cpu_features.h"
 #include "inftrees.h"
 #include "inflate.h"
 #include "inffast.h"

--- a/inflate.c
+++ b/inflate.c
@@ -105,11 +105,7 @@ int32_t Z_EXPORT PREFIX(inflateInit2_)(PREFIX3(stream) *strm, int32_t windowBits
     int32_t ret;
     struct inflate_state *state;
 
-#if defined(X86_FEATURES)
-    x86_check_features();
-#elif defined(ARM_FEATURES)
-    arm_check_features();
-#endif
+    cpu_check_features();
 
     if (version == NULL || version[0] != PREFIX2(VERSION)[0] || stream_size != (int)(sizeof(PREFIX3(stream))))
         return Z_VERSION_ERROR;

--- a/test/benchmarks/benchmark_adler32.cc
+++ b/test/benchmarks/benchmark_adler32.cc
@@ -20,8 +20,6 @@ extern "C" {
 #define MAX_RANDOM_INTS (1024 * 1024)
 #define MAX_RANDOM_INTS_SIZE (MAX_RANDOM_INTS * sizeof(uint32_t))
 
-typedef uint32_t (*adler32_func)(uint32_t adler, const unsigned char *buf, size_t len);
-
 class adler32: public benchmark::Fixture {
 private:
     uint32_t *random_ints;

--- a/test/benchmarks/benchmark_compare256.cc
+++ b/test/benchmarks/benchmark_compare256.cc
@@ -18,8 +18,6 @@ extern "C" {
 
 #define MAX_COMPARE_SIZE (256)
 
-typedef uint32_t (*compare256_func)(const uint8_t *src0, const uint8_t *src1);
-
 class compare256: public benchmark::Fixture {
 private:
     uint8_t *str1;

--- a/test/benchmarks/benchmark_compare256.cc
+++ b/test/benchmarks/benchmark_compare256.cc
@@ -18,7 +18,7 @@ extern "C" {
 
 #define MAX_COMPARE_SIZE (256)
 
-typedef uint32_t (*compare256_func)(const unsigned char *src0, const unsigned char *src1);
+typedef uint32_t (*compare256_func)(const uint8_t *src0, const uint8_t *src1);
 
 class compare256: public benchmark::Fixture {
 private:

--- a/test/benchmarks/benchmark_crc32.cc
+++ b/test/benchmarks/benchmark_crc32.cc
@@ -20,8 +20,6 @@ extern "C" {
 #define MAX_RANDOM_INTS (1024 * 1024)
 #define MAX_RANDOM_INTS_SIZE (MAX_RANDOM_INTS * sizeof(uint32_t))
 
-typedef uint32_t (*crc32_func)(uint32_t crc32, const unsigned char * buf, uint64_t len);
-
 class crc32: public benchmark::Fixture {
 private:
     uint32_t *random_ints;

--- a/test/benchmarks/benchmark_slidehash.cc
+++ b/test/benchmarks/benchmark_slidehash.cc
@@ -19,8 +19,6 @@ extern "C" {
 
 #define MAX_RANDOM_INTS 32768
 
-typedef void (*slide_hash_func)(deflate_state *s);
-
 class slide_hash: public benchmark::Fixture {
 private:
     uint16_t *l0;

--- a/zutil.h
+++ b/zutil.h
@@ -259,14 +259,4 @@ void Z_INTERNAL   zng_cfree(void *opaque, void *ptr);
 #  define ALIGNED_(x) __declspec(align(x))
 #endif
 
-#if defined(X86_FEATURES)
-#  include "arch/x86/x86.h"
-#elif defined(ARM_FEATURES)
-#  include "arch/arm/arm.h"
-#elif defined(PPC_FEATURES) || defined(POWER_FEATURES)
-#  include "arch/power/power.h"
-#elif defined(S390_FEATURES)
-#  include "arch/s390/s390.h"
-#endif
-
 #endif /* ZUTIL_H_ */


### PR DESCRIPTION
Clean up and moving arch feature includes out of zutil.h. This is good because zutil.h is included by many files and not all of them use cpu features. 
