### PR TITLE
[AArch64] Add missing LD4 test for configure.

### DIFF
--- a/configure
+++ b/configure
@@ -1812,6 +1812,8 @@ EOF
         fi
 
         if test $without_optimizations -eq 0; then
+            check_neon_ld4_intrinsics
+
             CFLAGS="${CFLAGS} -DARM_FEATURES"
             SFLAGS="${SFLAGS} -DARM_FEATURES"
             ARCH_STATIC_OBJS="${ARCH_STATIC_OBJS} armfeature.o"


### PR DESCRIPTION
Should fix #1167.