### PR TITLE
Use _msan_unposion to unposion end of window

### DIFF
--- a/zbuild.h
+++ b/zbuild.h
@@ -246,4 +246,11 @@
 #  define zmemcmp_8(str1, str2) memcmp(str1, str2, 8)
 #endif
 
+#if defined(__has_feature)
+#  if __has_feature(memory_sanitizer)
+#    define Z_MEMORY_SANITIZER 1
+#    include <sanitizer/msan_interface.h>
+#  endif
+#endif
+
 #endif


### PR DESCRIPTION
This is for when the `compare256` functions needs to read the past < chunksize bytes in the window. See #1245 where it was first discussed. I have put it in `zbuild.h` so `Z_MEMORY_SANITIZER` can also be used by #1245. 