### PR TITLE
[Benchmarks] Fix adler32/vmx benchmark not found under 32-bit PowerPC

### DIFF
--- a/test/benchmarks/benchmark_adler32.cc
+++ b/test/benchmarks/benchmark_adler32.cc
@@ -69,10 +69,13 @@ BENCHMARK_ADLER32(c, adler32_c, 1);
 
 #ifdef ARM_NEON_ADLER32
 BENCHMARK_ADLER32(neon, adler32_neon, arm_cpu_has_neon);
-#elif defined(POWER8_VSX_ADLER32)
-BENCHMARK_ADLER32(power8, adler32_power8, power_cpu_has_arch_2_07);
-#elif defined(PPC_VMX_ADLER32)
+#endif
+
+#ifdef PPC_VMX_ADLER32
 BENCHMARK_ADLER32(vmx, adler32_vmx, power_cpu_has_altivec);
+#endif
+#ifdef POWER8_VSX_ADLER32
+BENCHMARK_ADLER32(power8, adler32_power8, power_cpu_has_arch_2_07);
 #endif
 
 #ifdef X86_SSSE3_ADLER32


### PR DESCRIPTION
If `WITH_POWER8` is set, VMX adler32 benchmark isn't enabled even if current CPU doesn't support VSX.