### PR TITLE
Define check_match for coverity

### DIFF
--- a/deflate_p.h
+++ b/deflate_p.h
@@ -11,7 +11,7 @@
 
 /* Forward declare common non-inlined functions declared in deflate.c */
 
-#ifdef ZLIB_DEBUG
+#if defined(ZLIB_DEBUG) || defined(__COVERITY__)
 /* ===========================================================================
  * Check that the match at match_start is indeed a match.
  */


### PR DESCRIPTION
We should either close #1073 or accept this PR, hoping that it will make the coverity warning go away.