### PR TITLE
arch/arm/arm_features.c: fix uclibc build

### DIFF
--- a/arch/arm/arm_features.c
+++ b/arch/arm/arm_features.c
@@ -1,6 +1,6 @@
 #include "../../zbuild.h"
 
-#if defined(__linux__)
+#if defined(__linux__) && (defined(ARM_AUXV_HAS_CRC32) || defined(ARM_AUXV_HAS_NEON))
 #  include <sys/auxv.h>
 #  ifdef ARM_ASM_HWCAP
 #    include <asm/hwcap.h>


### PR DESCRIPTION
Fix the following build failure on uclibc:

```
/home/autobuild/autobuild/instance-1/output-1/build/zlib-ng-2.0.6/arch/arm/armfeature.c:4:12: fatal error: sys/auxv.h: No such file or directory
    4 | #  include <sys/auxv.h>
      |            ^~~~~~~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/6e04affd52528d7c8398f303f4af720f3ad67bfd

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>