### PR TITLE
Clean up header includes

### DIFF
--- a/arch/x86/crc32_fold_pclmulqdq.c
+++ b/arch/x86/crc32_fold_pclmulqdq.c
@@ -19,7 +19,6 @@
 #ifdef X86_PCLMULQDQ_CRC
 #include "../../zbuild.h"
 
-#include <stdint.h>
 #include <immintrin.h>
 #include <wmmintrin.h>
 #include <smmintrin.h> // _mm_extract_epi32

--- a/cpu_features.h
+++ b/cpu_features.h
@@ -6,7 +6,6 @@
 #ifndef CPU_FEATURES
 #define CPU_FEATURES
 
-#include "deflate.h"
 #include "crc32_fold.h"
 
 #if defined(X86_FEATURES)
@@ -128,6 +127,7 @@ extern uint32_t compare256_unaligned_avx2(const uint8_t *src0, const uint8_t *sr
 #endif
 #endif
 
+#ifdef DEFLATE_H_
 /* insert_string */
 extern void insert_string_c(deflate_state *const s, const uint32_t str, uint32_t count);
 #ifdef X86_SSE42_CRC_HASH
@@ -200,6 +200,7 @@ extern uint32_t update_hash_c(deflate_state *const s, uint32_t h, uint32_t val);
 extern uint32_t update_hash_sse4(deflate_state *const s, uint32_t h, uint32_t val);
 #elif defined(ARM_ACLE_CRC_HASH)
 extern uint32_t update_hash_acle(deflate_state *const s, uint32_t h, uint32_t val);
+#endif
 #endif
 
 #endif

--- a/cpu_features.h
+++ b/cpu_features.h
@@ -3,8 +3,8 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-#ifndef CPU_FEATURES
-#define CPU_FEATURES
+#ifndef CPU_FEATURES_H_
+#define CPU_FEATURES_H_
 
 #include "crc32_fold.h"
 

--- a/crc32.c
+++ b/crc32.c
@@ -11,7 +11,6 @@
 
 #include "zbuild.h"
 #include "zendian.h"
-#include <stdint.h>
 #include "deflate.h"
 #include "functable.h"
 #include "crc32_tbl.h"

--- a/crc32_comb.c
+++ b/crc32_comb.c
@@ -10,7 +10,6 @@
  */
 
 #include "zbuild.h"
-#include <stdint.h>
 #include "deflate.h"
 #include "crc32_p.h"
 #include "crc32_comb_tbl.h"

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -7,7 +7,6 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 #ifndef NO_MEDIUM_STRATEGY
-#include <stdint.h>
 #include "zbuild.h"
 #include "deflate.h"
 #include "deflate_p.h"

--- a/test/benchmarks/benchmark_adler32.cc
+++ b/test/benchmarks/benchmark_adler32.cc
@@ -3,9 +3,7 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-#include <stdint.h>
 #include <stdio.h>
-#include <stdint.h>
 #include <assert.h>
 
 #include <benchmark/benchmark.h>

--- a/test/benchmarks/benchmark_compare256.cc
+++ b/test/benchmarks/benchmark_compare256.cc
@@ -3,9 +3,7 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-#include <stdint.h>
 #include <stdio.h>
-#include <stdint.h>
 
 #include <benchmark/benchmark.h>
 

--- a/test/benchmarks/benchmark_crc32.cc
+++ b/test/benchmarks/benchmark_crc32.cc
@@ -3,9 +3,7 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-#include <stdint.h>
 #include <stdio.h>
-#include <stdint.h>
 #include <assert.h>
 
 #include <benchmark/benchmark.h>

--- a/test/benchmarks/benchmark_main.cc
+++ b/test/benchmarks/benchmark_main.cc
@@ -3,9 +3,7 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-#include <stdint.h>
 #include <stdio.h>
-#include <stdint.h>
 
 #include <benchmark/benchmark.h>
 

--- a/test/benchmarks/benchmark_slidehash.cc
+++ b/test/benchmarks/benchmark_slidehash.cc
@@ -11,8 +11,8 @@ extern "C" {
 #  include "zbuild.h"
 #  include "zutil.h"
 #  include "zutil_p.h"
-#  include "cpu_features.h"
 #  include "deflate.h"
+#  include "cpu_features.h"
 }
 
 #include <benchmark/benchmark.h>

--- a/test/benchmarks/benchmark_slidehash.cc
+++ b/test/benchmarks/benchmark_slidehash.cc
@@ -3,9 +3,9 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-#include <stdint.h>
-#include <stdint.h>
 #include <limits.h>
+
+#include <benchmark/benchmark.h>
 
 extern "C" {
 #  include "zbuild.h"
@@ -14,8 +14,6 @@ extern "C" {
 #  include "deflate.h"
 #  include "cpu_features.h"
 }
-
-#include <benchmark/benchmark.h>
 
 #define MAX_RANDOM_INTS 32768
 

--- a/test/fuzz/fuzzer_example_flush.c
+++ b/test/fuzz/fuzzer_example_flush.c
@@ -1,9 +1,5 @@
 #include <stdio.h>
-#include <stddef.h>
-#include <stdint.h>
-#include <string.h>
 #include <assert.h>
-#include <stdlib.h>
 
 #include "zbuild.h"
 #ifdef ZLIB_COMPAT


### PR DESCRIPTION
zbuild.h already includes stdint.h so no need to reinclude it.