### PR TITLE
Use PREFIX() for some of the Z_INTERNAL symbols

### DIFF
--- a/arch/s390/crc32-vx.c
+++ b/arch/s390/crc32-vx.c
@@ -198,7 +198,7 @@ static uint32_t crc32_le_vgfm_16(uint32_t crc, const unsigned char *buf, size_t 
 #define VX_ALIGNMENT 16L
 #define VX_ALIGN_MASK (VX_ALIGNMENT - 1)
 
-uint32_t Z_INTERNAL s390_crc32_vx(uint32_t crc, const unsigned char *buf, uint64_t len) {
+uint32_t Z_INTERNAL PREFIX(s390_crc32_vx)(uint32_t crc, const unsigned char *buf, uint64_t len) {
     uint64_t prealign, aligned, remaining;
 
     if (len < VX_MIN_LEN + VX_ALIGN_MASK)

--- a/arch/s390/dfltcc_common.c
+++ b/arch/s390/dfltcc_common.c
@@ -35,7 +35,7 @@ static inline int is_dfltcc_enabled(void) {
     return is_bit_set((const char *)facilities, DFLTCC_FACILITY);
 }
 
-void Z_INTERNAL dfltcc_reset(PREFIX3(streamp) strm, uInt size) {
+void Z_INTERNAL PREFIX(dfltcc_reset)(PREFIX3(streamp) strm, uInt size) {
     struct dfltcc_state *dfltcc_state = (struct dfltcc_state *)((char *)strm->state + ALIGN_UP(size, 8));
     struct dfltcc_qaf_param *param = (struct dfltcc_qaf_param *)&dfltcc_state->param;
 
@@ -58,17 +58,17 @@ void Z_INTERNAL dfltcc_reset(PREFIX3(streamp) strm, uInt size) {
     dfltcc_state->param.ribm = DFLTCC_RIBM;
 }
 
-void Z_INTERNAL *dfltcc_alloc_state(PREFIX3(streamp) strm, uInt items, uInt size) {
+void Z_INTERNAL *PREFIX(dfltcc_alloc_state)(PREFIX3(streamp) strm, uInt items, uInt size) {
     return ZALLOC(strm, ALIGN_UP(items * size, 8) + sizeof(struct dfltcc_state), sizeof(unsigned char));
 }
 
-void Z_INTERNAL dfltcc_copy_state(void *dst, const void *src, uInt size) {
+void Z_INTERNAL PREFIX(dfltcc_copy_state)(void *dst, const void *src, uInt size) {
     memcpy(dst, src, ALIGN_UP(size, 8) + sizeof(struct dfltcc_state));
 }
 
 static const int PAGE_ALIGN = 0x1000;
 
-void Z_INTERNAL *dfltcc_alloc_window(PREFIX3(streamp) strm, uInt items, uInt size) {
+void Z_INTERNAL *PREFIX(dfltcc_alloc_window)(PREFIX3(streamp) strm, uInt items, uInt size) {
     void *p;
     void *w;
 
@@ -83,7 +83,7 @@ void Z_INTERNAL *dfltcc_alloc_window(PREFIX3(streamp) strm, uInt items, uInt siz
     return w;
 }
 
-void Z_INTERNAL dfltcc_free_window(PREFIX3(streamp) strm, void *w) {
+void Z_INTERNAL PREFIX(dfltcc_free_window)(PREFIX3(streamp) strm, void *w) {
     if (w)
         ZFREE(strm, *(void **)((unsigned char *)w - sizeof(void *)));
 }

--- a/arch/s390/dfltcc_common.h
+++ b/arch/s390/dfltcc_common.h
@@ -3,23 +3,23 @@
 
 #include "zutil.h"
 
-void Z_INTERNAL *dfltcc_alloc_state(PREFIX3(streamp) strm, uInt items, uInt size);
-void Z_INTERNAL dfltcc_copy_state(void *dst, const void *src, uInt size);
-void Z_INTERNAL dfltcc_reset(PREFIX3(streamp) strm, uInt size);
-void Z_INTERNAL *dfltcc_alloc_window(PREFIX3(streamp) strm, uInt items, uInt size);
-void Z_INTERNAL dfltcc_free_window(PREFIX3(streamp) strm, void *w);
+void Z_INTERNAL *PREFIX(dfltcc_alloc_state)(PREFIX3(streamp) strm, uInt items, uInt size);
+void Z_INTERNAL PREFIX(dfltcc_copy_state)(void *dst, const void *src, uInt size);
+void Z_INTERNAL PREFIX(dfltcc_reset)(PREFIX3(streamp) strm, uInt size);
+void Z_INTERNAL *PREFIX(dfltcc_alloc_window)(PREFIX3(streamp) strm, uInt items, uInt size);
+void Z_INTERNAL PREFIX(dfltcc_free_window)(PREFIX3(streamp) strm, void *w);
 
-#define ZALLOC_STATE dfltcc_alloc_state
+#define ZALLOC_STATE PREFIX(dfltcc_alloc_state)
 
 #define ZFREE_STATE ZFREE
 
-#define ZCOPY_STATE dfltcc_copy_state
+#define ZCOPY_STATE PREFIX(dfltcc_copy_state)
 
-#define ZALLOC_WINDOW dfltcc_alloc_window
+#define ZALLOC_WINDOW PREFIX(dfltcc_alloc_window)
 
-#define ZFREE_WINDOW dfltcc_free_window
+#define ZFREE_WINDOW PREFIX(dfltcc_free_window)
 
-#define TRY_FREE_WINDOW dfltcc_free_window
+#define TRY_FREE_WINDOW PREFIX(dfltcc_free_window)
 
 #define DFLTCC_BLOCK_HEADER_BITS 3
 #define DFLTCC_HLITS_COUNT_BITS 5

--- a/arch/s390/dfltcc_deflate.c
+++ b/arch/s390/dfltcc_deflate.c
@@ -43,7 +43,7 @@ static inline int dfltcc_can_deflate_with_params(PREFIX3(streamp) strm, int leve
     return 1;
 }
 
-int Z_INTERNAL dfltcc_can_deflate(PREFIX3(streamp) strm) {
+int Z_INTERNAL PREFIX(dfltcc_can_deflate)(PREFIX3(streamp) strm) {
     deflate_state *state = (deflate_state *)strm->state;
 
     return dfltcc_can_deflate_with_params(strm, state->level, state->w_bits, state->strategy, state->reproducible);
@@ -77,8 +77,8 @@ static inline dfltcc_cc dfltcc_cmpr(PREFIX3(streamp) strm) {
 static inline void send_eobs(PREFIX3(streamp) strm, const struct dfltcc_param_v0 *param) {
     deflate_state *state = (deflate_state *)strm->state;
 
-    send_bits(state, bi_reverse(param->eobs >> (15 - param->eobl), param->eobl), param->eobl, state->bi_buf, state->bi_valid);
-    flush_pending(strm);
+    send_bits(state, PREFIX(bi_reverse)(param->eobs >> (15 - param->eobl), param->eobl), param->eobl, state->bi_buf, state->bi_valid);
+    PREFIX(flush_pending)(strm);
     if (state->pending != 0) {
         /* The remaining data is located in pending_out[0:pending]. If someone
          * calls put_byte() - this might happen in deflate() - the byte will be
@@ -94,7 +94,7 @@ static inline void send_eobs(PREFIX3(streamp) strm, const struct dfltcc_param_v0
 #endif
 }
 
-int Z_INTERNAL dfltcc_deflate(PREFIX3(streamp) strm, int flush, block_state *result) {
+int Z_INTERNAL PREFIX(dfltcc_deflate)(PREFIX3(streamp) strm, int flush, block_state *result) {
     deflate_state *state = (deflate_state *)strm->state;
     struct dfltcc_state *dfltcc_state = GET_DFLTCC_STATE(state);
     struct dfltcc_param_v0 *param = &dfltcc_state->param;
@@ -104,7 +104,7 @@ int Z_INTERNAL dfltcc_deflate(PREFIX3(streamp) strm, int flush, block_state *res
     int soft_bcc;
     int no_flush;
 
-    if (!dfltcc_can_deflate(strm)) {
+    if (!PREFIX(dfltcc_can_deflate)(strm)) {
         /* Clear history. */
         if (flush == Z_FULL_FLUSH)
             param->hl = 0;
@@ -299,9 +299,9 @@ static int dfltcc_was_deflate_used(PREFIX3(streamp) strm) {
     return strm->total_in > 0 || param->nt == 0 || param->hl > 0;
 }
 
-int Z_INTERNAL dfltcc_deflate_params(PREFIX3(streamp) strm, int level, int strategy, int *flush) {
+int Z_INTERNAL PREFIX(dfltcc_deflate_params)(PREFIX3(streamp) strm, int level, int strategy, int *flush) {
     deflate_state *state = (deflate_state *)strm->state;
-    int could_deflate = dfltcc_can_deflate(strm);
+    int could_deflate = PREFIX(dfltcc_can_deflate)(strm);
     int can_deflate = dfltcc_can_deflate_with_params(strm, level, state->w_bits, strategy, state->reproducible);
 
     if (can_deflate == could_deflate)
@@ -317,7 +317,7 @@ int Z_INTERNAL dfltcc_deflate_params(PREFIX3(streamp) strm, int level, int strat
     return Z_OK;
 }
 
-int Z_INTERNAL dfltcc_deflate_done(PREFIX3(streamp) strm, int flush) {
+int Z_INTERNAL PREFIX(dfltcc_deflate_done)(PREFIX3(streamp) strm, int flush) {
     deflate_state *state = (deflate_state *)strm->state;
     struct dfltcc_state *dfltcc_state = GET_DFLTCC_STATE(state);
     struct dfltcc_param_v0 *param = &dfltcc_state->param;
@@ -333,10 +333,10 @@ int Z_INTERNAL dfltcc_deflate_done(PREFIX3(streamp) strm, int flush) {
      * buffered some data (Continuation Flag is set), or has not written EOBS
      * yet (Block-Continuation Flag is set).
      */
-    return !dfltcc_can_deflate(strm) || (!param->cf && !param->bcf);
+    return !PREFIX(dfltcc_can_deflate)(strm) || (!param->cf && !param->bcf);
 }
 
-int Z_INTERNAL dfltcc_can_set_reproducible(PREFIX3(streamp) strm, int reproducible) {
+int Z_INTERNAL PREFIX(dfltcc_can_set_reproducible)(PREFIX3(streamp) strm, int reproducible) {
     deflate_state *state = (deflate_state *)strm->state;
 
     return reproducible != state->reproducible && !dfltcc_was_deflate_used(strm);
@@ -375,7 +375,7 @@ static void append_history(struct dfltcc_param_v0 *param, unsigned char *history
     }
 }
 
-int Z_INTERNAL dfltcc_deflate_set_dictionary(PREFIX3(streamp) strm,
+int Z_INTERNAL PREFIX(dfltcc_deflate_set_dictionary)(PREFIX3(streamp) strm,
                                                 const unsigned char *dictionary, uInt dict_length) {
     deflate_state *state = (deflate_state *)strm->state;
     struct dfltcc_state *dfltcc_state = GET_DFLTCC_STATE(state);
@@ -387,7 +387,7 @@ int Z_INTERNAL dfltcc_deflate_set_dictionary(PREFIX3(streamp) strm,
     return Z_OK;
 }
 
-int Z_INTERNAL dfltcc_deflate_get_dictionary(PREFIX3(streamp) strm, unsigned char *dictionary, uInt *dict_length) {
+int Z_INTERNAL PREFIX(dfltcc_deflate_get_dictionary)(PREFIX3(streamp) strm, unsigned char *dictionary, uInt *dict_length) {
     deflate_state *state = (deflate_state *)strm->state;
     struct dfltcc_state *dfltcc_state = GET_DFLTCC_STATE(state);
     struct dfltcc_param_v0 *param = &dfltcc_state->param;

--- a/arch/s390/dfltcc_deflate.h
+++ b/arch/s390/dfltcc_deflate.h
@@ -3,53 +3,53 @@
 
 #include "dfltcc_common.h"
 
-int Z_INTERNAL dfltcc_can_deflate(PREFIX3(streamp) strm);
-int Z_INTERNAL dfltcc_deflate(PREFIX3(streamp) strm, int flush, block_state *result);
-int Z_INTERNAL dfltcc_deflate_params(PREFIX3(streamp) strm, int level, int strategy, int *flush);
-int Z_INTERNAL dfltcc_deflate_done(PREFIX3(streamp) strm, int flush);
-int Z_INTERNAL dfltcc_can_set_reproducible(PREFIX3(streamp) strm, int reproducible);
-int Z_INTERNAL dfltcc_deflate_set_dictionary(PREFIX3(streamp) strm,
+int Z_INTERNAL PREFIX(dfltcc_can_deflate)(PREFIX3(streamp) strm);
+int Z_INTERNAL PREFIX(dfltcc_deflate)(PREFIX3(streamp) strm, int flush, block_state *result);
+int Z_INTERNAL PREFIX(dfltcc_deflate_params)(PREFIX3(streamp) strm, int level, int strategy, int *flush);
+int Z_INTERNAL PREFIX(dfltcc_deflate_done)(PREFIX3(streamp) strm, int flush);
+int Z_INTERNAL PREFIX(dfltcc_can_set_reproducible)(PREFIX3(streamp) strm, int reproducible);
+int Z_INTERNAL PREFIX(dfltcc_deflate_set_dictionary)(PREFIX3(streamp) strm,
                                                 const unsigned char *dictionary, uInt dict_length);
-int Z_INTERNAL dfltcc_deflate_get_dictionary(PREFIX3(streamp) strm, unsigned char *dictionary, uInt* dict_length);
+int Z_INTERNAL PREFIX(dfltcc_deflate_get_dictionary)(PREFIX3(streamp) strm, unsigned char *dictionary, uInt* dict_length);
 
 #define DEFLATE_SET_DICTIONARY_HOOK(strm, dict, dict_len) \
     do { \
-        if (dfltcc_can_deflate((strm))) \
-            return dfltcc_deflate_set_dictionary((strm), (dict), (dict_len)); \
+        if (PREFIX(dfltcc_can_deflate)((strm))) \
+            return PREFIX(dfltcc_deflate_set_dictionary)((strm), (dict), (dict_len)); \
     } while (0)
 
 #define DEFLATE_GET_DICTIONARY_HOOK(strm, dict, dict_len) \
     do { \
-        if (dfltcc_can_deflate((strm))) \
-            return dfltcc_deflate_get_dictionary((strm), (dict), (dict_len)); \
+        if (PREFIX(dfltcc_can_deflate)((strm))) \
+            return PREFIX(dfltcc_deflate_get_dictionary)((strm), (dict), (dict_len)); \
     } while (0)
 
 #define DEFLATE_RESET_KEEP_HOOK(strm) \
-    dfltcc_reset((strm), sizeof(deflate_state))
+    PREFIX(dfltcc_reset)((strm), sizeof(deflate_state))
 
 #define DEFLATE_PARAMS_HOOK(strm, level, strategy, hook_flush) \
     do { \
         int err; \
 \
-        err = dfltcc_deflate_params((strm), (level), (strategy), (hook_flush)); \
+        err = PREFIX(dfltcc_deflate_params)((strm), (level), (strategy), (hook_flush)); \
         if (err == Z_STREAM_ERROR) \
             return err; \
     } while (0)
 
-#define DEFLATE_DONE dfltcc_deflate_done
+#define DEFLATE_DONE PREFIX(dfltcc_deflate_done)
 
 #define DEFLATE_BOUND_ADJUST_COMPLEN(strm, complen, source_len) \
     do { \
-        if (dfltcc_can_deflate((strm))) \
+        if (PREFIX(dfltcc_can_deflate)((strm))) \
             (complen) = DEFLATE_BOUND_COMPLEN(source_len); \
     } while (0)
 
-#define DEFLATE_NEED_CONSERVATIVE_BOUND(strm) (dfltcc_can_deflate((strm)))
+#define DEFLATE_NEED_CONSERVATIVE_BOUND(strm) (PREFIX(dfltcc_can_deflate)((strm)))
 
-#define DEFLATE_HOOK dfltcc_deflate
+#define DEFLATE_HOOK PREFIX(dfltcc_deflate)
 
-#define DEFLATE_NEED_CHECKSUM(strm) (!dfltcc_can_deflate((strm)))
+#define DEFLATE_NEED_CHECKSUM(strm) (!PREFIX(dfltcc_can_deflate)((strm)))
 
-#define DEFLATE_CAN_SET_REPRODUCIBLE dfltcc_can_set_reproducible
+#define DEFLATE_CAN_SET_REPRODUCIBLE PREFIX(dfltcc_can_set_reproducible)
 
 #endif

--- a/arch/s390/dfltcc_inflate.c
+++ b/arch/s390/dfltcc_inflate.c
@@ -20,7 +20,7 @@
 #include "dfltcc_inflate.h"
 #include "dfltcc_detail.h"
 
-int Z_INTERNAL dfltcc_can_inflate(PREFIX3(streamp) strm) {
+int Z_INTERNAL PREFIX(dfltcc_can_inflate)(PREFIX3(streamp) strm) {
     struct inflate_state *state = (struct inflate_state *)strm->state;
     struct dfltcc_state *dfltcc_state = GET_DFLTCC_STATE(state);
 
@@ -47,7 +47,7 @@ static inline dfltcc_cc dfltcc_xpnd(PREFIX3(streamp) strm) {
     return cc;
 }
 
-dfltcc_inflate_action Z_INTERNAL dfltcc_inflate(PREFIX3(streamp) strm, int flush, int *ret) {
+dfltcc_inflate_action Z_INTERNAL PREFIX(dfltcc_inflate)(PREFIX3(streamp) strm, int flush, int *ret) {
     struct inflate_state *state = (struct inflate_state *)strm->state;
     struct dfltcc_state *dfltcc_state = GET_DFLTCC_STATE(state);
     struct dfltcc_param_v0 *param = &dfltcc_state->param;
@@ -55,7 +55,7 @@ dfltcc_inflate_action Z_INTERNAL dfltcc_inflate(PREFIX3(streamp) strm, int flush
 
     if (flush == Z_BLOCK || flush == Z_TREES) {
         /* DFLTCC does not support stopping on block boundaries */
-        if (dfltcc_inflate_disable(strm)) {
+        if (PREFIX(dfltcc_inflate_disable)(strm)) {
             *ret = Z_STREAM_ERROR;
             return DFLTCC_INFLATE_BREAK;
         } else
@@ -75,7 +75,7 @@ dfltcc_inflate_action Z_INTERNAL dfltcc_inflate(PREFIX3(streamp) strm, int flush
     if (strm->avail_in == 0 && !param->cf)
         return DFLTCC_INFLATE_BREAK;
 
-    if (inflate_ensure_window(state)) {
+    if (PREFIX(inflate_ensure_window)(state)) {
         state->mode = MEM;
         return DFLTCC_INFLATE_CONTINUE;
     }
@@ -112,20 +112,20 @@ dfltcc_inflate_action Z_INTERNAL dfltcc_inflate(PREFIX3(streamp) strm, int flush
         DFLTCC_INFLATE_BREAK : DFLTCC_INFLATE_CONTINUE;
 }
 
-int Z_INTERNAL dfltcc_was_inflate_used(PREFIX3(streamp) strm) {
+int Z_INTERNAL PREFIX(dfltcc_was_inflate_used)(PREFIX3(streamp) strm) {
     struct inflate_state *state = (struct inflate_state *)strm->state;
     struct dfltcc_param_v0 *param = &GET_DFLTCC_STATE(state)->param;
 
     return !param->nt;
 }
 
-int Z_INTERNAL dfltcc_inflate_disable(PREFIX3(streamp) strm) {
+int Z_INTERNAL PREFIX(dfltcc_inflate_disable)(PREFIX3(streamp) strm) {
     struct inflate_state *state = (struct inflate_state *)strm->state;
     struct dfltcc_state *dfltcc_state = GET_DFLTCC_STATE(state);
 
-    if (!dfltcc_can_inflate(strm))
+    if (!PREFIX(dfltcc_can_inflate)(strm))
         return 0;
-    if (dfltcc_was_inflate_used(strm))
+    if (PREFIX(dfltcc_was_inflate_used)(strm))
         /* DFLTCC has already decompressed some data. Since there is not
          * enough information to resume decompression in software, the call
          * must fail.

--- a/arch/s390/dfltcc_inflate.h
+++ b/arch/s390/dfltcc_inflate.h
@@ -3,28 +3,28 @@
 
 #include "dfltcc_common.h"
 
-int Z_INTERNAL dfltcc_can_inflate(PREFIX3(streamp) strm);
+int Z_INTERNAL PREFIX(dfltcc_can_inflate)(PREFIX3(streamp) strm);
 typedef enum {
     DFLTCC_INFLATE_CONTINUE,
     DFLTCC_INFLATE_BREAK,
     DFLTCC_INFLATE_SOFTWARE,
 } dfltcc_inflate_action;
-dfltcc_inflate_action Z_INTERNAL dfltcc_inflate(PREFIX3(streamp) strm, int flush, int *ret);
-int Z_INTERNAL dfltcc_was_inflate_used(PREFIX3(streamp) strm);
-int Z_INTERNAL dfltcc_inflate_disable(PREFIX3(streamp) strm);
+dfltcc_inflate_action Z_INTERNAL PREFIX(dfltcc_inflate)(PREFIX3(streamp) strm, int flush, int *ret);
+int Z_INTERNAL PREFIX(dfltcc_was_inflate_used)(PREFIX3(streamp) strm);
+int Z_INTERNAL PREFIX(dfltcc_inflate_disable)(PREFIX3(streamp) strm);
 
 #define INFLATE_RESET_KEEP_HOOK(strm) \
-    dfltcc_reset((strm), sizeof(struct inflate_state))
+    PREFIX(dfltcc_reset)((strm), sizeof(struct inflate_state))
 
 #define INFLATE_PRIME_HOOK(strm, bits, value) \
-    do { if (dfltcc_inflate_disable((strm))) return Z_STREAM_ERROR; } while (0)
+    do { if (PREFIX(dfltcc_inflate_disable)((strm))) return Z_STREAM_ERROR; } while (0)
 
 #define INFLATE_TYPEDO_HOOK(strm, flush) \
-    if (dfltcc_can_inflate((strm))) { \
+    if (PREFIX(dfltcc_can_inflate)((strm))) { \
         dfltcc_inflate_action action; \
 \
         RESTORE(); \
-        action = dfltcc_inflate((strm), (flush), &ret); \
+        action = PREFIX(dfltcc_inflate)((strm), (flush), &ret); \
         LOAD(); \
         if (action == DFLTCC_INFLATE_CONTINUE) \
             break; \
@@ -32,18 +32,18 @@ int Z_INTERNAL dfltcc_inflate_disable(PREFIX3(streamp) strm);
             goto inf_leave; \
     }
 
-#define INFLATE_NEED_CHECKSUM(strm) (!dfltcc_can_inflate((strm)))
+#define INFLATE_NEED_CHECKSUM(strm) (!PREFIX(dfltcc_can_inflate)((strm)))
 
-#define INFLATE_NEED_UPDATEWINDOW(strm) (!dfltcc_can_inflate((strm)))
+#define INFLATE_NEED_UPDATEWINDOW(strm) (!PREFIX(dfltcc_can_inflate)((strm)))
 
 #define INFLATE_MARK_HOOK(strm) \
     do { \
-        if (dfltcc_was_inflate_used((strm))) return -(1L << 16); \
+        if (PREFIX(dfltcc_was_inflate_used)((strm))) return -(1L << 16); \
     } while (0)
 
 #define INFLATE_SYNC_POINT_HOOK(strm) \
     do { \
-        if (dfltcc_was_inflate_used((strm))) return Z_STREAM_ERROR; \
+        if (PREFIX(dfltcc_was_inflate_used)((strm))) return Z_STREAM_ERROR; \
     } while (0)
 
 #endif

--- a/arch/s390/s390_features.c
+++ b/arch/s390/s390_features.c
@@ -5,10 +5,10 @@
 #  include <sys/auxv.h>
 #endif
 
-Z_INTERNAL int s390_cpu_has_vx = 0;
+Z_INTERNAL int PREFIX(s390_cpu_has_vx) = 0;
 
-void Z_INTERNAL s390_check_features(void) {
+void Z_INTERNAL PREFIX(s390_check_features)(void) {
 #ifdef S390_FEATURES
-    s390_cpu_has_vx = getauxval(AT_HWCAP) & HWCAP_S390_VX;
+    PREFIX(s390_cpu_has_vx) = getauxval(AT_HWCAP) & HWCAP_S390_VX;
 #endif
 }

--- a/arch/s390/s390_features.h
+++ b/arch/s390/s390_features.h
@@ -1,8 +1,8 @@
 #ifndef S390_FEATURES_H_
 #define S390_FEATURES_H_
 
-extern int s390_cpu_has_vx;
+extern int PREFIX(s390_cpu_has_vx);
 
-void Z_INTERNAL s390_check_features(void);
+void Z_INTERNAL PREFIX(s390_check_features)(void);
 
 #endif

--- a/cpu_features.c
+++ b/cpu_features.c
@@ -18,7 +18,7 @@ Z_INTERNAL void cpu_check_features(void) {
 #elif defined(PPC_FEATURES) || defined(POWER_FEATURES)
     power_check_features();
 #elif defined(S390_FEATURES)
-    s390_check_features();
+    PREFIX(s390_check_features)();
 #endif
     features_checked = 1;
 }

--- a/cpu_features.h
+++ b/cpu_features.h
@@ -105,7 +105,7 @@ extern uint32_t crc32_acle(uint32_t crc, const unsigned char *buf, uint64_t len)
 #elif defined(POWER8_VSX_CRC32)
 extern uint32_t crc32_power8(uint32_t crc, const unsigned char *buf, uint64_t len);
 #elif defined(S390_CRC32_VX)
-extern uint32_t s390_crc32_vx(uint32_t crc, const unsigned char *buf, uint64_t len);
+extern uint32_t PREFIX(s390_crc32_vx)(uint32_t crc, const unsigned char *buf, uint64_t len);
 #endif
 
 /* compare256 */

--- a/deflate.c
+++ b/deflate.c
@@ -662,7 +662,7 @@ unsigned long Z_EXPORT PREFIX(deflateBound)(PREFIX3(stream) *strm, unsigned long
  * applications may wish to modify it to avoid allocating a large
  * strm->next_out buffer and copying into it. (See also read_buf()).
  */
-Z_INTERNAL void flush_pending(PREFIX3(stream) *strm) {
+Z_INTERNAL void PREFIX(flush_pending)(PREFIX3(stream) *strm) {
     uint32_t len;
     deflate_state *s = strm->state;
 
@@ -715,7 +715,7 @@ int32_t Z_EXPORT PREFIX(deflate)(PREFIX3(stream) *strm, int32_t flush) {
 
     /* Flush as much pending output as possible */
     if (s->pending != 0) {
-        flush_pending(strm);
+        PREFIX(flush_pending)(strm);
         if (strm->avail_out == 0) {
             /* Since avail_out is 0, deflate will be called again with
              * more output space, but possibly with both pending and
@@ -770,7 +770,7 @@ int32_t Z_EXPORT PREFIX(deflate)(PREFIX3(stream) *strm, int32_t flush) {
         s->status = BUSY_STATE;
 
         /* Compression must start with an empty pending buffer */
-        flush_pending(strm);
+        PREFIX(flush_pending)(strm);
         if (s->pending != 0) {
             s->last_flush = -1;
             return Z_OK;
@@ -792,7 +792,7 @@ int32_t Z_EXPORT PREFIX(deflate)(PREFIX3(stream) *strm, int32_t flush) {
             s->status = BUSY_STATE;
 
             /* Compression must start with an empty pending buffer */
-            flush_pending(strm);
+            PREFIX(flush_pending)(strm);
             if (s->pending != 0) {
                 s->last_flush = -1;
                 return Z_OK;
@@ -826,7 +826,7 @@ int32_t Z_EXPORT PREFIX(deflate)(PREFIX3(stream) *strm, int32_t flush) {
                 s->pending = s->pending_buf_size;
                 HCRC_UPDATE(beg);
                 s->gzindex += copy;
-                flush_pending(strm);
+                PREFIX(flush_pending)(strm);
                 if (s->pending != 0) {
                     s->last_flush = -1;
                     return Z_OK;
@@ -849,7 +849,7 @@ int32_t Z_EXPORT PREFIX(deflate)(PREFIX3(stream) *strm, int32_t flush) {
             do {
                 if (s->pending == s->pending_buf_size) {
                     HCRC_UPDATE(beg);
-                    flush_pending(strm);
+                    PREFIX(flush_pending)(strm);
                     if (s->pending != 0) {
                         s->last_flush = -1;
                         return Z_OK;
@@ -872,7 +872,7 @@ int32_t Z_EXPORT PREFIX(deflate)(PREFIX3(stream) *strm, int32_t flush) {
             do {
                 if (s->pending == s->pending_buf_size) {
                     HCRC_UPDATE(beg);
-                    flush_pending(strm);
+                    PREFIX(flush_pending)(strm);
                     if (s->pending != 0) {
                         s->last_flush = -1;
                         return Z_OK;
@@ -889,7 +889,7 @@ int32_t Z_EXPORT PREFIX(deflate)(PREFIX3(stream) *strm, int32_t flush) {
     if (s->status == HCRC_STATE) {
         if (s->gzhead->hcrc) {
             if (s->pending + 2 > s->pending_buf_size) {
-                flush_pending(strm);
+                PREFIX(flush_pending)(strm);
                 if (s->pending != 0) {
                     s->last_flush = -1;
                     return Z_OK;
@@ -901,7 +901,7 @@ int32_t Z_EXPORT PREFIX(deflate)(PREFIX3(stream) *strm, int32_t flush) {
         s->status = BUSY_STATE;
 
         /* Compression must start with an empty pending buffer */
-        flush_pending(strm);
+        PREFIX(flush_pending)(strm);
         if (s->pending != 0) {
             s->last_flush = -1;
             return Z_OK;
@@ -953,7 +953,7 @@ int32_t Z_EXPORT PREFIX(deflate)(PREFIX3(stream) *strm, int32_t flush) {
                     }
                 }
             }
-            flush_pending(strm);
+            PREFIX(flush_pending)(strm);
             if (strm->avail_out == 0) {
                 s->last_flush = -1; /* avoid BUF_ERROR at next call, see above */
                 return Z_OK;
@@ -975,7 +975,7 @@ int32_t Z_EXPORT PREFIX(deflate)(PREFIX3(stream) *strm, int32_t flush) {
 #endif
     if (s->wrap == 1)
         put_uint32_msb(s, strm->adler);
-    flush_pending(strm);
+    PREFIX(flush_pending)(strm);
     /* If avail_out is zero, the application will call deflate again
      * to flush the rest.
      */

--- a/deflate.h
+++ b/deflate.h
@@ -381,8 +381,8 @@ void Z_INTERNAL zng_tr_flush_block(deflate_state *s, char *buf, uint32_t stored_
 void Z_INTERNAL zng_tr_flush_bits(deflate_state *s);
 void Z_INTERNAL zng_tr_align(deflate_state *s);
 void Z_INTERNAL zng_tr_stored_block(deflate_state *s, char *buf, uint32_t stored_len, int last);
-uint16_t Z_INTERNAL bi_reverse(unsigned code, int len);
-void Z_INTERNAL flush_pending(PREFIX3(streamp) strm);
+uint16_t Z_INTERNAL PREFIX(bi_reverse)(unsigned code, int len);
+void Z_INTERNAL PREFIX(flush_pending)(PREFIX3(streamp) strm);
 #define d_code(dist) ((dist) < 256 ? zng_dist_code[dist] : zng_dist_code[256+((dist)>>7)])
 /* Mapping from a distance to a distance code. dist is the distance - 1 and
  * must not have side effects. zng_dist_code[256] and zng_dist_code[257] are never

--- a/deflate_p.h
+++ b/deflate_p.h
@@ -47,7 +47,7 @@ static inline void check_match(deflate_state *s, Pos start, Pos match, int lengt
 #define check_match(s, start, match, length)
 #endif
 
-Z_INTERNAL void flush_pending(PREFIX3(stream) *strm);
+Z_INTERNAL void PREFIX(flush_pending)(PREFIX3(stream) *strm);
 Z_INTERNAL unsigned read_buf(PREFIX3(stream) *strm, unsigned char *buf, unsigned size);
 
 /* ===========================================================================
@@ -96,7 +96,7 @@ static inline int zng_tr_tally_dist(deflate_state *s, uint32_t dist, uint32_t le
                    (uint32_t)((int)s->strstart - s->block_start), \
                    (last)); \
     s->block_start = (int)s->strstart; \
-    flush_pending(s->strm); \
+    PREFIX(flush_pending)(s->strm); \
 }
 
 /* Same but force premature exit if necessary. */

--- a/deflate_quick.c
+++ b/deflate_quick.c
@@ -37,7 +37,7 @@ extern const ct_data static_dtree[D_CODES];
         zng_tr_emit_end_block(s, static_ltree, last); \
         s->block_open = 0; \
         s->block_start = (int)s->strstart; \
-        flush_pending(s->strm); \
+        PREFIX(flush_pending)(s->strm); \
         if (s->strm->avail_out == 0) \
             return (last) ? finish_started : need_more; \
     } \
@@ -63,7 +63,7 @@ Z_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
 
     for (;;) {
         if (UNLIKELY(s->pending + ((BIT_BUF_SIZE + 7) >> 3) >= s->pending_buf_size)) {
-            flush_pending(s->strm);
+            PREFIX(flush_pending)(s->strm);
             if (s->strm->avail_out == 0) {
                 return (last && s->strm->avail_in == 0 && s->bi_valid == 0 && s->block_open == 0) ? finish_started : need_more;
             }

--- a/deflate_stored.c
+++ b/deflate_stored.c
@@ -73,7 +73,7 @@ Z_INTERNAL block_state deflate_stored(deflate_state *s, int flush) {
         put_short(s, (uint16_t)~len);
 
         /* Write the stored block header bytes. */
-        flush_pending(s->strm);
+        PREFIX(flush_pending)(s->strm);
 
         /* Update debugging counts for the data about to be copied. */
         cmpr_bits_add(s, len << 3);
@@ -178,7 +178,7 @@ Z_INTERNAL block_state deflate_stored(deflate_state *s, int flush) {
         last = flush == Z_FINISH && s->strm->avail_in == 0 && len == left ? 1 : 0;
         zng_tr_stored_block(s, (char *)s->window + s->block_start, len, last);
         s->block_start += (int)len;
-        flush_pending(s->strm);
+        PREFIX(flush_pending)(s->strm);
     }
 
     /* We've done all we can with the available input and output. */

--- a/functable.c
+++ b/functable.c
@@ -371,8 +371,8 @@ Z_INTERNAL uint32_t crc32_stub(uint32_t crc, const unsigned char *buf, uint64_t 
     if (power_cpu_has_arch_2_07)
         functable.crc32 = &crc32_power8;
 #elif defined(S390_CRC32_VX)
-    if (s390_cpu_has_vx)
-        functable.crc32 = &s390_crc32_vx;
+    if (PREFIX(s390_cpu_has_vx))
+        functable.crc32 = &PREFIX(s390_crc32_vx);
 #elif defined(X86_PCLMULQDQ_CRC)
     if (x86_cpu_has_pclmulqdq)
         functable.crc32 = &crc32_pclmulqdq;

--- a/inflate.c
+++ b/inflate.c
@@ -198,7 +198,7 @@ void Z_INTERNAL fixedtables(struct inflate_state *state) {
     state->distbits = 5;
 }
 
-int Z_INTERNAL inflate_ensure_window(struct inflate_state *state) {
+int Z_INTERNAL PREFIX(inflate_ensure_window)(struct inflate_state *state) {
     /* if it hasn't been done already, allocate space for the window */
     if (state->window == NULL) {
         unsigned wsize = 1U << state->wbits;
@@ -243,7 +243,7 @@ static int32_t updatewindow(PREFIX3(stream) *strm, const uint8_t *end, uint32_t 
 
     state = (struct inflate_state *)strm->state;
 
-    if (inflate_ensure_window(state)) return 1;
+    if (PREFIX(inflate_ensure_window)(state)) return 1;
 
     /* copy state->wsize or less output bytes into the circular window */
     if (copy >= state->wsize) {

--- a/inflate.h
+++ b/inflate.h
@@ -133,7 +133,7 @@ struct inflate_state {
     uint32_t chunksize;         /* size of memory copying chunk */
 };
 
-int Z_INTERNAL inflate_ensure_window(struct inflate_state *state);
+int Z_INTERNAL PREFIX(inflate_ensure_window)(struct inflate_state *state);
 void Z_INTERNAL fixedtables(struct inflate_state *state);
 
 #endif /* INFLATE_H_ */

--- a/test/benchmarks/benchmark_crc32.cc
+++ b/test/benchmarks/benchmark_crc32.cc
@@ -62,7 +62,7 @@ BENCHMARK_CRC32(acle, crc32_acle, arm_cpu_has_crc32);
 #elif defined(POWER8_VSX_CRC32)
 BENCHMARK_CRC32(power8, crc32_power8, power_cpu_has_arch_2_07);
 #elif defined(S390_CRC32_VX)
-BENCHMARK_CRC32(vx, s390_crc32_vx, s390_cpu_has_vx);
+BENCHMARK_CRC32(vx, PREFIX(s390_crc32_vx), PREFIX(s390_cpu_has_vx));
 #elif defined(X86_PCLMULQDQ_CRC)
 /* CRC32 fold does a memory copy while hashing */
 BENCHMARK_CRC32(pclmulqdq, crc32_pclmulqdq, x86_cpu_has_pclmulqdq);

--- a/test/test_crc32.cc
+++ b/test/test_crc32.cc
@@ -213,7 +213,7 @@ TEST_CRC32(acle, crc32_acle, arm_cpu_has_crc32)
 #elif defined(POWER8_VSX_CRC32)
 TEST_CRC32(power8, crc32_power8, power_cpu_has_arch_2_07)
 #elif defined(S390_CRC32_VX)
-TEST_CRC32(vx, s390_crc32_vx, s390_cpu_has_vx)
+TEST_CRC32(vx, PREFIX(s390_crc32_vx), PREFIX(s390_cpu_has_vx))
 #elif defined(X86_PCLMULQDQ_CRC)
 TEST_CRC32(pclmulqdq, crc32_pclmulqdq, x86_cpu_has_pclmulqdq)
 #endif

--- a/tools/maketrees.c
+++ b/tools/maketrees.c
@@ -90,7 +90,7 @@ static void tr_static_init(void) {
     /* The static distance tree is trivial: */
     for (n = 0; n < D_CODES; n++) {
         static_dtree[n].Len = 5;
-        static_dtree[n].Code = bi_reverse((unsigned)n, 5);
+        static_dtree[n].Code = PREFIX(bi_reverse)((unsigned)n, 5);
     }
 }
 

--- a/trees.c
+++ b/trees.c
@@ -305,7 +305,7 @@ Z_INTERNAL void gen_codes(ct_data *tree, int max_code, uint16_t *bl_count) {
         if (len == 0)
             continue;
         /* Now reverse the bits */
-        tree[n].Code = bi_reverse(next_code[len]++, len);
+        tree[n].Code = PREFIX(bi_reverse)(next_code[len]++, len);
 
         Tracecv(tree != static_ltree, (stderr, "\nn %3d %c l %2d c %4x (%x) ",
              n, (isgraph(n & 0xff) ? n : ' '), len, tree[n].Code, next_code[len]-1));
@@ -808,7 +808,7 @@ static void bi_flush(deflate_state *s) {
 /* ===========================================================================
  * Reverse the first len bits of a code using bit manipulation
  */
-Z_INTERNAL uint16_t bi_reverse(unsigned code, int len) {
+Z_INTERNAL uint16_t PREFIX(bi_reverse)(unsigned code, int len) {
     /* code: the value to invert */
     /* len: its bit length */
     Assert(len >= 1 && len <= 15, "code length must be 1-15");


### PR DESCRIPTION
https://github.com/powturbo/TurboBench links zlib and zlib-ng into the
same binary, causing non-static symbol conflicts. Fix by using PREFIX()
for flush_pending(), bi_reverse(), inflate_ensure_window() and all of
the IBM Z symbols.

Note: do not use an explicit zng_, since one of the long-term goals is
to be able to link two versions of zlib-ng into the same binary for
benchmarking [1].

[1] https://github.com/zlib-ng/zlib-ng/pull/1248#issuecomment-1096648932