### PR TITLE
Added GitHub workflow to scan and upload to coverity.

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,27 @@
+name: CI Coverity Scan
+# We only want to test official release code, not every pull request.
+on:
+  push:
+    branches:
+      - stable
+      - develop
+      - pre-release
+      - '2.*'
+    tags:
+      - '*'
+
+jobs:
+  coverity:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Generate project files
+      run: ./configure
+
+    - name: Run scan
+      uses: vapier/coverity-scan-action@v1
+      with:
+        email: ${{ secrets.COVERITY_SCAN_EMAIL }}
+        token: ${{ secrets.COVERITY_SCAN_TOKEN }}


### PR DESCRIPTION
This workflow uses this GH action:
https://github.com/vapier/coverity-scan-action

You must add two secrets to this repository:
```
COVERITY_SCAN_EMAIL
COVERITY_SCAN_TOKEN
```
@Dead2 I figure this might make it easier for you so you don't have to manually upload the scans.