### PR TITLE
Refresh abicheck

### DIFF
--- a/test/abi/zlib-ng-2.0.0-x86_64-pc-linux-gnu.abi
+++ b/test/abi/zlib-ng-2.0.0-x86_64-pc-linux-gnu.abi
@@ -1,0 +1,1852 @@
+<abi-corpus version='2.0' path='btmp1/libz-ng.so.2.0.0' architecture='elf-amd-x86_64' soname='libz-ng.so.2'>
+  <elf-needed>
+    <dependency name='libc.so.6'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='zlibng_version' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_adler32' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_adler32_combine' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_adler32_z' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_compress2' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_compress' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_compressBound' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_crc32' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_crc32_combine' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_crc32_combine_gen' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_crc32_combine_op' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_crc32_z' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_deflate' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_deflateBound' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_deflateCopy' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_deflateEnd' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_deflateGetDictionary' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_deflateGetParams' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_deflateInit2_' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_deflateInit_' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_deflateParams' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_deflatePending' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_deflatePrime' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_deflateReset' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_deflateResetKeep' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_deflateSetDictionary' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_deflateSetHeader' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_deflateSetParams' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_deflateTune' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_get_crc_table' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_gzbuffer' version='ZLIB_NG_GZ_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_gzclearerr' version='ZLIB_NG_GZ_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_gzclose' version='ZLIB_NG_GZ_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_gzclose_r' version='ZLIB_NG_GZ_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_gzclose_w' version='ZLIB_NG_GZ_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_gzdirect' version='ZLIB_NG_GZ_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_gzdopen' version='ZLIB_NG_GZ_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_gzeof' version='ZLIB_NG_GZ_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_gzerror' version='ZLIB_NG_GZ_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_gzflush' version='ZLIB_NG_GZ_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_gzfread' version='ZLIB_NG_GZ_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_gzfwrite' version='ZLIB_NG_GZ_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_gzgetc' version='ZLIB_NG_GZ_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_gzgetc_' version='ZLIB_NG_GZ_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_gzgets' version='ZLIB_NG_GZ_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_gzoffset' version='ZLIB_NG_GZ_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_gzopen' version='ZLIB_NG_GZ_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_gzprintf' version='ZLIB_NG_GZ_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_gzputc' version='ZLIB_NG_GZ_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_gzputs' version='ZLIB_NG_GZ_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_gzread' version='ZLIB_NG_GZ_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_gzrewind' version='ZLIB_NG_GZ_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_gzseek' version='ZLIB_NG_GZ_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_gzsetparams' version='ZLIB_NG_GZ_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_gztell' version='ZLIB_NG_GZ_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_gzungetc' version='ZLIB_NG_GZ_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_gzvprintf' version='ZLIB_NG_GZ_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_gzwrite' version='ZLIB_NG_GZ_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_inflate' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_inflateBack' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_inflateBackEnd' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_inflateBackInit_' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_inflateCodesUsed' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_inflateCopy' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_inflateEnd' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_inflateGetDictionary' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_inflateGetHeader' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_inflateInit2_' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_inflateInit_' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_inflateMark' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_inflatePrime' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_inflateReset2' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_inflateReset' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_inflateResetKeep' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_inflateSetDictionary' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_inflateSync' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_inflateSyncPoint' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_inflateUndermine' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_inflateValidate' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_uncompress2' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_uncompress' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_zError' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zng_zlibCompileFlags' version='ZLIB_NG_2.0.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <elf-variable-symbols>
+    <elf-symbol name='zlibng_string' size='32' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-variable-symbols>
+  <abi-instr address-size='64' path='/home/dank/src/zlib-ng/btmp1/src.d/adler32.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C99'>
+    <type-decl name='long int' size-in-bits='64' id='type-id-1'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-2'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-3'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-4'/>
+    <typedef-decl name='uint32_t' type-id='type-id-5' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='26' column='1' id='type-id-6'/>
+    <typedef-decl name='__uint32_t' type-id='type-id-3' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='42' column='1' id='type-id-5'/>
+    <typedef-decl name='__off64_t' type-id='type-id-1' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='153' column='1' id='type-id-7'/>
+    <typedef-decl name='off64_t' type-id='type-id-7' filepath='/usr/include/x86_64-linux-gnu/sys/types.h' line='92' column='1' id='type-id-8'/>
+    <typedef-decl name='size_t' type-id='type-id-4' filepath='/usr/lib/gcc/x86_64-linux-gnu/11/include/stddef.h' line='209' column='1' id='type-id-9'/>
+    <qualified-type-def type-id='type-id-2' const='yes' id='type-id-10'/>
+    <pointer-type-def type-id='type-id-10' size-in-bits='64' id='type-id-11'/>
+    <function-decl name='zng_adler32_z' mangled-name='zng_adler32_z' filepath='/home/dank/src/zlib-ng/btmp1/src.d/adler32.c' line='85' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_adler32_z@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-6' name='adler' filepath='/home/dank/src/zlib-ng/btmp1/src.d/adler32.c' line='85' column='1'/>
+      <parameter type-id='type-id-11' name='buf' filepath='/home/dank/src/zlib-ng/btmp1/src.d/adler32.c' line='85' column='1'/>
+      <parameter type-id='type-id-9' name='len' filepath='/home/dank/src/zlib-ng/btmp1/src.d/adler32.c' line='85' column='1'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='zng_adler32' mangled-name='zng_adler32' filepath='/home/dank/src/zlib-ng/btmp1/src.d/adler32.c' line='96' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_adler32@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-6' name='adler' filepath='/home/dank/src/zlib-ng/btmp1/src.d/adler32.c' line='96' column='1'/>
+      <parameter type-id='type-id-11' name='buf' filepath='/home/dank/src/zlib-ng/btmp1/src.d/adler32.c' line='96' column='1'/>
+      <parameter type-id='type-id-6' name='len' filepath='/home/dank/src/zlib-ng/btmp1/src.d/adler32.c' line='96' column='1'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='zng_adler32_combine' mangled-name='zng_adler32_combine' filepath='/home/dank/src/zlib-ng/btmp1/src.d/adler32.c' line='136' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_adler32_combine@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-6' name='adler1' filepath='/home/dank/src/zlib-ng/btmp1/src.d/adler32.c' line='136' column='1'/>
+      <parameter type-id='type-id-6' name='adler2' filepath='/home/dank/src/zlib-ng/btmp1/src.d/adler32.c' line='136' column='1'/>
+      <parameter type-id='type-id-8' name='len2' filepath='/home/dank/src/zlib-ng/btmp1/src.d/adler32.c' line='136' column='1'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='/home/dank/src/zlib-ng/btmp1/src.d/compress.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C99'>
+    <type-decl name='char' size-in-bits='8' id='type-id-12'/>
+    <class-decl name='internal_state' size-in-bits='48320' is-struct='yes' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='103' column='1' id='type-id-13'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='strm' type-id='type-id-14' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='104' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='pending_buf' type-id='type-id-15' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='105' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='pending_out' type-id='type-id-15' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='106' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='pending_buf_size' type-id='type-id-6' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='107' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='pending' type-id='type-id-6' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='108' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='wrap' type-id='type-id-16' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='109' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='gzindex' type-id='type-id-6' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='110' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='gzhead' type-id='type-id-17' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='111' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='status' type-id='type-id-16' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='112' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='last_flush' type-id='type-id-16' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='113' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='reproducible' type-id='type-id-16' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='114' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='480'>
+        <var-decl name='block_open' type-id='type-id-16' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='116' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='w_size' type-id='type-id-3' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='123' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='544'>
+        <var-decl name='w_bits' type-id='type-id-3' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='124' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='w_mask' type-id='type-id-3' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='125' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='608'>
+        <var-decl name='lookahead' type-id='type-id-3' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='126' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='high_water' type-id='type-id-3' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='128' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='672'>
+        <var-decl name='window_size' type-id='type-id-3' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='135' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='window' type-id='type-id-15' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='140' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='prev' type-id='type-id-18' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='150' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='head' type-id='type-id-18' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='156' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='block_start' type-id='type-id-16' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='158' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='928'>
+        <var-decl name='match_length' type-id='type-id-3' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='163' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='prev_match' type-id='type-id-19' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='164' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='992'>
+        <var-decl name='match_available' type-id='type-id-16' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='165' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='strstart' type-id='type-id-3' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='166' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1056'>
+        <var-decl name='match_start' type-id='type-id-3' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='167' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1088'>
+        <var-decl name='prev_length' type-id='type-id-3' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='169' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1120'>
+        <var-decl name='max_chain_length' type-id='type-id-3' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='174' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1152'>
+        <var-decl name='max_lazy_match' type-id='type-id-3' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='179' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1184'>
+        <var-decl name='level' type-id='type-id-16' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='189' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1216'>
+        <var-decl name='strategy' type-id='type-id-16' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='190' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1248'>
+        <var-decl name='good_match' type-id='type-id-3' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='192' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='nice_match' type-id='type-id-16' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='195' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1312'>
+        <var-decl name='crc0' type-id='type-id-20' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='199' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1952'>
+        <var-decl name='dyn_ltree' type-id='type-id-21' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='204' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='20288'>
+        <var-decl name='dyn_dtree' type-id='type-id-22' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='205' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='22240'>
+        <var-decl name='bl_tree' type-id='type-id-23' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='206' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='23488'>
+        <var-decl name='l_desc' type-id='type-id-24' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='208' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='23680'>
+        <var-decl name='d_desc' type-id='type-id-24' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='209' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='23872'>
+        <var-decl name='bl_desc' type-id='type-id-24' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='210' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='24064'>
+        <var-decl name='bl_count' type-id='type-id-25' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='212' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='24320'>
+        <var-decl name='heap' type-id='type-id-26' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='215' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='42656'>
+        <var-decl name='heap_len' type-id='type-id-16' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='216' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='42688'>
+        <var-decl name='heap_max' type-id='type-id-16' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='217' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='42720'>
+        <var-decl name='depth' type-id='type-id-27' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='222' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47328'>
+        <var-decl name='lit_bufsize' type-id='type-id-3' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='226' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47360'>
+        <var-decl name='sym_buf' type-id='type-id-15' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='246' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47424'>
+        <var-decl name='sym_next' type-id='type-id-3' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='247' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47456'>
+        <var-decl name='sym_end' type-id='type-id-3' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='248' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47488'>
+        <var-decl name='opt_len' type-id='type-id-4' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='250' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47552'>
+        <var-decl name='static_len' type-id='type-id-4' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='251' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47616'>
+        <var-decl name='matches' type-id='type-id-3' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='252' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47648'>
+        <var-decl name='insert' type-id='type-id-3' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='253' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47680'>
+        <var-decl name='compressed_len' type-id='type-id-4' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='256' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47744'>
+        <var-decl name='bits_sent' type-id='type-id-4' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='257' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47808'>
+        <var-decl name='reserved_p' type-id='type-id-28' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='260' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47872'>
+        <var-decl name='bi_buf' type-id='type-id-29' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='262' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47936'>
+        <var-decl name='bi_valid' type-id='type-id-30' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='265' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47968'>
+        <var-decl name='reserved' type-id='type-id-31' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='269' column='1'/>
+      </data-member>
+    </class-decl>
+    <type-decl name='int' size-in-bits='32' id='type-id-16'/>
+    <type-decl name='void' id='type-id-32'/>
+    <typedef-decl name='alloc_func' type-id='type-id-33' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='80' column='1' id='type-id-34'/>
+    <typedef-decl name='free_func' type-id='type-id-35' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='81' column='1' id='type-id-36'/>
+    <class-decl name='zng_stream_s' size-in-bits='832' is-struct='yes' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='85' column='1' id='type-id-37'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next_in' type-id='type-id-38' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='86' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='avail_in' type-id='type-id-6' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='87' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='total_in' type-id='type-id-9' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='88' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='next_out' type-id='type-id-39' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='90' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='avail_out' type-id='type-id-6' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='91' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='total_out' type-id='type-id-9' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='92' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='msg' type-id='type-id-40' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='94' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='state' type-id='type-id-41' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='95' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='zalloc' type-id='type-id-34' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='97' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='zfree' type-id='type-id-36' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='98' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='opaque' type-id='type-id-42' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='99' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='data_type' type-id='type-id-16' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='101' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='736'>
+        <var-decl name='adler' type-id='type-id-6' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='103' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='reserved' type-id='type-id-4' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='104' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zng_stream' type-id='type-id-37' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='105' column='1' id='type-id-43'/>
+    <typedef-decl name='int32_t' type-id='type-id-44' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-intn.h' line='26' column='1' id='type-id-30'/>
+    <typedef-decl name='uint8_t' type-id='type-id-45' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='24' column='1' id='type-id-46'/>
+    <typedef-decl name='__uint8_t' type-id='type-id-2' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='38' column='1' id='type-id-45'/>
+    <typedef-decl name='__int32_t' type-id='type-id-16' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='41' column='1' id='type-id-44'/>
+    <qualified-type-def type-id='type-id-12' const='yes' id='type-id-47'/>
+    <pointer-type-def type-id='type-id-47' size-in-bits='64' id='type-id-40'/>
+    <qualified-type-def type-id='type-id-46' const='yes' id='type-id-48'/>
+    <pointer-type-def type-id='type-id-48' size-in-bits='64' id='type-id-38'/>
+    <pointer-type-def type-id='type-id-13' size-in-bits='64' id='type-id-41'/>
+    <pointer-type-def type-id='type-id-9' size-in-bits='64' id='type-id-49'/>
+    <pointer-type-def type-id='type-id-46' size-in-bits='64' id='type-id-39'/>
+    <pointer-type-def type-id='type-id-2' size-in-bits='64' id='type-id-15'/>
+    <pointer-type-def type-id='type-id-50' size-in-bits='64' id='type-id-35'/>
+    <pointer-type-def type-id='type-id-32' size-in-bits='64' id='type-id-42'/>
+    <pointer-type-def type-id='type-id-51' size-in-bits='64' id='type-id-33'/>
+    <pointer-type-def type-id='type-id-43' size-in-bits='64' id='type-id-14'/>
+    <function-decl name='zng_compress2' mangled-name='zng_compress2' filepath='/home/dank/src/zlib-ng/btmp1/src.d/compress.c' line='25' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_compress2@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-15' name='dest' filepath='/home/dank/src/zlib-ng/btmp1/src.d/compress.c' line='25' column='1'/>
+      <parameter type-id='type-id-49' name='destLen' filepath='/home/dank/src/zlib-ng/btmp1/src.d/compress.c' line='25' column='1'/>
+      <parameter type-id='type-id-11' name='source' filepath='/home/dank/src/zlib-ng/btmp1/src.d/compress.c' line='25' column='1'/>
+      <parameter type-id='type-id-9' name='sourceLen' filepath='/home/dank/src/zlib-ng/btmp1/src.d/compress.c' line='26' column='1'/>
+      <parameter type-id='type-id-16' name='level' filepath='/home/dank/src/zlib-ng/btmp1/src.d/compress.c' line='26' column='1'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='zng_compress' mangled-name='zng_compress' filepath='/home/dank/src/zlib-ng/btmp1/src.d/compress.c' line='67' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_compress@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-15' name='dest' filepath='/home/dank/src/zlib-ng/btmp1/src.d/compress.c' line='67' column='1'/>
+      <parameter type-id='type-id-49' name='destLen' filepath='/home/dank/src/zlib-ng/btmp1/src.d/compress.c' line='67' column='1'/>
+      <parameter type-id='type-id-11' name='source' filepath='/home/dank/src/zlib-ng/btmp1/src.d/compress.c' line='67' column='1'/>
+      <parameter type-id='type-id-9' name='sourceLen' filepath='/home/dank/src/zlib-ng/btmp1/src.d/compress.c' line='67' column='1'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='zng_compressBound' mangled-name='zng_compressBound' filepath='/home/dank/src/zlib-ng/btmp1/src.d/compress.c' line='75' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_compressBound@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-9' name='sourceLen' filepath='/home/dank/src/zlib-ng/btmp1/src.d/compress.c' line='75' column='1'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='zng_deflate' mangled-name='zng_deflate' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='239' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_deflate@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14'/>
+      <parameter type-id='type-id-30'/>
+      <return type-id='type-id-30'/>
+    </function-decl>
+    <function-decl name='zng_deflateEnd' mangled-name='zng_deflateEnd' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='353' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_deflateEnd@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14'/>
+      <return type-id='type-id-30'/>
+    </function-decl>
+    <function-decl name='zng_deflateInit_' mangled-name='zng_deflateInit_' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='1786' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_deflateInit_@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14'/>
+      <parameter type-id='type-id-30'/>
+      <parameter type-id='type-id-40'/>
+      <parameter type-id='type-id-30'/>
+      <return type-id='type-id-30'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-50'>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-42'/>
+      <return type-id='type-id-32'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-51'>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-3'/>
+      <return type-id='type-id-42'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='/home/dank/src/zlib-ng/btmp1/src.d/crc32.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C99'>
+    <class-decl name='static_tree_desc_s' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-52'/>
+    <array-type-def dimensions='1' type-id='type-id-53' size-in-bits='1248' id='type-id-23'>
+      <subrange length='39' type-id='type-id-4' id='type-id-54'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-53' size-in-bits='18336' id='type-id-21'>
+      <subrange length='573' type-id='type-id-4' id='type-id-55'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-53' size-in-bits='1952' id='type-id-22'>
+      <subrange length='61' type-id='type-id-4' id='type-id-56'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-30' size-in-bits='352' id='type-id-31'>
+      <subrange length='11' type-id='type-id-4' id='type-id-57'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-16' size-in-bits='18336' id='type-id-26'>
+      <subrange length='573' type-id='type-id-4' id='type-id-55'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-58' size-in-bits='256' id='type-id-25'>
+      <subrange length='16' type-id='type-id-4' id='type-id-59'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-2' size-in-bits='4584' id='type-id-27'>
+      <subrange length='573' type-id='type-id-4' id='type-id-55'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-3' size-in-bits='640' id='type-id-20'>
+      <subrange length='20' type-id='type-id-4' id='type-id-60'/>
+    </array-type-def>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-61'/>
+    <class-decl name='ct_data_s' size-in-bits='32' is-struct='yes' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='73' column='1' id='type-id-53'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='fc' type-id='type-id-62' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='77' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='dl' type-id='type-id-63' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='81' column='1'/>
+      </data-member>
+    </class-decl>
+    <union-decl name='__anonymous_union__' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='74' column='1' id='type-id-62'>
+      <data-member access='public'>
+        <var-decl name='freq' type-id='type-id-58' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='75' column='1'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='code' type-id='type-id-58' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='76' column='1'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='__anonymous_union__1' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='78' column='1' id='type-id-63'>
+      <data-member access='public'>
+        <var-decl name='dad' type-id='type-id-58' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='79' column='1'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='len' type-id='type-id-58' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='80' column='1'/>
+      </data-member>
+    </union-decl>
+    <typedef-decl name='ct_data' type-id='type-id-53' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='82' column='1' id='type-id-64'/>
+    <typedef-decl name='static_tree_desc' type-id='type-id-52' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='89' column='1' id='type-id-65'/>
+    <class-decl name='tree_desc_s' size-in-bits='192' is-struct='yes' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='91' column='1' id='type-id-24'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dyn_tree' type-id='type-id-66' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='92' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='max_code' type-id='type-id-16' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='93' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='stat_desc' type-id='type-id-67' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='94' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='Pos' type-id='type-id-58' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='97' column='1' id='type-id-19'/>
+    <typedef-decl name='deflate_state' type-id='type-id-13' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='270' column='1' id='type-id-68'/>
+    <class-decl name='zng_gz_header_s' size-in-bits='640' is-struct='yes' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='113' column='1' id='type-id-69'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='text' type-id='type-id-30' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='114' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='time' type-id='type-id-4' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='115' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='xflags' type-id='type-id-30' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='116' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='os' type-id='type-id-30' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='117' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='extra' type-id='type-id-39' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='118' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='extra_len' type-id='type-id-6' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='119' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='extra_max' type-id='type-id-6' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='120' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='name' type-id='type-id-39' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='121' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='name_max' type-id='type-id-6' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='122' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='comment' type-id='type-id-39' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='123' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='comm_max' type-id='type-id-6' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='124' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='544'>
+        <var-decl name='hcrc' type-id='type-id-30' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='125' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='done' type-id='type-id-30' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='126' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zng_gz_header' type-id='type-id-69' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='127' column='1' id='type-id-70'/>
+    <typedef-decl name='zng_gz_headerp' type-id='type-id-71' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='129' column='1' id='type-id-17'/>
+    <typedef-decl name='uint16_t' type-id='type-id-72' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='25' column='1' id='type-id-58'/>
+    <typedef-decl name='uint64_t' type-id='type-id-73' filepath='/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h' line='27' column='1' id='type-id-29'/>
+    <typedef-decl name='__uint16_t' type-id='type-id-61' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='40' column='1' id='type-id-72'/>
+    <typedef-decl name='__uint64_t' type-id='type-id-4' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='45' column='1' id='type-id-73'/>
+    <pointer-type-def type-id='type-id-19' size-in-bits='64' id='type-id-18'/>
+    <pointer-type-def type-id='type-id-12' size-in-bits='64' id='type-id-28'/>
+    <qualified-type-def type-id='type-id-65' const='yes' id='type-id-74'/>
+    <pointer-type-def type-id='type-id-74' size-in-bits='64' id='type-id-67'/>
+    <qualified-type-def type-id='type-id-6' const='yes' id='type-id-75'/>
+    <pointer-type-def type-id='type-id-75' size-in-bits='64' id='type-id-76'/>
+    <pointer-type-def type-id='type-id-64' size-in-bits='64' id='type-id-66'/>
+    <pointer-type-def type-id='type-id-68' size-in-bits='64' id='type-id-77'/>
+    <qualified-type-def type-id='type-id-77' const='yes' id='type-id-78'/>
+    <pointer-type-def type-id='type-id-70' size-in-bits='64' id='type-id-71'/>
+    <class-decl name='static_tree_desc_s' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-52'/>
+    <function-decl name='crc_fold_init' filepath='/home/dank/src/zlib-ng/btmp1/src.d/arch/x86/crc_folding.h' line='15' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-78'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='crc_fold_512to32' filepath='/home/dank/src/zlib-ng/btmp1/src.d/arch/x86/crc_folding.h' line='16' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-78'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='crc_fold_copy' filepath='/home/dank/src/zlib-ng/btmp1/src.d/arch/x86/crc_folding.h' line='17' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-78'/>
+      <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-1'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='x86_check_features' filepath='/home/dank/src/zlib-ng/btmp1/src.d/arch/x86/x86.h' line='16' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='zng_get_crc_table' mangled-name='zng_get_crc_table' filepath='/home/dank/src/zlib-ng/btmp1/src.d/crc32.c' line='22' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_get_crc_table@@ZLIB_NG_2.0.0'>
+      <return type-id='type-id-76'/>
+    </function-decl>
+    <function-decl name='zng_crc32_z' mangled-name='zng_crc32_z' filepath='/home/dank/src/zlib-ng/btmp1/src.d/crc32.c' line='33' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_crc32_z@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-6' name='crc' filepath='/home/dank/src/zlib-ng/btmp1/src.d/crc32.c' line='33' column='1'/>
+      <parameter type-id='type-id-11' name='buf' filepath='/home/dank/src/zlib-ng/btmp1/src.d/crc32.c' line='33' column='1'/>
+      <parameter type-id='type-id-9' name='len' filepath='/home/dank/src/zlib-ng/btmp1/src.d/crc32.c' line='33' column='1'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='zng_crc32' mangled-name='zng_crc32' filepath='/home/dank/src/zlib-ng/btmp1/src.d/crc32.c' line='71' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_crc32@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-6' name='crc' filepath='/home/dank/src/zlib-ng/btmp1/src.d/crc32.c' line='71' column='1'/>
+      <parameter type-id='type-id-11' name='buf' filepath='/home/dank/src/zlib-ng/btmp1/src.d/crc32.c' line='71' column='1'/>
+      <parameter type-id='type-id-6' name='len' filepath='/home/dank/src/zlib-ng/btmp1/src.d/crc32.c' line='71' column='1'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='/home/dank/src/zlib-ng/btmp1/src.d/crc32_comb.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C99'>
+    <pointer-type-def type-id='type-id-6' size-in-bits='64' id='type-id-79'/>
+    <function-decl name='zng_crc32_combine' mangled-name='zng_crc32_combine' filepath='/home/dank/src/zlib-ng/btmp1/src.d/crc32_comb.c' line='45' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_crc32_combine@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-6' name='crc1' filepath='/home/dank/src/zlib-ng/btmp1/src.d/crc32_comb.c' line='45' column='1'/>
+      <parameter type-id='type-id-6' name='crc2' filepath='/home/dank/src/zlib-ng/btmp1/src.d/crc32_comb.c' line='45' column='1'/>
+      <parameter type-id='type-id-8' name='len2' filepath='/home/dank/src/zlib-ng/btmp1/src.d/crc32_comb.c' line='45' column='1'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='zng_crc32_combine_gen' mangled-name='zng_crc32_combine_gen' filepath='/home/dank/src/zlib-ng/btmp1/src.d/crc32_comb.c' line='101' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_crc32_combine_gen@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-79' name='op' filepath='/home/dank/src/zlib-ng/btmp1/src.d/crc32_comb.c' line='101' column='1'/>
+      <parameter type-id='type-id-8' name='len2' filepath='/home/dank/src/zlib-ng/btmp1/src.d/crc32_comb.c' line='101' column='1'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='zng_crc32_combine_op' mangled-name='zng_crc32_combine_op' filepath='/home/dank/src/zlib-ng/btmp1/src.d/crc32_comb.c' line='106' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_crc32_combine_op@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-6' name='crc1' filepath='/home/dank/src/zlib-ng/btmp1/src.d/crc32_comb.c' line='106' column='1'/>
+      <parameter type-id='type-id-6' name='crc2' filepath='/home/dank/src/zlib-ng/btmp1/src.d/crc32_comb.c' line='106' column='1'/>
+      <parameter type-id='type-id-76' name='op' filepath='/home/dank/src/zlib-ng/btmp1/src.d/crc32_comb.c' line='106' column='1'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C99'>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-80'/>
+    <enum-decl name='block_state' naming-typedef-id='type-id-81' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='272' column='1' id='type-id-82'>
+      <underlying-type type-id='type-id-80'/>
+      <enumerator name='need_more' value='0'/>
+      <enumerator name='block_done' value='1'/>
+      <enumerator name='finish_started' value='2'/>
+      <enumerator name='finish_done' value='3'/>
+    </enum-decl>
+    <typedef-decl name='block_state' type-id='type-id-82' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='277' column='1' id='type-id-81'/>
+    <enum-decl name='zng_deflate_param' naming-typedef-id='type-id-83' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='1823' column='1' id='type-id-84'>
+      <underlying-type type-id='type-id-80'/>
+      <enumerator name='Z_DEFLATE_LEVEL' value='0'/>
+      <enumerator name='Z_DEFLATE_STRATEGY' value='1'/>
+      <enumerator name='Z_DEFLATE_REPRODUCIBLE' value='2'/>
+    </enum-decl>
+    <typedef-decl name='zng_deflate_param' type-id='type-id-84' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='1833' column='1' id='type-id-83'/>
+    <class-decl name='zng_deflate_param_value' size-in-bits='256' is-struct='yes' naming-typedef-id='type-id-85' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='1835' column='1' id='type-id-86'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='param' type-id='type-id-83' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='1836' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='buf' type-id='type-id-42' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='1837' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='size' type-id='type-id-9' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='1838' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='status' type-id='type-id-30' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='1839' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='zng_deflate_param_value' type-id='type-id-86' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='1840' column='1' id='type-id-85'/>
+    <pointer-type-def type-id='type-id-30' size-in-bits='64' id='type-id-87'/>
+    <pointer-type-def type-id='type-id-85' size-in-bits='64' id='type-id-88'/>
+    <function-decl name='deflate_fast' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='108' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-77'/>
+      <parameter type-id='type-id-16'/>
+      <return type-id='type-id-81'/>
+    </function-decl>
+    <function-decl name='deflate_quick' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='109' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-77'/>
+      <parameter type-id='type-id-16'/>
+      <return type-id='type-id-81'/>
+    </function-decl>
+    <function-decl name='deflate_medium' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='111' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-77'/>
+      <parameter type-id='type-id-16'/>
+      <return type-id='type-id-81'/>
+    </function-decl>
+    <function-decl name='deflate_slow' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='113' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-77'/>
+      <parameter type-id='type-id-16'/>
+      <return type-id='type-id-81'/>
+    </function-decl>
+    <function-decl name='crc_reset' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='119' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-78'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='crc_finalize' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='121' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-78'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='copy_with_crc' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='123' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-14'/>
+      <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-4'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='zng_deflateInit2_' mangled-name='zng_deflateInit2_' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='255' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_deflateInit2_@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14' name='strm' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='255' column='1'/>
+      <parameter type-id='type-id-30' name='level' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='255' column='1'/>
+      <parameter type-id='type-id-30' name='method' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='255' column='1'/>
+      <parameter type-id='type-id-30' name='windowBits' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='255' column='1'/>
+      <parameter type-id='type-id-30' name='memLevel' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='256' column='1'/>
+      <parameter type-id='type-id-30' name='strategy' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='256' column='1'/>
+      <parameter type-id='type-id-40' name='version' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='256' column='1'/>
+      <parameter type-id='type-id-30' name='stream_size' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='256' column='1'/>
+      <return type-id='type-id-30'/>
+    </function-decl>
+    <function-decl name='zng_deflateSetDictionary' mangled-name='zng_deflateSetDictionary' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='419' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_deflateSetDictionary@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14' name='strm' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='419' column='1'/>
+      <parameter type-id='type-id-38' name='dictionary' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='419' column='1'/>
+      <parameter type-id='type-id-6' name='dictLength' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='419' column='1'/>
+      <return type-id='type-id-30'/>
+    </function-decl>
+    <function-decl name='zng_deflateGetDictionary' mangled-name='zng_deflateGetDictionary' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='478' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_deflateGetDictionary@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14' name='strm' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='478' column='1'/>
+      <parameter type-id='type-id-39' name='dictionary' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='478' column='1'/>
+      <parameter type-id='type-id-79' name='dictLength' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='478' column='1'/>
+      <return type-id='type-id-30'/>
+    </function-decl>
+    <function-decl name='zng_deflateResetKeep' mangled-name='zng_deflateResetKeep' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='497' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_deflateResetKeep@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14' name='strm' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='497' column='1'/>
+      <return type-id='type-id-30'/>
+    </function-decl>
+    <function-decl name='zng_deflateReset' mangled-name='zng_deflateReset' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='536' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_deflateReset@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14' name='strm' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='536' column='1'/>
+      <return type-id='type-id-30'/>
+    </function-decl>
+    <function-decl name='zng_deflateSetHeader' mangled-name='zng_deflateSetHeader' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='546' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_deflateSetHeader@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14' name='strm' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='546' column='1'/>
+      <parameter type-id='type-id-17' name='head' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='546' column='1'/>
+      <return type-id='type-id-30'/>
+    </function-decl>
+    <function-decl name='zng_deflatePending' mangled-name='zng_deflatePending' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='554' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_deflatePending@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14' name='strm' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='554' column='1'/>
+      <parameter type-id='type-id-79' name='pending' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='554' column='1'/>
+      <parameter type-id='type-id-87' name='bits' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='554' column='1'/>
+      <return type-id='type-id-30'/>
+    </function-decl>
+    <function-decl name='zng_deflatePrime' mangled-name='zng_deflatePrime' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='565' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_deflatePrime@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14' name='strm' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='565' column='1'/>
+      <parameter type-id='type-id-30' name='bits' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='565' column='1'/>
+      <parameter type-id='type-id-30' name='value' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='565' column='1'/>
+      <return type-id='type-id-30'/>
+    </function-decl>
+    <function-decl name='zng_deflateParams' mangled-name='zng_deflateParams' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='593' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_deflateParams@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14' name='strm' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='593' column='1'/>
+      <parameter type-id='type-id-30' name='level' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='593' column='1'/>
+      <parameter type-id='type-id-30' name='strategy' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='593' column='1'/>
+      <return type-id='type-id-30'/>
+    </function-decl>
+    <function-decl name='zng_deflateTune' mangled-name='zng_deflateTune' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='639' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_deflateTune@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14' name='strm' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='639' column='1'/>
+      <parameter type-id='type-id-30' name='good_length' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='639' column='1'/>
+      <parameter type-id='type-id-30' name='max_lazy' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='639' column='1'/>
+      <parameter type-id='type-id-30' name='nice_length' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='639' column='1'/>
+      <parameter type-id='type-id-30' name='max_chain' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='639' column='1'/>
+      <return type-id='type-id-30'/>
+    </function-decl>
+    <function-decl name='zng_deflateBound' mangled-name='zng_deflateBound' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='669' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_deflateBound@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14' name='strm' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='669' column='1'/>
+      <parameter type-id='type-id-4' name='sourceLen' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='669' column='1'/>
+      <return type-id='type-id-4'/>
+    </function-decl>
+    <function-decl name='zng_deflateCopy' mangled-name='zng_deflateCopy' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='1085' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_deflateCopy@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14' name='dest' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='1085' column='1'/>
+      <parameter type-id='type-id-14' name='source' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='1085' column='1'/>
+      <return type-id='type-id-30'/>
+    </function-decl>
+    <function-decl name='zng_deflateSetParams' mangled-name='zng_deflateSetParams' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='1661' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_deflateSetParams@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14' name='strm' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='1661' column='1'/>
+      <parameter type-id='type-id-88' name='params' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='1661' column='1'/>
+      <parameter type-id='type-id-9' name='count' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='1661' column='1'/>
+      <return type-id='type-id-30'/>
+    </function-decl>
+    <function-decl name='zng_deflateGetParams' mangled-name='zng_deflateGetParams' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='1737' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_deflateGetParams@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14' name='strm' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='1737' column='1'/>
+      <parameter type-id='type-id-88' name='params' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='1737' column='1'/>
+      <parameter type-id='type-id-9' name='count' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.c' line='1737' column='1'/>
+      <return type-id='type-id-30'/>
+    </function-decl>
+    <function-decl name='zng_tr_init' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='385' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-77'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='zng_tr_flush_block' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='386' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-77'/>
+      <parameter type-id='type-id-28'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-16'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='zng_tr_flush_bits' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='387' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-77'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='zng_tr_align' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='388' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-77'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='zng_tr_stored_block' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='389' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-77'/>
+      <parameter type-id='type-id-28'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-16'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='zng_calloc' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zutil.h' line='159' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-3'/>
+      <return type-id='type-id-42'/>
+    </function-decl>
+    <function-decl name='zng_cfree' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zutil.h' line='160' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-42'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='/home/dank/src/zlib-ng/btmp1/src.d/deflate_fast.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C99'>
+    <function-decl name='fill_window' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='381' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-77'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='flush_pending' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate_p.h' line='19' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-14'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C99'>
+    <class-decl name='functable_s' size-in-bits='832' is-struct='yes' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.h' line='11' column='1' id='type-id-89'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='insert_string' type-id='type-id-90' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.h' line='12' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='quick_insert_string' type-id='type-id-91' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.h' line='13' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='adler32' type-id='type-id-92' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.h' line='14' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='crc32' type-id='type-id-93' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.h' line='15' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='slide_hash' type-id='type-id-94' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.h' line='16' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='compare258' type-id='type-id-95' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.h' line='17' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='longest_match' type-id='type-id-96' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.h' line='18' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='chunksize' type-id='type-id-97' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.h' line='19' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='chunkcopy' type-id='type-id-98' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.h' line='20' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='chunkcopy_safe' type-id='type-id-99' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.h' line='21' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='chunkunroll' type-id='type-id-100' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.h' line='22' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='chunkmemset' type-id='type-id-101' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.h' line='23' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='chunkmemset_safe' type-id='type-id-102' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.h' line='24' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-103' size-in-bits='64' id='type-id-91'/>
+    <pointer-type-def type-id='type-id-104' size-in-bits='64' id='type-id-97'/>
+    <pointer-type-def type-id='type-id-105' size-in-bits='64' id='type-id-95'/>
+    <pointer-type-def type-id='type-id-106' size-in-bits='64' id='type-id-96'/>
+    <pointer-type-def type-id='type-id-107' size-in-bits='64' id='type-id-92'/>
+    <pointer-type-def type-id='type-id-108' size-in-bits='64' id='type-id-93'/>
+    <pointer-type-def type-id='type-id-109' size-in-bits='64' id='type-id-98'/>
+    <pointer-type-def type-id='type-id-110' size-in-bits='64' id='type-id-99'/>
+    <pointer-type-def type-id='type-id-111' size-in-bits='64' id='type-id-100'/>
+    <pointer-type-def type-id='type-id-112' size-in-bits='64' id='type-id-101'/>
+    <pointer-type-def type-id='type-id-113' size-in-bits='64' id='type-id-102'/>
+    <pointer-type-def type-id='type-id-3' size-in-bits='64' id='type-id-114'/>
+    <pointer-type-def type-id='type-id-115' size-in-bits='64' id='type-id-90'/>
+    <pointer-type-def type-id='type-id-116' size-in-bits='64' id='type-id-94'/>
+    <function-decl name='slide_hash_c' filepath='/home/dank/src/zlib-ng/btmp1/src.d/deflate.h' line='382' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-77'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='insert_string_c' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' line='18' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-78'/>
+      <parameter type-id='type-id-75'/>
+      <parameter type-id='type-id-6'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='insert_string_sse4' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' line='20' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-78'/>
+      <parameter type-id='type-id-75'/>
+      <parameter type-id='type-id-6'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='quick_insert_string_c' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' line='26' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-78'/>
+      <parameter type-id='type-id-75'/>
+      <return type-id='type-id-19'/>
+    </function-decl>
+    <function-decl name='quick_insert_string_sse4' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' line='28' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-78'/>
+      <parameter type-id='type-id-75'/>
+      <return type-id='type-id-19'/>
+    </function-decl>
+    <function-decl name='slide_hash_sse2' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' line='35' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-77'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='slide_hash_avx2' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' line='42' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-77'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='adler32_c' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' line='46' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-9'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='adler32_ssse3' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' line='51' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-9'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='adler32_avx2' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' line='54' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-9'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='chunksize_c' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' line='61' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='chunkcopy_c' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' line='62' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-38'/>
+      <parameter type-id='type-id-3'/>
+      <return type-id='type-id-39'/>
+    </function-decl>
+    <function-decl name='chunkcopy_safe_c' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' line='63' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-38'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-39'/>
+      <return type-id='type-id-39'/>
+    </function-decl>
+    <function-decl name='chunkunroll_c' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' line='64' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-114'/>
+      <parameter type-id='type-id-114'/>
+      <return type-id='type-id-39'/>
+    </function-decl>
+    <function-decl name='chunkmemset_c' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' line='65' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-3'/>
+      <return type-id='type-id-39'/>
+    </function-decl>
+    <function-decl name='chunkmemset_safe_c' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' line='66' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-3'/>
+      <return type-id='type-id-39'/>
+    </function-decl>
+    <function-decl name='chunksize_sse2' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' line='68' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='chunkcopy_sse2' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' line='69' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-38'/>
+      <parameter type-id='type-id-3'/>
+      <return type-id='type-id-39'/>
+    </function-decl>
+    <function-decl name='chunkcopy_safe_sse2' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' line='70' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-38'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-39'/>
+      <return type-id='type-id-39'/>
+    </function-decl>
+    <function-decl name='chunkunroll_sse2' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' line='71' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-114'/>
+      <parameter type-id='type-id-114'/>
+      <return type-id='type-id-39'/>
+    </function-decl>
+    <function-decl name='chunkmemset_sse2' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' line='72' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-3'/>
+      <return type-id='type-id-39'/>
+    </function-decl>
+    <function-decl name='chunkmemset_safe_sse2' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' line='73' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-3'/>
+      <return type-id='type-id-39'/>
+    </function-decl>
+    <function-decl name='chunksize_avx' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' line='76' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='chunkcopy_avx' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' line='77' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-38'/>
+      <parameter type-id='type-id-3'/>
+      <return type-id='type-id-39'/>
+    </function-decl>
+    <function-decl name='chunkcopy_safe_avx' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' line='78' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-38'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-39'/>
+      <return type-id='type-id-39'/>
+    </function-decl>
+    <function-decl name='chunkunroll_avx' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' line='79' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-114'/>
+      <parameter type-id='type-id-114'/>
+      <return type-id='type-id-39'/>
+    </function-decl>
+    <function-decl name='chunkmemset_avx' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' line='80' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-3'/>
+      <return type-id='type-id-39'/>
+    </function-decl>
+    <function-decl name='chunkmemset_safe_avx' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' line='81' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-3'/>
+      <return type-id='type-id-39'/>
+    </function-decl>
+    <function-decl name='crc32_generic' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' line='93' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-29'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='crc32_little' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' line='100' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-29'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='compare258_c' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' line='106' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-11'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='compare258_unaligned_64' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' line='111' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-11'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='compare258_unaligned_sse4' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' line='114' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-11'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='compare258_unaligned_avx2' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' line='117' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-11'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='longest_match_c' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' line='122' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-78'/>
+      <parameter type-id='type-id-19'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='longest_match_unaligned_64' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' line='127' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-78'/>
+      <parameter type-id='type-id-19'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='longest_match_unaligned_sse4' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' line='130' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-78'/>
+      <parameter type-id='type-id-19'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='longest_match_unaligned_avx2' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.c' line='133' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-78'/>
+      <parameter type-id='type-id-19'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <var-decl name='functable' type-id='type-id-89' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/functable.h' line='27' column='1'/>
+    <function-type size-in-bits='64' id='type-id-103'>
+      <parameter type-id='type-id-78'/>
+      <parameter type-id='type-id-75'/>
+      <return type-id='type-id-19'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-104'>
+      <return type-id='type-id-6'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-105'>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-11'/>
+      <return type-id='type-id-6'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-106'>
+      <parameter type-id='type-id-78'/>
+      <parameter type-id='type-id-19'/>
+      <return type-id='type-id-6'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-107'>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-9'/>
+      <return type-id='type-id-6'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-108'>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-29'/>
+      <return type-id='type-id-6'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-109'>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-38'/>
+      <parameter type-id='type-id-3'/>
+      <return type-id='type-id-39'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-110'>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-38'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-39'/>
+      <return type-id='type-id-39'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-111'>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-114'/>
+      <parameter type-id='type-id-114'/>
+      <return type-id='type-id-39'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-112'>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-3'/>
+      <return type-id='type-id-39'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-113'>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-3'/>
+      <return type-id='type-id-39'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-115'>
+      <parameter type-id='type-id-78'/>
+      <parameter type-id='type-id-75'/>
+      <parameter type-id='type-id-6'/>
+      <return type-id='type-id-32'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-116'>
+      <parameter type-id='type-id-77'/>
+      <return type-id='type-id-32'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='/home/dank/src/zlib-ng/btmp1/src.d/gzlib.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C99'>
+    <type-decl name='variadic parameter type' id='type-id-117'/>
+    <typedef-decl name='gzFile' type-id='type-id-118' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='1286' column='1' id='type-id-119'/>
+    <class-decl name='gzFile_s' size-in-bits='192' is-struct='yes' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='1812' column='1' id='type-id-120'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='have' type-id='type-id-3' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='1813' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='next' type-id='type-id-15' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='1814' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='pos' type-id='type-id-8' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='1815' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-120' size-in-bits='64' id='type-id-118'/>
+    <pointer-type-def type-id='type-id-16' size-in-bits='64' id='type-id-121'/>
+    <function-decl name='zng_gzopen' mangled-name='zng_gzopen' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzlib.c' line='215' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_gzopen@@ZLIB_NG_GZ_2.0.0'>
+      <parameter type-id='type-id-40' name='path' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzlib.c' line='215' column='1'/>
+      <parameter type-id='type-id-40' name='mode' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzlib.c' line='215' column='1'/>
+      <return type-id='type-id-119'/>
+    </function-decl>
+    <function-decl name='zng_gzdopen' mangled-name='zng_gzdopen' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzlib.c' line='226' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_gzdopen@@ZLIB_NG_GZ_2.0.0'>
+      <parameter type-id='type-id-16' name='fd' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzlib.c' line='226' column='1'/>
+      <parameter type-id='type-id-40' name='mode' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzlib.c' line='226' column='1'/>
+      <return type-id='type-id-119'/>
+    </function-decl>
+    <function-decl name='zng_gzclose' mangled-name='zng_gzclose' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzlib.c' line='245' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_gzclose@@ZLIB_NG_GZ_2.0.0'>
+      <parameter type-id='type-id-119' name='file' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzlib.c' line='245' column='1'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='zng_gzbuffer' mangled-name='zng_gzbuffer' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzlib.c' line='260' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_gzbuffer@@ZLIB_NG_GZ_2.0.0'>
+      <parameter type-id='type-id-119' name='file' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzlib.c' line='260' column='1'/>
+      <parameter type-id='type-id-3' name='size' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzlib.c' line='260' column='1'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='zng_gzrewind' mangled-name='zng_gzrewind' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzlib.c' line='284' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_gzrewind@@ZLIB_NG_GZ_2.0.0'>
+      <parameter type-id='type-id-119' name='file' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzlib.c' line='284' column='1'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='zng_gzseek' mangled-name='zng_gzseek' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzlib.c' line='304' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_gzseek@@ZLIB_NG_GZ_2.0.0'>
+      <parameter type-id='type-id-119' name='file' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzlib.c' line='304' column='1'/>
+      <parameter type-id='type-id-8' name='offset' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzlib.c' line='304' column='1'/>
+      <parameter type-id='type-id-16' name='whence' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzlib.c' line='304' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='zng_gztell' mangled-name='zng_gztell' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzlib.c' line='385' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_gztell@@ZLIB_NG_GZ_2.0.0'>
+      <parameter type-id='type-id-119' name='file' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzlib.c' line='385' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='zng_gzoffset' mangled-name='zng_gzoffset' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzlib.c' line='411' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_gzoffset@@ZLIB_NG_GZ_2.0.0'>
+      <parameter type-id='type-id-119' name='file' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzlib.c' line='411' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='zng_gzeof' mangled-name='zng_gzeof' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzlib.c' line='442' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_gzeof@@ZLIB_NG_GZ_2.0.0'>
+      <parameter type-id='type-id-119' name='file' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzlib.c' line='442' column='1'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='zng_gzerror' mangled-name='zng_gzerror' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzlib.c' line='457' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_gzerror@@ZLIB_NG_GZ_2.0.0'>
+      <parameter type-id='type-id-119' name='file' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzlib.c' line='457' column='1'/>
+      <parameter type-id='type-id-121' name='errnum' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzlib.c' line='457' column='1'/>
+      <return type-id='type-id-40'/>
+    </function-decl>
+    <function-decl name='zng_gzclearerr' mangled-name='zng_gzclearerr' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzlib.c' line='474' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_gzclearerr@@ZLIB_NG_GZ_2.0.0'>
+      <parameter type-id='type-id-119' name='file' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzlib.c' line='474' column='1'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='zng_gzclose_r' mangled-name='zng_gzclose_r' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='1642' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_gzclose_r@@ZLIB_NG_GZ_2.0.0'>
+      <parameter type-id='type-id-119'/>
+      <return type-id='type-id-30'/>
+    </function-decl>
+    <function-decl name='zng_gzclose_w' mangled-name='zng_gzclose_w' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='1644' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_gzclose_w@@ZLIB_NG_GZ_2.0.0'>
+      <parameter type-id='type-id-119'/>
+      <return type-id='type-id-30'/>
+    </function-decl>
+    <function-decl name='malloc' filepath='/usr/include/stdlib.h' line='540' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-9'/>
+      <return type-id='type-id-42'/>
+    </function-decl>
+    <function-decl name='strlen' filepath='/usr/include/string.h' line='407' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-40'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='lseek64' filepath='/usr/include/unistd.h' line='350' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-7'/>
+      <parameter type-id='type-id-16'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='__open_2' filepath='/usr/include/x86_64-linux-gnu/bits/fcntl2.h' line='26' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-40'/>
+      <parameter type-id='type-id-16'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='__open_too_many_args' filepath='/usr/include/x86_64-linux-gnu/bits/fcntl2.h' line='35' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='__open_missing_mode' filepath='/usr/include/x86_64-linux-gnu/bits/fcntl2.h' line='37' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-32'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='/home/dank/src/zlib-ng/btmp1/src.d/gzread.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C99'>
+    <class-decl name='gz_state' size-in-bits='1856' is-struct='yes' naming-typedef-id='type-id-122' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzguts.h' line='106' column='1' id='type-id-123'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='x' type-id='type-id-120' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzguts.h' line='108' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='mode' type-id='type-id-16' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzguts.h' line='113' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='fd' type-id='type-id-16' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzguts.h' line='114' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='path' type-id='type-id-28' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzguts.h' line='115' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='size' type-id='type-id-3' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzguts.h' line='116' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='want' type-id='type-id-3' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzguts.h' line='117' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='in' type-id='type-id-15' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzguts.h' line='118' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='out' type-id='type-id-15' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzguts.h' line='119' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='direct' type-id='type-id-16' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzguts.h' line='120' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='544'>
+        <var-decl name='how' type-id='type-id-16' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzguts.h' line='122' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='start' type-id='type-id-8' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzguts.h' line='123' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='eof' type-id='type-id-16' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzguts.h' line='124' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='672'>
+        <var-decl name='past' type-id='type-id-16' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzguts.h' line='125' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='level' type-id='type-id-16' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzguts.h' line='127' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='736'>
+        <var-decl name='strategy' type-id='type-id-16' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzguts.h' line='128' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='reset' type-id='type-id-16' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzguts.h' line='129' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='skip' type-id='type-id-8' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzguts.h' line='131' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='seek' type-id='type-id-16' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzguts.h' line='132' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='928'>
+        <var-decl name='err' type-id='type-id-16' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzguts.h' line='134' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='msg' type-id='type-id-28' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzguts.h' line='135' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='strm' type-id='type-id-43' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzguts.h' line='137' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='gz_state' type-id='type-id-123' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzguts.h' line='138' column='1' id='type-id-122'/>
+    <typedef-decl name='__ssize_t' type-id='type-id-1' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='194' column='1' id='type-id-124'/>
+    <typedef-decl name='ssize_t' type-id='type-id-124' filepath='/usr/include/x86_64-linux-gnu/sys/types.h' line='108' column='1' id='type-id-125'/>
+    <pointer-type-def type-id='type-id-122' size-in-bits='64' id='type-id-126'/>
+    <function-decl name='gz_error' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzguts.h' line='142' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-126'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-40'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='zng_gzread' mangled-name='zng_gzread' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzread.c' line='347' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_gzread@@ZLIB_NG_GZ_2.0.0'>
+      <parameter type-id='type-id-119' name='file' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzread.c' line='347' column='1'/>
+      <parameter type-id='type-id-42' name='buf' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzread.c' line='347' column='1'/>
+      <parameter type-id='type-id-3' name='len' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzread.c' line='347' column='1'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='zng_gzfread' mangled-name='zng_gzfread' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzread.c' line='379' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_gzfread@@ZLIB_NG_GZ_2.0.0'>
+      <parameter type-id='type-id-42' name='buf' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzread.c' line='379' column='1'/>
+      <parameter type-id='type-id-9' name='size' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzread.c' line='379' column='1'/>
+      <parameter type-id='type-id-9' name='nitems' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzread.c' line='379' column='1'/>
+      <parameter type-id='type-id-119' name='file' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzread.c' line='379' column='1'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='zng_gzgetc' mangled-name='zng_gzgetc' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzread.c' line='411' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_gzgetc@@ZLIB_NG_GZ_2.0.0'>
+      <parameter type-id='type-id-119' name='file' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzread.c' line='411' column='1'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='zng_gzgetc_' mangled-name='zng_gzgetc_' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzread.c' line='435' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_gzgetc_@@ZLIB_NG_GZ_2.0.0'>
+      <parameter type-id='type-id-119' name='file' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzread.c' line='435' column='1'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='zng_gzungetc' mangled-name='zng_gzungetc' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzread.c' line='440' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_gzungetc@@ZLIB_NG_GZ_2.0.0'>
+      <parameter type-id='type-id-16' name='c' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzread.c' line='440' column='1'/>
+      <parameter type-id='type-id-119' name='file' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzread.c' line='440' column='1'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='zng_gzgets' mangled-name='zng_gzgets' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzread.c' line='496' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_gzgets@@ZLIB_NG_GZ_2.0.0'>
+      <parameter type-id='type-id-119' name='file' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzread.c' line='496' column='1'/>
+      <parameter type-id='type-id-28' name='buf' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzread.c' line='496' column='1'/>
+      <parameter type-id='type-id-16' name='len' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzread.c' line='496' column='1'/>
+      <return type-id='type-id-28'/>
+    </function-decl>
+    <function-decl name='zng_gzdirect' mangled-name='zng_gzdirect' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzread.c' line='557' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_gzdirect@@ZLIB_NG_GZ_2.0.0'>
+      <parameter type-id='type-id-119' name='file' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzread.c' line='557' column='1'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='__errno_location' filepath='/usr/include/errno.h' line='37' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-121'/>
+    </function-decl>
+    <function-decl name='memchr' filepath='/usr/include/string.h' line='107' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-9'/>
+      <return type-id='type-id-42'/>
+    </function-decl>
+    <function-decl name='strerror' filepath='/usr/include/string.h' line='419' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-16'/>
+      <return type-id='type-id-28'/>
+    </function-decl>
+    <function-decl name='close' filepath='/usr/include/unistd.h' line='358' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-16'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='__read_chk' filepath='/usr/include/x86_64-linux-gnu/bits/unistd.h' line='23' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-9'/>
+      <parameter type-id='type-id-9'/>
+      <return type-id='type-id-125'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='/home/dank/src/zlib-ng/btmp1/src.d/gzwrite.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C99'>
+    <class-decl name='__va_list_tag' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-127'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='gp_offset' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='fp_offset' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='overflow_arg_area' type-id='type-id-42' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='reg_save_area' type-id='type-id-42' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-127' size-in-bits='64' id='type-id-128'/>
+    <function-decl name='zng_gzwrite' mangled-name='zng_gzwrite' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzwrite.c' line='234' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_gzwrite@@ZLIB_NG_GZ_2.0.0'>
+      <parameter type-id='type-id-119' name='file' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzwrite.c' line='234' column='1'/>
+      <parameter type-id='type-id-42' name='buf' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzwrite.c' line='234' column='1'/>
+      <parameter type-id='type-id-3' name='len' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzwrite.c' line='234' column='1'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='zng_gzfwrite' mangled-name='zng_gzfwrite' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzwrite.c' line='258' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_gzfwrite@@ZLIB_NG_GZ_2.0.0'>
+      <parameter type-id='type-id-42' name='buf' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzwrite.c' line='258' column='1'/>
+      <parameter type-id='type-id-9' name='size' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzwrite.c' line='258' column='1'/>
+      <parameter type-id='type-id-9' name='nitems' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzwrite.c' line='258' column='1'/>
+      <parameter type-id='type-id-119' name='file' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzwrite.c' line='258' column='1'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='zng_gzputc' mangled-name='zng_gzputc' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzwrite.c' line='287' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_gzputc@@ZLIB_NG_GZ_2.0.0'>
+      <parameter type-id='type-id-119' name='file' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzwrite.c' line='287' column='1'/>
+      <parameter type-id='type-id-16' name='c' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzwrite.c' line='287' column='1'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='zng_gzputs' mangled-name='zng_gzputs' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzwrite.c' line='332' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_gzputs@@ZLIB_NG_GZ_2.0.0'>
+      <parameter type-id='type-id-119' name='file' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzwrite.c' line='332' column='1'/>
+      <parameter type-id='type-id-40' name='s' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzwrite.c' line='332' column='1'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='zng_gzvprintf' mangled-name='zng_gzvprintf' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzwrite.c' line='356' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_gzvprintf@@ZLIB_NG_GZ_2.0.0'>
+      <parameter type-id='type-id-119' name='file' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzwrite.c' line='356' column='1'/>
+      <parameter type-id='type-id-40' name='format' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzwrite.c' line='356' column='1'/>
+      <parameter type-id='type-id-128' name='va' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzwrite.c' line='356' column='1'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='zng_gzprintf' mangled-name='zng_gzprintf' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzwrite.c' line='412' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_gzprintf@@ZLIB_NG_GZ_2.0.0'>
+      <parameter type-id='type-id-119' name='file' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzwrite.c' line='412' column='1'/>
+      <parameter type-id='type-id-40' name='format' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzwrite.c' line='412' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='zng_gzflush' mangled-name='zng_gzflush' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzwrite.c' line='423' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_gzflush@@ZLIB_NG_GZ_2.0.0'>
+      <parameter type-id='type-id-119' name='file' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzwrite.c' line='423' column='1'/>
+      <parameter type-id='type-id-16' name='flush' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzwrite.c' line='423' column='1'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='zng_gzsetparams' mangled-name='zng_gzsetparams' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzwrite.c' line='452' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_gzsetparams@@ZLIB_NG_GZ_2.0.0'>
+      <parameter type-id='type-id-119' name='file' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzwrite.c' line='452' column='1'/>
+      <parameter type-id='type-id-16' name='level' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzwrite.c' line='452' column='1'/>
+      <parameter type-id='type-id-16' name='strategy' filepath='/home/dank/src/zlib-ng/btmp1/src.d/gzwrite.c' line='452' column='1'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='write' filepath='/usr/include/unistd.h' line='378' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-9'/>
+      <return type-id='type-id-125'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='/home/dank/src/zlib-ng/btmp1/src.d/infback.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-129' size-in-bits='46208' id='type-id-130'>
+      <subrange length='1444' type-id='type-id-4' id='type-id-131'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-58' size-in-bits='4608' id='type-id-132'>
+      <subrange length='288' type-id='type-id-4' id='type-id-133'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-58' size-in-bits='5120' id='type-id-134'>
+      <subrange length='320' type-id='type-id-4' id='type-id-135'/>
+    </array-type-def>
+    <enum-decl name='inflate_mode' naming-typedef-id='type-id-136' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='22' column='1' id='type-id-137'>
+      <underlying-type type-id='type-id-80'/>
+      <enumerator name='HEAD' value='16180'/>
+      <enumerator name='FLAGS' value='16181'/>
+      <enumerator name='TIME' value='16182'/>
+      <enumerator name='OS' value='16183'/>
+      <enumerator name='EXLEN' value='16184'/>
+      <enumerator name='EXTRA' value='16185'/>
+      <enumerator name='NAME' value='16186'/>
+      <enumerator name='COMMENT' value='16187'/>
+      <enumerator name='HCRC' value='16188'/>
+      <enumerator name='DICTID' value='16189'/>
+      <enumerator name='DICT' value='16190'/>
+      <enumerator name='TYPE' value='16191'/>
+      <enumerator name='TYPEDO' value='16192'/>
+      <enumerator name='STORED' value='16193'/>
+      <enumerator name='COPY_' value='16194'/>
+      <enumerator name='COPY' value='16195'/>
+      <enumerator name='TABLE' value='16196'/>
+      <enumerator name='LENLENS' value='16197'/>
+      <enumerator name='CODELENS' value='16198'/>
+      <enumerator name='LEN_' value='16199'/>
+      <enumerator name='LEN' value='16200'/>
+      <enumerator name='LENEXT' value='16201'/>
+      <enumerator name='DIST' value='16202'/>
+      <enumerator name='DISTEXT' value='16203'/>
+      <enumerator name='MATCH' value='16204'/>
+      <enumerator name='LIT' value='16205'/>
+      <enumerator name='CHECK' value='16206'/>
+      <enumerator name='LENGTH' value='16207'/>
+      <enumerator name='DONE' value='16208'/>
+      <enumerator name='BAD' value='16209'/>
+      <enumerator name='MEM' value='16210'/>
+      <enumerator name='SYNC' value='16211'/>
+    </enum-decl>
+    <typedef-decl name='inflate_mode' type-id='type-id-137' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='55' column='1' id='type-id-136'/>
+    <class-decl name='inflate_state' size-in-bits='57280' is-struct='yes' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='84' column='1' id='type-id-138'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='strm' type-id='type-id-14' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='85' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='mode' type-id='type-id-136' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='86' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='last' type-id='type-id-16' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='87' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='wrap' type-id='type-id-16' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='88' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='havedict' type-id='type-id-16' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='90' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='flags' type-id='type-id-16' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='91' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='dmax' type-id='type-id-3' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='93' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='check' type-id='type-id-4' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='94' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='total' type-id='type-id-4' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='95' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='head' type-id='type-id-17' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='96' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='wbits' type-id='type-id-3' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='98' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='480'>
+        <var-decl name='wsize' type-id='type-id-6' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='99' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='whave' type-id='type-id-6' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='100' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='544'>
+        <var-decl name='wnext' type-id='type-id-6' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='101' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='window' type-id='type-id-15' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='102' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='hold' type-id='type-id-6' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='104' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='672'>
+        <var-decl name='bits' type-id='type-id-3' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='105' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='length' type-id='type-id-6' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='107' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='736'>
+        <var-decl name='offset' type-id='type-id-3' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='108' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='extra' type-id='type-id-3' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='110' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='lencode' type-id='type-id-139' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='112' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='distcode' type-id='type-id-139' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='113' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='lenbits' type-id='type-id-3' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='114' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='992'>
+        <var-decl name='distbits' type-id='type-id-3' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='115' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='ncode' type-id='type-id-3' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='117' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1056'>
+        <var-decl name='nlen' type-id='type-id-3' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='118' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1088'>
+        <var-decl name='ndist' type-id='type-id-3' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='119' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1120'>
+        <var-decl name='have' type-id='type-id-6' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='120' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1152'>
+        <var-decl name='next' type-id='type-id-140' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='121' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1216'>
+        <var-decl name='lens' type-id='type-id-134' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='122' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='6336'>
+        <var-decl name='work' type-id='type-id-132' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='123' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='10944'>
+        <var-decl name='codes' type-id='type-id-130' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='124' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='57152'>
+        <var-decl name='sane' type-id='type-id-16' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='125' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='57184'>
+        <var-decl name='back' type-id='type-id-16' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='126' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='57216'>
+        <var-decl name='was' type-id='type-id-3' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='127' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='57248'>
+        <var-decl name='chunksize' type-id='type-id-6' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='128' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='code' size-in-bits='32' is-struct='yes' naming-typedef-id='type-id-129' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inftrees.h' line='27' column='1' id='type-id-141'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-2' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inftrees.h' line='28' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8'>
+        <var-decl name='bits' type-id='type-id-2' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inftrees.h' line='29' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='val' type-id='type-id-58' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inftrees.h' line='30' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='code' type-id='type-id-141' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inftrees.h' line='31' column='1' id='type-id-129'/>
+    <enum-decl name='codetype' naming-typedef-id='type-id-142' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inftrees.h' line='57' column='1' id='type-id-143'>
+      <underlying-type type-id='type-id-80'/>
+      <enumerator name='CODES' value='0'/>
+      <enumerator name='LENS' value='1'/>
+      <enumerator name='DISTS' value='2'/>
+    </enum-decl>
+    <typedef-decl name='codetype' type-id='type-id-143' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inftrees.h' line='61' column='1' id='type-id-142'/>
+    <typedef-decl name='in_func' type-id='type-id-144' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='1076' column='1' id='type-id-145'/>
+    <typedef-decl name='out_func' type-id='type-id-146' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zlib-ng.h' line='1077' column='1' id='type-id-147'/>
+    <pointer-type-def type-id='type-id-129' size-in-bits='64' id='type-id-140'/>
+    <pointer-type-def type-id='type-id-140' size-in-bits='64' id='type-id-148'/>
+    <qualified-type-def type-id='type-id-129' const='yes' id='type-id-149'/>
+    <pointer-type-def type-id='type-id-149' size-in-bits='64' id='type-id-139'/>
+    <pointer-type-def type-id='type-id-38' size-in-bits='64' id='type-id-150'/>
+    <pointer-type-def type-id='type-id-138' size-in-bits='64' id='type-id-151'/>
+    <pointer-type-def type-id='type-id-152' size-in-bits='64' id='type-id-146'/>
+    <pointer-type-def type-id='type-id-153' size-in-bits='64' id='type-id-144'/>
+    <pointer-type-def type-id='type-id-58' size-in-bits='64' id='type-id-154'/>
+    <function-decl name='zng_inflateBackInit_' mangled-name='zng_inflateBackInit_' filepath='/home/dank/src/zlib-ng/btmp1/src.d/infback.c' line='28' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_inflateBackInit_@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14' name='strm' filepath='/home/dank/src/zlib-ng/btmp1/src.d/infback.c' line='28' column='1'/>
+      <parameter type-id='type-id-30' name='windowBits' filepath='/home/dank/src/zlib-ng/btmp1/src.d/infback.c' line='28' column='1'/>
+      <parameter type-id='type-id-39' name='window' filepath='/home/dank/src/zlib-ng/btmp1/src.d/infback.c' line='28' column='1'/>
+      <parameter type-id='type-id-40' name='version' filepath='/home/dank/src/zlib-ng/btmp1/src.d/infback.c' line='29' column='1'/>
+      <parameter type-id='type-id-30' name='stream_size' filepath='/home/dank/src/zlib-ng/btmp1/src.d/infback.c' line='29' column='1'/>
+      <return type-id='type-id-30'/>
+    </function-decl>
+    <function-decl name='zng_inflateBack' mangled-name='zng_inflateBack' filepath='/home/dank/src/zlib-ng/btmp1/src.d/infback.c' line='130' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_inflateBack@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14' name='strm' filepath='/home/dank/src/zlib-ng/btmp1/src.d/infback.c' line='130' column='1'/>
+      <parameter type-id='type-id-145' name='in' filepath='/home/dank/src/zlib-ng/btmp1/src.d/infback.c' line='130' column='1'/>
+      <parameter type-id='type-id-42' name='in_desc' filepath='/home/dank/src/zlib-ng/btmp1/src.d/infback.c' line='130' column='1'/>
+      <parameter type-id='type-id-147' name='out' filepath='/home/dank/src/zlib-ng/btmp1/src.d/infback.c' line='130' column='1'/>
+      <parameter type-id='type-id-42' name='out_desc' filepath='/home/dank/src/zlib-ng/btmp1/src.d/infback.c' line='130' column='1'/>
+      <return type-id='type-id-30'/>
+    </function-decl>
+    <function-decl name='zng_inflateBackEnd' mangled-name='zng_inflateBackEnd' filepath='/home/dank/src/zlib-ng/btmp1/src.d/infback.c' line='503' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_inflateBackEnd@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14' name='strm' filepath='/home/dank/src/zlib-ng/btmp1/src.d/infback.c' line='503' column='1'/>
+      <return type-id='type-id-30'/>
+    </function-decl>
+    <function-decl name='zng_inflate_fast' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inffast.h' line='13' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-14'/>
+      <parameter type-id='type-id-4'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='fixedtables' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.h' line='132' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-151'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='zng_inflate_table' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inftrees.h' line='63' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-142'/>
+      <parameter type-id='type-id-154'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-148'/>
+      <parameter type-id='type-id-114'/>
+      <parameter type-id='type-id-154'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-152'>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-6'/>
+      <return type-id='type-id-30'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-153'>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-150'/>
+      <return type-id='type-id-6'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C99'>
+    <function-decl name='zng_inflateResetKeep' mangled-name='zng_inflateResetKeep' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='57' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_inflateResetKeep@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14' name='strm' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='57' column='1'/>
+      <return type-id='type-id-30'/>
+    </function-decl>
+    <function-decl name='zng_inflateReset' mangled-name='zng_inflateReset' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='84' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_inflateReset@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14' name='strm' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='84' column='1'/>
+      <return type-id='type-id-30'/>
+    </function-decl>
+    <function-decl name='zng_inflateReset2' mangled-name='zng_inflateReset2' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='96' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_inflateReset2@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14' name='strm' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='96' column='1'/>
+      <parameter type-id='type-id-30' name='windowBits' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='96' column='1'/>
+      <return type-id='type-id-30'/>
+    </function-decl>
+    <function-decl name='zng_inflateInit2_' mangled-name='zng_inflateInit2_' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='131' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_inflateInit2_@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14' name='strm' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='131' column='1'/>
+      <parameter type-id='type-id-30' name='windowBits' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='131' column='1'/>
+      <parameter type-id='type-id-40' name='version' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='131' column='1'/>
+      <parameter type-id='type-id-30' name='stream_size' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='131' column='1'/>
+      <return type-id='type-id-30'/>
+    </function-decl>
+    <function-decl name='zng_inflateInit_' mangled-name='zng_inflateInit_' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='169' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_inflateInit_@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14' name='strm' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='169' column='1'/>
+      <parameter type-id='type-id-40' name='version' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='169' column='1'/>
+      <parameter type-id='type-id-30' name='stream_size' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='169' column='1'/>
+      <return type-id='type-id-30'/>
+    </function-decl>
+    <function-decl name='zng_inflatePrime' mangled-name='zng_inflatePrime' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='173' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_inflatePrime@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14' name='strm' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='173' column='1'/>
+      <parameter type-id='type-id-30' name='bits' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='173' column='1'/>
+      <parameter type-id='type-id-30' name='value' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='173' column='1'/>
+      <return type-id='type-id-30'/>
+    </function-decl>
+    <function-decl name='zng_inflate' mangled-name='zng_inflate' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='370' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_inflate@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14' name='strm' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='370' column='1'/>
+      <parameter type-id='type-id-30' name='flush' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='370' column='1'/>
+      <return type-id='type-id-30'/>
+    </function-decl>
+    <function-decl name='zng_inflateEnd' mangled-name='zng_inflateEnd' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='1062' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_inflateEnd@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14' name='strm' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='1062' column='1'/>
+      <return type-id='type-id-30'/>
+    </function-decl>
+    <function-decl name='zng_inflateGetDictionary' mangled-name='zng_inflateGetDictionary' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='1075' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_inflateGetDictionary@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14' name='strm' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='1075' column='1'/>
+      <parameter type-id='type-id-39' name='dictionary' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='1075' column='1'/>
+      <parameter type-id='type-id-79' name='dictLength' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='1075' column='1'/>
+      <return type-id='type-id-30'/>
+    </function-decl>
+    <function-decl name='zng_inflateSetDictionary' mangled-name='zng_inflateSetDictionary' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='1093' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_inflateSetDictionary@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14' name='strm' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='1093' column='1'/>
+      <parameter type-id='type-id-38' name='dictionary' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='1093' column='1'/>
+      <parameter type-id='type-id-6' name='dictLength' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='1093' column='1'/>
+      <return type-id='type-id-30'/>
+    </function-decl>
+    <function-decl name='zng_inflateGetHeader' mangled-name='zng_inflateGetHeader' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='1124' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_inflateGetHeader@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14' name='strm' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='1124' column='1'/>
+      <parameter type-id='type-id-17' name='head' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='1124' column='1'/>
+      <return type-id='type-id-30'/>
+    </function-decl>
+    <function-decl name='zng_inflateSync' mangled-name='zng_inflateSync' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='1169' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_inflateSync@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14' name='strm' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='1169' column='1'/>
+      <return type-id='type-id-30'/>
+    </function-decl>
+    <function-decl name='zng_inflateSyncPoint' mangled-name='zng_inflateSyncPoint' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='1230' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_inflateSyncPoint@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14' name='strm' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='1230' column='1'/>
+      <return type-id='type-id-30'/>
+    </function-decl>
+    <function-decl name='zng_inflateCopy' mangled-name='zng_inflateCopy' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='1240' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_inflateCopy@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14' name='dest' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='1240' column='1'/>
+      <parameter type-id='type-id-14' name='source' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='1240' column='1'/>
+      <return type-id='type-id-30'/>
+    </function-decl>
+    <function-decl name='zng_inflateUndermine' mangled-name='zng_inflateUndermine' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='1282' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_inflateUndermine@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14' name='strm' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='1282' column='1'/>
+      <parameter type-id='type-id-30' name='subvert' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='1282' column='1'/>
+      <return type-id='type-id-30'/>
+    </function-decl>
+    <function-decl name='zng_inflateValidate' mangled-name='zng_inflateValidate' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='1298' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_inflateValidate@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14' name='strm' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='1298' column='1'/>
+      <parameter type-id='type-id-30' name='check' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='1298' column='1'/>
+      <return type-id='type-id-30'/>
+    </function-decl>
+    <function-decl name='zng_inflateMark' mangled-name='zng_inflateMark' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='1311' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_inflateMark@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14' name='strm' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='1311' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='zng_inflateCodesUsed' mangled-name='zng_inflateCodesUsed' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='1323' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_inflateCodesUsed@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-14' name='strm' filepath='/home/dank/src/zlib-ng/btmp1/src.d/inflate.c' line='1323' column='1'/>
+      <return type-id='type-id-4'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='/home/dank/src/zlib-ng/btmp1/src.d/trees.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-155' size-in-bits='9216' id='type-id-156'>
+      <subrange length='288' type-id='type-id-4' id='type-id-133'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-155' size-in-bits='960' id='type-id-157'>
+      <subrange length='30' type-id='type-id-4' id='type-id-158'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-159' size-in-bits='928' id='type-id-160'>
+      <subrange length='29' type-id='type-id-4' id='type-id-161'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-159' size-in-bits='960' id='type-id-162'>
+      <subrange length='30' type-id='type-id-4' id='type-id-158'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-10' size-in-bits='2048' id='type-id-163'>
+      <subrange length='256' type-id='type-id-4' id='type-id-164'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-10' size-in-bits='4096' id='type-id-165'>
+      <subrange length='512' type-id='type-id-4' id='type-id-166'/>
+    </array-type-def>
+    <qualified-type-def type-id='type-id-64' const='yes' id='type-id-155'/>
+    <qualified-type-def type-id='type-id-16' const='yes' id='type-id-159'/>
+    <var-decl name='static_ltree' type-id='type-id-156' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/trees_emit.h' line='15' column='1'/>
+    <var-decl name='static_dtree' type-id='type-id-157' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/trees_emit.h' line='16' column='1'/>
+    <var-decl name='zng_dist_code' type-id='type-id-165' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/trees_emit.h' line='18' column='1'/>
+    <var-decl name='zng_length_code' type-id='type-id-163' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/trees_emit.h' line='19' column='1'/>
+    <var-decl name='base_length' type-id='type-id-160' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/trees_emit.h' line='21' column='1'/>
+    <var-decl name='base_dist' type-id='type-id-162' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/trees_emit.h' line='22' column='1'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='/home/dank/src/zlib-ng/btmp1/src.d/uncompr.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C99'>
+    <function-decl name='zng_uncompress2' mangled-name='zng_uncompress2' filepath='/home/dank/src/zlib-ng/btmp1/src.d/uncompr.c' line='30' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_uncompress2@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-15' name='dest' filepath='/home/dank/src/zlib-ng/btmp1/src.d/uncompr.c' line='30' column='1'/>
+      <parameter type-id='type-id-49' name='destLen' filepath='/home/dank/src/zlib-ng/btmp1/src.d/uncompr.c' line='30' column='1'/>
+      <parameter type-id='type-id-11' name='source' filepath='/home/dank/src/zlib-ng/btmp1/src.d/uncompr.c' line='30' column='1'/>
+      <parameter type-id='type-id-49' name='sourceLen' filepath='/home/dank/src/zlib-ng/btmp1/src.d/uncompr.c' line='30' column='1'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+    <function-decl name='zng_uncompress' mangled-name='zng_uncompress' filepath='/home/dank/src/zlib-ng/btmp1/src.d/uncompr.c' line='83' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_uncompress@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-15' name='dest' filepath='/home/dank/src/zlib-ng/btmp1/src.d/uncompr.c' line='83' column='1'/>
+      <parameter type-id='type-id-49' name='destLen' filepath='/home/dank/src/zlib-ng/btmp1/src.d/uncompr.c' line='83' column='1'/>
+      <parameter type-id='type-id-11' name='source' filepath='/home/dank/src/zlib-ng/btmp1/src.d/uncompr.c' line='83' column='1'/>
+      <parameter type-id='type-id-9' name='sourceLen' filepath='/home/dank/src/zlib-ng/btmp1/src.d/uncompr.c' line='83' column='1'/>
+      <return type-id='type-id-16'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='/home/dank/src/zlib-ng/btmp1/src.d/zutil.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C99'>
+    <array-type-def dimensions='1' type-id='type-id-167' size-in-bits='640' id='type-id-168'>
+      <subrange length='10' type-id='type-id-4' id='type-id-169'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-47' size-in-bits='256' id='type-id-170'>
+      <subrange length='32' type-id='type-id-4' id='type-id-171'/>
+    </array-type-def>
+    <qualified-type-def type-id='type-id-40' const='yes' id='type-id-167'/>
+    <var-decl name='zlibng_string' type-id='type-id-170' mangled-name='zlibng_string' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zutil.c' line='23' column='1' elf-symbol-id='zlibng_string'/>
+    <function-decl name='zlibng_version' mangled-name='zlibng_version' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zutil.c' line='32' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zlibng_version'>
+      <return type-id='type-id-40'/>
+    </function-decl>
+    <function-decl name='zng_zlibCompileFlags' mangled-name='zng_zlibCompileFlags' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zutil.c' line='36' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_zlibCompileFlags@@ZLIB_NG_2.0.0'>
+      <return type-id='type-id-4'/>
+    </function-decl>
+    <function-decl name='zng_zError' mangled-name='zng_zError' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zutil.c' line='99' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zng_zError@@ZLIB_NG_2.0.0'>
+      <parameter type-id='type-id-16' name='err' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zutil.c' line='99' column='1'/>
+      <return type-id='type-id-40'/>
+    </function-decl>
+    <var-decl name='zng_z_errmsg' type-id='type-id-168' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/zutil.h' line='46' column='1'/>
+    <function-decl name='free' filepath='/usr/include/malloc.h' line='64' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-42'/>
+      <return type-id='type-id-32'/>
+    </function-decl>
+    <function-decl name='memalign' filepath='/usr/include/malloc.h' line='67' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-9'/>
+      <parameter type-id='type-id-9'/>
+      <return type-id='type-id-42'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='/home/dank/src/zlib-ng/btmp1/src.d/arch/x86/x86.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1/arch/x86' language='LANG_C99'>
+    <var-decl name='x86_cpu_has_avx2' type-id='type-id-16' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/arch/x86/../../arch/x86/x86.h' line='9' column='1'/>
+    <var-decl name='x86_cpu_has_sse2' type-id='type-id-16' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/arch/x86/../../arch/x86/x86.h' line='10' column='1'/>
+    <var-decl name='x86_cpu_has_ssse3' type-id='type-id-16' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/arch/x86/../../arch/x86/x86.h' line='11' column='1'/>
+    <var-decl name='x86_cpu_has_sse42' type-id='type-id-16' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/arch/x86/../../arch/x86/x86.h' line='12' column='1'/>
+    <var-decl name='x86_cpu_has_pclmulqdq' type-id='type-id-16' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/arch/x86/../../arch/x86/x86.h' line='13' column='1'/>
+    <var-decl name='x86_cpu_has_tzcnt' type-id='type-id-16' visibility='default' filepath='/home/dank/src/zlib-ng/btmp1/src.d/arch/x86/../../arch/x86/x86.h' line='14' column='1'/>
+  </abi-instr>
+</abi-corpus>

