### PR TITLE
IBM Z DFLTCC: Split deflate and inflate states

### DIFF
--- a/arch/s390/README.md
+++ b/arch/s390/README.md
@@ -61,7 +61,8 @@ integrated with the rest of zlib-ng using hook macros.
 ## Hook macros
 
 DFLTCC takes as arguments a parameter block, an input buffer, an output
-buffer and a window. `ZALLOC_STATE()`, `ZFREE_STATE()`, `ZCOPY_STATE()`,
+buffer and a window. `ZALLOC_DEFLATE_STATE()`, `ZALLOC_INFLATE_STATE()`,
+`ZFREE_STATE()`, `ZCOPY_DEFLATE_STATE()`, `ZCOPY_INFLATE_STATE()`,
 `ZALLOC_WINDOW()` and `TRY_FREE_WINDOW()` macros encapsulate allocation
 details for the parameter block (which is allocated alongside zlib-ng
 state) and the window (which must be page-aligned).

--- a/arch/s390/dfltcc_common.c
+++ b/arch/s390/dfltcc_common.c
@@ -12,59 +12,6 @@
    `posix_memalign' is not an option. Thus, we overallocate and take the
    aligned portion of the buffer.
 */
-static inline int is_dfltcc_enabled(void) {
-    uint64_t facilities[(DFLTCC_FACILITY / 64) + 1];
-    Z_REGISTER uint8_t r0 __asm__("r0");
-
-    memset(facilities, 0, sizeof(facilities));
-    r0 = sizeof(facilities) / sizeof(facilities[0]) - 1;
-    /* STFLE is supported since z9-109 and only in z/Architecture mode. When
-     * compiling with -m31, gcc defaults to ESA mode, however, since the kernel
-     * is 64-bit, it's always z/Architecture mode at runtime.
-     */
-    __asm__ volatile(
-#ifndef __clang__
-                     ".machinemode push\n"
-                     ".machinemode zarch\n"
-#endif
-                     "stfle %[facilities]\n"
-#ifndef __clang__
-                     ".machinemode pop\n"
-#endif
-                     : [facilities] "=Q" (facilities), [r0] "+r" (r0) :: "cc");
-    return is_bit_set((const char *)facilities, DFLTCC_FACILITY);
-}
-
-void Z_INTERNAL PREFIX(dfltcc_reset)(PREFIX3(streamp) strm, uInt size) {
-    struct dfltcc_state *dfltcc_state = (struct dfltcc_state *)((char *)strm->state + ALIGN_UP(size, 8));
-    struct dfltcc_qaf_param *param = (struct dfltcc_qaf_param *)&dfltcc_state->param;
-
-    /* Initialize available functions */
-    if (is_dfltcc_enabled()) {
-        dfltcc(DFLTCC_QAF, param, NULL, NULL, NULL, NULL, NULL);
-        memmove(&dfltcc_state->af, param, sizeof(dfltcc_state->af));
-    } else
-        memset(&dfltcc_state->af, 0, sizeof(dfltcc_state->af));
-
-    /* Initialize parameter block */
-    memset(&dfltcc_state->param, 0, sizeof(dfltcc_state->param));
-    dfltcc_state->param.nt = 1;
-
-    /* Initialize tuning parameters */
-    dfltcc_state->level_mask = DFLTCC_LEVEL_MASK;
-    dfltcc_state->block_size = DFLTCC_BLOCK_SIZE;
-    dfltcc_state->block_threshold = DFLTCC_FIRST_FHT_BLOCK_SIZE;
-    dfltcc_state->dht_threshold = DFLTCC_DHT_MIN_SAMPLE_SIZE;
-    dfltcc_state->param.ribm = DFLTCC_RIBM;
-}
-
-void Z_INTERNAL *PREFIX(dfltcc_alloc_state)(PREFIX3(streamp) strm, uInt items, uInt size) {
-    return ZALLOC(strm, ALIGN_UP(items * size, 8) + sizeof(struct dfltcc_state), sizeof(unsigned char));
-}
-
-void Z_INTERNAL PREFIX(dfltcc_copy_state)(void *dst, const void *src, uInt size) {
-    memcpy(dst, src, ALIGN_UP(size, 8) + sizeof(struct dfltcc_state));
-}
 
 static const int PAGE_ALIGN = 0x1000;
 

--- a/arch/s390/dfltcc_common.h
+++ b/arch/s390/dfltcc_common.h
@@ -3,17 +3,10 @@
 
 #include "zutil.h"
 
-void Z_INTERNAL *PREFIX(dfltcc_alloc_state)(PREFIX3(streamp) strm, uInt items, uInt size);
-void Z_INTERNAL PREFIX(dfltcc_copy_state)(void *dst, const void *src, uInt size);
-void Z_INTERNAL PREFIX(dfltcc_reset)(PREFIX3(streamp) strm, uInt size);
 void Z_INTERNAL *PREFIX(dfltcc_alloc_window)(PREFIX3(streamp) strm, uInt items, uInt size);
 void Z_INTERNAL PREFIX(dfltcc_free_window)(PREFIX3(streamp) strm, void *w);
 
-#define ZALLOC_STATE PREFIX(dfltcc_alloc_state)
-
 #define ZFREE_STATE ZFREE
-
-#define ZCOPY_STATE PREFIX(dfltcc_copy_state)
 
 #define ZALLOC_WINDOW PREFIX(dfltcc_alloc_window)
 

--- a/arch/s390/dfltcc_deflate.h
+++ b/arch/s390/dfltcc_deflate.h
@@ -3,6 +3,9 @@
 
 #include "dfltcc_common.h"
 
+void Z_INTERNAL *PREFIX(dfltcc_alloc_deflate_state)(PREFIX3(streamp));
+void Z_INTERNAL PREFIX(dfltcc_reset_deflate_state)(PREFIX3(streamp));
+void Z_INTERNAL PREFIX(dfltcc_copy_deflate_state)(void *dst, const void *src);
 int Z_INTERNAL PREFIX(dfltcc_can_deflate)(PREFIX3(streamp) strm);
 int Z_INTERNAL PREFIX(dfltcc_deflate)(PREFIX3(streamp) strm, int flush, block_state *result);
 int Z_INTERNAL PREFIX(dfltcc_deflate_params)(PREFIX3(streamp) strm, int level, int strategy, int *flush);
@@ -11,6 +14,9 @@ int Z_INTERNAL PREFIX(dfltcc_can_set_reproducible)(PREFIX3(streamp) strm, int re
 int Z_INTERNAL PREFIX(dfltcc_deflate_set_dictionary)(PREFIX3(streamp) strm,
                                                 const unsigned char *dictionary, uInt dict_length);
 int Z_INTERNAL PREFIX(dfltcc_deflate_get_dictionary)(PREFIX3(streamp) strm, unsigned char *dictionary, uInt* dict_length);
+
+#define ZALLOC_DEFLATE_STATE PREFIX(dfltcc_alloc_deflate_state)
+#define ZCOPY_DEFLATE_STATE PREFIX(dfltcc_copy_deflate_state)
 
 #define DEFLATE_SET_DICTIONARY_HOOK(strm, dict, dict_len) \
     do { \
@@ -24,8 +30,7 @@ int Z_INTERNAL PREFIX(dfltcc_deflate_get_dictionary)(PREFIX3(streamp) strm, unsi
             return PREFIX(dfltcc_deflate_get_dictionary)((strm), (dict), (dict_len)); \
     } while (0)
 
-#define DEFLATE_RESET_KEEP_HOOK(strm) \
-    PREFIX(dfltcc_reset)((strm), sizeof(deflate_state))
+#define DEFLATE_RESET_KEEP_HOOK PREFIX(dfltcc_reset_deflate_state)
 
 #define DEFLATE_PARAMS_HOOK(strm, level, strategy, hook_flush) \
     do { \

--- a/arch/s390/dfltcc_inflate.c
+++ b/arch/s390/dfltcc_inflate.c
@@ -20,6 +20,21 @@
 #include "dfltcc_inflate.h"
 #include "dfltcc_detail.h"
 
+struct inflate_state Z_INTERNAL *PREFIX(dfltcc_alloc_inflate_state)(PREFIX3(streamp) strm) {
+    return (struct inflate_state *)dfltcc_alloc_state(strm, sizeof(struct inflate_state), sizeof(struct dfltcc_state));
+}
+
+void Z_INTERNAL PREFIX(dfltcc_reset_inflate_state)(PREFIX3(streamp) strm) {
+    struct inflate_state *state = (struct inflate_state *)strm->state;
+    struct dfltcc_state *dfltcc_state = GET_DFLTCC_STATE(state);
+
+    dfltcc_reset_state(dfltcc_state);
+}
+
+void Z_INTERNAL PREFIX(dfltcc_copy_inflate_state)(struct inflate_state *dst, const struct inflate_state *src) {
+    dfltcc_copy_state(dst, src, sizeof(struct inflate_state), sizeof(struct dfltcc_state));
+}
+
 int Z_INTERNAL PREFIX(dfltcc_can_inflate)(PREFIX3(streamp) strm) {
     struct inflate_state *state = (struct inflate_state *)strm->state;
     struct dfltcc_state *dfltcc_state = GET_DFLTCC_STATE(state);

--- a/arch/s390/dfltcc_inflate.h
+++ b/arch/s390/dfltcc_inflate.h
@@ -3,6 +3,9 @@
 
 #include "dfltcc_common.h"
 
+struct inflate_state Z_INTERNAL *PREFIX(dfltcc_alloc_inflate_state)(PREFIX3(streamp) strm);
+void Z_INTERNAL PREFIX(dfltcc_reset_inflate_state)(PREFIX3(streamp) strm);
+void Z_INTERNAL PREFIX(dfltcc_copy_inflate_state)(struct inflate_state *dst, const struct inflate_state *src);
 int Z_INTERNAL PREFIX(dfltcc_can_inflate)(PREFIX3(streamp) strm);
 typedef enum {
     DFLTCC_INFLATE_CONTINUE,
@@ -13,8 +16,10 @@ dfltcc_inflate_action Z_INTERNAL PREFIX(dfltcc_inflate)(PREFIX3(streamp) strm, i
 int Z_INTERNAL PREFIX(dfltcc_was_inflate_used)(PREFIX3(streamp) strm);
 int Z_INTERNAL PREFIX(dfltcc_inflate_disable)(PREFIX3(streamp) strm);
 
-#define INFLATE_RESET_KEEP_HOOK(strm) \
-    PREFIX(dfltcc_reset)((strm), sizeof(struct inflate_state))
+#define ZALLOC_INFLATE_STATE PREFIX(dfltcc_alloc_inflate_state)
+#define ZCOPY_INFLATE_STATE PREFIX(dfltcc_copy_inflate_state)
+
+#define INFLATE_RESET_KEEP_HOOK PREFIX(dfltcc_reset_inflate_state)
 
 #define INFLATE_PRIME_HOOK(strm, bits, value) \
     do { if (PREFIX(dfltcc_inflate_disable)((strm))) return Z_STREAM_ERROR; } while (0)

--- a/deflate.c
+++ b/deflate.c
@@ -68,9 +68,9 @@ const char PREFIX(deflate_copyright)[] = " deflate 1.2.11.f Copyright 1995-2016 
 #  include "arch/s390/dfltcc_deflate.h"
 #else
 /* Memory management for the deflate state. Useful for allocating arch-specific extension blocks. */
-#  define ZALLOC_STATE(strm, items, size) ZALLOC(strm, items, size)
+#  define ZALLOC_DEFLATE_STATE(strm) ((deflate_state *)ZALLOC(strm, 1, sizeof(deflate_state)))
 #  define ZFREE_STATE(strm, addr) ZFREE(strm, addr)
-#  define ZCOPY_STATE(dst, src, size) memcpy(dst, src, size)
+#  define ZCOPY_DEFLATE_STATE(dst, src) memcpy(dst, src, sizeof(deflate_state))
 /* Memory management for the window. Useful for allocation the aligned window. */
 #  define ZALLOC_WINDOW(strm, items, size) ZALLOC(strm, items, size)
 #  define TRY_FREE_WINDOW(strm, addr) TRY_FREE(strm, addr)
@@ -230,7 +230,7 @@ int32_t Z_EXPORT PREFIX(deflateInit2_)(PREFIX3(stream) *strm, int32_t level, int
     if (windowBits == 8)
         windowBits = 9;  /* until 256-byte window bug fixed */
 
-    s = (deflate_state *) ZALLOC_STATE(strm, 1, sizeof(deflate_state));
+    s = ZALLOC_DEFLATE_STATE(strm);
     if (s == NULL)
         return Z_MEM_ERROR;
     strm->state = (struct internal_state *)s;
@@ -1024,11 +1024,11 @@ int32_t Z_EXPORT PREFIX(deflateCopy)(PREFIX3(stream) *dest, PREFIX3(stream) *sou
 
     memcpy((void *)dest, (void *)source, sizeof(PREFIX3(stream)));
 
-    ds = (deflate_state *) ZALLOC_STATE(dest, 1, sizeof(deflate_state));
+    ds = ZALLOC_DEFLATE_STATE(dest);
     if (ds == NULL)
         return Z_MEM_ERROR;
     dest->state = (struct internal_state *) ds;
-    ZCOPY_STATE((void *)ds, (void *)ss, sizeof(deflate_state));
+    ZCOPY_DEFLATE_STATE(ds, ss);
     ds->strm = dest;
 
 #ifdef X86_PCLMULQDQ_CRC

--- a/infback.c
+++ b/infback.c
@@ -40,7 +40,7 @@ int32_t Z_EXPORT PREFIX(inflateBackInit_)(PREFIX3(stream) *strm, int32_t windowB
     }
     if (strm->zfree == NULL)
         strm->zfree = zng_cfree;
-    state = (struct inflate_state *)ZALLOC_STATE(strm, 1, sizeof(struct inflate_state));
+    state = ZALLOC_INFLATE_STATE(strm);
     if (state == NULL)
         return Z_MEM_ERROR;
     Tracev((stderr, "inflate: allocated\n"));

--- a/inflate.c
+++ b/inflate.c
@@ -145,7 +145,7 @@ int32_t Z_EXPORT PREFIX(inflateInit2_)(PREFIX3(stream) *strm, int32_t windowBits
     }
     if (strm->zfree == NULL)
         strm->zfree = zng_cfree;
-    state = (struct inflate_state *) ZALLOC_STATE(strm, 1, sizeof(struct inflate_state));
+    state = ZALLOC_INFLATE_STATE(strm);
     if (state == NULL)
         return Z_MEM_ERROR;
     Tracev((stderr, "inflate: allocated\n"));
@@ -1278,7 +1278,7 @@ int32_t Z_EXPORT PREFIX(inflateCopy)(PREFIX3(stream) *dest, PREFIX3(stream) *sou
     state = (struct inflate_state *)source->state;
 
     /* allocate space */
-    copy = (struct inflate_state *)ZALLOC_STATE(source, 1, sizeof(struct inflate_state));
+    copy = ZALLOC_INFLATE_STATE(source);
     if (copy == NULL)
         return Z_MEM_ERROR;
     window = NULL;
@@ -1293,7 +1293,7 @@ int32_t Z_EXPORT PREFIX(inflateCopy)(PREFIX3(stream) *dest, PREFIX3(stream) *sou
 
     /* copy state */
     memcpy((void *)dest, (void *)source, sizeof(PREFIX3(stream)));
-    ZCOPY_STATE((void *)copy, (void *)state, sizeof(struct inflate_state));
+    ZCOPY_INFLATE_STATE(copy, state);
     copy->strm = dest;
     if (state->lencode >= state->codes && state->lencode <= state->codes + ENOUGH - 1) {
         copy->lencode = copy->codes + (state->lencode - state->codes);

--- a/inflate_p.h
+++ b/inflate_p.h
@@ -10,9 +10,9 @@
 #  include "arch/s390/dfltcc_inflate.h"
 #else
 /* Memory management for the inflate state. Useful for allocating arch-specific extension blocks. */
-#  define ZALLOC_STATE(strm, items, size) ZALLOC(strm, items, size)
+#  define ZALLOC_INFLATE_STATE(strm) ((struct inflate_state *)ZALLOC(strm, 1, sizeof(struct inflate_state)))
 #  define ZFREE_STATE(strm, addr) ZFREE(strm, addr)
-#  define ZCOPY_STATE(dst, src, size) memcpy(dst, src, size)
+#  define ZCOPY_INFLATE_STATE(dst, src) memcpy(dst, src, sizeof(struct inflate_state))
 /* Memory management for the window. Useful for allocation the aligned window. */
 #  define ZALLOC_WINDOW(strm, items, size) ZALLOC(strm, items, size)
 #  define ZFREE_WINDOW(strm, addr) ZFREE(strm, addr)


### PR DESCRIPTION
Hi,

I implemented this patch in context of the buffering discussion, but I believe it makes sense on its own.

---

Currently deflate and inflate both use a common state struct. There are
several variables in this struct that we don't need for inflate, and
more may be coming in the future. Therefore split them in two separate
structs. This in turn requires splitting ZALLOC_STATE and ZCOPY_STATE
macros.