### PR TITLE
Use add_link_options in CMake projects.

### DIFF
--- a/cmake/detect-coverage.cmake
+++ b/cmake/detect-coverage.cmake
@@ -2,35 +2,27 @@
 # Licensed under the Zlib license, see LICENSE.md for details
 
 macro(add_code_coverage)
-    # Check for -coverage flag support for Clang/GCC
     if(CMAKE_VERSION VERSION_LESS 3.14)
-        set(CMAKE_REQUIRED_LIBRARIES -lgcov)
-    else()
-        set(CMAKE_REQUIRED_LINK_OPTIONS -coverage)
+        message(FATAL_ERROR "CMake 3.14 or later is required for code coverage")
     endif()
+
+    # Check for -coverage flag support for Clang/GCC
+    set(CMAKE_REQUIRED_LINK_OPTIONS -coverage)
     check_c_compiler_flag(-coverage HAVE_COVERAGE)
-    set(CMAKE_REQUIRED_LIBRARIES)
     set(CMAKE_REQUIRED_LINK_OPTIONS)
 
     if(HAVE_COVERAGE)
         set(CMAKE_C_FLAGS "-O0 ${CMAKE_C_FLAGS} -coverage")
-        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -coverage")
-        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -coverage")
+        add_link_options(-coverage)
     else()
         # Some versions of GCC don't support -coverage shorthand
-        if(CMAKE_VERSION VERSION_LESS 3.14)
-            set(CMAKE_REQUIRED_LIBRARIES -lgcov)
-        else()
-            set(CMAKE_REQUIRED_LINK_OPTIONS -lgcov -fprofile-arcs)
-        endif()
+        set(CMAKE_REQUIRED_LINK_OPTIONS -lgcov -fprofile-arcs)
         check_c_compiler_flag("-ftest-coverage -fprofile-arcs -fprofile-values" HAVE_TEST_COVERAGE)
-        set(CMAKE_REQUIRED_LIBRARIES)
         set(CMAKE_REQUIRED_LINK_OPTIONS)
 
         if(HAVE_TEST_COVERAGE)
             set(CMAKE_C_FLAGS "-O0 ${CMAKE_C_FLAGS} -ftest-coverage -fprofile-arcs -fprofile-values")
-            set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lgcov -fprofile-arcs")
-            set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -lgcov -fprofile-arcs")
+            add_link_options(-lgcov -fprofile-arcs)
         else()
             message(WARNING "Compiler does not support code coverage")
         endif()


### PR DESCRIPTION
CMake 3.14 is required for `add_link_options`, so throw error for code coverage if using CMake less than 3.14. This also makes the CMake code less branchy. Using `add_link_options` should help with getting C++ linking working better. I encountered many issues when adding Google Test (C++) trying to compile sanitizers and it not working unless using `add_link_options`.