### PR TITLE
Simplify zlib-ng native API usage

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -325,18 +325,16 @@ int32_t Z_EXPORT PREFIX(deflateInit)(PREFIX3(stream) *strm, int32_t level) {
 
 /* Function used by zlib.h and zlib-ng version 2.0 macros */
 int32_t Z_EXPORT PREFIX(deflateInit_)(PREFIX3(stream) *strm, int32_t level, const char *version, int32_t stream_size) {
-    if (version == NULL || version[0] != PREFIX2(VERSION)[0] || stream_size != sizeof(PREFIX3(stream))) {
+    if (CHECK_VER_STSIZE(version, stream_size))
         return Z_VERSION_ERROR;
-    }
     return PREFIX(deflateInit2)(strm, level, Z_DEFLATED, MAX_WBITS, DEF_MEM_LEVEL, Z_DEFAULT_STRATEGY);
 }
 
 /* Function used by zlib.h and zlib-ng version 2.0 macros */
 int32_t Z_EXPORT PREFIX(deflateInit2_)(PREFIX3(stream) *strm, int32_t level, int32_t method, int32_t windowBits,
                            int32_t memLevel, int32_t strategy, const char *version, int32_t stream_size) {
-    if (version == NULL || version[0] != PREFIX2(VERSION)[0] || stream_size != sizeof(PREFIX3(stream))) {
+    if (CHECK_VER_STSIZE(version, stream_size))
         return Z_VERSION_ERROR;
-    }
     return PREFIX(deflateInit2)(strm, level, method, windowBits, memLevel, strategy);
 }
 

--- a/gzread.c.in
+++ b/gzread.c.in
@@ -432,9 +432,11 @@ int Z_EXPORT PREFIX(gzgetc)(gzFile file) {
     return gz_read(state, buf, 1) < 1 ? -1 : buf[0];
 }
 
+#ifdef ZLIB_COMPAT
 int Z_EXPORT PREFIX(gzgetc_)(gzFile file) {
     return PREFIX(gzgetc)(file);
 }
+#endif
 
 /* -- see zlib.h -- */
 int Z_EXPORT PREFIX(gzungetc)(int c, gzFile file) {

--- a/infback.c
+++ b/infback.c
@@ -62,9 +62,8 @@ int32_t ZNG_CONDEXPORT PREFIX(inflateBackInit)(PREFIX3(stream) *strm, int32_t wi
 /* Function used by zlib.h and zlib-ng version 2.0 macros */
 int32_t Z_EXPORT PREFIX(inflateBackInit_)(PREFIX3(stream) *strm, int32_t windowBits, uint8_t *window,
                               const char *version, int32_t stream_size) {
-    if (version == NULL || version[0] != PREFIX2(VERSION)[0] || stream_size != (int)(sizeof(PREFIX3(stream)))) {
+    if (CHECK_VER_STSIZE(version, stream_size))
         return Z_VERSION_ERROR;
-    }
     return PREFIX(inflateBackInit)(strm, windowBits, window);
 }
 

--- a/inflate.c
+++ b/inflate.c
@@ -175,14 +175,14 @@ int32_t Z_EXPORT PREFIX(inflateInit)(PREFIX3(stream) *strm) {
 
 /* Function used by zlib.h and zlib-ng version 2.0 macros */
 int32_t Z_EXPORT PREFIX(inflateInit_)(PREFIX3(stream) *strm, const char *version, int32_t stream_size) {
-    if (version == NULL || version[0] != PREFIX2(VERSION)[0] || stream_size != (int)(sizeof(PREFIX3(stream))))
+    if (CHECK_VER_STSIZE(version, stream_size))
         return Z_VERSION_ERROR;
     return PREFIX(inflateInit2)(strm, DEF_WBITS);
 }
 
 /* Function used by zlib.h and zlib-ng version 2.0 macros */
 int32_t Z_EXPORT PREFIX(inflateInit2_)(PREFIX3(stream) *strm, int32_t windowBits, const char *version, int32_t stream_size) {
-    if (version == NULL || version[0] != PREFIX2(VERSION)[0] || stream_size != (int)(sizeof(PREFIX3(stream))))
+    if (CHECK_VER_STSIZE(version, stream_size))
         return Z_VERSION_ERROR;
     return PREFIX(inflateInit2)(strm, windowBits);
 }

--- a/test/infcover.c
+++ b/test/infcover.c
@@ -368,12 +368,14 @@ static void cover_support(void) {
     inf("3 0", "use fixed blocks", 0, -15, 1, Z_STREAM_END);
     inf("", "bad window size", 0, 1, 0, Z_STREAM_ERROR);
 
+#ifdef ZLIB_COMPAT
     mem_setup(&strm);
     strm.avail_in = 0;
     strm.next_in = NULL;
     ret = PREFIX(inflateInit_)(&strm, &PREFIX2(VERSION)[1], (int)sizeof(PREFIX3(stream)));
                                                 assert(ret == Z_VERSION_ERROR);
     mem_done(&strm, "wrong version");
+#endif
 
     strm.avail_in = 0;
     strm.next_in = NULL;
@@ -474,8 +476,11 @@ static void cover_back(void) {
     PREFIX3(stream) strm;
     unsigned char win[32768];
 
+#ifdef ZLIB_COMPAT
     ret = PREFIX(inflateBackInit_)(NULL, 0, win, 0, 0);
                                                 assert(ret == Z_VERSION_ERROR);
+#endif
+
     ret = PREFIX(inflateBackInit)(NULL, 0, win);
                                                 assert(ret == Z_STREAM_ERROR);
     ret = PREFIX(inflateBack)(NULL, NULL, NULL, NULL, NULL);

--- a/win32/zlib-ng.def.in
+++ b/win32/zlib-ng.def.in
@@ -4,8 +4,13 @@ EXPORTS
     @ZLIB_SYMBOL_PREFIX@zlibng_version
     @ZLIB_SYMBOL_PREFIX@zng_deflate
     @ZLIB_SYMBOL_PREFIX@zng_deflateEnd
+    @ZLIB_SYMBOL_PREFIX@zng_deflateInit
+    @ZLIB_SYMBOL_PREFIX@zng_deflateInit2
     @ZLIB_SYMBOL_PREFIX@zng_inflate
     @ZLIB_SYMBOL_PREFIX@zng_inflateEnd
+    @ZLIB_SYMBOL_PREFIX@zng_inflateInit
+    @ZLIB_SYMBOL_PREFIX@zng_inflateInit2
+    @ZLIB_SYMBOL_PREFIX@zng_inflateBackInit
 ; advanced functions
     @ZLIB_SYMBOL_PREFIX@zng_deflateSetDictionary
     @ZLIB_SYMBOL_PREFIX@zng_deflateGetDictionary
@@ -45,11 +50,6 @@ EXPORTS
     @ZLIB_SYMBOL_PREFIX@zng_adler32_combine
     @ZLIB_SYMBOL_PREFIX@zng_crc32_combine
 ; various hacks, don't look :)
-    @ZLIB_SYMBOL_PREFIX@zng_deflateInit_
-    @ZLIB_SYMBOL_PREFIX@zng_deflateInit2_
-    @ZLIB_SYMBOL_PREFIX@zng_inflateInit_
-    @ZLIB_SYMBOL_PREFIX@zng_inflateInit2_
-    @ZLIB_SYMBOL_PREFIX@zng_inflateBackInit_
     @ZLIB_SYMBOL_PREFIX@zng_zError
     @ZLIB_SYMBOL_PREFIX@zng_inflateSyncPoint
     @ZLIB_SYMBOL_PREFIX@zng_get_crc_table

--- a/zconf-ng.h.in
+++ b/zconf-ng.h.in
@@ -88,6 +88,9 @@
 #  define Z_EXPORTVA
 #endif
 
+/* Conditional exports */
+#define ZNG_CONDEXPORT Z_EXPORT
+
 /* Fallback for something that includes us. */
 typedef unsigned char Byte;
 typedef Byte Bytef;

--- a/zconf.h.in
+++ b/zconf.h.in
@@ -96,6 +96,9 @@
 #  define Z_EXPORTVA
 #endif
 
+/* Conditional exports */
+#define ZNG_CONDEXPORT Z_INTERNAL
+
 /* For backwards compatibility */
 
 #ifndef ZEXTERN

--- a/zlib-ng.h.in
+++ b/zlib-ng.h.in
@@ -219,14 +219,12 @@ Z_EXTERN Z_EXPORT
 const char *zlibng_version(void);
 /* The application can compare zlibng_version and ZLIBNG_VERSION for consistency.
    If the first character differs, the library code actually used is not
-   compatible with the zlib-ng.h header file used by the application.  This check
-   is automatically made by deflateInit and inflateInit.
+   compatible with the zlib-ng.h header file used by the application.
  */
 
-/*
 Z_EXTERN Z_EXPORT
-int zng_deflateInit(zng_stream *strm, int level);
-
+int32_t zng_deflateInit(zng_stream *strm, int32_t level);
+/*
      Initializes the internal stream state for compression.  The fields
    zalloc, zfree and opaque must be initialized before by the caller.  If
    zalloc and zfree are set to NULL, deflateInit updates them to use default
@@ -239,11 +237,9 @@ int zng_deflateInit(zng_stream *strm, int level);
    equivalent to level 6).
 
      deflateInit returns Z_OK if success, Z_MEM_ERROR if there was not enough
-   memory, Z_STREAM_ERROR if level is not a valid compression level, or
-   Z_VERSION_ERROR if the zlib library version (zng_version) is incompatible
-   with the version assumed by the caller (ZLIBNG_VERSION).  msg is set to null
-   if there is no error message.  deflateInit does not perform any compression:
-   this will be done by deflate().
+   memory, Z_STREAM_ERROR if level is not a valid compression level.
+   msg is set to null if there is no error message.  deflateInit does not perform
+   any compression: this will be done by deflate().
 */
 
 
@@ -376,10 +372,9 @@ int32_t zng_deflateEnd(zng_stream *strm);
 */
 
 
-/*
 Z_EXTERN Z_EXPORT
-int zng_inflateInit(zng_stream *strm);
-
+int32_t zng_inflateInit(zng_stream *strm);
+/*
      Initializes the internal stream state for decompression.  The fields
    next_in, avail_in, zalloc, zfree and opaque must be initialized before by
    the caller.  In the current version of inflate, the provided input is not
@@ -389,14 +384,13 @@ int zng_inflateInit(zng_stream *strm);
    them to use default allocation functions.
 
      inflateInit returns Z_OK if success, Z_MEM_ERROR if there was not enough
-   memory, Z_VERSION_ERROR if the zlib library version is incompatible with the
-   version assumed by the caller, or Z_STREAM_ERROR if the parameters are
-   invalid, such as a null pointer to the structure.  msg is set to null if
-   there is no error message.  inflateInit does not perform any decompression.
-   Actual decompression will be done by inflate().  So next_in, and avail_in,
-   next_out, and avail_out are unused and unchanged.  The current
-   implementation of inflateInit() does not process any header information --
-   that is deferred until inflate() is called.
+   memory, or Z_STREAM_ERROR if the parameters are invalid, such as a null
+   pointer to the structure.  msg is set to null if there is no error message.
+   inflateInit does not perform any decompression. Actual decompression will
+   be done by inflate().  So next_in, and avail_in, next_out, and avail_out
+   are unused and unchanged.  The current implementation of inflateInit()
+   does not process any header information -- that is deferred until inflate()
+   is called.
 */
 
 
@@ -539,10 +533,9 @@ int32_t zng_inflateEnd(zng_stream *strm);
     The following functions are needed only in some special applications.
 */
 
-/*
 Z_EXTERN Z_EXPORT
-int zng_deflateInit2(zng_stream *strm, int  level, int  method, int  windowBits, int  memLevel, int  strategy);
-
+int32_t zng_deflateInit2(zng_stream *strm, int32_t level, int32_t method, int32_t windowBits, int32_t memLevel, int32_t strategy);
+/*
      This is another version of deflateInit with more compression options.  The
    fields zalloc, zfree and opaque must be initialized before by the caller.
 
@@ -601,11 +594,9 @@ int zng_deflateInit2(zng_stream *strm, int  level, int  method, int  windowBits,
    decoder for special applications.
 
      deflateInit2 returns Z_OK if success, Z_MEM_ERROR if there was not enough
-   memory, Z_STREAM_ERROR if any parameter is invalid (such as an invalid
-   method), or Z_VERSION_ERROR if the zlib library version (zng_version) is
-   incompatible with the version assumed by the caller (ZLIBNG_VERSION).  msg is
-   set to null if there is no error message.  deflateInit2 does not perform any
-   compression: this will be done by deflate().
+   memory, Z_STREAM_ERROR if any parameter is invalid (such as an invalid method).
+   msg is set to null if there is no error message.  deflateInit2 does not perform
+   any compression: this will be done by deflate().
 */
 
 Z_EXTERN Z_EXPORT
@@ -822,10 +813,9 @@ int32_t zng_deflateSetHeader(zng_stream *strm, zng_gz_headerp head);
    stream state was inconsistent.
 */
 
-/*
 Z_EXTERN Z_EXPORT
-int zng_inflateInit2(zng_stream *strm, int  windowBits);
-
+int32_t zng_inflateInit2(zng_stream *strm, int32_t windowBits);
+/*
      This is another version of inflateInit with an extra parameter.  The
    fields next_in, avail_in, zalloc, zfree and opaque must be initialized
    before by the caller.
@@ -866,15 +856,13 @@ int zng_inflateInit2(zng_stream *strm, int  windowBits);
    decompression to be compliant with the gzip standard (RFC 1952).
 
      inflateInit2 returns Z_OK if success, Z_MEM_ERROR if there was not enough
-   memory, Z_VERSION_ERROR if the zlib library version is incompatible with the
-   version assumed by the caller, or Z_STREAM_ERROR if the parameters are
-   invalid, such as a null pointer to the structure.  msg is set to null if
-   there is no error message.  inflateInit2 does not perform any decompression
-   apart from possibly reading the zlib header if present: actual decompression
-   will be done by inflate().  (So next_in and avail_in may be modified, but
-   next_out and avail_out are unused and unchanged.) The current implementation
-   of inflateInit2() does not process any header information -- that is
-   deferred until inflate() is called.
+   memory, or Z_STREAM_ERROR if the parameters are invalid, such as a null
+   pointer to the structure.  msg is set to null if there is no error message.
+   inflateInit2 does not perform any decompression apart from possibly reading
+   the zlib header if present: actual decompression will be done by inflate().
+   (So next_in and avail_in may be modified, but next_out and avail_out are
+   unused and unchanged.) The current implementation of inflateInit2() does not
+   process any header information -- that is deferred until inflate() is called.
 */
 
 Z_EXTERN Z_EXPORT
@@ -1063,10 +1051,9 @@ int32_t zng_inflateGetHeader(zng_stream *strm, zng_gz_headerp head);
    stream state was inconsistent.
 */
 
-/*
 Z_EXTERN Z_EXPORT
-int zng_inflateBackInit(zng_stream *strm, int windowBits, unsigned char *window);
-
+int32_t zng_inflateBackInit(zng_stream *strm, int32_t windowBits, uint8_t *window);
+/*
      Initialize the internal stream state for decompression using inflateBack()
    calls.  The fields zalloc, zfree and opaque in strm must be initialized
    before the call.  If zalloc and zfree are NULL, then the default library-
@@ -1081,8 +1068,7 @@ int zng_inflateBackInit(zng_stream *strm, int windowBits, unsigned char *window)
 
      inflateBackInit will return Z_OK on success, Z_STREAM_ERROR if any of
    the parameters are invalid, Z_MEM_ERROR if the internal state could not be
-   allocated, or Z_VERSION_ERROR if the version of the library does not match
-   the version of the header file.
+   allocated.
 */
 
 typedef uint32_t (*in_func) (void *, const uint8_t * *);
@@ -1790,26 +1776,6 @@ uint32_t zng_crc32_combine_op(uint32_t crc1, uint32_t crc2, const uint32_t op);
 */
 
                         /* various hacks, don't look :) */
-
-/* zng_deflateInit and zng_inflateInit are macros to allow checking the zlib version
- * and the compiler's view of zng_stream:
- */
-Z_EXTERN Z_EXPORT int32_t zng_deflateInit_(zng_stream *strm, int32_t level, const char *version, int32_t stream_size);
-Z_EXTERN Z_EXPORT int32_t zng_inflateInit_(zng_stream *strm, const char *version, int32_t stream_size);
-Z_EXTERN Z_EXPORT int32_t zng_deflateInit2_(zng_stream *strm, int32_t  level, int32_t  method, int32_t windowBits, int32_t memLevel,
-                                         int32_t strategy, const char *version, int32_t stream_size);
-Z_EXTERN Z_EXPORT int32_t zng_inflateInit2_(zng_stream *strm, int32_t  windowBits, const char *version, int32_t stream_size);
-Z_EXTERN Z_EXPORT int32_t zng_inflateBackInit_(zng_stream *strm, int32_t windowBits, uint8_t *window,
-                                         const char *version, int32_t stream_size);
-
-#define @ZLIB_SYMBOL_PREFIX@zng_deflateInit(strm, level) zng_deflateInit_((strm), (level), ZLIBNG_VERSION, (int32_t)sizeof(zng_stream))
-#define @ZLIB_SYMBOL_PREFIX@zng_inflateInit(strm) zng_inflateInit_((strm), ZLIBNG_VERSION, (int32_t)sizeof(zng_stream))
-#define @ZLIB_SYMBOL_PREFIX@zng_deflateInit2(strm, level, method, windowBits, memLevel, strategy) \
-        zng_deflateInit2_((strm), (level), (method), (windowBits), (memLevel), \
-                     (strategy), ZLIBNG_VERSION, (int32_t)sizeof(zng_stream))
-#define @ZLIB_SYMBOL_PREFIX@zng_inflateInit2(strm, windowBits) zng_inflateInit2_((strm), (windowBits), ZLIBNG_VERSION, (int32_t)sizeof(zng_stream))
-#define @ZLIB_SYMBOL_PREFIX@zng_inflateBackInit(strm, windowBits, window) \
-                        zng_inflateBackInit_((strm), (windowBits), (window), ZLIBNG_VERSION, (int32_t)sizeof(zng_stream))
 
 #ifdef WITH_GZFILEOP
 

--- a/zlib-ng.h.in
+++ b/zlib-ng.h.in
@@ -1791,7 +1791,6 @@ struct gzFile_s {
     unsigned char *next;
     z_off64_t pos;
 };
-Z_EXTERN Z_EXPORT int32_t zng_gzgetc_(gzFile file);  /* backward compatibility */
 #  define @ZLIB_SYMBOL_PREFIX@zng_gzgetc(g) ((g)->have ? ((g)->have--, (g)->pos++, *((g)->next)++) : (@ZLIB_SYMBOL_PREFIX@zng_gzgetc)(g))
 
 #endif /* WITH_GZFILEOP */

--- a/zlib-ng.map
+++ b/zlib-ng.map
@@ -93,7 +93,6 @@ ZLIB_NG_GZ_2.0.0 {
     zng_gzfread;
     zng_gzfwrite;
     zng_gzgetc;
-    zng_gzgetc_;
     zng_gzgets;
     zng_gzoffset;
     zng_gzoffset64;

--- a/zlib-ng.map
+++ b/zlib-ng.map
@@ -1,3 +1,12 @@
+ZLIB_NG_2.1.0 {
+  global:
+    zng_deflateInit;
+    zng_deflateInit2;
+    zng_inflateBackInit;
+    zng_inflateInit;
+    zng_inflateInit2;
+};
+
 ZLIB_NG_2.0.0 {
   global:
     zng_adler32;

--- a/zutil.h
+++ b/zutil.h
@@ -120,6 +120,10 @@ extern z_const char * const PREFIX(z_errmsg)[10]; /* indexed by 2-zlib_error */
 #  define OS_CODE  3  /* assume Unix */
 #endif
 
+         /* macros */
+
+#define CHECK_VER_STSIZE(_ver,_stsize) ((_ver) == NULL || (_ver)[0] != PREFIX2(VERSION)[0] || (_stsize) != (int32_t)sizeof(PREFIX3(stream)))
+
          /* memory allocation functions */
 
 void Z_INTERNAL *zng_calloc(void *opaque, unsigned items, unsigned size);


### PR DESCRIPTION
Simplify zlib-ng native API by removing version and struct size checks. See #1045
This should be backwards compatible with applications compiled for 2.0.x.

I believe that this version checking is really making more problems than it is solving.
Most libraries do not do this kind of checks, and I think library version control has become a bit better since this was first implemented.

Also remove zng_gzgetc_ function from zlib-ng native API.
It exists in zlib for backwards compatibility, but has never been documented/advertised for use in zlib-ngs native API.