### PR TITLE
Correct typo in functable

### DIFF
--- a/functable.c
+++ b/functable.c
@@ -133,7 +133,7 @@ Z_INTERNAL uint32_t longest_match_slow_stub(deflate_state *const s, Pos cur_matc
 #  endif
 #  if defined(X86_SSE2) && defined(HAVE_BUILTIN_CTZ)
     if (x86_cpu_has_sse2)
-        functable.longest_match = &longest_match_slow_unaligned_sse2;
+        functable.longest_match_slow = &longest_match_slow_unaligned_sse2;
 #  endif
 #  if defined(X86_AVX2) && defined(HAVE_BUILTIN_CTZ)
     if (x86_cpu_has_avx2)


### PR DESCRIPTION
I could be wrong about this being an error, but I don't see any discussion suggesting this was intended, and can't immediately come up with why it would be the correct choice given the context.