### PR TITLE
Move macros from zutil.h to zbuild.h

### DIFF
--- a/adler32.c
+++ b/adler32.c
@@ -4,7 +4,6 @@
  */
 
 #include "zbuild.h"
-#include "zutil.h"
 #include "functable.h"
 #include "adler32_p.h"
 

--- a/arch/x86/adler32_avx2.c
+++ b/arch/x86/adler32_avx2.c
@@ -6,8 +6,6 @@
  */
 
 #include "../../zbuild.h"
-#include "../../zutil.h"
-
 #include "../../adler32_p.h"
 #include "../../fallback_builtins.h"
 

--- a/arch/x86/adler32_avx512.c
+++ b/arch/x86/adler32_avx512.c
@@ -7,8 +7,6 @@
  */
 
 #include "../../zbuild.h"
-#include "../../zutil.h"
-
 #include "../../adler32_p.h"
 #include "../../cpu_features.h"
 #include "../../fallback_builtins.h"

--- a/arch/x86/adler32_avx512_vnni.c
+++ b/arch/x86/adler32_avx512_vnni.c
@@ -8,8 +8,6 @@
  */
 
 #include "../../zbuild.h"
-#include "../../zutil.h"
-
 #include "../../adler32_p.h"
 #include "../../cpu_features.h"
 #include "../../fallback_builtins.h"

--- a/arch/x86/adler32_sse41.c
+++ b/arch/x86/adler32_sse41.c
@@ -7,8 +7,6 @@
  */
 
 #include "../../zbuild.h"
-#include "../../zutil.h"
-
 #include "../../adler32_p.h"
 
 #ifdef X86_SSE41_ADLER32

--- a/arch/x86/adler32_ssse3.c
+++ b/arch/x86/adler32_ssse3.c
@@ -6,8 +6,6 @@
  */
 
 #include "../../zbuild.h"
-#include "../../zutil.h"
-
 #include "../../adler32_p.h"
 
 #ifdef X86_SSSE3_ADLER32

--- a/arch/x86/chunkset_avx.c
+++ b/arch/x86/chunkset_avx.c
@@ -2,7 +2,6 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 #include "zbuild.h"
-#include "zutil.h"
 
 #ifdef X86_AVX_CHUNKSET
 #include <immintrin.h>

--- a/arch/x86/chunkset_sse2.c
+++ b/arch/x86/chunkset_sse2.c
@@ -3,7 +3,6 @@
  */
 
 #include "zbuild.h"
-#include "zutil.h"
 
 #ifdef X86_SSE2
 #include <immintrin.h>

--- a/arch/x86/compare256_avx2.c
+++ b/arch/x86/compare256_avx2.c
@@ -4,7 +4,6 @@
  */
 
 #include "../../zbuild.h"
-#include "../../zutil.h"
 
 #include "fallback_builtins.h"
 

--- a/arch/x86/compare256_sse42.c
+++ b/arch/x86/compare256_sse42.c
@@ -16,7 +16,6 @@
  */
 
 #include "../../zbuild.h"
-#include "../../zutil.h"
 
 #ifdef X86_SSE42_CMP_STR
 
