### PR TITLE
IBM Z: Delete stale self-hosted builder containers

### DIFF
--- a/arch/s390/self-hosted-builder/actions-runner.service
+++ b/arch/s390/self-hosted-builder/actions-runner.service
@@ -7,6 +7,7 @@ StartLimitIntervalSec=0
 [Service]
 Type=simple
 Restart=always
+ExecStartPre=-/usr/bin/docker rm --force actions-runner
 ExecStart=/usr/bin/docker run \
               --env-file=/etc/actions-runner \
               --init \


### PR DESCRIPTION
Inspired by https://github.com/zlib-ng/zlib-ng/pull/1096#issuecomment-1067275910.
This change is already deployed on the IBM Z builder.

Due to things like power outage ExecStop may not run, resulting in a
stale actions-runner container. This would prevent ExecStart from
succeeding, so try deleting such stale containers in ExecStartPre.