### PR TITLE
IBM Z DFLTCC: Buffer deflate() input data 

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -252,6 +252,12 @@ jobs:
             ldflags: -static
             codecov: ubuntu_gcc_s390x_dfltcc_compat
 
+          - name: Ubuntu Clang S390X DFLTCC MSAN
+            os: z15
+            compiler: clang-11
+            cxx-compiler: clang++-11
+            cmake-args: -GNinja -DWITH_DFLTCC_DEFLATE=ON -DWITH_DFLTCC_INFLATE=ON -DWITH_SANITIZER=Memory
+
           - name: Ubuntu MinGW i686
             os: ubuntu-latest
             cmake-args: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-mingw-i686.cmake

--- a/arch/s390/dfltcc_detail.h
+++ b/arch/s390/dfltcc_detail.h
@@ -23,6 +23,9 @@
 #ifndef DFLTCC_RIBM
 #define DFLTCC_RIBM 0
 #endif
+#ifndef DFLTCC_BUF_SIZE
+#define DFLTCC_BUF_SIZE 262144
+#endif
 
 /*
    Parameter Block for Query Available Functions.

--- a/arch/s390/dfltcc_detail.h
+++ b/arch/s390/dfltcc_detail.h
@@ -1,7 +1,5 @@
-#include <stddef.h>
-#include <stdint.h>
+#include "../../zbuild.h"
 #include <stdio.h>
-#include <string.h>
 
 #ifdef HAVE_SYS_SDT_H
 #include <sys/sdt.h>

--- a/arch/s390/dfltcc_detail.h
+++ b/arch/s390/dfltcc_detail.h
@@ -27,74 +27,6 @@
 #endif
 
 /*
-   C wrapper for the DEFLATE CONVERSION CALL instruction.
- */
-typedef enum {
-    DFLTCC_CC_OK = 0,
-    DFLTCC_CC_OP1_TOO_SHORT = 1,
-    DFLTCC_CC_OP2_TOO_SHORT = 2,
-    DFLTCC_CC_OP2_CORRUPT = 2,
-    DFLTCC_CC_AGAIN = 3,
-} dfltcc_cc;
-
-#define DFLTCC_QAF 0
-#define DFLTCC_GDHT 1
-#define DFLTCC_CMPR 2
-#define DFLTCC_XPND 4
-#define HBT_CIRCULAR (1 << 7)
-#define HB_BITS 15
-#define HB_SIZE (1 << HB_BITS)
-#define DFLTCC_FACILITY 151
-
-static inline dfltcc_cc dfltcc(int fn, void *param,
-                               unsigned char **op1, size_t *len1, z_const unsigned char **op2, size_t *len2, void *hist) {
-    unsigned char *t2 = op1 ? *op1 : NULL;
-    size_t t3 = len1 ? *len1 : 0;
-    z_const unsigned char *t4 = op2 ? *op2 : NULL;
-    size_t t5 = len2 ? *len2 : 0;
-    Z_REGISTER int r0 __asm__("r0") = fn;
-    Z_REGISTER void *r1 __asm__("r1") = param;
-    Z_REGISTER unsigned char *r2 __asm__("r2") = t2;
-    Z_REGISTER size_t r3 __asm__("r3") = t3;
-    Z_REGISTER z_const unsigned char *r4 __asm__("r4") = t4;
-    Z_REGISTER size_t r5 __asm__("r5") = t5;
-    int cc;
-
-    __asm__ volatile(
-#ifdef HAVE_SYS_SDT_H
-                     STAP_PROBE_ASM(zlib, dfltcc_entry, STAP_PROBE_ASM_TEMPLATE(5))
-#endif
-                     ".insn rrf,0xb9390000,%[r2],%[r4],%[hist],0\n"
-#ifdef HAVE_SYS_SDT_H
-                     STAP_PROBE_ASM(zlib, dfltcc_exit, STAP_PROBE_ASM_TEMPLATE(5))
-#endif
-                     "ipm %[cc]\n"
-                     : [r2] "+r" (r2)
-                     , [r3] "+r" (r3)
-                     , [r4] "+r" (r4)
-                     , [r5] "+r" (r5)
-                     , [cc] "=r" (cc)
-                     : [r0] "r" (r0)
-                     , [r1] "r" (r1)
-                     , [hist] "r" (hist)
-#ifdef HAVE_SYS_SDT_H
-                     , STAP_PROBE_ASM_OPERANDS(5, r2, r3, r4, r5, hist)
-#endif
-                     : "cc", "memory");
-    t2 = r2; t3 = r3; t4 = r4; t5 = r5;
-
-    if (op1)
-        *op1 = t2;
-    if (len1)
-        *len1 = t3;
-    if (op2)
-        *op2 = t4;
-    if (len2)
-        *len2 = t5;
-    return (cc >> 28) & 3;
-}
-
-/*
    Parameter Block for Query Available Functions.
  */
 #define static_assert(c, msg) __attribute__((unused)) static char static_assert_failed_ ## msg[c ? 1 : -1]
