### PR TITLE
Fixed off-by-one error when benchmarking compare256.

### DIFF
--- a/test/benchmarks/benchmark_compare256.cc
+++ b/test/benchmarks/benchmark_compare256.cc
@@ -32,7 +32,7 @@ public:
     }
 
     void Bench(benchmark::State& state, compare256_func compare256) {
-        int32_t match_len = (int32_t)state.range(0);
+        int32_t match_len = (int32_t)state.range(0) - 1;
         uint32_t len;
 
         str2[match_len] = 0;


### PR DESCRIPTION
From issue #1239:
```
==1819==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x612000005240 at pc 0x55e217d1b3c7 bp 0x7ffd3a7a0290 sp 0x7ffd3a7a0280
WRITE of size 1 at 0x612000005240 thread T0
    #0 0x55e217d1b3c6 in compare256::Bench(benchmark::State&, unsigned int (*)(unsigned char const*, unsigned char const*)) /home/adam/scratch/zlib-ng/test/benchmarks/benchmark_compare256.cc:38
    #1 0x55e217d1a999 in compare256_c_Benchmark::BenchmarkCase(benchmark::State&) /home/adam/scratch/zlib-ng/test/benchmarks/benchmark_compare256.cc:62
    #2 0x55e217d198f3 in benchmark::Fixture::Run(benchmark::State&) /usr/include/benchmark/benchmark.h:1217
    #3 0x7f8073bb1107 in benchmark::internal::BenchmarkInstance::Run(unsigned long, int, benchmark::internal::ThreadTimer*, benchmark::internal::ThreadManager*, benchmark::internal::PerfCountersMeasurement*) const (/usr/lib64/libbenchmark.so.1+0x18107)
    #4 0x7f8073bcb3a3  (/usr/lib64/libbenchmark.so.1+0x323a3)
    #5 0x7f8073bcc3f3 in benchmark::internal::BenchmarkRunner::DoNIterations() (/usr/lib64/libbenchmark.so.1+0x333f3)
    #6 0x7f8073bd05d2 in benchmark::internal::BenchmarkRunner::DoOneRepetition() (/usr/lib64/libbenchmark.so.1+0x375d2)
    #7 0x7f8073bba1d6  (/usr/lib64/libbenchmark.so.1+0x211d6)
    #8 0x7f8073bbbb8c in benchmark::RunSpecifiedBenchmarks(benchmark::BenchmarkReporter*, benchmark::BenchmarkReporter*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (/usr/lib64/libbenchmark.so.1+0x22b8c)
    #9 0x7f8073bbbd67 in benchmark::RunSpecifiedBenchmarks() (/usr/lib64/libbenchmark.so.1+0x22d67)
    #10 0x55e217d1d07b in main /home/adam/scratch/zlib-ng/test/benchmarks/benchmark_main.cc:23
    #11 0x7f80736a92f9 in __libc_start_call_main (/lib64/libc.so.6+0x292f9)
    #12 0x7f80736a93a7 in __libc_start_main_alias_1 (/lib64/libc.so.6+0x293a7)
    #13 0x55e217d19380 in _start (/scratchdir/adam/zlib-ng/build7/test/benchmarks/benchmark_zlib+0x7380)

0x612000005240 is located 0 bytes to the right of 256-byte region [0x612000005140,0x612000005240)
allocated by thread T0 here:
    #0 0x7f8073cc498a in __interceptor_posix_memalign (/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/libasan.so.6+0xd398a)
    #1 0x55e217d1af91 in zng_alloc /home/adam/scratch/zlib-ng/zutil_p.h:21
    #2 0x55e217d1b117 in compare256::SetUp(benchmark::State const&) /home/adam/scratch/zlib-ng/test/benchmarks/benchmark_compare256.cc:29
    #3 0x55e217d199e8 in benchmark::Fixture::SetUp(benchmark::State&) /usr/include/benchmark/benchmark.h:1225
    #4 0x55e217d19892 in benchmark::Fixture::Run(benchmark::State&) /usr/include/benchmark/benchmark.h:1216
    #5 0x7f8073bb1107 in benchmark::internal::BenchmarkInstance::Run(unsigned long, int, benchmark::internal::ThreadTimer*, benchmark::internal::ThreadManager*, benchmark::internal::PerfCountersMeasurement*) const (/usr/lib64/libbenchmark.so.1+0x18107)
    #6 0x7f8073bcc3f3 in benchmark::internal::BenchmarkRunner::DoNIterations() (/usr/lib64/libbenchmark.so.1+0x333f3)

SUMMARY: AddressSanitizer: heap-buffer-overflow /home/adam/scratch/zlib-ng/test/benchmarks/benchmark_compare256.cc:38 in compare256::Bench(benchmark::State&, unsigned int (*)(unsigned char const*, unsigned char const*))
```
