### PR TITLE
Make cmake and configure release flags consistent

### DIFF
--- a/configure
+++ b/configure
@@ -396,6 +396,9 @@ if test "$gcc" -eq 1 && ($cc $CFLAGS -c $test.c) >> configure.log 2>&1; then
   if test $debug -eq 1; then
     CFLAGS="${CFLAGS} -DZLIB_DEBUG"
     SFLAGS="${SFLAGS} -DZLIB_DEBUG"
+  else
+    CFLAGS="${CFLAGS} -DNDEBUG"
+    SFLAGS="${SFLAGS} -DNDEBUG"
   fi
   if test -z "$uname"; then
     uname=$((uname -s || echo unknown) 2>/dev/null)


### PR DESCRIPTION
CMake sufficiently appends -DNDEBUG to the preprocessor macros when not
compiling with debug symbols.  This turns off debug level assertions and
has some other side effects.  As such, we should equally append this
define to the configure scripts' CFLAGS.