### PR TITLE
Use static keyword for vec_sumsu to prevent undefined reference error

### DIFF
--- a/arch/power/adler32_power8.c
+++ b/arch/power/adler32_power8.c
@@ -44,7 +44,7 @@
 #include "adler32_p.h"
 
 /* Vector across sum unsigned int (saturate).  */
-inline vector unsigned int vec_sumsu(vector unsigned int __a, vector unsigned int __b) {
+static inline vector unsigned int vec_sumsu(vector unsigned int __a, vector unsigned int __b) {
     __b = vec_sld(__a, __a, 8);
     __b = vec_add(__b, __a);
     __a = vec_sld(__b, __b, 4);


### PR DESCRIPTION
```
/usr/lib/gcc-cross/powerpc64-linux-gnu/9/../../../../powerpc64-linux-gnu/bin/ld: libz-ng.a(adler32_power8.c.o): in function `adler32_power8':
adler32_power8.c:(.text+0x830): undefined reference to `vec_sumsu'
/usr/lib/gcc-cross/powerpc64-linux-gnu/9/../../../../powerpc64-linux-gnu/bin/ld: adler32_power8.c:(.text+0x8d8): undefined reference to `vec_sumsu'
/usr/lib/gcc-cross/powerpc64-linux-gnu/9/../../../../powerpc64-linux-gnu/bin/ld: adler32_power8.c:(.text+0xb80): undefined reference to `vec_sumsu'
/usr/lib/gcc-cross/powerpc64-linux-gnu/9/../../../../powerpc64-linux-gnu/bin/ld: adler32_power8.c:(.text+0xc28): undefined reference to `vec_sumsu'
```