--- a/test/abi/zlib-v1.2.12-x86_64-pc-linux-gnu.abi
+++ b/test/abi/zlib-v1.2.12-x86_64-pc-linux-gnu.abi
@@ -1,0 +1,1281 @@
+<abi-corpus version='2.0' path='btmp1/libz.so.1.2.12' architecture='elf-amd-x86_64' soname='libz.so.1'>
+  <elf-needed>
+    <dependency name='libc.so.6'/>
+  </elf-needed>
+  <elf-function-symbols>
+    <elf-symbol name='adler32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='adler32_combine64' version='ZLIB_1.2.3.3' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='adler32_combine' version='ZLIB_1.2.2' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='adler32_z' version='ZLIB_1.2.9' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='compress' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='compress2' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='compressBound' version='ZLIB_1.2.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='crc32' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='crc32_combine64' version='ZLIB_1.2.3.3' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='crc32_combine' version='ZLIB_1.2.2' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='crc32_combine_gen64' version='ZLIB_1.2.12' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='crc32_combine_gen' version='ZLIB_1.2.12' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='crc32_combine_op' version='ZLIB_1.2.12' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='crc32_z' version='ZLIB_1.2.9' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflate' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflateBound' version='ZLIB_1.2.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflateCopy' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflateEnd' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflateGetDictionary' version='ZLIB_1.2.9' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflateInit2_' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflateInit_' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflateParams' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflatePending' version='ZLIB_1.2.5.1' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflatePrime' version='ZLIB_1.2.0.8' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflateReset' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflateResetKeep' version='ZLIB_1.2.5.2' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflateSetDictionary' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflateSetHeader' version='ZLIB_1.2.2' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='deflateTune' version='ZLIB_1.2.2.3' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='get_crc_table' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzbuffer' version='ZLIB_1.2.3.5' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzclearerr' version='ZLIB_1.2.0.2' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzclose' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzclose_r' version='ZLIB_1.2.3.5' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzclose_w' version='ZLIB_1.2.3.5' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzdirect' version='ZLIB_1.2.2.3' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzdopen' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzeof' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzerror' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzflush' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzfread' version='ZLIB_1.2.9' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzfwrite' version='ZLIB_1.2.9' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzgetc' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzgetc_' version='ZLIB_1.2.5.2' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzgets' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzoffset64' version='ZLIB_1.2.3.5' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzoffset' version='ZLIB_1.2.3.5' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzopen' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzopen64' version='ZLIB_1.2.3.3' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzprintf' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzputc' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzputs' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzread' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzrewind' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzseek' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzseek64' version='ZLIB_1.2.3.3' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzsetparams' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gztell' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gztell64' version='ZLIB_1.2.3.3' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzungetc' version='ZLIB_1.2.0.2' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzvprintf' version='ZLIB_1.2.7.1' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='gzwrite' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflate' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateBack' version='ZLIB_1.2.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateBackEnd' version='ZLIB_1.2.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateBackInit_' version='ZLIB_1.2.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateCodesUsed' version='ZLIB_1.2.9' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateCopy' version='ZLIB_1.2.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateEnd' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateGetDictionary' version='ZLIB_1.2.7.1' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateGetHeader' version='ZLIB_1.2.2' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateInit2_' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateInit_' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateMark' version='ZLIB_1.2.3.4' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflatePrime' version='ZLIB_1.2.2.4' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateReset' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateReset2' version='ZLIB_1.2.3.4' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateResetKeep' version='ZLIB_1.2.5.2' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateSetDictionary' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateSync' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateSyncPoint' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateUndermine' version='ZLIB_1.2.3.3' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='inflateValidate' version='ZLIB_1.2.9' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uncompress' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='uncompress2' version='ZLIB_1.2.9' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zError' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zlibCompileFlags' version='ZLIB_1.2.0.2' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='zlibVersion' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+  </elf-function-symbols>
+  <abi-instr address-size='64' path='src.d/adler32.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C11'>
+    <type-decl name='long int' size-in-bits='64' id='type-id-1'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-2'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-3'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-4'/>
+    <typedef-decl name='z_size_t' type-id='type-id-5' filepath='./zconf.h' line='248' column='1' id='type-id-6'/>
+    <typedef-decl name='Byte' type-id='type-id-2' filepath='./zconf.h' line='391' column='1' id='type-id-7'/>
+    <typedef-decl name='uInt' type-id='type-id-3' filepath='./zconf.h' line='393' column='1' id='type-id-8'/>
+    <typedef-decl name='uLong' type-id='type-id-4' filepath='./zconf.h' line='394' column='1' id='type-id-9'/>
+    <typedef-decl name='Bytef' type-id='type-id-7' filepath='./zconf.h' line='400' column='1' id='type-id-10'/>
+    <typedef-decl name='__off_t' type-id='type-id-1' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='152' column='1' id='type-id-11'/>
+    <typedef-decl name='__off64_t' type-id='type-id-1' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='153' column='1' id='type-id-12'/>
+    <typedef-decl name='off_t' type-id='type-id-11' filepath='/usr/include/x86_64-linux-gnu/sys/types.h' line='85' column='1' id='type-id-13'/>
+    <typedef-decl name='off64_t' type-id='type-id-12' filepath='/usr/include/x86_64-linux-gnu/sys/types.h' line='92' column='1' id='type-id-14'/>
+    <typedef-decl name='size_t' type-id='type-id-4' filepath='/usr/lib/gcc/x86_64-linux-gnu/11/include/stddef.h' line='209' column='1' id='type-id-5'/>
+    <qualified-type-def type-id='type-id-10' const='yes' id='type-id-15'/>
+    <pointer-type-def type-id='type-id-15' size-in-bits='64' id='type-id-16'/>
+    <function-decl name='adler32_z' mangled-name='adler32_z' filepath='src.d/adler32.c' line='63' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='adler32_z@@ZLIB_1.2.9'>
+      <parameter type-id='type-id-9' name='adler' filepath='src.d/adler32.c' line='64' column='1'/>
+      <parameter type-id='type-id-16' name='buf' filepath='src.d/adler32.c' line='65' column='1'/>
+      <parameter type-id='type-id-6' name='len' filepath='src.d/adler32.c' line='66' column='1'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='adler32' mangled-name='adler32' filepath='src.d/adler32.c' line='134' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='adler32'>
+      <parameter type-id='type-id-9' name='adler' filepath='src.d/adler32.c' line='135' column='1'/>
+      <parameter type-id='type-id-16' name='buf' filepath='src.d/adler32.c' line='136' column='1'/>
+      <parameter type-id='type-id-8' name='len' filepath='src.d/adler32.c' line='137' column='1'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='adler32_combine' mangled-name='adler32_combine' filepath='src.d/adler32.c' line='172' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='adler32_combine@@ZLIB_1.2.2'>
+      <parameter type-id='type-id-9' name='adler1' filepath='src.d/adler32.c' line='173' column='1'/>
+      <parameter type-id='type-id-9' name='adler2' filepath='src.d/adler32.c' line='174' column='1'/>
+      <parameter type-id='type-id-13' name='len2' filepath='src.d/adler32.c' line='175' column='1'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='adler32_combine64' mangled-name='adler32_combine64' filepath='src.d/adler32.c' line='180' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='adler32_combine64@@ZLIB_1.2.3.3'>
+      <parameter type-id='type-id-9' name='adler1' filepath='src.d/adler32.c' line='181' column='1'/>
+      <parameter type-id='type-id-9' name='adler2' filepath='src.d/adler32.c' line='182' column='1'/>
+      <parameter type-id='type-id-14' name='len2' filepath='src.d/adler32.c' line='183' column='1'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='src.d/compress.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C11'>
+    <typedef-decl name='uLongf' type-id='type-id-9' filepath='./zconf.h' line='405' column='1' id='type-id-17'/>
+    <pointer-type-def type-id='type-id-17' size-in-bits='64' id='type-id-18'/>
+    <function-decl name='compress2' mangled-name='compress2' filepath='src.d/compress.c' line='22' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='compress2'>
+      <parameter type-id='type-id-19' name='dest' filepath='src.d/compress.c' line='23' column='1'/>
+      <parameter type-id='type-id-18' name='destLen' filepath='src.d/compress.c' line='24' column='1'/>
+      <parameter type-id='type-id-16' name='source' filepath='src.d/compress.c' line='25' column='1'/>
+      <parameter type-id='type-id-9' name='sourceLen' filepath='src.d/compress.c' line='26' column='1'/>
+      <parameter type-id='type-id-20' name='level' filepath='src.d/compress.c' line='27' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='compress' mangled-name='compress' filepath='src.d/compress.c' line='68' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='compress'>
+      <parameter type-id='type-id-19' name='dest' filepath='src.d/compress.c' line='69' column='1'/>
+      <parameter type-id='type-id-18' name='destLen' filepath='src.d/compress.c' line='70' column='1'/>
+      <parameter type-id='type-id-16' name='source' filepath='src.d/compress.c' line='71' column='1'/>
+      <parameter type-id='type-id-9' name='sourceLen' filepath='src.d/compress.c' line='72' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='compressBound' mangled-name='compressBound' filepath='src.d/compress.c' line='81' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='compressBound@@ZLIB_1.2.0'>
+      <parameter type-id='type-id-9' name='sourceLen' filepath='src.d/compress.c' line='82' column='1'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='src.d/crc32.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C11'>
+    <typedef-decl name='z_crc_t' type-id='type-id-3' filepath='./zconf.h' line='429' column='1' id='type-id-21'/>
+    <qualified-type-def type-id='type-id-2' const='yes' id='type-id-22'/>
+    <pointer-type-def type-id='type-id-22' size-in-bits='64' id='type-id-23'/>
+    <qualified-type-def type-id='type-id-21' const='yes' id='type-id-24'/>
+    <pointer-type-def type-id='type-id-24' size-in-bits='64' id='type-id-25'/>
+    <function-decl name='get_crc_table' mangled-name='get_crc_table' filepath='src.d/crc32.c' line='586' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='get_crc_table'>
+      <return type-id='type-id-25'/>
+    </function-decl>
+    <function-decl name='crc32_z' mangled-name='crc32_z' filepath='src.d/crc32.c' line='739' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_z@@ZLIB_1.2.9'>
+      <parameter type-id='type-id-4' name='crc' filepath='src.d/crc32.c' line='740' column='1'/>
+      <parameter type-id='type-id-23' name='buf' filepath='src.d/crc32.c' line='741' column='1'/>
+      <parameter type-id='type-id-6' name='len' filepath='src.d/crc32.c' line='742' column='1'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='crc32' mangled-name='crc32' filepath='src.d/crc32.c' line='1063' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32'>
+      <parameter type-id='type-id-4' name='crc' filepath='src.d/crc32.c' line='1064' column='1'/>
+      <parameter type-id='type-id-23' name='buf' filepath='src.d/crc32.c' line='1065' column='1'/>
+      <parameter type-id='type-id-8' name='len' filepath='src.d/crc32.c' line='1066' column='1'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='crc32_combine64' mangled-name='crc32_combine64' filepath='src.d/crc32.c' line='1072' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_combine64@@ZLIB_1.2.3.3'>
+      <parameter type-id='type-id-9' name='crc1' filepath='src.d/crc32.c' line='1073' column='1'/>
+      <parameter type-id='type-id-9' name='crc2' filepath='src.d/crc32.c' line='1074' column='1'/>
+      <parameter type-id='type-id-14' name='len2' filepath='src.d/crc32.c' line='1075' column='1'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='crc32_combine' mangled-name='crc32_combine' filepath='src.d/crc32.c' line='1084' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_combine@@ZLIB_1.2.2'>
+      <parameter type-id='type-id-9' name='crc1' filepath='src.d/crc32.c' line='1085' column='1'/>
+      <parameter type-id='type-id-9' name='crc2' filepath='src.d/crc32.c' line='1086' column='1'/>
+      <parameter type-id='type-id-13' name='len2' filepath='src.d/crc32.c' line='1087' column='1'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='crc32_combine_gen64' mangled-name='crc32_combine_gen64' filepath='src.d/crc32.c' line='1093' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_combine_gen64@@ZLIB_1.2.12'>
+      <parameter type-id='type-id-14' name='len2' filepath='src.d/crc32.c' line='1094' column='1'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='crc32_combine_gen' mangled-name='crc32_combine_gen' filepath='src.d/crc32.c' line='1103' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_combine_gen@@ZLIB_1.2.12'>
+      <parameter type-id='type-id-13' name='len2' filepath='src.d/crc32.c' line='1104' column='1'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='crc32_combine_op' mangled-name='crc32_combine_op' filepath='src.d/crc32.c' line='1110' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_combine_op@@ZLIB_1.2.12'>
+      <parameter type-id='type-id-9' name='crc1' filepath='src.d/crc32.c' line='1111' column='1'/>
+      <parameter type-id='type-id-9' name='crc2' filepath='src.d/crc32.c' line='1112' column='1'/>
+      <parameter type-id='type-id-9' name='op' filepath='src.d/crc32.c' line='1113' column='1'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='src.d/deflate.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C11'>
+    <type-decl name='char' size-in-bits='8' id='type-id-26'/>
+    <class-decl name='static_tree_desc_s' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-27'/>
+    <array-type-def dimensions='1' type-id='type-id-28' size-in-bits='1248' id='type-id-29'>
+      <subrange length='39' type-id='type-id-4' id='type-id-30'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-28' size-in-bits='18336' id='type-id-31'>
+      <subrange length='573' type-id='type-id-4' id='type-id-32'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-28' size-in-bits='1952' id='type-id-33'>
+      <subrange length='61' type-id='type-id-4' id='type-id-34'/>
+    </array-type-def>
+    <type-decl name='int' size-in-bits='32' id='type-id-20'/>
+    <array-type-def dimensions='1' type-id='type-id-20' size-in-bits='18336' id='type-id-35'>
+      <subrange length='573' type-id='type-id-4' id='type-id-32'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-36' size-in-bits='4584' id='type-id-37'>
+      <subrange length='573' type-id='type-id-4' id='type-id-32'/>
+    </array-type-def>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-38'/>
+    <array-type-def dimensions='1' type-id='type-id-39' size-in-bits='256' id='type-id-40'>
+      <subrange length='16' type-id='type-id-4' id='type-id-41'/>
+    </array-type-def>
+    <type-decl name='void' id='type-id-42'/>
+    <typedef-decl name='charf' type-id='type-id-26' filepath='./zconf.h' line='402' column='1' id='type-id-43'/>
+    <typedef-decl name='voidpf' type-id='type-id-44' filepath='./zconf.h' line='409' column='1' id='type-id-45'/>
+    <class-decl name='ct_data_s' size-in-bits='32' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='68' column='1' id='type-id-28'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='fc' type-id='type-id-46' visibility='default' filepath='src.d/deflate.h' line='72' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='dl' type-id='type-id-47' visibility='default' filepath='src.d/deflate.h' line='76' column='1'/>
+      </data-member>
+    </class-decl>
+    <union-decl name='__anonymous_union__' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='69' column='1' id='type-id-46'>
+      <data-member access='public'>
+        <var-decl name='freq' type-id='type-id-39' visibility='default' filepath='src.d/deflate.h' line='70' column='1'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='code' type-id='type-id-39' visibility='default' filepath='src.d/deflate.h' line='71' column='1'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='__anonymous_union__1' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='73' column='1' id='type-id-47'>
+      <data-member access='public'>
+        <var-decl name='dad' type-id='type-id-39' visibility='default' filepath='src.d/deflate.h' line='74' column='1'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='len' type-id='type-id-39' visibility='default' filepath='src.d/deflate.h' line='75' column='1'/>
+      </data-member>
+    </union-decl>
+    <typedef-decl name='ct_data' type-id='type-id-28' filepath='src.d/deflate.h' line='77' column='1' id='type-id-48'/>
+    <typedef-decl name='static_tree_desc' type-id='type-id-27' filepath='src.d/deflate.h' line='84' column='1' id='type-id-49'/>
+    <class-decl name='tree_desc_s' size-in-bits='192' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='86' column='1' id='type-id-50'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dyn_tree' type-id='type-id-51' visibility='default' filepath='src.d/deflate.h' line='87' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='max_code' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='88' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='stat_desc' type-id='type-id-52' visibility='default' filepath='src.d/deflate.h' line='89' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='Pos' type-id='type-id-39' filepath='src.d/deflate.h' line='92' column='1' id='type-id-53'/>
+    <typedef-decl name='Posf' type-id='type-id-53' filepath='src.d/deflate.h' line='93' column='1' id='type-id-54'/>
+    <typedef-decl name='IPos' type-id='type-id-3' filepath='src.d/deflate.h' line='94' column='1' id='type-id-55'/>
+    <class-decl name='internal_state' size-in-bits='47616' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='100' column='1' id='type-id-56'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='strm' type-id='type-id-57' visibility='default' filepath='src.d/deflate.h' line='101' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='status' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='102' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='pending_buf' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='103' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='pending_buf_size' type-id='type-id-58' visibility='default' filepath='src.d/deflate.h' line='104' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='pending_out' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='105' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='pending' type-id='type-id-58' visibility='default' filepath='src.d/deflate.h' line='106' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='wrap' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='107' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='gzhead' type-id='type-id-59' visibility='default' filepath='src.d/deflate.h' line='108' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='gzindex' type-id='type-id-58' visibility='default' filepath='src.d/deflate.h' line='109' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='method' type-id='type-id-7' visibility='default' filepath='src.d/deflate.h' line='110' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='608'>
+        <var-decl name='last_flush' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='111' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='w_size' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='115' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='672'>
+        <var-decl name='w_bits' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='116' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='w_mask' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='117' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='window' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='119' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='window_size' type-id='type-id-58' visibility='default' filepath='src.d/deflate.h' line='129' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='prev' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='134' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='head' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='140' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='ins_h' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='142' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1056'>
+        <var-decl name='hash_size' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='143' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1088'>
+        <var-decl name='hash_bits' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='144' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1120'>
+        <var-decl name='hash_mask' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='145' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1152'>
+        <var-decl name='hash_shift' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='147' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1216'>
+        <var-decl name='block_start' type-id='type-id-1' visibility='default' filepath='src.d/deflate.h' line='154' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='match_length' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='159' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1312'>
+        <var-decl name='prev_match' type-id='type-id-55' visibility='default' filepath='src.d/deflate.h' line='160' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1344'>
+        <var-decl name='match_available' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='161' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1376'>
+        <var-decl name='strstart' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='162' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1408'>
+        <var-decl name='match_start' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='163' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1440'>
+        <var-decl name='lookahead' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='164' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1472'>
+        <var-decl name='prev_length' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='166' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1504'>
+        <var-decl name='max_chain_length' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='171' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1536'>
+        <var-decl name='max_lazy_match' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='177' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1568'>
+        <var-decl name='level' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='188' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1600'>
+        <var-decl name='strategy' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='189' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1632'>
+        <var-decl name='good_match' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='191' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1664'>
+        <var-decl name='nice_match' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='194' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1696'>
+        <var-decl name='dyn_ltree' type-id='type-id-31' visibility='default' filepath='src.d/deflate.h' line='198' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='20032'>
+        <var-decl name='dyn_dtree' type-id='type-id-33' visibility='default' filepath='src.d/deflate.h' line='199' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='21984'>
+        <var-decl name='bl_tree' type-id='type-id-29' visibility='default' filepath='src.d/deflate.h' line='200' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='23232'>
+        <var-decl name='l_desc' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='202' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='23424'>
+        <var-decl name='d_desc' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='203' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='23616'>
+        <var-decl name='bl_desc' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='204' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='23808'>
+        <var-decl name='bl_count' type-id='type-id-40' visibility='default' filepath='src.d/deflate.h' line='206' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='24064'>
+        <var-decl name='heap' type-id='type-id-35' visibility='default' filepath='src.d/deflate.h' line='209' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='42400'>
+        <var-decl name='heap_len' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='210' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='42432'>
+        <var-decl name='heap_max' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='211' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='42464'>
+        <var-decl name='depth' type-id='type-id-37' visibility='default' filepath='src.d/deflate.h' line='216' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47104'>
+        <var-decl name='sym_buf' type-id='type-id-61' visibility='default' filepath='src.d/deflate.h' line='220' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47168'>
+        <var-decl name='lit_bufsize' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='222' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47200'>
+        <var-decl name='sym_next' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='242' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47232'>
+        <var-decl name='sym_end' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='243' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47296'>
+        <var-decl name='opt_len' type-id='type-id-58' visibility='default' filepath='src.d/deflate.h' line='245' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47360'>
+        <var-decl name='static_len' type-id='type-id-58' visibility='default' filepath='src.d/deflate.h' line='246' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47424'>
+        <var-decl name='matches' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='247' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47456'>
+        <var-decl name='insert' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='248' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47488'>
+        <var-decl name='bi_buf' type-id='type-id-39' visibility='default' filepath='src.d/deflate.h' line='255' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47520'>
+        <var-decl name='bi_valid' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='259' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47552'>
+        <var-decl name='high_water' type-id='type-id-58' visibility='default' filepath='src.d/deflate.h' line='264' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='deflate_state' type-id='type-id-56' filepath='src.d/deflate.h' line='271' column='1' id='type-id-62'/>
+    <typedef-decl name='alloc_func' type-id='type-id-63' filepath='src.d/zlib.h' line='81' column='1' id='type-id-64'/>
+    <typedef-decl name='free_func' type-id='type-id-65' filepath='src.d/zlib.h' line='82' column='1' id='type-id-66'/>
+    <class-decl name='z_stream_s' size-in-bits='896' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='86' column='1' id='type-id-67'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next_in' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='87' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='avail_in' type-id='type-id-8' visibility='default' filepath='src.d/zlib.h' line='88' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='total_in' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='89' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='next_out' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='91' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='avail_out' type-id='type-id-8' visibility='default' filepath='src.d/zlib.h' line='92' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='total_out' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='93' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='msg' type-id='type-id-68' visibility='default' filepath='src.d/zlib.h' line='95' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='state' type-id='type-id-69' visibility='default' filepath='src.d/zlib.h' line='96' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='zalloc' type-id='type-id-64' visibility='default' filepath='src.d/zlib.h' line='98' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='zfree' type-id='type-id-66' visibility='default' filepath='src.d/zlib.h' line='99' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='opaque' type-id='type-id-45' visibility='default' filepath='src.d/zlib.h' line='100' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='data_type' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='102' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='adler' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='104' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='reserved' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='105' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='z_stream' type-id='type-id-67' filepath='src.d/zlib.h' line='106' column='1' id='type-id-70'/>
+    <typedef-decl name='z_streamp' type-id='type-id-71' filepath='src.d/zlib.h' line='108' column='1' id='type-id-57'/>
+    <class-decl name='gz_header_s' size-in-bits='640' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='114' column='1' id='type-id-72'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='text' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='115' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='time' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='116' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='xflags' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='117' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='os' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='118' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='extra' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='119' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='extra_len' type-id='type-id-8' visibility='default' filepath='src.d/zlib.h' line='120' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='extra_max' type-id='type-id-8' visibility='default' filepath='src.d/zlib.h' line='121' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='name' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='122' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='name_max' type-id='type-id-8' visibility='default' filepath='src.d/zlib.h' line='123' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='comment' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='124' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='comm_max' type-id='type-id-8' visibility='default' filepath='src.d/zlib.h' line='125' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='544'>
+        <var-decl name='hcrc' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='126' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='done' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='127' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='gz_header' type-id='type-id-72' filepath='src.d/zlib.h' line='129' column='1' id='type-id-73'/>
+    <typedef-decl name='gz_headerp' type-id='type-id-74' filepath='src.d/zlib.h' line='131' column='1' id='type-id-59'/>
+    <typedef-decl name='uch' type-id='type-id-2' filepath='src.d/zutil.h' line='39' column='1' id='type-id-36'/>
+    <typedef-decl name='uchf' type-id='type-id-36' filepath='src.d/zutil.h' line='40' column='1' id='type-id-75'/>
+    <typedef-decl name='ush' type-id='type-id-38' filepath='src.d/zutil.h' line='41' column='1' id='type-id-39'/>
+    <typedef-decl name='ulg' type-id='type-id-4' filepath='src.d/zutil.h' line='43' column='1' id='type-id-58'/>
+    <pointer-type-def type-id='type-id-10' size-in-bits='64' id='type-id-19'/>
+    <pointer-type-def type-id='type-id-54' size-in-bits='64' id='type-id-60'/>
+    <pointer-type-def type-id='type-id-26' size-in-bits='64' id='type-id-68'/>
+    <pointer-type-def type-id='type-id-43' size-in-bits='64' id='type-id-76'/>
+    <qualified-type-def type-id='type-id-26' const='yes' id='type-id-77'/>
+    <pointer-type-def type-id='type-id-77' size-in-bits='64' id='type-id-78'/>
+    <qualified-type-def type-id='type-id-49' const='yes' id='type-id-79'/>
+    <pointer-type-def type-id='type-id-79' size-in-bits='64' id='type-id-52'/>
+    <pointer-type-def type-id='type-id-48' size-in-bits='64' id='type-id-51'/>
+    <pointer-type-def type-id='type-id-62' size-in-bits='64' id='type-id-80'/>
+    <pointer-type-def type-id='type-id-73' size-in-bits='64' id='type-id-74'/>
+    <pointer-type-def type-id='type-id-20' size-in-bits='64' id='type-id-81'/>
+    <pointer-type-def type-id='type-id-56' size-in-bits='64' id='type-id-69'/>
+    <pointer-type-def type-id='type-id-82' size-in-bits='64' id='type-id-63'/>
+    <pointer-type-def type-id='type-id-8' size-in-bits='64' id='type-id-83'/>
+    <pointer-type-def type-id='type-id-75' size-in-bits='64' id='type-id-61'/>
+    <pointer-type-def type-id='type-id-3' size-in-bits='64' id='type-id-84'/>
+    <pointer-type-def type-id='type-id-85' size-in-bits='64' id='type-id-65'/>
+    <pointer-type-def type-id='type-id-42' size-in-bits='64' id='type-id-44'/>
+    <pointer-type-def type-id='type-id-70' size-in-bits='64' id='type-id-71'/>
+    <class-decl name='static_tree_desc_s' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-27'/>
+    <function-decl name='memcpy' filepath='/usr/include/string.h' line='43' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-5'/>
+      <return type-id='type-id-44'/>
+    </function-decl>
+    <function-decl name='memset' filepath='/usr/include/string.h' line='61' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-5'/>
+      <return type-id='type-id-44'/>
+    </function-decl>
+    <function-decl name='deflateInit_' mangled-name='deflateInit_' filepath='src.d/deflate.c' line='231' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateInit_'>
+      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='232' column='1'/>
+      <parameter type-id='type-id-20' name='level' filepath='src.d/deflate.c' line='233' column='1'/>
+      <parameter type-id='type-id-78' name='version' filepath='src.d/deflate.c' line='234' column='1'/>
+      <parameter type-id='type-id-20' name='stream_size' filepath='src.d/deflate.c' line='235' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='deflateInit2_' mangled-name='deflateInit2_' filepath='src.d/deflate.c' line='243' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateInit2_'>
+      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='245' column='1'/>
+      <parameter type-id='type-id-20' name='level' filepath='src.d/deflate.c' line='246' column='1'/>
+      <parameter type-id='type-id-20' name='method' filepath='src.d/deflate.c' line='247' column='1'/>
+      <parameter type-id='type-id-20' name='windowBits' filepath='src.d/deflate.c' line='248' column='1'/>
+      <parameter type-id='type-id-20' name='memLevel' filepath='src.d/deflate.c' line='249' column='1'/>
+      <parameter type-id='type-id-20' name='strategy' filepath='src.d/deflate.c' line='250' column='1'/>
+      <parameter type-id='type-id-78' name='version' filepath='src.d/deflate.c' line='251' column='1'/>
+      <parameter type-id='type-id-20' name='stream_size' filepath='src.d/deflate.c' line='252' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='deflateSetDictionary' mangled-name='deflateSetDictionary' filepath='src.d/deflate.c' line='416' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateSetDictionary'>
+      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='417' column='1'/>
+      <parameter type-id='type-id-16' name='dictionary' filepath='src.d/deflate.c' line='418' column='1'/>
+      <parameter type-id='type-id-8' name='dictLength' filepath='src.d/deflate.c' line='419' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='deflateGetDictionary' mangled-name='deflateGetDictionary' filepath='src.d/deflate.c' line='485' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateGetDictionary@@ZLIB_1.2.9'>
+      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='486' column='1'/>
+      <parameter type-id='type-id-19' name='dictionary' filepath='src.d/deflate.c' line='487' column='1'/>
+      <parameter type-id='type-id-83' name='dictLength' filepath='src.d/deflate.c' line='488' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='deflateResetKeep' mangled-name='deflateResetKeep' filepath='src.d/deflate.c' line='507' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateResetKeep@@ZLIB_1.2.5.2'>
+      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='508' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='deflateReset' mangled-name='deflateReset' filepath='src.d/deflate.c' line='545' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateReset'>
+      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='546' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='deflateSetHeader' mangled-name='deflateSetHeader' filepath='src.d/deflate.c' line='557' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateSetHeader@@ZLIB_1.2.2'>
+      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='558' column='1'/>
+      <parameter type-id='type-id-59' name='head' filepath='src.d/deflate.c' line='559' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='deflatePending' mangled-name='deflatePending' filepath='src.d/deflate.c' line='568' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflatePending@@ZLIB_1.2.5.1'>
+      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='571' column='1'/>
+      <parameter type-id='type-id-84' name='pending' filepath='src.d/deflate.c' line='569' column='1'/>
+      <parameter type-id='type-id-81' name='bits' filepath='src.d/deflate.c' line='570' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='deflatePrime' mangled-name='deflatePrime' filepath='src.d/deflate.c' line='582' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflatePrime@@ZLIB_1.2.0.8'>
+      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='583' column='1'/>
+      <parameter type-id='type-id-20' name='bits' filepath='src.d/deflate.c' line='584' column='1'/>
+      <parameter type-id='type-id-20' name='value' filepath='src.d/deflate.c' line='585' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='deflateParams' mangled-name='deflateParams' filepath='src.d/deflate.c' line='609' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateParams'>
+      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='610' column='1'/>
+      <parameter type-id='type-id-20' name='level' filepath='src.d/deflate.c' line='611' column='1'/>
+      <parameter type-id='type-id-20' name='strategy' filepath='src.d/deflate.c' line='612' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='deflateTune' mangled-name='deflateTune' filepath='src.d/deflate.c' line='658' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateTune@@ZLIB_1.2.2.3'>
+      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='659' column='1'/>
+      <parameter type-id='type-id-20' name='good_length' filepath='src.d/deflate.c' line='660' column='1'/>
+      <parameter type-id='type-id-20' name='max_lazy' filepath='src.d/deflate.c' line='661' column='1'/>
+      <parameter type-id='type-id-20' name='nice_length' filepath='src.d/deflate.c' line='662' column='1'/>
+      <parameter type-id='type-id-20' name='max_chain' filepath='src.d/deflate.c' line='663' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='deflateBound' mangled-name='deflateBound' filepath='src.d/deflate.c' line='693' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateBound@@ZLIB_1.2.0'>
+      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='694' column='1'/>
+      <parameter type-id='type-id-9' name='sourceLen' filepath='src.d/deflate.c' line='695' column='1'/>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='deflate' mangled-name='deflate' filepath='src.d/deflate.c' line='804' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflate'>
+      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='805' column='1'/>
+      <parameter type-id='type-id-20' name='flush' filepath='src.d/deflate.c' line='806' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='deflateEnd' mangled-name='deflateEnd' filepath='src.d/deflate.c' line='1119' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateEnd'>
+      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='1120' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='deflateCopy' mangled-name='deflateCopy' filepath='src.d/deflate.c' line='1145' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateCopy'>
+      <parameter type-id='type-id-57' name='dest' filepath='src.d/deflate.c' line='1146' column='1'/>
+      <parameter type-id='type-id-57' name='source' filepath='src.d/deflate.c' line='1147' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='_tr_init' filepath='src.d/deflate.h' line='294' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-80'/>
+      <return type-id='type-id-42'/>
+    </function-decl>
+    <function-decl name='_tr_flush_block' filepath='src.d/deflate.h' line='296' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-80'/>
+      <parameter type-id='type-id-76'/>
+      <parameter type-id='type-id-58'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-42'/>
+    </function-decl>
+    <function-decl name='_tr_flush_bits' filepath='src.d/deflate.h' line='298' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-80'/>
+      <return type-id='type-id-42'/>
+    </function-decl>
+    <function-decl name='_tr_align' filepath='src.d/deflate.h' line='299' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-80'/>
+      <return type-id='type-id-42'/>
+    </function-decl>
+    <function-decl name='_tr_stored_block' filepath='src.d/deflate.h' line='300' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-80'/>
+      <parameter type-id='type-id-76'/>
+      <parameter type-id='type-id-58'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-42'/>
+    </function-decl>
+    <function-decl name='zcalloc' filepath='src.d/zutil.h' line='260' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-45'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-3'/>
+      <return type-id='type-id-45'/>
+    </function-decl>
+    <function-decl name='zcfree' filepath='src.d/zutil.h' line='262' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-45'/>
+      <parameter type-id='type-id-45'/>
+      <return type-id='type-id-42'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-82'>
+      <parameter type-id='type-id-45'/>
+      <parameter type-id='type-id-8'/>
+      <parameter type-id='type-id-8'/>
+      <return type-id='type-id-45'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-85'>
+      <parameter type-id='type-id-45'/>
+      <parameter type-id='type-id-45'/>
+      <return type-id='type-id-42'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='src.d/gzclose.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C11'>
+    <typedef-decl name='gzFile' type-id='type-id-86' filepath='src.d/zlib.h' line='1302' column='1' id='type-id-87'/>
+    <class-decl name='gzFile_s' size-in-bits='192' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='1834' column='1' id='type-id-88'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='have' type-id='type-id-3' visibility='default' filepath='src.d/zlib.h' line='1835' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='next' type-id='type-id-89' visibility='default' filepath='src.d/zlib.h' line='1836' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='pos' type-id='type-id-14' visibility='default' filepath='src.d/zlib.h' line='1837' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-88' size-in-bits='64' id='type-id-86'/>
+    <function-decl name='gzclose' mangled-name='gzclose' filepath='src.d/gzclose.c' line='11' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzclose'>
+      <parameter type-id='type-id-87' name='file' filepath='src.d/gzclose.c' line='12' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzclose_r' mangled-name='gzclose_r' filepath='src.d/zlib.h' line='1644' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzclose_r@@ZLIB_1.2.3.5'>
+      <parameter type-id='type-id-87'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzclose_w' mangled-name='gzclose_w' filepath='src.d/zlib.h' line='1645' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzclose_w@@ZLIB_1.2.3.5'>
+      <parameter type-id='type-id-87'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='src.d/gzlib.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C11'>
+    <type-decl name='variadic parameter type' id='type-id-90'/>
+    <function-decl name='open' filepath='/usr/include/fcntl.h' line='181' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-78'/>
+      <parameter type-id='type-id-20'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='snprintf' filepath='/usr/include/stdio.h' line='378' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-68'/>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-78'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='strlen' filepath='/usr/include/string.h' line='407' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-78'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
+    <function-decl name='lseek64' filepath='/usr/include/unistd.h' line='350' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-12'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+    <function-decl name='gzopen' mangled-name='gzopen' filepath='src.d/gzlib.c' line='272' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzopen'>
+      <parameter type-id='type-id-78' name='path' filepath='src.d/gzlib.c' line='273' column='1'/>
+      <parameter type-id='type-id-78' name='mode' filepath='src.d/gzlib.c' line='274' column='1'/>
+      <return type-id='type-id-87'/>
+    </function-decl>
+    <function-decl name='gzopen64' mangled-name='gzopen64' filepath='src.d/gzlib.c' line='280' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzopen64@@ZLIB_1.2.3.3'>
+      <parameter type-id='type-id-78' name='path' filepath='src.d/gzlib.c' line='281' column='1'/>
+      <parameter type-id='type-id-78' name='mode' filepath='src.d/gzlib.c' line='282' column='1'/>
+      <return type-id='type-id-87'/>
+    </function-decl>
+    <function-decl name='gzdopen' mangled-name='gzdopen' filepath='src.d/gzlib.c' line='288' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzdopen'>
+      <parameter type-id='type-id-20' name='fd' filepath='src.d/gzlib.c' line='289' column='1'/>
+      <parameter type-id='type-id-78' name='mode' filepath='src.d/gzlib.c' line='290' column='1'/>
+      <return type-id='type-id-87'/>
+    </function-decl>
+    <function-decl name='gzbuffer' mangled-name='gzbuffer' filepath='src.d/gzlib.c' line='318' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzbuffer@@ZLIB_1.2.3.5'>
+      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='319' column='1'/>
+      <parameter type-id='type-id-3' name='size' filepath='src.d/gzlib.c' line='320' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzrewind' mangled-name='gzrewind' filepath='src.d/gzlib.c' line='345' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzrewind'>
+      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='346' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzseek64' mangled-name='gzseek64' filepath='src.d/gzlib.c' line='368' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzseek64@@ZLIB_1.2.3.3'>
+      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='369' column='1'/>
+      <parameter type-id='type-id-14' name='offset' filepath='src.d/gzlib.c' line='370' column='1'/>
+      <parameter type-id='type-id-20' name='whence' filepath='src.d/gzlib.c' line='371' column='1'/>
+      <return type-id='type-id-14'/>
+    </function-decl>
+    <function-decl name='gzseek' mangled-name='gzseek' filepath='src.d/gzlib.c' line='445' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzseek'>
+      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='446' column='1'/>
+      <parameter type-id='type-id-13' name='offset' filepath='src.d/gzlib.c' line='447' column='1'/>
+      <parameter type-id='type-id-20' name='whence' filepath='src.d/gzlib.c' line='448' column='1'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+    <function-decl name='gztell64' mangled-name='gztell64' filepath='src.d/gzlib.c' line='457' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gztell64@@ZLIB_1.2.3.3'>
+      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='458' column='1'/>
+      <return type-id='type-id-14'/>
+    </function-decl>
+    <function-decl name='gztell' mangled-name='gztell' filepath='src.d/gzlib.c' line='474' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gztell'>
+      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='475' column='1'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+    <function-decl name='gzoffset64' mangled-name='gzoffset64' filepath='src.d/gzlib.c' line='484' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzoffset64@@ZLIB_1.2.3.5'>
+      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='485' column='1'/>
+      <return type-id='type-id-14'/>
+    </function-decl>
+    <function-decl name='gzoffset' mangled-name='gzoffset' filepath='src.d/gzlib.c' line='507' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzoffset@@ZLIB_1.2.3.5'>
+      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='508' column='1'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+    <function-decl name='gzeof' mangled-name='gzeof' filepath='src.d/gzlib.c' line='517' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzeof'>
+      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='518' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzerror' mangled-name='gzerror' filepath='src.d/gzlib.c' line='534' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzerror'>
+      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='535' column='1'/>
+      <parameter type-id='type-id-81' name='errnum' filepath='src.d/gzlib.c' line='536' column='1'/>
+      <return type-id='type-id-78'/>
+    </function-decl>
+    <function-decl name='gzclearerr' mangled-name='gzclearerr' filepath='src.d/gzlib.c' line='555' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzclearerr@@ZLIB_1.2.0.2'>
+      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='556' column='1'/>
+      <return type-id='type-id-42'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='src.d/gzread.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C11'>
+    <typedef-decl name='voidp' type-id='type-id-44' filepath='./zconf.h' line='410' column='1' id='type-id-91'/>
+    <typedef-decl name='__ssize_t' type-id='type-id-1' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='194' column='1' id='type-id-92'/>
+    <typedef-decl name='ssize_t' type-id='type-id-92' filepath='/usr/include/x86_64-linux-gnu/sys/types.h' line='108' column='1' id='type-id-93'/>
+    <class-decl name='gz_state' size-in-bits='1920' is-struct='yes' naming-typedef-id='type-id-94' visibility='default' filepath='src.d/gzguts.h' line='170' column='1' id='type-id-95'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='x' type-id='type-id-88' visibility='default' filepath='src.d/gzguts.h' line='172' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='mode' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='177' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='fd' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='178' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='path' type-id='type-id-68' visibility='default' filepath='src.d/gzguts.h' line='179' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='size' type-id='type-id-3' visibility='default' filepath='src.d/gzguts.h' line='180' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='want' type-id='type-id-3' visibility='default' filepath='src.d/gzguts.h' line='181' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='in' type-id='type-id-89' visibility='default' filepath='src.d/gzguts.h' line='182' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='out' type-id='type-id-89' visibility='default' filepath='src.d/gzguts.h' line='183' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='direct' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='184' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='544'>
+        <var-decl name='how' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='186' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='start' type-id='type-id-14' visibility='default' filepath='src.d/gzguts.h' line='187' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='eof' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='188' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='672'>
+        <var-decl name='past' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='189' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='level' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='191' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='736'>
+        <var-decl name='strategy' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='192' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='reset' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='193' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='skip' type-id='type-id-14' visibility='default' filepath='src.d/gzguts.h' line='195' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='seek' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='196' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='928'>
+        <var-decl name='err' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='198' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='msg' type-id='type-id-68' visibility='default' filepath='src.d/gzguts.h' line='199' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='strm' type-id='type-id-70' visibility='default' filepath='src.d/gzguts.h' line='201' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='gz_state' type-id='type-id-95' filepath='src.d/gzguts.h' line='202' column='1' id='type-id-94'/>
+    <typedef-decl name='gz_statep' type-id='type-id-96' filepath='src.d/gzguts.h' line='203' column='1' id='type-id-97'/>
+    <pointer-type-def type-id='type-id-94' size-in-bits='64' id='type-id-96'/>
+    <function-decl name='__errno_location' filepath='/usr/include/errno.h' line='37' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-81'/>
+    </function-decl>
+    <function-decl name='memchr' filepath='/usr/include/string.h' line='107' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-5'/>
+      <return type-id='type-id-44'/>
+    </function-decl>
+    <function-decl name='strerror' filepath='/usr/include/string.h' line='419' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-68'/>
+    </function-decl>
+    <function-decl name='close' filepath='/usr/include/unistd.h' line='358' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='read' filepath='/usr/include/unistd.h' line='371' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-5'/>
+      <return type-id='type-id-93'/>
+    </function-decl>
+    <function-decl name='gz_error' filepath='src.d/gzguts.h' line='206' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-97'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-78'/>
+      <return type-id='type-id-42'/>
+    </function-decl>
+    <function-decl name='gzread' mangled-name='gzread' filepath='src.d/gzread.c' line='375' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzread'>
+      <parameter type-id='type-id-87' name='file' filepath='src.d/gzread.c' line='376' column='1'/>
+      <parameter type-id='type-id-91' name='buf' filepath='src.d/gzread.c' line='377' column='1'/>
+      <parameter type-id='type-id-3' name='len' filepath='src.d/gzread.c' line='378' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzfread' mangled-name='gzfread' filepath='src.d/gzread.c' line='411' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzfread@@ZLIB_1.2.9'>
+      <parameter type-id='type-id-91' name='buf' filepath='src.d/gzread.c' line='412' column='1'/>
+      <parameter type-id='type-id-6' name='size' filepath='src.d/gzread.c' line='413' column='1'/>
+      <parameter type-id='type-id-6' name='nitems' filepath='src.d/gzread.c' line='414' column='1'/>
+      <parameter type-id='type-id-87' name='file' filepath='src.d/gzread.c' line='415' column='1'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='gzgetc' mangled-name='gzgetc' filepath='src.d/gzread.c' line='447' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzgetc'>
+      <parameter type-id='type-id-87' name='file' filepath='src.d/gzread.c' line='448' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzgetc_' mangled-name='gzgetc_' filepath='src.d/gzread.c' line='474' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzgetc_@@ZLIB_1.2.5.2'>
+      <parameter type-id='type-id-87' name='file' filepath='src.d/gzread.c' line='475' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzungetc' mangled-name='gzungetc' filepath='src.d/gzread.c' line='481' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzungetc@@ZLIB_1.2.0.2'>
+      <parameter type-id='type-id-20' name='c' filepath='src.d/gzread.c' line='482' column='1'/>
+      <parameter type-id='type-id-87' name='file' filepath='src.d/gzread.c' line='483' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzgets' mangled-name='gzgets' filepath='src.d/gzread.c' line='541' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzgets'>
+      <parameter type-id='type-id-87' name='file' filepath='src.d/gzread.c' line='542' column='1'/>
+      <parameter type-id='type-id-68' name='buf' filepath='src.d/gzread.c' line='543' column='1'/>
+      <parameter type-id='type-id-20' name='len' filepath='src.d/gzread.c' line='544' column='1'/>
+      <return type-id='type-id-68'/>
+    </function-decl>
+    <function-decl name='gzdirect' mangled-name='gzdirect' filepath='src.d/gzread.c' line='605' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzdirect@@ZLIB_1.2.2.3'>
+      <parameter type-id='type-id-87' name='file' filepath='src.d/gzread.c' line='606' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='src.d/gzwrite.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C11'>
+    <class-decl name='__va_list_tag' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-98'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='gp_offset' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='fp_offset' type-id='type-id-3' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='overflow_arg_area' type-id='type-id-44' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='reg_save_area' type-id='type-id-44' visibility='default'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='voidpc' type-id='type-id-44' filepath='./zconf.h' line='408' column='1' id='type-id-99'/>
+    <pointer-type-def type-id='type-id-98' size-in-bits='64' id='type-id-100'/>
+    <function-decl name='vsnprintf' filepath='/usr/include/stdio.h' line='382' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-68'/>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-78'/>
+      <parameter type-id='type-id-100'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='memmove' filepath='/usr/include/string.h' line='47' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-5'/>
+      <return type-id='type-id-44'/>
+    </function-decl>
+    <function-decl name='write' filepath='/usr/include/unistd.h' line='378' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-5'/>
+      <return type-id='type-id-93'/>
+    </function-decl>
+    <function-decl name='gzwrite' mangled-name='gzwrite' filepath='src.d/gzwrite.c' line='255' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzwrite'>
+      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='256' column='1'/>
+      <parameter type-id='type-id-99' name='buf' filepath='src.d/gzwrite.c' line='257' column='1'/>
+      <parameter type-id='type-id-3' name='len' filepath='src.d/gzwrite.c' line='258' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzfwrite' mangled-name='gzfwrite' filepath='src.d/gzwrite.c' line='283' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzfwrite@@ZLIB_1.2.9'>
+      <parameter type-id='type-id-99' name='buf' filepath='src.d/gzwrite.c' line='284' column='1'/>
+      <parameter type-id='type-id-6' name='size' filepath='src.d/gzwrite.c' line='285' column='1'/>
+      <parameter type-id='type-id-6' name='nitems' filepath='src.d/gzwrite.c' line='286' column='1'/>
+      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='287' column='1'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='gzputc' mangled-name='gzputc' filepath='src.d/gzwrite.c' line='313' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzputc'>
+      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='314' column='1'/>
+      <parameter type-id='type-id-20' name='c' filepath='src.d/gzwrite.c' line='315' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzputs' mangled-name='gzputs' filepath='src.d/gzwrite.c' line='361' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzputs'>
+      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='362' column='1'/>
+      <parameter type-id='type-id-78' name='s' filepath='src.d/gzwrite.c' line='363' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzvprintf' mangled-name='gzvprintf' filepath='src.d/gzwrite.c' line='391' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzvprintf@@ZLIB_1.2.7.1'>
+      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='391' column='1'/>
+      <parameter type-id='type-id-78' name='format' filepath='src.d/gzwrite.c' line='391' column='1'/>
+      <parameter type-id='type-id-100' name='va' filepath='src.d/gzwrite.c' line='391' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzprintf' mangled-name='gzprintf' filepath='src.d/gzwrite.c' line='463' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzprintf'>
+      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='463' column='1'/>
+      <parameter type-id='type-id-78' name='format' filepath='src.d/gzwrite.c' line='463' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzflush' mangled-name='gzflush' filepath='src.d/gzwrite.c' line='565' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzflush'>
+      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='566' column='1'/>
+      <parameter type-id='type-id-20' name='flush' filepath='src.d/gzwrite.c' line='567' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzsetparams' mangled-name='gzsetparams' filepath='src.d/gzwrite.c' line='597' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzsetparams'>
+      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='598' column='1'/>
+      <parameter type-id='type-id-20' name='level' filepath='src.d/gzwrite.c' line='599' column='1'/>
+      <parameter type-id='type-id-20' name='strategy' filepath='src.d/gzwrite.c' line='600' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='src.d/infback.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C11'>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-101'/>
+    <class-decl name='code' size-in-bits='32' is-struct='yes' naming-typedef-id='type-id-102' visibility='default' filepath='src.d/inftrees.h' line='24' column='1' id='type-id-103'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-2' visibility='default' filepath='src.d/inftrees.h' line='25' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8'>
+        <var-decl name='bits' type-id='type-id-2' visibility='default' filepath='src.d/inftrees.h' line='26' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='val' type-id='type-id-38' visibility='default' filepath='src.d/inftrees.h' line='27' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='code' type-id='type-id-103' filepath='src.d/inftrees.h' line='28' column='1' id='type-id-102'/>
+    <enum-decl name='codetype' naming-typedef-id='type-id-104' filepath='src.d/inftrees.h' line='54' column='1' id='type-id-105'>
+      <underlying-type type-id='type-id-101'/>
+      <enumerator name='CODES' value='0'/>
+      <enumerator name='LENS' value='1'/>
+      <enumerator name='DISTS' value='2'/>
+    </enum-decl>
+    <typedef-decl name='codetype' type-id='type-id-105' filepath='src.d/inftrees.h' line='58' column='1' id='type-id-104'/>
+    <typedef-decl name='in_func' type-id='type-id-106' filepath='src.d/zlib.h' line='1094' column='1' id='type-id-107'/>
+    <typedef-decl name='out_func' type-id='type-id-108' filepath='src.d/zlib.h' line='1096' column='1' id='type-id-109'/>
+    <pointer-type-def type-id='type-id-102' size-in-bits='64' id='type-id-110'/>
+    <pointer-type-def type-id='type-id-110' size-in-bits='64' id='type-id-111'/>
+    <pointer-type-def type-id='type-id-112' size-in-bits='64' id='type-id-108'/>
+    <pointer-type-def type-id='type-id-2' size-in-bits='64' id='type-id-89'/>
+    <pointer-type-def type-id='type-id-89' size-in-bits='64' id='type-id-113'/>
+    <pointer-type-def type-id='type-id-114' size-in-bits='64' id='type-id-106'/>
+    <pointer-type-def type-id='type-id-38' size-in-bits='64' id='type-id-115'/>
+    <function-decl name='inflateBackInit_' mangled-name='inflateBackInit_' filepath='src.d/infback.c' line='28' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateBackInit_@@ZLIB_1.2.0'>
+      <parameter type-id='type-id-57' name='strm' filepath='src.d/infback.c' line='29' column='1'/>
+      <parameter type-id='type-id-20' name='windowBits' filepath='src.d/infback.c' line='30' column='1'/>
+      <parameter type-id='type-id-89' name='window' filepath='src.d/infback.c' line='31' column='1'/>
+      <parameter type-id='type-id-78' name='version' filepath='src.d/infback.c' line='32' column='1'/>
+      <parameter type-id='type-id-20' name='stream_size' filepath='src.d/infback.c' line='33' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateBack' mangled-name='inflateBack' filepath='src.d/infback.c' line='250' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateBack@@ZLIB_1.2.0'>
+      <parameter type-id='type-id-57' name='strm' filepath='src.d/infback.c' line='251' column='1'/>
+      <parameter type-id='type-id-107' name='in' filepath='src.d/infback.c' line='252' column='1'/>
+      <parameter type-id='type-id-44' name='in_desc' filepath='src.d/infback.c' line='253' column='1'/>
+      <parameter type-id='type-id-109' name='out' filepath='src.d/infback.c' line='254' column='1'/>
+      <parameter type-id='type-id-44' name='out_desc' filepath='src.d/infback.c' line='255' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateBackEnd' mangled-name='inflateBackEnd' filepath='src.d/infback.c' line='632' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateBackEnd@@ZLIB_1.2.0'>
+      <parameter type-id='type-id-57' name='strm' filepath='src.d/infback.c' line='633' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflate_fast' filepath='src.d/inffast.h' line='11' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-57'/>
+      <parameter type-id='type-id-3'/>
+      <return type-id='type-id-42'/>
+    </function-decl>
+    <function-decl name='inflate_table' filepath='src.d/inftrees.h' line='60' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-104'/>
+      <parameter type-id='type-id-115'/>
+      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-111'/>
+      <parameter type-id='type-id-84'/>
+      <parameter type-id='type-id-115'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-112'>
+      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-89'/>
+      <parameter type-id='type-id-3'/>
+      <return type-id='type-id-20'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-114'>
+      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-113'/>
+      <return type-id='type-id-3'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='64' path='src.d/inflate.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C11'>
+    <function-decl name='inflateResetKeep' mangled-name='inflateResetKeep' filepath='src.d/inflate.c' line='119' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateResetKeep@@ZLIB_1.2.5.2'>
+      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='120' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateReset' mangled-name='inflateReset' filepath='src.d/inflate.c' line='145' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateReset'>
+      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='146' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateReset2' mangled-name='inflateReset2' filepath='src.d/inflate.c' line='158' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateReset2@@ZLIB_1.2.3.4'>
+      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='159' column='1'/>
+      <parameter type-id='type-id-20' name='windowBits' filepath='src.d/inflate.c' line='160' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateInit2_' mangled-name='inflateInit2_' filepath='src.d/inflate.c' line='196' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateInit2_'>
+      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='197' column='1'/>
+      <parameter type-id='type-id-20' name='windowBits' filepath='src.d/inflate.c' line='198' column='1'/>
+      <parameter type-id='type-id-78' name='version' filepath='src.d/inflate.c' line='199' column='1'/>
+      <parameter type-id='type-id-20' name='stream_size' filepath='src.d/inflate.c' line='200' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateInit_' mangled-name='inflateInit_' filepath='src.d/inflate.c' line='240' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateInit_'>
+      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='241' column='1'/>
+      <parameter type-id='type-id-78' name='version' filepath='src.d/inflate.c' line='242' column='1'/>
+      <parameter type-id='type-id-20' name='stream_size' filepath='src.d/inflate.c' line='243' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflatePrime' mangled-name='inflatePrime' filepath='src.d/inflate.c' line='248' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflatePrime@@ZLIB_1.2.2.4'>
+      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='249' column='1'/>
+      <parameter type-id='type-id-20' name='bits' filepath='src.d/inflate.c' line='250' column='1'/>
+      <parameter type-id='type-id-20' name='value' filepath='src.d/inflate.c' line='251' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflate' mangled-name='inflate' filepath='src.d/inflate.c' line='623' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflate'>
+      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='624' column='1'/>
+      <parameter type-id='type-id-20' name='flush' filepath='src.d/inflate.c' line='625' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateEnd' mangled-name='inflateEnd' filepath='src.d/inflate.c' line='1301' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateEnd'>
+      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1302' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateGetDictionary' mangled-name='inflateGetDictionary' filepath='src.d/inflate.c' line='1315' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateGetDictionary@@ZLIB_1.2.7.1'>
+      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1316' column='1'/>
+      <parameter type-id='type-id-19' name='dictionary' filepath='src.d/inflate.c' line='1317' column='1'/>
+      <parameter type-id='type-id-83' name='dictLength' filepath='src.d/inflate.c' line='1318' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateSetDictionary' mangled-name='inflateSetDictionary' filepath='src.d/inflate.c' line='1338' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateSetDictionary'>
+      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1339' column='1'/>
+      <parameter type-id='type-id-16' name='dictionary' filepath='src.d/inflate.c' line='1340' column='1'/>
+      <parameter type-id='type-id-8' name='dictLength' filepath='src.d/inflate.c' line='1341' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateGetHeader' mangled-name='inflateGetHeader' filepath='src.d/inflate.c' line='1373' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateGetHeader@@ZLIB_1.2.2'>
+      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1374' column='1'/>
+      <parameter type-id='type-id-59' name='head' filepath='src.d/inflate.c' line='1375' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateSync' mangled-name='inflateSync' filepath='src.d/inflate.c' line='1424' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateSync'>
+      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1425' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateSyncPoint' mangled-name='inflateSyncPoint' filepath='src.d/inflate.c' line='1482' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateSyncPoint'>
+      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1483' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateCopy' mangled-name='inflateCopy' filepath='src.d/inflate.c' line='1492' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateCopy@@ZLIB_1.2.0'>
+      <parameter type-id='type-id-57' name='dest' filepath='src.d/inflate.c' line='1493' column='1'/>
+      <parameter type-id='type-id-57' name='source' filepath='src.d/inflate.c' line='1494' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateUndermine' mangled-name='inflateUndermine' filepath='src.d/inflate.c' line='1539' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateUndermine@@ZLIB_1.2.3.3'>
+      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1540' column='1'/>
+      <parameter type-id='type-id-20' name='subvert' filepath='src.d/inflate.c' line='1541' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateValidate' mangled-name='inflateValidate' filepath='src.d/inflate.c' line='1557' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateValidate@@ZLIB_1.2.9'>
+      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1558' column='1'/>
+      <parameter type-id='type-id-20' name='check' filepath='src.d/inflate.c' line='1559' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateMark' mangled-name='inflateMark' filepath='src.d/inflate.c' line='1572' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateMark@@ZLIB_1.2.3.4'>
+      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1573' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='inflateCodesUsed' mangled-name='inflateCodesUsed' filepath='src.d/inflate.c' line='1585' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateCodesUsed@@ZLIB_1.2.9'>
+      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1586' column='1'/>
+      <return type-id='type-id-4'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='src.d/trees.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C11'>
+    <array-type-def dimensions='1' type-id='type-id-116' size-in-bits='2048' id='type-id-117'>
+      <subrange length='256' type-id='type-id-4' id='type-id-118'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-116' size-in-bits='4096' id='type-id-119'>
+      <subrange length='512' type-id='type-id-4' id='type-id-120'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-116' size-in-bits='infinite' id='type-id-121'>
+      <subrange length='infinite' id='type-id-122'/>
+    </array-type-def>
+    <qualified-type-def type-id='type-id-36' const='yes' id='type-id-116'/>
+    <var-decl name='_length_code' type-id='type-id-121' visibility='default' filepath='src.d/deflate.h' line='317' column='1'/>
+    <var-decl name='_dist_code' type-id='type-id-121' visibility='default' filepath='src.d/deflate.h' line='318' column='1'/>
+  </abi-instr>
+  <abi-instr address-size='64' path='src.d/uncompr.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C11'>
+    <pointer-type-def type-id='type-id-9' size-in-bits='64' id='type-id-123'/>
+    <function-decl name='uncompress2' mangled-name='uncompress2' filepath='src.d/uncompr.c' line='27' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uncompress2@@ZLIB_1.2.9'>
+      <parameter type-id='type-id-19' name='dest' filepath='src.d/uncompr.c' line='28' column='1'/>
+      <parameter type-id='type-id-18' name='destLen' filepath='src.d/uncompr.c' line='29' column='1'/>
+      <parameter type-id='type-id-16' name='source' filepath='src.d/uncompr.c' line='30' column='1'/>
+      <parameter type-id='type-id-123' name='sourceLen' filepath='src.d/uncompr.c' line='31' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='uncompress' mangled-name='uncompress' filepath='src.d/uncompr.c' line='86' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uncompress'>
+      <parameter type-id='type-id-19' name='dest' filepath='src.d/uncompr.c' line='87' column='1'/>
+      <parameter type-id='type-id-18' name='destLen' filepath='src.d/uncompr.c' line='88' column='1'/>
+      <parameter type-id='type-id-16' name='source' filepath='src.d/uncompr.c' line='89' column='1'/>
+      <parameter type-id='type-id-9' name='sourceLen' filepath='src.d/uncompr.c' line='90' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='64' path='src.d/zutil.c' comp-dir-path='/home/dank/src/zlib-ng/btmp1' language='LANG_C11'>
+    <array-type-def dimensions='1' type-id='type-id-124' size-in-bits='640' id='type-id-125'>
+      <subrange length='10' type-id='type-id-4' id='type-id-126'/>
+    </array-type-def>
+    <qualified-type-def type-id='type-id-68' const='yes' id='type-id-124'/>
+    <function-decl name='malloc' filepath='/usr/include/stdlib.h' line='540' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-5'/>
+      <return type-id='type-id-44'/>
+    </function-decl>
+    <function-decl name='free' filepath='/usr/include/stdlib.h' line='555' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-44'/>
+      <return type-id='type-id-42'/>
+    </function-decl>
+    <function-decl name='zlibVersion' mangled-name='zlibVersion' filepath='src.d/zutil.c' line='27' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zlibVersion'>
+      <return type-id='type-id-78'/>
+    </function-decl>
+    <function-decl name='zlibCompileFlags' mangled-name='zlibCompileFlags' filepath='src.d/zutil.c' line='32' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zlibCompileFlags@@ZLIB_1.2.0.2'>
+      <return type-id='type-id-9'/>
+    </function-decl>
+    <function-decl name='zError' mangled-name='zError' filepath='src.d/zutil.c' line='133' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zError'>
+      <parameter type-id='type-id-20' name='err' filepath='src.d/zutil.c' line='134' column='1'/>
+      <return type-id='type-id-78'/>
+    </function-decl>
+    <var-decl name='z_errmsg' type-id='type-id-125' visibility='default' filepath='src.d/zutil.h' line='56' column='1'/>
+  </abi-instr>
+</abi-corpus>

