### PR TITLE
Fixed warning about strict prototypes for cpu_check_features.

### DIFF
--- a/cpu_features.h
+++ b/cpu_features.h
@@ -19,7 +19,7 @@
 #  include "arch/s390/s390_features.h"
 #endif
 
-extern void cpu_check_features();
+extern void cpu_check_features(void);
 
 /* adler32 */
 typedef uint32_t (*adler32_func)(uint32_t adler, const unsigned char *buf, size_t len);


### PR DESCRIPTION
This warning happens for every time `cpu_features.h` is included:
```c
cpu_features.h:22:31: warning: this function declaration is not a prototype [-Wstrict-prototypes]
extern void cpu_check_features();
                              ^
                               void
```
In cpu_features.c it is defined as:
```c
Z_INTERNAL void cpu_check_features(void)
```