### PR TITLE
Update NMake GitHub Actions to use Visual Studio 2022 Enterprise.

### DIFF
--- a/.github/workflows/nmake.yml
+++ b/.github/workflows/nmake.yml
@@ -9,40 +9,40 @@ jobs:
       matrix:
         include:
           - name: Windows NMake x86
-            os: windows-latest
+            os: windows-2022
             makefile: win32/Makefile.msc
             vc-vars: x86
 
           - name: Windows NMake x64 compat
-            os: windows-latest
+            os: windows-2022
             makefile: win32/Makefile.msc
             vc-vars: x86_amd64
             additional-args: ZLIB_COMPAT=yes
 
           - name: Windows NMake x64 sprefix
-            os: windows-latest
+            os: windows-2022
             makefile: win32/Makefile.msc
             vc-vars: x86_amd64
             additional-args: SYMBOL_PREFIX=zTest_
 
           - name: Windows NMake x64 sprefix compat
-            os: windows-latest
+            os: windows-2022
             makefile: win32/Makefile.msc
             vc-vars: x86_amd64
             additional-args: ZLIB_COMPAT=yes SYMBOL_PREFIX=zTest_
 
           - name: Windows NMake x64
-            os: windows-latest
+            os: windows-2022
             makefile: win32/Makefile.msc
             vc-vars: x86_amd64
 
           - name: Windows NMake ARM No Test
-            os: windows-latest
+            os: windows-2022
             makefile: win32/Makefile.arm
             vc-vars: x86_arm
 
           - name: Windows NMake ARM64 No Test
-            os: windows-latest
+            os: windows-2022
             makefile: win32/Makefile.a64
             vc-vars: x86_arm64
 
@@ -53,7 +53,7 @@ jobs:
     - name: Compile source code
       shell: cmd
       run: |
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.vc-vars }}
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.vc-vars }}
         nmake -f ${{ matrix.makefile }} ${{ matrix.additional-args }}
 
     - name: Run test cases
@@ -61,6 +61,6 @@ jobs:
       # Don't run tests on Windows ARM
       if: contains(matrix.vc-vars, 'arm') == false
       run: |
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.vc-vars }}
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.vc-vars }}
         nmake -f ${{ matrix.makefile }} ${{ matrix.additional-args }} test
         nmake -f ${{ matrix.makefile }} ${{ matrix.additional-args }} testdll


### PR DESCRIPTION
It makes more sense to explicitly specify Visual Studio version, so we don't need to constantly check if the runner has correct version installed.