--- a/test/abicheck.sh
+++ b/test/abicheck.sh
@@ -124,7 +124,7 @@ then
   git reset --hard FETCH_HEAD
   cd ..
   # Build unstripped, uninstalled, very debug shared library
-  CFLAGS="$CFLAGS -ggdb" sh src.d/configure $CONFIGURE_ARGS
+  CFLAGS="$CFLAGS -ggdb" src.d/configure $CONFIGURE_ARGS
   make -j2
   cd ..
   # Find shared library, extract its abi

--- a/test/abicheck.sh
+++ b/test/abicheck.sh
@@ -49,7 +49,10 @@ do
   --refresh)
     refresh=true
     ;;
-  --refresh_if)
+  --refresh-if)
+    refresh_if=true
+    ;;
+  --refresh_if)   # oops
     refresh_if=true
     ;;
   --help)

--- a/test/abicheck.sh
+++ b/test/abicheck.sh
@@ -95,7 +95,7 @@ then
 fi
 
 # Canonicalize CHOST to work around bug in original zlib's configure
-export CHOST=$(sh $TESTDIR/../tools/config.sub $CHOST)
+CHOST=$(sh $TESTDIR/../tools/config.sub $CHOST)
 
 if test "$CHOST" = ""
 then

--- a/test/abicheck.sh
+++ b/test/abicheck.sh
@@ -70,15 +70,13 @@ done
 # Choose reference repo and commit
 if test "$suffix" = ""
 then
