### PR TITLE
abicheck.sh: don't export CHOST if it wasn't already exported.

### DIFF
--- a/test/abicheck.sh
+++ b/test/abicheck.sh
@@ -94,7 +94,11 @@ then
 fi
 
 # Canonicalize CHOST to work around bug in original zlib's configure
-export CHOST=$(sh $TESTDIR/../tools/config.sub $CHOST)
+# (Don't export it if it wasn't already exported, else may cause
+# default compiler detection failure and shared library link error
+# when building both zlib and zlib-ng.
+# See https://github.com/zlib-ng/zlib-ng/issues/1219)
+CHOST=$(sh $TESTDIR/../tools/config.sub $CHOST)
 
 if test "$CHOST" = ""
 then


### PR DESCRIPTION
This should fix https://github.com/zlib-ng/zlib-ng/issues/1219,
a regression when running abicheck.sh with default compiler, without breaking anything else.

Bit subtle, so deserves careful review.  See https://github.com/zlib-ng/zlib-ng/issues/705#issuecomment-766523874 for original reason for the change being reverted, which I now think was mistaken because it missed the note about why it was important to not export CHOST in the default compiler case.

(Untested locally at the moment because I'm traveling with the wrong laptop, and this is its first test on its own in CI, but tested previously at home and as part of https://github.com/zlib-ng/zlib-ng/pull/1220.)