### PR TITLE
Regression: stream adler checksum no longer matches after inflateSetDictionary (bisected)

### DIFF
--- a/test/test_dict.cc
+++ b/test/test_dict.cc
@@ -72,6 +72,7 @@ TEST(dictionary, basic) {
             EXPECT_EQ(d_stream.adler, dict_adler);
             err = PREFIX(inflateSetDictionary)(&d_stream, (const unsigned char*)dictionary,
                 (uint32_t)sizeof(dictionary));
+            EXPECT_EQ(d_stream.adler, dict_adler);
         }
         EXPECT_EQ(err, Z_OK);
     }


### PR DESCRIPTION
The latest version of zlib-ng produced a regression, detected by the flate2-rs testsuite: after setting a custom dictionary with `inflateSetDictionary`, the stream's adler checksum doesn't match that dictionary's adler checksum.

I reduced this to the new test included in this PR, and bisected with this test. This regression was introduced by commit 8550a90de4dcb8589a7d48fe308c4c45bba5a466 ("Leverage inline CRC + copy"); the test passes before that commit, and fails on or after that commit.