-  # Reference is zlib 1.2.11
+  # Reference is zlib 1.2.12
   ABI_GIT_REPO=https://github.com/madler/zlib.git
-  ABI_GIT_COMMIT=v1.2.11
+  ABI_GIT_COMMIT=v1.2.12
 else
-  # Reference should be the tag for zlib-ng 2.0
-  # but until that bright, shining day, use some
-  # random recent SHA.  Annoyingly, can't shorten it.
+  # Reference is the tag for zlib-ng 2.0
   ABI_GIT_REPO=https://github.com/zlib-ng/zlib-ng.git
-  ABI_GIT_COMMIT=56ce27343bf295ae9457f8e3d38ec96d2f949a1c
+  ABI_GIT_COMMIT=2.0.0
 fi
 # FIXME: even when using a tag, check the hash.
 


### PR DESCRIPTION
Updates reference tags for both zlib and zlib-ng.

Also:
- fix missing --zlib-compat option
- don't assume configure is a sh script
- fix funky CHOST problem described at https://github.com/zlib-ng/zlib-ng/issues/1219; this deserves careful review.

Note that zlib changed the signatures of two functions (cf. discussion in https://github.com/zlib-ng/zlib-ng/issues/1217 )
so this does not quite pass yet.

Best reviewed as individual commits.