### PR TITLE
Rename memory alignment functions

### DIFF
--- a/test/test_aligned_alloc.cc
+++ b/test/test_aligned_alloc.cc
@@ -1,4 +1,4 @@
-/* test_aligned_alloc.cc - Test zng_calloc_aligned and zng_cfree_aligned */
+/* test_aligned_alloc.cc - Test zng_alloc_aligned and zng_free_aligned */
 
 #include <stdlib.h>
 #include <errno.h>
@@ -39,8 +39,8 @@ void zng_cfree_unaligned(void *opaque, void *ptr) {
 }
 
 TEST(zalloc, aligned_64) {
-    void *return_ptr = zng_calloc_aligned(zng_calloc_unaligned, 0, 1, 100, 64);
+    void *return_ptr = zng_alloc_aligned(zng_calloc_unaligned, 0, 1, 100, 64);
     ASSERT_TRUE(return_ptr != NULL);
     EXPECT_EQ((intptr_t)return_ptr % 64, 0);
-    zng_cfree_aligned(zng_cfree_unaligned, 0, return_ptr);
+    zng_free_aligned(zng_cfree_unaligned, 0, return_ptr);
 }

--- a/zutil.c
+++ b/zutil.c
@@ -112,7 +112,7 @@ void Z_INTERNAL zng_cfree(void *opaque, void *ptr) {
 
 /* Since we support custom memory allocators, some which might not align memory as we expect,
  * we have to ask for extra memory and return an aligned pointer. */
-void Z_INTERNAL *zng_calloc_aligned(zng_calloc_func zalloc, void *opaque, unsigned items, unsigned size, unsigned align) {
+void Z_INTERNAL *zng_alloc_aligned(zng_calloc_func zalloc, void *opaque, unsigned items, unsigned size, unsigned align) {
     uintptr_t return_ptr, original_ptr;
     uint32_t alloc_size, align_diff;
     void *ptr;
@@ -141,7 +141,7 @@ void Z_INTERNAL *zng_calloc_aligned(zng_calloc_func zalloc, void *opaque, unsign
     return (void *)return_ptr;
 }
 
-void Z_INTERNAL zng_cfree_aligned(zng_cfree_func zfree, void *opaque, void *ptr) {
+void Z_INTERNAL zng_free_aligned(zng_cfree_func zfree, void *opaque, void *ptr) {
     /* If no custom cfree function used then call zlib-ng's aligned cfree */
     if (zfree == zng_cfree) {
         zng_cfree(opaque, ptr);

--- a/zutil.h
+++ b/zutil.h
@@ -120,7 +120,7 @@ extern z_const char * const PREFIX(z_errmsg)[10]; /* indexed by 2-zlib_error */
 #  define OS_CODE  3  /* assume Unix */
 #endif
 
-         /* functions */
+         /* memory allocation functions */
 
 void Z_INTERNAL *zng_calloc(void *opaque, unsigned items, unsigned size);
 void Z_INTERNAL   zng_cfree(void *opaque, void *ptr);
@@ -128,11 +128,11 @@ void Z_INTERNAL   zng_cfree(void *opaque, void *ptr);
 typedef void *zng_calloc_func(void *opaque, unsigned items, unsigned size);
 typedef void  zng_cfree_func(void *opaque, void *ptr);
 
-void Z_INTERNAL *zng_calloc_aligned(zng_calloc_func zalloc, void *opaque, unsigned items, unsigned size, unsigned align);
-void Z_INTERNAL  zng_cfree_aligned(zng_cfree_func zfree, void *opaque, void *ptr);
+void Z_INTERNAL *zng_alloc_aligned(zng_calloc_func zalloc, void *opaque, unsigned items, unsigned size, unsigned align);
+void Z_INTERNAL  zng_free_aligned(zng_cfree_func zfree, void *opaque, void *ptr);
 
-#define ZALLOC(strm, items, size) zng_calloc_aligned((strm)->zalloc, (strm)->opaque, (items), (size), 64)
-#define ZFREE(strm, addr)         zng_cfree_aligned((strm)->zfree, (strm)->opaque, (void *)(addr))
+#define ZALLOC(strm, items, size) zng_alloc_aligned((strm)->zalloc, (strm)->opaque, (items), (size), 64)
+#define ZFREE(strm, addr)         zng_free_aligned((strm)->zfree, (strm)->opaque, (void *)(addr))
 
 #define TRY_FREE(s, p)            {if (p) ZFREE(s, p);}
 


### PR DESCRIPTION
These functions use custom allocator callback (the first parameter) so having calloc and cfree (c = custom) is confusing in the name.