### PR TITLE
Fix some CI tests not running on push

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,5 +1,15 @@
 name: CI Fuzz
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - stable
+      - develop
+      - pre-release
+      - '2.*'
+    tags:
+      - '*'
+
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest

--- a/.github/workflows/libpng.yml
+++ b/.github/workflows/libpng.yml
@@ -1,5 +1,5 @@
 name: CI Libpng
-on: [pull_request]
+on: [push, pull_request]
 jobs:
   pngtest:
     name: Ubuntu Clang


### PR DESCRIPTION
- Run libpng tests on push in addition to pull-requests.
- Also run oss-fuzz on push to the main branches.