@@ -30,22 +29,22 @@ static inline uint32_t compare256_unaligned_sse4_static(const uint8_t *src0, con
     uint32_t len = 0;
 
     do {
-        #define mode _SIDD_UBYTE_OPS | _SIDD_CMP_EQUAL_EACH | _SIDD_NEGATIVE_POLARITY
+        #define cmp_mode _SIDD_UBYTE_OPS | _SIDD_CMP_EQUAL_EACH | _SIDD_NEGATIVE_POLARITY
         __m128i xmm_src0, xmm_src1;
         uint32_t ret;
 
         xmm_src0 = _mm_loadu_si128((__m128i *)src0);
         xmm_src1 = _mm_loadu_si128((__m128i *)src1);
-        ret = (uint32_t)_mm_cmpestri(xmm_src0, 16, xmm_src1, 16, mode);
-        if (_mm_cmpestrc(xmm_src0, 16, xmm_src1, 16, mode)) {
+        ret = (uint32_t)_mm_cmpestri(xmm_src0, 16, xmm_src1, 16, cmp_mode);
+        if (_mm_cmpestrc(xmm_src0, 16, xmm_src1, 16, cmp_mode)) {
             return len + ret;
         }
         src0 += 16, src1 += 16, len += 16;
 
         xmm_src0 = _mm_loadu_si128((__m128i *)src0);
         xmm_src1 = _mm_loadu_si128((__m128i *)src1);
-        ret = (uint32_t)_mm_cmpestri(xmm_src0, 16, xmm_src1, 16, mode);
-        if (_mm_cmpestrc(xmm_src0, 16, xmm_src1, 16, mode)) {
+        ret = (uint32_t)_mm_cmpestri(xmm_src0, 16, xmm_src1, 16, cmp_mode);
+        if (_mm_cmpestrc(xmm_src0, 16, xmm_src1, 16, cmp_mode)) {
             return len + ret;
         }
         src0 += 16, src1 += 16, len += 16;

--- a/arch/x86/crc32_fold_pclmulqdq.c
+++ b/arch/x86/crc32_fold_pclmulqdq.c
@@ -17,7 +17,7 @@
  */
 
 #ifdef X86_PCLMULQDQ_CRC
-#include "../../zutil.h"
+#include "../../zbuild.h"
 
 #include <stdint.h>
 #include <immintrin.h>

--- a/arch/x86/crc32_fold_vpclmulqdq.c
+++ b/arch/x86/crc32_fold_vpclmulqdq.c
@@ -4,7 +4,7 @@
  */
 
 #ifdef X86_VPCLMULQDQ_CRC
-#include "../../zutil.h"
+#include "../../zbuild.h"
 
 #include <immintrin.h>
 
@@ -14,9 +14,9 @@ size_t fold_16_vpclmulqdq(__m128i *xmm_crc0, __m128i *xmm_crc1,
     __m512i zmm_t0, zmm_t1, zmm_t2, zmm_t3;
     __m512i zmm_crc0, zmm_crc1, zmm_crc2, zmm_crc3;
     __m512i z0, z1, z2, z3;
-    z_const __m512i zmm_fold4 = _mm512_set4_epi32(
+    const __m512i zmm_fold4 = _mm512_set4_epi32(
         0x00000001, 0x54442bd4, 0x00000001, 0xc6e41596);
-    z_const __m512i zmm_fold16 = _mm512_set4_epi32(
+    const __m512i zmm_fold16 = _mm512_set4_epi32(
         0x00000001, 0x1542778a, 0x00000001, 0x322d1430);
 
     // zmm register init

--- a/arch/x86/x86.c
+++ b/arch/x86/x86.c
@@ -7,7 +7,7 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-#include "../../zutil.h"
+#include "../../zbuild.h"
 
 #ifdef _MSC_VER
 #  include <intrin.h>

--- a/chunkset.c
+++ b/chunkset.c
@@ -3,7 +3,6 @@
  */
 
 #include "zbuild.h"
-#include "zutil.h"
 
 /* Define 8 byte chunks differently depending on unaligned support */
 #if defined(UNALIGNED64_OK)

--- a/chunkset_tpl.h
+++ b/chunkset_tpl.h
@@ -2,6 +2,8 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
+#include "zbuild.h"
+
 /* Returns the chunk size */
 Z_INTERNAL uint32_t CHUNKSIZE(void) {
     return sizeof(chunk_t);

--- a/compare256.c
+++ b/compare256.c
@@ -4,8 +4,6 @@
  */
 
 #include "zbuild.h"
-#include "zutil.h"
-
 #include "fallback_builtins.h"
 
 /* ALIGNED, byte comparison */

--- a/crc32_fold.c
+++ b/crc32_fold.c
@@ -3,7 +3,6 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 #include "zbuild.h"
-#include "zutil.h"
 #include "functable.h"
 
 #include "crc32_fold.h"

--- a/crc32_p.h
+++ b/crc32_p.h
@@ -1,7 +1,7 @@
 #ifndef CRC32_P_H_
 #define CRC32_P_H_
 
-#include "zutil.h"
+#include "zbuild.h"
 #include "zendian.h"
 
 #define GF2_DIM 32      /* dimension of GF(2) vectors (length of CRC) */

--- a/test/benchmarks/benchmark_main.cc
+++ b/test/benchmarks/benchmark_main.cc
@@ -11,7 +11,6 @@
 
 extern "C" {
 #  include "zbuild.h"
-#  include "zutil.h"
 #  include "cpu_features.h"
 }
 

--- a/test/example.c
+++ b/test/example.c
@@ -12,9 +12,6 @@
 #include "deflate.h"
 
 #include <stdio.h>
-
-#include <string.h>
-#include <stdlib.h>
 #include <stdarg.h>
 #include <inttypes.h>
 

--- a/test/fuzz/fuzzer_checksum.c
+++ b/test/fuzz/fuzzer_checksum.c
@@ -1,9 +1,5 @@
 #include <stdio.h>
-#include <stddef.h>
-#include <stdint.h>
-#include <string.h>
 #include <assert.h>
-#include <stdlib.h>
 
 #include "zbuild.h"
 #ifdef ZLIB_COMPAT

--- a/test/fuzz/fuzzer_compress.c
+++ b/test/fuzz/fuzzer_compress.c
@@ -1,9 +1,5 @@
 #include <stdio.h>
-#include <stddef.h>
-#include <stdint.h>
-#include <string.h>
 #include <assert.h>
-#include <stdlib.h>
 
 #include "zbuild.h"
 #ifdef ZLIB_COMPAT

--- a/test/fuzz/fuzzer_example_dict.c
+++ b/test/fuzz/fuzzer_example_dict.c
@@ -1,9 +1,5 @@
 #include <stdio.h>
-#include <stddef.h>
-#include <stdint.h>
-#include <string.h>
 #include <assert.h>
-#include <stdlib.h>
 
 #include "zbuild.h"
 #ifdef ZLIB_COMPAT

--- a/test/fuzz/fuzzer_example_large.c
+++ b/test/fuzz/fuzzer_example_large.c
@@ -1,8 +1,5 @@
 #include <stdio.h>
-#include <stddef.h>
-#include <string.h>
 #include <assert.h>
-#include <stdlib.h>
 #include <inttypes.h>
 
 #include "zbuild.h"

--- a/test/fuzz/fuzzer_example_small.c
+++ b/test/fuzz/fuzzer_example_small.c
@@ -1,9 +1,5 @@
 #include <stdio.h>
-#include <stddef.h>
-#include <stdint.h>
-#include <string.h>
 #include <assert.h>
-#include <stdlib.h>
 
 #include "zbuild.h"
 #ifdef ZLIB_COMPAT

--- a/test/fuzz/fuzzer_minigzip.c
+++ b/test/fuzz/fuzzer_minigzip.c
@@ -12,9 +12,6 @@
  * real thing.
  */
 
-#define _POSIX_SOURCE 1  /* This file needs POSIX for fileno(). */
-#define _POSIX_C_SOURCE 200112  /* For snprintf(). */
-
 #include "zbuild.h"
 #ifdef ZLIB_COMPAT
 #  include "zlib.h"
@@ -23,8 +20,6 @@
 #endif
 #include <stdio.h>
 #include <assert.h>
-#include <string.h>
-#include <stdlib.h>
 
 #ifdef USE_MMAP
 #  include <sys/types.h>

--- a/test/fuzz/standalone_fuzz_target_runner.c
+++ b/test/fuzz/standalone_fuzz_target_runner.c
@@ -1,6 +1,5 @@
 #include <assert.h>
 #include <stdio.h>
-#include <stdlib.h>
 
 #include "zbuild.h"
 

--- a/test/minideflate.c
+++ b/test/minideflate.c
@@ -3,15 +3,8 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-#define _POSIX_SOURCE 1  /* This file needs POSIX for fileno(). */
-#define _POSIX_C_SOURCE 200112  /* For snprintf(). */
-
 #include <stdio.h>
-#include <stddef.h>
-#include <stdint.h>
-#include <string.h>
 #include <assert.h>
-#include <stdlib.h>
 
 #include "zbuild.h"
 #ifdef ZLIB_COMPAT
@@ -272,7 +265,7 @@ int main(int argc, char **argv) {
         } else if (argv[i][0] == '-') {
             show_help();
             return 64;   /* EX_USAGE */
-        } else 
+        } else
             break;
     }
 

--- a/test/minigzip.c
+++ b/test/minigzip.c
@@ -12,9 +12,6 @@
  * real thing.
  */
 
-#define _POSIX_SOURCE 1
-#define _POSIX_C_SOURCE 200112  /* For snprintf(). */
-
 #include "zbuild.h"
 #ifdef ZLIB_COMPAT
 #  include "zlib.h"

--- a/test/switchlevels.c
+++ b/test/switchlevels.c
@@ -2,8 +2,6 @@
  * Each chunk is compressed with a user-specified level.
  */
 
-#define _POSIX_SOURCE 1  /* This file needs POSIX for fileno(). */
-
 #include "zbuild.h"
 #ifdef ZLIB_COMPAT
 #  include "zlib.h"
@@ -12,8 +10,6 @@
 #endif
 
 #include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 
 #if defined(_WIN32) || defined(__CYGWIN__)
 #  include <fcntl.h>

--- a/test/test_adler32.c
+++ b/test/test_adler32.c
@@ -4,16 +4,14 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-
 #include "zbuild.h"
 #ifdef ZLIB_COMPAT
 #  include "zlib.h"
 #else
 #  include "zlib-ng.h"
 #endif
+
+#include <stdio.h>
 
 typedef struct {
     uint32_t line;

--- a/test/test_crc32.c
+++ b/test/test_crc32.c
@@ -5,16 +5,14 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-
 #include "zbuild.h"
 #ifdef ZLIB_COMPAT
 #  include "zlib.h"
 #else
 #  include "zlib-ng.h"
 #endif
+
+#include <stdio.h>
 
 typedef struct {
     uint32_t line;

--- a/uncompr.c
+++ b/uncompr.c
@@ -3,7 +3,6 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-#define Z_INTERNAL
 #include "zbuild.h"
 #ifdef ZLIB_COMPAT
 #  include "zlib.h"

--- a/zbuild.h
+++ b/zbuild.h
@@ -1,6 +1,11 @@
 #ifndef _ZBUILD_H
 #define _ZBUILD_H
 
+#define _POSIX_SOURCE 1  /* fileno */
+#ifndef _POSIX_C_SOURCE
+#  define _POSIX_C_SOURCE 200112L /* snprintf, posix_memalign */
+#endif
+
 #include <stddef.h>
 #include <string.h>
 #include <stdlib.h>

--- a/zutil.h
+++ b/zutil.h
@@ -10,30 +10,12 @@
    subject to change. Applications should only use zlib.h.
  */
 
-#if defined(HAVE_VISIBILITY_INTERNAL)
-#  define Z_INTERNAL __attribute__((visibility ("internal")))
-#elif defined(HAVE_VISIBILITY_HIDDEN)
-#  define Z_INTERNAL __attribute__((visibility ("hidden")))
-#else
-#  define Z_INTERNAL
-#endif
-
-#ifndef __cplusplus
-#  define Z_REGISTER register
-#else
-#  define Z_REGISTER
-#endif
-
-#include <stddef.h>
-#include <string.h>
-#include <stdlib.h>
-#include <stdint.h>
+#include "zbuild.h"
 #ifdef ZLIB_COMPAT
 #  include "zlib.h"
 #else
 #  include "zlib-ng.h"
 #endif
-#include "zbuild.h"
 
 typedef unsigned char uch; /* Included for compatibility with external code only */
 typedef uint16_t ush;      /* Included for compatibility with external code only */
@@ -132,12 +114,6 @@ extern z_const char * const PREFIX(z_errmsg)[10]; /* indexed by 2-zlib_error */
 #  define OS_CODE 19
 #endif
 
-/* MS Visual Studio does not allow inline in C, only C++.
-   But it provides __inline instead, so use that. */
-#if defined(_MSC_VER) && !defined(inline) && !defined(__cplusplus)
-#  define inline __inline
-#endif
-
         /* common defaults */
 
 #ifndef OS_CODE
@@ -146,113 +122,11 @@ extern z_const char * const PREFIX(z_errmsg)[10]; /* indexed by 2-zlib_error */
 
          /* functions */
 
-/* Diagnostic functions */
-#ifdef ZLIB_DEBUG
-#  include <stdio.h>
-   extern int Z_INTERNAL z_verbose;
-   extern void Z_INTERNAL z_error(char *m);
-#  define Assert(cond, msg) {if (!(cond)) z_error(msg);}
-#  define Trace(x) {if (z_verbose >= 0) fprintf x;}
-#  define Tracev(x) {if (z_verbose > 0) fprintf x;}
-#  define Tracevv(x) {if (z_verbose > 1) fprintf x;}
-#  define Tracec(c, x) {if (z_verbose > 0 && (c)) fprintf x;}
-#  define Tracecv(c, x) {if (z_verbose > 1 && (c)) fprintf x;}
-#else
-#  define Assert(cond, msg)
-#  define Trace(x)
-#  define Tracev(x)
-#  define Tracevv(x)
-#  define Tracec(c, x)
-#  define Tracecv(c, x)
-#endif
-
 void Z_INTERNAL *zng_calloc(void *opaque, unsigned items, unsigned size);
 void Z_INTERNAL   zng_cfree(void *opaque, void *ptr);
 
 #define ZALLOC(strm, items, size) (*((strm)->zalloc))((strm)->opaque, (items), (size))
 #define ZFREE(strm, addr)         (*((strm)->zfree))((strm)->opaque, (void *)(addr))
 #define TRY_FREE(s, p)            {if (p) ZFREE(s, p);}
-
-/* Reverse the bytes in a value. Use compiler intrinsics when
-   possible to take advantage of hardware implementations. */
-#if defined(_MSC_VER) && (_MSC_VER >= 1300)
-#  pragma intrinsic(_byteswap_ulong)
-#  define ZSWAP16(q) _byteswap_ushort(q)
-#  define ZSWAP32(q) _byteswap_ulong(q)
-#  define ZSWAP64(q) _byteswap_uint64(q)
-
-#elif defined(__Clang__) || (defined(__GNUC__) && \
-        (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)))
-#  define ZSWAP16(q) __builtin_bswap16(q)
-#  define ZSWAP32(q) __builtin_bswap32(q)
-#  define ZSWAP64(q) __builtin_bswap64(q)
-
-#elif defined(__GNUC__) && (__GNUC__ >= 2) && defined(__linux__)
-#  include <byteswap.h>
-#  define ZSWAP16(q) bswap_16(q)
-#  define ZSWAP32(q) bswap_32(q)
-#  define ZSWAP64(q) bswap_64(q)
-
-#elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
-#  include <sys/endian.h>
-#  define ZSWAP16(q) bswap16(q)
-#  define ZSWAP32(q) bswap32(q)
-#  define ZSWAP64(q) bswap64(q)
-#elif defined(__OpenBSD__)
-#  include <sys/endian.h>
-#  define ZSWAP16(q) swap16(q)
-#  define ZSWAP32(q) swap32(q)
-#  define ZSWAP64(q) swap64(q)
-#elif defined(__INTEL_COMPILER)
-/* ICC does not provide a two byte swap. */
-#  define ZSWAP16(q) ((((q) & 0xff) << 8) | (((q) & 0xff00) >> 8))
-#  define ZSWAP32(q) _bswap(q)
-#  define ZSWAP64(q) _bswap64(q)
-
-#else
-#  define ZSWAP16(q) ((((q) & 0xff) << 8) | (((q) & 0xff00) >> 8))
-#  define ZSWAP32(q) ((((q) >> 24) & 0xff) + (((q) >> 8) & 0xff00) + \
-                     (((q) & 0xff00) << 8) + (((q) & 0xff) << 24))
-#  define ZSWAP64(q)                           \
-         (((q & 0xFF00000000000000u) >> 56u) | \
-          ((q & 0x00FF000000000000u) >> 40u) | \
-          ((q & 0x0000FF0000000000u) >> 24u) | \
-          ((q & 0x000000FF00000000u) >> 8u)  | \
-          ((q & 0x00000000FF000000u) << 8u)  | \
-          ((q & 0x0000000000FF0000u) << 24u) | \
-          ((q & 0x000000000000FF00u) << 40u) | \
-          ((q & 0x00000000000000FFu) << 56u))
-#endif
-
-/* Only enable likely/unlikely if the compiler is known to support it */
-#if (defined(__GNUC__) && (__GNUC__ >= 3)) || defined(__INTEL_COMPILER) || defined(__Clang__)
-#  define LIKELY_NULL(x)        __builtin_expect((x) != 0, 0)
-#  define LIKELY(x)             __builtin_expect(!!(x), 1)
-#  define UNLIKELY(x)           __builtin_expect(!!(x), 0)
-#  define PREFETCH_L1(addr)     __builtin_prefetch(addr, 0, 3)
-#  define PREFETCH_L2(addr)     __builtin_prefetch(addr, 0, 2)
-#  define PREFETCH_RW(addr)     __builtin_prefetch(addr, 1, 2)
-#elif defined(__WIN__)
-#  include <xmmintrin.h>
-#  define LIKELY_NULL(x)        x
-#  define LIKELY(x)             x
-#  define UNLIKELY(x)           x
-#  define PREFETCH_L1(addr)     _mm_prefetch((char *) addr, _MM_HINT_T0)
-#  define PREFETCH_L2(addr)     _mm_prefetch((char *) addr, _MM_HINT_T1)
-#  define PREFETCH_RW(addr)     _mm_prefetch((char *) addr, _MM_HINT_T1)
-#else
-#  define LIKELY_NULL(x)        x
-#  define LIKELY(x)             x
-#  define UNLIKELY(x)           x
-#  define PREFETCH_L1(addr)     addr
-#  define PREFETCH_L2(addr)     addr
-#  define PREFETCH_RW(addr)     addr
-#endif /* (un)likely */
-
-#if defined(__clang__) || defined(__GNUC__)
-#  define ALIGNED_(x) __attribute__ ((aligned(x)))
-#elif defined(_MSC_VER)
-#  define ALIGNED_(x) __declspec(align(x))
-#endif
 
 #endif /* ZUTIL_H_ */

--- a/zutil_p.h
+++ b/zutil_p.h
@@ -1,13 +1,9 @@
 /* zutil_p.h -- Private inline functions used internally in zlib-ng
- *
+ * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
 #ifndef ZUTIL_P_H
 #define ZUTIL_P_H
-
-#if defined(HAVE_POSIX_MEMALIGN) && !defined(_POSIX_C_SOURCE)
-#  define _POSIX_C_SOURCE 200112L  /* For posix_memalign(). */
-#endif
 
 #if defined(__APPLE__) || defined(HAVE_POSIX_MEMALIGN)
 #  include <stdlib.h>


### PR DESCRIPTION
This removes the dependency of zutil.h in several files. Why does it matter? Because zutil.h includes zlib.h. We should only include zlib.h or zlib-ng.h where it is absolutely necessary.

