### PR TITLE
Benchmarks compilation fix on older compilers

### DIFF
--- a/test/benchmarks/CMakeLists.txt
+++ b/test/benchmarks/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.12)
 
 include(FetchContent)
 
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS ON)
 enable_language(CXX)
 
 # Search for Google benchmark package


### PR DESCRIPTION
Fix compilation of benchmark when compiler supports, but does not default to enable C++11 or higher.