### PR TITLE
Add one extra byte to return value of deflateBound for small lengths.

### DIFF
--- a/compress.c
+++ b/compress.c
@@ -87,6 +87,8 @@ z_size_t Z_EXPORT PREFIX(compressBound)(z_size_t sourceLen) {
 
 #ifndef NO_QUICK_STRATEGY
     return sourceLen                       /* The source size itself */
+      + (sourceLen == 0 ? 1 : 0)           /* Always at least one byte for any input */
+      + (sourceLen < 9 ? 1 : 0)            /* One extra byte for lengths less than 9 */
       + DEFLATE_QUICK_OVERHEAD(sourceLen)  /* Source encoding overhead, padded to next full byte */
       + DEFLATE_BLOCK_OVERHEAD             /* Deflate block overhead bytes */
       + ZLIB_WRAPLEN;                      /* zlib wrapper */

--- a/deflate.c
+++ b/deflate.c
@@ -646,6 +646,8 @@ unsigned long Z_EXPORT PREFIX(deflateBound)(PREFIX3(stream) *strm, unsigned long
 
 #ifndef NO_QUICK_STRATEGY
     return sourceLen                       /* The source size itself */
+      + (sourceLen == 0 ? 1 : 0)           /* Always at least one byte for any input */
+      + (sourceLen < 9 ? 1 : 0)            /* One extra byte for lengths less than 9 */
       + DEFLATE_QUICK_OVERHEAD(sourceLen)  /* Source encoding overhead, padded to next full byte */
       + DEFLATE_BLOCK_OVERHEAD             /* Deflate block overhead bytes */
       + wraplen;                           /* none, zlib or gzip wrapper */

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -74,7 +74,7 @@ testCVEinputs: check_cross_dep
 	@EXE=$(EXE) QEMU_RUN="${QEMU_RUN}" $(SRCDIR)/testCVEinputs.sh
 
 .PHONY: ghtests
-ghtests: testGH-361 testGH-364 testGH-751
+ghtests: testGH-361 testGH-364 testGH-751 testGH-1235
 
 .PHONY: testGH-361
 testGH-361:
@@ -91,9 +91,16 @@ testGH-364: switchlevels$(EXE)
 testGH-751:
 	$(QEMU_RUN) ../minigzip$(EXE) <$(SRCDIR)/GH-751/test.txt | $(QEMU_RUN) ../minigzip$(EXE) -d >/dev/null
 
+gh1235$(EXE): $(SRCDIR)/gh1235.c
+	$(CC) $(CFLAGS) -I.. -I$(SRCTOP) -o $@ $< $(TEST_LDFLAGS)
+
+.PHONY: testGH-1235
+testGH-1235: gh1235$(EXE)
+	$(QEMU_RUN) ./gh1235$(EXE)
+
 clean:
 	rm -f *.o *.gcda *.gcno *.gcov
-	rm -f switchlevels$(EXE)
+	rm -f switchlevels$(EXE) gh1235$(EXE)
 
 distclean:
 	rm -f Makefile

--- a/test/gh1235.c
+++ b/test/gh1235.c
@@ -1,0 +1,39 @@
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include "zutil.h"
+
+int main(void) {
+    unsigned char plain[32];
+    unsigned char compressed[130];
+    PREFIX3(stream) strm;
+    int bound;
+    z_size_t bytes;
+
+    for (int i = 0; i <= 32; i++) {
+        memset(plain, 6, i);
+        memset(&strm, 0, sizeof(strm));
+        PREFIX(deflateInit2)(&strm, 0, 8, 31, 1, Z_DEFAULT_STRATEGY);
+        bound = PREFIX(deflateBound)(&strm, i);
+        strm.next_in = plain;
+        strm.next_out = compressed;
+        strm.avail_in = i;
+        strm.avail_out = sizeof(compressed);
+        if (PREFIX(deflate)(&strm, Z_FINISH) != Z_STREAM_END) return -1;
+        if (strm.avail_in != 0) return -1;
+        printf("bytes = %2i, deflateBound = %2i, total_out = %2zi\n", i, bound, strm.total_out);
+        if (bound < strm.total_out) return -1;
+        if (PREFIX(deflateEnd)(&strm) != Z_OK) return -1;
+    }
+    for (int i = 0; i <= 32; i++) {
+        bytes = sizeof(compressed);
+        for (int j = 0; j < i; j++) {
+            plain[j] = j;
+        }
+        bound = PREFIX(compressBound)(i);
+        if (PREFIX(compress2)(compressed, &bytes, plain, i, 1) != Z_OK) return -1;
+        printf("bytes = %2i, compressBound = %2i, total_out = %2zi\n", i, bound, (size_t)bytes);
+        if (bytes > bound) return -1;
+    }
+    return 0;
+}


### PR DESCRIPTION
Due to right shift by 3 in DEFLATE_QUICK_OVERHEAD() macro, the return value of deflateBound() is 1 too small for lengths smaller than 9.

See #1235.