### PR TITLE
Fixed missing crc32_combine exports for zlib 1.2.12.

### DIFF
--- a/win32/zlib.def.in
+++ b/win32/zlib.def.in
@@ -38,6 +38,7 @@ EXPORTS
 ; large file functions
     @ZLIB_SYMBOL_PREFIX@adler32_combine64
     @ZLIB_SYMBOL_PREFIX@crc32_combine64
+    @ZLIB_SYMBOL_PREFIX@crc32_combine_gen64
 ; checksum functions
     @ZLIB_SYMBOL_PREFIX@adler32
     @ZLIB_SYMBOL_PREFIX@adler32_z
@@ -45,6 +46,8 @@ EXPORTS
     @ZLIB_SYMBOL_PREFIX@crc32_z
     @ZLIB_SYMBOL_PREFIX@adler32_combine
     @ZLIB_SYMBOL_PREFIX@crc32_combine
+    @ZLIB_SYMBOL_PREFIX@crc32_combine_gen
+    @ZLIB_SYMBOL_PREFIX@crc32_combine_op
 ; various hacks, don't look :)
     @ZLIB_SYMBOL_PREFIX@deflateInit_
     @ZLIB_SYMBOL_PREFIX@deflateInit2_

--- a/win32/zlibcompat.def.in
+++ b/win32/zlibcompat.def.in
@@ -69,6 +69,7 @@ EXPORTS
     @ZLIB_SYMBOL_PREFIX@gzoffset64
     @ZLIB_SYMBOL_PREFIX@adler32_combine64
     @ZLIB_SYMBOL_PREFIX@crc32_combine64
+    @ZLIB_SYMBOL_PREFIX@crc32_combine_gen64
 ; checksum functions
     @ZLIB_SYMBOL_PREFIX@adler32
     @ZLIB_SYMBOL_PREFIX@adler32_z
@@ -76,6 +77,8 @@ EXPORTS
     @ZLIB_SYMBOL_PREFIX@crc32_z
     @ZLIB_SYMBOL_PREFIX@adler32_combine
     @ZLIB_SYMBOL_PREFIX@crc32_combine
+    @ZLIB_SYMBOL_PREFIX@crc32_combine_gen
+    @ZLIB_SYMBOL_PREFIX@crc32_combine_op
 ; various hacks, don't look :)
     @ZLIB_SYMBOL_PREFIX@deflateInit_
     @ZLIB_SYMBOL_PREFIX@deflateInit2_

--- a/zlib_name_mangling-ng.h.in
+++ b/zlib_name_mangling-ng.h.in
@@ -26,6 +26,9 @@
 #define zng_crc32                 @ZLIB_SYMBOL_PREFIX@zng_crc32
 #define zng_crc32_combine         @ZLIB_SYMBOL_PREFIX@zng_crc32_combine
 #define zng_crc32_combine64       @ZLIB_SYMBOL_PREFIX@zng_crc32_combine64
+#define zng_crc32_combine_gen     @ZLIB_SYMBOL_PREFIX@zng_crc32_combine_gen
+#define zng_crc32_combine_gen64   @ZLIB_SYMBOL_PREFIX@zng_crc32_combine_gen64
+#define zng_crc32_combine_op      @ZLIB_SYMBOL_PREFIX@zng_crc32_combine_op
 #define zng_crc32_z               @ZLIB_SYMBOL_PREFIX@zng_crc32_z
 #define zng_deflate               @ZLIB_SYMBOL_PREFIX@zng_deflate
 #define zng_deflateBound          @ZLIB_SYMBOL_PREFIX@zng_deflateBound

--- a/zlib_name_mangling.h.in
+++ b/zlib_name_mangling.h.in
@@ -26,6 +26,9 @@
 #define crc32                 @ZLIB_SYMBOL_PREFIX@crc32
 #define crc32_combine         @ZLIB_SYMBOL_PREFIX@crc32_combine
 #define crc32_combine64       @ZLIB_SYMBOL_PREFIX@crc32_combine64
+#define crc32_combine_gen     @ZLIB_SYMBOL_PREFIX@crc32_combine_gen
+#define crc32_combine_gen64   @ZLIB_SYMBOL_PREFIX@crc32_combine_gen64
+#define crc32_combine_op      @ZLIB_SYMBOL_PREFIX@crc32_combine_op
 #define crc32_z               @ZLIB_SYMBOL_PREFIX@crc32_z
 #define deflate               @ZLIB_SYMBOL_PREFIX@deflate
 #define deflateBound          @ZLIB_SYMBOL_PREFIX@deflateBound


### PR DESCRIPTION
See #1217 for background.