### PR TITLE
Don't force CMAKE_BUILD_TYPE on multi config generators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,13 +59,15 @@ endif()
 
 # Make sure we use an appropriate BUILD_TYPE by default, "Release" to be exact
 # this should select the maximum generic optimisation on the current platform (i.e. -O3 for gcc/clang)
-if(NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE "Release" CACHE STRING
-        "Choose the type of build, standard options are: Debug Release RelWithDebInfo MinSizeRel."
-        FORCE)
-    add_feature_info(CMAKE_BUILD_TYPE 1 "Build type: ${CMAKE_BUILD_TYPE} (default)")
-else()
-    add_feature_info(CMAKE_BUILD_TYPE 1 "Build type: ${CMAKE_BUILD_TYPE} (selected)")
+if(NOT GENERATOR_IS_MULTI_CONFIG)
+    if(NOT CMAKE_BUILD_TYPE)
+        set(CMAKE_BUILD_TYPE "Release" CACHE STRING
+            "Choose the type of build, standard options are: Debug Release RelWithDebInfo MinSizeRel."
+            FORCE)
+        add_feature_info(CMAKE_BUILD_TYPE 1 "Build type: ${CMAKE_BUILD_TYPE} (default)")
+    else()
+        add_feature_info(CMAKE_BUILD_TYPE 1 "Build type: ${CMAKE_BUILD_TYPE} (selected)")
+    endif()
 endif()
 
 #


### PR DESCRIPTION
This issue is currently causing problems for us when building with multi-config generator such as Xcode or MSVC. If we choose `RelWithDebInfo` through `cmake .. -A Win32 && cmake --build . --config RelWithDebInfo` then it ends up building in `Release` build type which conflicts with the project as a whole. 

Ideally it would be better if we don't try and set `CMAKE_BUILD_TYPE` ourselves, but in leu of that..