### PR TITLE
Use latest stable version of google test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,7 +34,7 @@ if(NOT DEFINED GTEST_TAG)
     if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS_EQUAL 5.3)
         set(GTEST_TAG release-1.10.0)
     else()
-        set(GTEST_TAG main)
+        set(GTEST_TAG release-1.11.0)
     endif()
 endif()
 


### PR DESCRIPTION
I've been experiencing out of date `_deps` folder because I think googletest `main` branch keeps changing. When I delete `_deps` it starts working. But I think we should start using a stable release anyways in case errors are produced in `main` branch.

```
  Performing update step for 'googletest-populate'
  BUG: refs/files-backend.c:465: returning non-zero -1, should have set myerr!
  CMake Error at C:/Users/nathan/Source/zlib-ng/build/_deps/googletest-subbuild/googletest-populate-prefix/tmp/googletest-populate-gitupdate.cmake:160 (message):
    Failed to get the status


C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(245,5): error MSB8066: Custom build for 'C:\Users\nathan\Source\zlib-ng\build\_deps\googletest-subbuild\CMakeFiles\1e2d5b8156b4dcd0ca90933067dd8a08\googletest-populate-update.rule;C:\Users\nathan\Source\zlib-ng\build\_deps\googletest-subbuild\CMakeFiles\1e2d5b8156b4dcd0ca90933067dd8a08\googletest-populate-patch.rule;C:\Users\nathan\Source\zlib-ng\build\_deps\googletest-subbuild\CMakeFiles\1e2d5b8156b4dcd0ca90933067dd8a08\googletest-populate-configure.rule;C:\Users\nathan\Source\zlib-ng\build\_deps\googletest-subbuild\CMakeFiles\1e2d5b8156b4dcd0ca90933067dd8a08\googletest-populate-build.rule;C:\Users\nathan\Source\zlib-ng\build\_deps\googletest-subbuild\CMakeFiles\1e2d5b8156b4dcd0ca90933067dd8a08\googletest-populate-install.rule;C:\Users\nathan\Source\zlib-ng\build\_deps\googletest-subbuild\CMakeFiles\1e2d5b8156b4dcd0ca90933067dd8a08\googletest-populate-test.rule;C:\Users\nathan\Source\zlib-ng\build\_deps\googletest-subbuild\CMakeFiles\6f6619575b05ea5e523a6bdd3b0f77fc\googletest-populate-complete.rule;C:\Users\nathan\Source\zlib-ng\build\_deps\googletest-subbuild\CMakeFiles\1b24f49ae65d282076cbdb90264625e9\googletest-populate.rule' exited with code 1. [C:\Users\nathan\Source\zlib-ng\build\_deps\googletest-subbuild\googletest-populate.vcxproj]

CMake Error at C:/Program Files/CMake/share/cmake-3.22/Modules/FetchContent.cmake:1087 (message):
  Build step for googletest failed: 1
Call Stack (most recent call first):
  C:/Program Files/CMake/share/cmake-3.22/Modules/FetchContent.cmake:1216:EVAL:2 (__FetchContent_directPopulate)
  C:/Program Files/CMake/share/cmake-3.22/Modules/FetchContent.cmake:1216 (cmake_language)
  test/CMakeLists.txt:48 (FetchContent_Populate)
```