### PR TITLE
Fix a latent issue with chunkmemset

### DIFF
--- a/chunkset_tpl.h
+++ b/chunkset_tpl.h
@@ -171,5 +171,8 @@ Z_INTERNAL uint8_t* CHUNKMEMSET_SAFE(uint8_t *out, unsigned dist, unsigned len, 
         }
         return out;
     }
-    return CHUNKMEMSET(out, dist, len);
+    if (len)
+        return CHUNKMEMSET(out, dist, len);
+
+    return out;
 }


### PR DESCRIPTION
It would seem that on some platforms, namely those which are
!UNALIGNED64_OK, there was a likelihood of chunkmemset_safe_c copying all
the bytes before passing control flow to chunkcopy, a function which is
explicitly unsafe to be called with a zero length copy.

This fixes that bug for those platforms.