### PR TITLE
Fixed inftrees.c should be compiled with infcover 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1235,7 +1235,7 @@ if(ZLIB_ENABLE_TESTS)
     target_link_libraries(switchlevels zlib)
 
     add_simple_test_executable(infcover)
-    if(NOT BUILD_SHARED_LIBS)
+    if(NOT DEFINED BUILD_SHARED_LIBS OR BUILD_SHARED_LIBS)
         target_sources(infcover PRIVATE inftrees.c)
     endif()
 


### PR DESCRIPTION
I think my previous commit https://github.com/zlib-ng/zlib-ng/commit/99913c9cd9d55c1211669406aeac2b5f61e79333 had this wrong. Inftrees.c should be compiled in whenever zlib is a shared library, because it doesn't have access to `zng_inflate_table` or `inflate_copyright`.

This error happens when compiling with ClangCl.