@@ -106,7 +38,8 @@ struct dfltcc_qaf_param {
     char reserved2[6];
 };
 
-static_assert(sizeof(struct dfltcc_qaf_param) == 32, sizeof_struct_dfltcc_qaf_param_is_32);
+#define DFLTCC_SIZEOF_QAF 32
+static_assert(sizeof(struct dfltcc_qaf_param) == DFLTCC_SIZEOF_QAF, qaf);
 
 static inline int is_bit_set(const char *bits, int n) {
     return bits[n / 8] & (1 << (7 - (n % 8)));
@@ -115,6 +48,8 @@ static inline int is_bit_set(const char *bits, int n) {
 static inline void clear_bit(char *bits, int n) {
     bits[n / 8] &= ~(1 << (7 - (n % 8)));
 }
+
+#define DFLTCC_FACILITY 151
 
 static inline int is_dfltcc_enabled(void) {
     uint64_t facilities[(DFLTCC_FACILITY / 64) + 1];
@@ -189,12 +124,16 @@ struct dfltcc_param_v0 {
     uint16_t cdhtl : 12;               /* Compressed-Dynamic-Huffman Table
                                           Length */
     uint8_t reserved464[6];
-    uint8_t cdht[288];
-    uint8_t reserved[32];
-    uint8_t csb[1152];
+    uint8_t cdht[288];                 /* Compressed-Dynamic-Huffman Table */
+    uint8_t reserved[24];
+    uint8_t ribm2[8];                  /* Reserved for IBM use */
+    uint8_t csb[1152];                 /* Continuation-State Buffer */
 };
 
-static_assert(sizeof(struct dfltcc_param_v0) == 1536, sizeof_struct_dfltcc_param_v0_is_1536);
+#define DFLTCC_SIZEOF_GDHT_V0 384
+#define DFLTCC_SIZEOF_CMPR_XPND_V0 1536
+static_assert(offsetof(struct dfltcc_param_v0, csb) == DFLTCC_SIZEOF_GDHT_V0, gdht_v0);
+static_assert(sizeof(struct dfltcc_param_v0) == DFLTCC_SIZEOF_CMPR_XPND_V0, cmpr_xpnd_v0);
 
 static inline z_const char *oesc_msg(char *buf, int oesc) {
     if (oesc == 0x00)
@@ -203,6 +142,97 @@ static inline z_const char *oesc_msg(char *buf, int oesc) {
         sprintf(buf, "Operation-Ending-Supplemental Code is 0x%.2X", oesc);
         return buf;
     }
+}
+
+/*
+   C wrapper for the DEFLATE CONVERSION CALL instruction.
+ */
+typedef enum {
+    DFLTCC_CC_OK = 0,
+    DFLTCC_CC_OP1_TOO_SHORT = 1,
+    DFLTCC_CC_OP2_TOO_SHORT = 2,
+    DFLTCC_CC_OP2_CORRUPT = 2,
+    DFLTCC_CC_AGAIN = 3,
+} dfltcc_cc;
+
+#define DFLTCC_QAF 0
+#define DFLTCC_GDHT 1
+#define DFLTCC_CMPR 2
+#define DFLTCC_XPND 4
+#define HBT_CIRCULAR (1 << 7)
+#define DFLTCC_FN_MASK ((1 << 7) - 1)
+#define HB_BITS 15
+#define HB_SIZE (1 << HB_BITS)
+
+static inline dfltcc_cc dfltcc(int fn, void *param,
+                               unsigned char **op1, size_t *len1,
+                               z_const unsigned char **op2, size_t *len2, void *hist) {
+    unsigned char *t2 = op1 ? *op1 : NULL;
+#ifdef Z_MEMORY_SANITIZER
+    unsigned char *orig_t2 = t2;
+#endif
+    size_t t3 = len1 ? *len1 : 0;
+    z_const unsigned char *t4 = op2 ? *op2 : NULL;
+    size_t t5 = len2 ? *len2 : 0;
+    Z_REGISTER int r0 __asm__("r0") = fn;
+    Z_REGISTER void *r1 __asm__("r1") = param;
+    Z_REGISTER unsigned char *r2 __asm__("r2") = t2;
+    Z_REGISTER size_t r3 __asm__("r3") = t3;
+    Z_REGISTER z_const unsigned char *r4 __asm__("r4") = t4;
+    Z_REGISTER size_t r5 __asm__("r5") = t5;
+    int cc;
+
+    __asm__ volatile(
+#ifdef HAVE_SYS_SDT_H
+                     STAP_PROBE_ASM(zlib, dfltcc_entry, STAP_PROBE_ASM_TEMPLATE(5))
+#endif
+                     ".insn rrf,0xb9390000,%[r2],%[r4],%[hist],0\n"
+#ifdef HAVE_SYS_SDT_H
+                     STAP_PROBE_ASM(zlib, dfltcc_exit, STAP_PROBE_ASM_TEMPLATE(5))
+#endif
+                     "ipm %[cc]\n"
+                     : [r2] "+r" (r2)
+                     , [r3] "+r" (r3)
+                     , [r4] "+r" (r4)
+                     , [r5] "+r" (r5)
+                     , [cc] "=r" (cc)
+                     : [r0] "r" (r0)
+                     , [r1] "r" (r1)
+                     , [hist] "r" (hist)
+#ifdef HAVE_SYS_SDT_H
+                     , STAP_PROBE_ASM_OPERANDS(5, r2, r3, r4, r5, hist)
+#endif
+                     : "cc", "memory");
+    t2 = r2; t3 = r3; t4 = r4; t5 = r5;
+
+#ifdef Z_MEMORY_SANITIZER
+    switch (fn & DFLTCC_FN_MASK) {
+    case DFLTCC_QAF:
+        __msan_unpoison(param, DFLTCC_SIZEOF_QAF);
+        break;
+    case DFLTCC_GDHT:
+        __msan_unpoison(param, DFLTCC_SIZEOF_GDHT_V0);
+        break;
+    case DFLTCC_CMPR:
+        __msan_unpoison(param, DFLTCC_SIZEOF_CMPR_XPND_V0);
+        __msan_unpoison(orig_t2, t2 - orig_t2 + (((struct dfltcc_param_v0 *)param)->sbb == 0 ? 0 : 1));
+        break;
+    case DFLTCC_XPND:
+        __msan_unpoison(param, DFLTCC_SIZEOF_CMPR_XPND_V0);
+        __msan_unpoison(orig_t2, t2 - orig_t2);
+        break;
+    }
+#endif
+
+    if (op1)
+        *op1 = t2;
+    if (len1)
+        *len1 = t3;
+    if (op2)
+        *op2 = t4;
+    if (len2)
+        *len2 = t5;
+    return (cc >> 28) & 3;
 }
 
 /*

--- a/arch/s390/self-hosted-builder/actions-runner.Dockerfile
+++ b/arch/s390/self-hosted-builder/actions-runner.Dockerfile
@@ -11,6 +11,7 @@ FROM s390x/ubuntu:20.04
 # Packages for zlib-ng testing.
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get -y install \
+        clang-11 \
         cmake \
         curl \
         gcc \
@@ -18,6 +19,7 @@ RUN apt-get update && apt-get -y install \
         jq \
         libxml2-dev \
         libxslt-dev \
+        llvm-11-tools \
         ninja-build \
         python-is-python3 \
         python3 \

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,9 +22,6 @@ if(NOT TARGET GTest::GTest)
     # Prevent overriding the parent project's compiler/linker settings for Windows
     set(gtest_force_shared_crt ON CACHE BOOL
         "Use shared (DLL) run-time lib even when Google Test is built as static lib." FORCE)
-    # Disable pthreads for simplicity
-    set(gtest_disable_pthreads ON CACHE BOOL
-        "Disable uses of pthreads in gtest." FORCE)
 
     # Allow specifying alternative Google test repository
     if(NOT DEFINED GTEST_REPOSITORY)
@@ -83,6 +80,11 @@ if(WITH_GZFILEOP)
     list(APPEND TEST_SRCS test_gzio.cc)
 endif()
 
+find_package(Threads)
+if(Threads_FOUND)
+    list(APPEND TEST_SRCS test_deflate_concurrency.cc)
+endif()
+
 add_executable(gtest_zlib test_main.cc ${TEST_SRCS})
 
 target_include_directories(gtest_zlib PRIVATE
@@ -99,6 +101,14 @@ if(WITH_SANITIZER STREQUAL "Memory")
 endif()
 
 target_link_libraries(gtest_zlib zlibstatic GTest::GTest)
+
+if(Threads_FOUND)
+    if(UNIX AND NOT APPLE)
+        # On Linux, use a workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=52590
+        target_link_libraries(gtest_zlib -Wl,--whole-archive -lpthread -Wl,--no-whole-archive)
+    endif()
+    target_link_libraries(gtest_zlib Threads::Threads)
+endif()
 
 if(ZLIB_ENABLE_TESTS)
     add_test(NAME gtest_zlib

--- a/test/test_deflate_concurrency.cc
+++ b/test/test_deflate_concurrency.cc
@@ -71,10 +71,6 @@ private:
 };
 
 TEST(deflate, concurrency) {
-#ifdef S390_DFLTCC_DEFLATE
-    GTEST_SKIP() << "XFAIL S390_DFLTCC_DEFLATE";
-#endif
-
     /* Create reusable mutator and streams. */
     Mutator mutator;
 

--- a/test/test_deflate_concurrency.cc
+++ b/test/test_deflate_concurrency.cc
@@ -1,0 +1,170 @@
+/* Test deflate() on concurrently modified next_in.
+ *
+ * Plain zlib does not document that this is supported, but in practice it tolerates this, and QEMU live migration is
+ * known to rely on this. Make sure zlib-ng tolerates this as well.
+ */
+
+#include "zbuild.h"
+#ifdef ZLIB_COMPAT
+#include "zlib.h"
+#else
+#include "zlib-ng.h"
+#endif
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cstring>
+#include <thread>
+
+static uint8_t buf[8 * 1024];
+static uint8_t zbuf[4 * 1024];
+static uint8_t tmp[8 * 1024];
+
+/* Thread that increments all bytes in buf by 1. */
+class Mutator {
+    enum class State {
+        PAUSED,
+        RUNNING,
+        STOPPED,
+    };
+
+public:
+    Mutator()
+        : m_state(State::PAUSED), m_target_state(State::PAUSED),
+          m_thread(&Mutator::run, this) {}
+    ~Mutator() {
+        transition(State::STOPPED);
+        m_thread.join();
+    }
+
+    void pause() {
+        transition(State::PAUSED);
+    }
+
+    void resume() {
+        transition(State::RUNNING);
+    }
+
+private:
+    void run() {
+        while (true) {
+            m_state.store(m_target_state);
+            if (m_state == State::PAUSED)
+                continue;
+            if (m_state == State::STOPPED)
+                break;
+            for (uint8_t & i: buf)
+                i++;
+        }
+    }
+
+    void transition(State target_state) {
+        m_target_state = target_state;
+        while (m_state != target_state) {
+        }
+    }
+
+    std::atomic<State> m_state, m_target_state;
+    std::thread m_thread;
+};
+
+TEST(deflate, concurrency) {
+#ifdef S390_DFLTCC_DEFLATE
+    GTEST_SKIP() << "XFAIL S390_DFLTCC_DEFLATE";
+#endif
+
+    /* Create reusable mutator and streams. */
+    Mutator mutator;
+
+    PREFIX3(stream) dstrm;
+    memset(&dstrm, 0, sizeof(dstrm));
+    int err = PREFIX(deflateInit2)(&dstrm, Z_BEST_SPEED, Z_DEFLATED, -15, 8, Z_DEFAULT_STRATEGY);
+    ASSERT_EQ(Z_OK, err) << dstrm.msg;
+
+    PREFIX3(stream) istrm;
+    memset(&istrm, 0, sizeof(istrm));
+    err = PREFIX(inflateInit2)(&istrm, -15);
+    ASSERT_EQ(Z_OK, err) << istrm.msg;
+
+    /* Iterate for a certain amount of time. */
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+    while (std::chrono::steady_clock::now() < deadline) {
+        /* Start each iteration with a fresh stream state. */
+        err = PREFIX(deflateReset)(&dstrm);
+        ASSERT_EQ(Z_OK, err) << dstrm.msg;
+
+        err = PREFIX(inflateReset)(&istrm);
+        ASSERT_EQ(Z_OK, err) << istrm.msg;
+
+        /* Mutate and compress the first half of buf concurrently.
+         * Decompress and throw away the results, which are unpredictable.
+         */
+        mutator.resume();
+        dstrm.next_in = buf;
+        dstrm.avail_in = sizeof(buf) / 2;
+        while (dstrm.avail_in > 0) {
+            dstrm.next_out = zbuf;
+            dstrm.avail_out = sizeof(zbuf);
+            err = PREFIX(deflate)(&dstrm, Z_NO_FLUSH);
+            ASSERT_EQ(Z_OK, err) << dstrm.msg;
+            istrm.next_in = zbuf;
+            istrm.avail_in = sizeof(zbuf) - dstrm.avail_out;
+            while (istrm.avail_in > 0) {
+                istrm.next_out = tmp;
+                istrm.avail_out = sizeof(tmp);
+                err = PREFIX(inflate)(&istrm, Z_NO_FLUSH);
+                ASSERT_EQ(Z_OK, err) << istrm.msg;
+            }
+        }
+
+        /* Stop mutation and compress the second half of buf.
+         * Decompress and check that the result matches.
+         */
+        mutator.pause();
+        dstrm.next_in = buf + sizeof(buf) / 2;
+        dstrm.avail_in = sizeof(buf) - sizeof(buf) / 2;
+        while (dstrm.avail_in > 0) {
+            dstrm.next_out = zbuf;
+            dstrm.avail_out = sizeof(zbuf);
+            err = PREFIX(deflate)(&dstrm, Z_FINISH);
+            if (err == Z_STREAM_END)
+                ASSERT_EQ(0u, dstrm.avail_in);
+            else
+                ASSERT_EQ(Z_OK, err) << dstrm.msg;
+            istrm.next_in = zbuf;
+            istrm.avail_in = sizeof(zbuf) - dstrm.avail_out;
+            while (istrm.avail_in > 0) {
+                size_t orig_total_out = istrm.total_out;
+                istrm.next_out = tmp;
+                istrm.avail_out = sizeof(tmp);
+                err = PREFIX(inflate)(&istrm, Z_NO_FLUSH);
+                if (err == Z_STREAM_END)
+                    ASSERT_EQ(0u, istrm.avail_in);
+                else
+                    ASSERT_EQ(Z_OK, err) << istrm.msg;
+                size_t concurrent_size = sizeof(buf) - sizeof(buf) / 2;
+                if (istrm.total_out > concurrent_size) {
+                    size_t tmp_offset, buf_offset, size;
+                    if (orig_total_out >= concurrent_size) {
+                        tmp_offset = 0;
+                        buf_offset = orig_total_out - concurrent_size;
+                        size = istrm.total_out - orig_total_out;
+                    } else {
+                        tmp_offset = concurrent_size - orig_total_out;
+                        buf_offset = 0;
+                        size = istrm.total_out - concurrent_size;
+                    }
+                    ASSERT_EQ(0, memcmp(tmp + tmp_offset, buf + sizeof(buf) / 2 + buf_offset, size));
+                }
+            }
+        }
+    }
+
+    err = PREFIX(inflateEnd)(&istrm);
+    ASSERT_EQ(Z_OK, err) << istrm.msg;
+
+    err = PREFIX(deflateEnd)(&dstrm);
+    ASSERT_EQ(Z_OK, err) << istrm.msg;
+}


### PR DESCRIPTION
Hi,

I'd like to gather some opinions on how to proceed with this.
I tried to initiate a discussion on the zlib mailing list, but it never got past the moderator, so only people on Cc: received my message:

```
Hello zlib developers,

I've been investigating a problem in the QEMU test suite on IBM Z [1]
[2] in connection with the IBM Z compression accelerator patch [3].

The problem is that a QEMU thread compresses data that is being
modified by another QEMU thread. zlib manual [4] does not state that
this is safe, however, the current stable zlib in fact tolerates it.

The accelerator, however, does not: not only what it compresses ends up
being unpredictable - QEMU actually resolves this just fine -
but the accelerator's internal state also ends up being corrupted.

I have a design question in connection to this: does zlib guarantee
that modifying deflate() input concurrently with deflate() is safe?
Or does it reserve the right to change this in the future versions?

Cc:ing zlib-ng folks for their opinion as well.

[1] https://lists.gnu.org/archive/html/qemu-devel/2022-03/msg06841.html
[2] https://lists.gnu.org/archive/html/qemu-devel/2022-04/msg00329.html
[3] https://github.com/madler/zlib/pull/410
[4] https://zlib.net/manual.html

Best regards,
Ilya
```

So far I got only the following responses from Dr. David Alan Gilbert:

```
Specifically what qemu does is :

    a) write block of RAM
    b) <notices block changed)
    c) write block of RAM again

we don't care whether (a)'s data is coherent on the destination
since we know we're going to keep rewriting it (c) until it stabilises.
So we accept undefined decoding of (a) under the assumption that the
stream will still be a valid stream and that a change in one instance
won't affect a future encoding to be invalid.  Is that assumption
correct?
```

and from @mtl1979:

```
Then the only issue is that the internal state used by hardware deflate
acceleration gets out of sync when the data is changed and compression is
restarted from known "good" position... As I said, in that case, the internal
state used by the accelerator needs to be either reset or resynced with the
state structure. As the code flow is unique to this specific "accelerator", it
is responsibility of the accelerator to detect it, not generic compression
code (in either zlib or zlib-ng).
```

I put some more details regarding the fix into the commit message: https://github.com/zlib-ng/zlib-ng/commit/28429507d69a5138a2f83ff3dba38e34cb56480e

Best regards,
Ilya