### PR TITLE
Mimic minigzip behavior and only unlink files if not using -c.

### DIFF
--- a/test/minideflate.c
+++ b/test/minideflate.c
@@ -344,7 +344,7 @@ int main(int argc, char **argv) {
 
     if (fin != stdin) {
         fclose(fin);
-        if (!keep) {
+        if (!copyout && !keep) {
             unlink(argv[i]);
         }
     }


### PR DESCRIPTION
Issue discovered in #1185:
```sh
adam@eggsbenedict ~/scratch/zlib-ng/build7 $ ~/scratch/deflatebench/deflatebench.py 
Loaded config file '/home/adam/deflatebench.conf'.
Tool: minideflate
Activated single file mode
Level 0-9: /tmp/silesia.tar  202.1 MiB   211,957,760 B
Starting run 1 of 15
Testing level 0: cdTraceback (most recent call last):
  File "/home/adam/scratch/deflatebench/deflatebench.py", line 681, in <module>
    main()
  File "/home/adam/scratch/deflatebench/deflatebench.py", line 680, in main
    benchmain()
  File "/home/adam/scratch/deflatebench/deflatebench.py", line 565, in benchmain
    compsize,comptime,decomptime,hashfail = runtest(tempfiles,level)
  File "/home/adam/scratch/deflatebench/deflatebench.py", line 341, in runtest
    os.unlink(compfile)
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/zlib-testfil.gz'
```