### PR TITLE
abicheck.sh: zlib-ng configure is a bash script, not a sh script

### DIFF
--- a/test/abicheck.sh
+++ b/test/abicheck.sh
@@ -121,7 +121,7 @@ then
   git reset --hard FETCH_HEAD
   cd ..
   # Build unstripped, uninstalled, very debug shared library
-  CFLAGS="$CFLAGS -ggdb" sh src.d/configure $CONFIGURE_ARGS
+  CFLAGS="$CFLAGS -ggdb" src.d/configure $CONFIGURE_ARGS
   make -j2
   cd ..
   # Find shared library, extract its abi


### PR DESCRIPTION
So don't hardcode shell when running configure, it might fail if sh is not bash.

This assumes 'configure' gets checked out with executable permissions, but that
seems to be the case as far back as I checked in git.