### PR TITLE
Disable redirection to 64-bit function variants when Z_SOLO is defined

### DIFF
--- a/zlib.h.in
+++ b/zlib.h.in
@@ -1803,7 +1803,7 @@ Z_EXTERN int Z_EXPORT gzgetc_(gzFile file);  /* backward compatibility */
 #endif
 #endif
 
-#if !defined(Z_INTERNAL) && defined(Z_WANT64)
+#if !defined(Z_SOLO) && !defined(Z_INTERNAL) && defined(Z_WANT64)
 #    define @ZLIB_SYMBOL_PREFIX@gzopen @ZLIB_SYMBOL_PREFIX@gzopen64
 #    define @ZLIB_SYMBOL_PREFIX@gzseek @ZLIB_SYMBOL_PREFIX@gzseek64
 #    define @ZLIB_SYMBOL_PREFIX@gztell @ZLIB_SYMBOL_PREFIX@gztell64
@@ -1821,13 +1821,15 @@ Z_EXTERN int Z_EXPORT gzgetc_(gzFile file);  /* backward compatibility */
      Z_EXTERN void Z_EXPORT @ZLIB_SYMBOL_PREFIX@crc32_combine_gen64(uint32_t *op, z_off64_t);
 #  endif
 #else
-   Z_EXTERN gzFile Z_EXPORT gzopen(const char *, const char *);
-   Z_EXTERN z_off_t Z_EXPORT gzseek(gzFile, z_off_t, int);
-   Z_EXTERN z_off_t Z_EXPORT gztell(gzFile);
-   Z_EXTERN z_off_t Z_EXPORT gzoffset(gzFile);
-   Z_EXTERN unsigned long Z_EXPORT adler32_combine(unsigned long, unsigned long, z_off_t);
-   Z_EXTERN unsigned long Z_EXPORT crc32_combine(unsigned long, unsigned long, z_off_t);
-   Z_EXTERN void Z_EXPORT crc32_combine_gen(uint32_t *op, z_off_t);
+#  ifndef Z_SOLO
+   Z_EXTERN gzFile Z_EXPORT @ZLIB_SYMBOL_PREFIX@gzopen(const char *, const char *);
+   Z_EXTERN z_off_t Z_EXPORT @ZLIB_SYMBOL_PREFIX@gzseek(gzFile, z_off_t, int);
+   Z_EXTERN z_off_t Z_EXPORT @ZLIB_SYMBOL_PREFIX@gztell(gzFile);
+   Z_EXTERN z_off_t Z_EXPORT @ZLIB_SYMBOL_PREFIX@gzoffset(gzFile);
+#  endif   
+   Z_EXTERN unsigned long Z_EXPORT @ZLIB_SYMBOL_PREFIX@adler32_combine(unsigned long, unsigned long, z_off_t);
+   Z_EXTERN unsigned long Z_EXPORT @ZLIB_SYMBOL_PREFIX@crc32_combine(unsigned long, unsigned long, z_off_t);
+   Z_EXTERN void Z_EXPORT @ZLIB_SYMBOL_PREFIX@crc32_combine_gen(uint32_t *op, z_off_t);
 #endif
 
 /* undocumented functions */


### PR DESCRIPTION
See #1262.