### PR TITLE
Fix MSVC possible loss of data warning in crc32_pclmulqdq.

### DIFF
--- a/adler32.c
+++ b/adler32.c
@@ -8,7 +8,7 @@
 #include "adler32_p.h"
 
 /* ========================================================================= */
-Z_INTERNAL uint32_t adler32_c(uint32_t adler, const unsigned char *buf, size_t len) {
+Z_INTERNAL uint32_t adler32_c(uint32_t adler, const unsigned char *buf, uint64_t len) {
     uint32_t sum2;
     unsigned n;
 

--- a/adler32.c
+++ b/adler32.c
@@ -8,7 +8,7 @@
 #include "adler32_p.h"
 
 /* ========================================================================= */
-Z_INTERNAL uint32_t adler32_c(uint32_t adler, const unsigned char *buf, uint64_t len) {
+Z_INTERNAL uint32_t adler32_c(uint32_t adler, const uint8_t *buf, uint64_t len) {
     uint32_t sum2;
     unsigned n;
 

--- a/adler32_fold.c
+++ b/adler32_fold.c
@@ -1,5 +1,5 @@
 /* adler32_fold.c -- adler32 folding interface
- * Copyright (C) 2022 Adam Stylinski 
+ * Copyright (C) 2022 Adam Stylinski
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
@@ -7,7 +7,16 @@
 #include "functable.h"
 #include "adler32_fold.h"
 
-Z_INTERNAL uint32_t adler32_fold_copy_c(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len) {
-    memcpy(dst, src, len);
-    return functable.adler32(adler, src, len);
+Z_INTERNAL uint32_t adler32_fold_copy_c(uint32_t adler, uint8_t *dst, const uint8_t *src, uint64_t len) {
+    adler = functable.adler32(adler, src, len);
+    while (len > SIZE_MAX) {
+        memcpy(dst, src, SIZE_MAX);
+        dst += SIZE_MAX;
+        src += SIZE_MAX;
+        len -= SIZE_MAX;
+    }
+    if (len) {
+        memcpy(dst, src, (size_t)len);
+    }
+    return adler;
 }

--- a/adler32_fold.h
+++ b/adler32_fold.h
@@ -6,6 +6,6 @@
 #ifndef ADLER32_FOLD_H_
 #define ADLER32_FOLD_H_
 
-Z_INTERNAL uint32_t adler32_fold_copy_c(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len);
+Z_INTERNAL uint32_t adler32_fold_copy_c(uint32_t adler, uint8_t *dst, const uint8_t *src, uint64_t len);
 
 #endif

--- a/adler32_p.h
+++ b/adler32_p.h
@@ -26,7 +26,7 @@ static inline uint32_t adler32_len_1(uint32_t adler, const unsigned char *buf, u
     return adler | (sum2 << 16);
 }
 
-static inline uint32_t adler32_len_16(uint32_t adler, const unsigned char *buf, size_t len, uint32_t sum2) {
+static inline uint32_t adler32_len_16(uint32_t adler, const unsigned char *buf, uint64_t len, uint32_t sum2) {
     while (len) {
         --len;
         adler += *buf++;
@@ -38,9 +38,9 @@ static inline uint32_t adler32_len_16(uint32_t adler, const unsigned char *buf, 
     return adler | (sum2 << 16);
 }
 
-static inline uint32_t adler32_copy_len_16(uint32_t adler, const unsigned char *buf, uint8_t *dst, size_t len, uint32_t sum2) {
+static inline uint32_t adler32_copy_len_16(uint32_t adler, const unsigned char *buf, uint8_t *dst, uint64_t len, uint32_t sum2) {
     while (len--) {
-        *dst = *buf++; 
+        *dst = *buf++;
         adler += *dst++;
         sum2 += adler;
     }
@@ -50,7 +50,7 @@ static inline uint32_t adler32_copy_len_16(uint32_t adler, const unsigned char *
     return adler | (sum2 << 16);
 }
 
-static inline uint32_t adler32_len_64(uint32_t adler, const unsigned char *buf, size_t len, uint32_t sum2) {
+static inline uint32_t adler32_len_64(uint32_t adler, const unsigned char *buf, uint64_t len, uint32_t sum2) {
 #ifdef UNROLL_MORE
     while (len >= 16) {
         len -= 16;

--- a/adler32_p.h
+++ b/adler32_p.h
@@ -18,7 +18,7 @@
 #define DO8(sum1, sum2, buf, i)  {DO4(sum1, sum2, buf, i); DO4(sum1, sum2, buf, i+4);}
 #define DO16(sum1, sum2, buf)    {DO8(sum1, sum2, buf, 0); DO8(sum1, sum2, buf, 8);}
 
-static inline uint32_t adler32_len_1(uint32_t adler, const unsigned char *buf, uint32_t sum2) {
+static inline uint32_t adler32_len_1(uint32_t adler, const uint8_t *buf, uint32_t sum2) {
     adler += buf[0];
     adler %= BASE;
     sum2 += adler;
@@ -26,7 +26,7 @@ static inline uint32_t adler32_len_1(uint32_t adler, const unsigned char *buf, u
     return adler | (sum2 << 16);
 }
 
-static inline uint32_t adler32_len_16(uint32_t adler, const unsigned char *buf, uint64_t len, uint32_t sum2) {
+static inline uint32_t adler32_len_16(uint32_t adler, const uint8_t *buf, uint64_t len, uint32_t sum2) {
     while (len) {
         --len;
         adler += *buf++;
@@ -38,7 +38,7 @@ static inline uint32_t adler32_len_16(uint32_t adler, const unsigned char *buf, 
     return adler | (sum2 << 16);
 }
 
-static inline uint32_t adler32_copy_len_16(uint32_t adler, const unsigned char *buf, uint8_t *dst, uint64_t len, uint32_t sum2) {
+static inline uint32_t adler32_copy_len_16(uint32_t adler, const uint8_t *buf, uint8_t *dst, uint64_t len, uint32_t sum2) {
     while (len--) {
         *dst = *buf++;
         adler += *dst++;
@@ -50,7 +50,7 @@ static inline uint32_t adler32_copy_len_16(uint32_t adler, const unsigned char *
     return adler | (sum2 << 16);
 }
 
-static inline uint32_t adler32_len_64(uint32_t adler, const unsigned char *buf, uint64_t len, uint32_t sum2) {
+static inline uint32_t adler32_len_64(uint32_t adler, const uint8_t *buf, uint64_t len, uint32_t sum2) {
 #ifdef UNROLL_MORE
     while (len >= 16) {
         len -= 16;

--- a/arch/arm/adler32_neon.c
+++ b/arch/arm/adler32_neon.c
@@ -15,7 +15,7 @@
 #include "../../adler32_p.h"
 #include "../../fallback_builtins.h"
 
-static void NEON_accum32(uint32_t *s, const unsigned char *buf, uint64_t len) {
+static void NEON_accum32(uint32_t *s, const uint8_t *buf, uint64_t len) {
     static const uint16_t ALIGNED_(16) taps[64] = {
         64, 63, 62, 61, 60, 59, 58, 57,
         56, 55, 54, 53, 52, 51, 50, 49,
@@ -138,7 +138,7 @@ static void NEON_accum32(uint32_t *s, const unsigned char *buf, uint64_t len) {
     s[1] = vget_lane_u32(as, 1);
 }
 
-static void NEON_handle_tail(uint32_t *pair, const unsigned char *buf, uint64_t len) {
+static void NEON_handle_tail(uint32_t *pair, const uint8_t *buf, uint64_t len) {
     unsigned int i;
     for (i = 0; i < len; ++i) {
         pair[0] += buf[i];
@@ -146,7 +146,7 @@ static void NEON_handle_tail(uint32_t *pair, const unsigned char *buf, uint64_t 
     }
 }
 
-uint32_t adler32_neon(uint32_t adler, const unsigned char *buf, uint64_t len) {
+uint32_t adler32_neon(uint32_t adler, const uint8_t *buf, uint64_t len) {
     /* split Adler-32 into component sums */
     uint32_t sum2 = (adler >> 16) & 0xffff;
     adler &= 0xffff;

--- a/arch/arm/adler32_neon.c
+++ b/arch/arm/adler32_neon.c
@@ -15,7 +15,7 @@
 #include "../../adler32_p.h"
 #include "../../fallback_builtins.h"
 
-static void NEON_accum32(uint32_t *s, const unsigned char *buf, size_t len) {
+static void NEON_accum32(uint32_t *s, const unsigned char *buf, uint64_t len) {
     static const uint16_t ALIGNED_(16) taps[64] = {
         64, 63, 62, 61, 60, 59, 58, 57,
         56, 55, 54, 53, 52, 51, 50, 49,
@@ -138,7 +138,7 @@ static void NEON_accum32(uint32_t *s, const unsigned char *buf, size_t len) {
     s[1] = vget_lane_u32(as, 1);
 }
 
-static void NEON_handle_tail(uint32_t *pair, const unsigned char *buf, size_t len) {
+static void NEON_handle_tail(uint32_t *pair, const unsigned char *buf, uint64_t len) {
     unsigned int i;
     for (i = 0; i < len; ++i) {
         pair[0] += buf[i];
@@ -146,7 +146,7 @@ static void NEON_handle_tail(uint32_t *pair, const unsigned char *buf, size_t le
     }
 }
 
-uint32_t adler32_neon(uint32_t adler, const unsigned char *buf, size_t len) {
+uint32_t adler32_neon(uint32_t adler, const unsigned char *buf, uint64_t len) {
     /* split Adler-32 into component sums */
     uint32_t sum2 = (adler >> 16) & 0xffff;
     adler &= 0xffff;

--- a/arch/arm/crc32_acle.c
+++ b/arch/arm/crc32_acle.c
@@ -11,7 +11,7 @@
 #endif
 #include "../../zbuild.h"
 
-uint32_t crc32_acle(uint32_t crc, const unsigned char *buf, uint64_t len) {
+uint32_t crc32_acle(uint32_t crc, const uint8_t *buf, uint64_t len) {
     Z_REGISTER uint32_t c;
     Z_REGISTER const uint16_t *buf2;
     Z_REGISTER const uint32_t *buf4;

--- a/arch/power/adler32_power8.c
+++ b/arch/power/adler32_power8.c
@@ -52,7 +52,7 @@ static inline vector unsigned int vec_sumsu(vector unsigned int __a, vector unsi
     return __a;
 }
 
-uint32_t adler32_power8(uint32_t adler, const unsigned char* buf, uint64_t len) {
+uint32_t adler32_power8(uint32_t adler, const uint8_t *buf, uint64_t len) {
     uint32_t s1 = adler & 0xffff;
     uint32_t s2 = (adler >> 16) & 0xffff;
 

--- a/arch/power/adler32_power8.c
+++ b/arch/power/adler32_power8.c
@@ -52,7 +52,7 @@ static inline vector unsigned int vec_sumsu(vector unsigned int __a, vector unsi
     return __a;
 }
 
-uint32_t adler32_power8(uint32_t adler, const unsigned char* buf, size_t len) {
+uint32_t adler32_power8(uint32_t adler, const unsigned char* buf, uint64_t len) {
     uint32_t s1 = adler & 0xffff;
     uint32_t s2 = (adler >> 16) & 0xffff;
 

--- a/arch/power/adler32_vmx.c
+++ b/arch/power/adler32_vmx.c
@@ -12,7 +12,7 @@
 
 #define vmx_zero()  (vec_splat_u32(0))
 
-static inline void vmx_handle_head_or_tail(uint32_t *pair, const unsigned char *buf, uint64_t len) {
+static inline void vmx_handle_head_or_tail(uint32_t *pair, const uint8_t *buf, uint64_t len) {
     unsigned int i;
     for (i = 0; i < len; ++i) {
         pair[0] += buf[i];
@@ -20,7 +20,7 @@ static inline void vmx_handle_head_or_tail(uint32_t *pair, const unsigned char *
     }
 }
 
-static void vmx_accum32(uint32_t *s, const unsigned char *buf, uint64_t len) {
+static void vmx_accum32(uint32_t *s, const uint8_t *buf, uint64_t len) {
     /* Different taps for the separable components of sums */
     const vector unsigned char t0 = {64, 63, 62, 61, 60, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49};
     const vector unsigned char t1 = {48, 47, 46, 45, 44, 43, 42, 41, 40, 39, 38, 37, 36, 35, 34, 33};
@@ -113,7 +113,7 @@ static void vmx_accum32(uint32_t *s, const unsigned char *buf, uint64_t len) {
     vec_ste(s2acc, 0, s+1);
 }
 
-uint32_t adler32_vmx(uint32_t adler, const unsigned char *buf, uint64_t len) {
+uint32_t adler32_vmx(uint32_t adler, const uint8_t *buf, uint64_t len) {
     uint32_t sum2;
     uint32_t pair[16] ALIGNED_(16);
     memset(&pair[2], 0, 14);

--- a/arch/power/adler32_vmx.c
+++ b/arch/power/adler32_vmx.c
@@ -12,7 +12,7 @@
 
 #define vmx_zero()  (vec_splat_u32(0))
 
-static inline void vmx_handle_head_or_tail(uint32_t *pair, const unsigned char *buf, size_t len) {
+static inline void vmx_handle_head_or_tail(uint32_t *pair, const unsigned char *buf, uint64_t len) {
     unsigned int i;
     for (i = 0; i < len; ++i) {
         pair[0] += buf[i];
@@ -20,7 +20,7 @@ static inline void vmx_handle_head_or_tail(uint32_t *pair, const unsigned char *
     }
 }
 
-static void vmx_accum32(uint32_t *s, const unsigned char *buf, size_t len) {
+static void vmx_accum32(uint32_t *s, const unsigned char *buf, uint64_t len) {
     /* Different taps for the separable components of sums */
     const vector unsigned char t0 = {64, 63, 62, 61, 60, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49};
     const vector unsigned char t1 = {48, 47, 46, 45, 44, 43, 42, 41, 40, 39, 38, 37, 36, 35, 34, 33};
@@ -113,7 +113,7 @@ static void vmx_accum32(uint32_t *s, const unsigned char *buf, size_t len) {
     vec_ste(s2acc, 0, s+1);
 }
 
-uint32_t adler32_vmx(uint32_t adler, const unsigned char *buf, size_t len) {
+uint32_t adler32_vmx(uint32_t adler, const unsigned char *buf, uint64_t len) {
     uint32_t sum2;
     uint32_t pair[16] ALIGNED_(16);
     memset(&pair[2], 0, 14);

--- a/arch/s390/crc32-vx.c
+++ b/arch/s390/crc32-vx.c
@@ -21,7 +21,7 @@ typedef unsigned char uv16qi __attribute__((vector_size(16)));
 typedef unsigned int uv4si __attribute__((vector_size(16)));
 typedef unsigned long long uv2di __attribute__((vector_size(16)));
 
-static uint32_t crc32_le_vgfm_16(uint32_t crc, const unsigned char *buf, uint64_t len) {
+static uint32_t crc32_le_vgfm_16(uint32_t crc, const uint8_t *buf, uint64_t len) {
     /*
      * The CRC-32 constant block contains reduction constants to fold and
      * process particular chunks of the input data stream in parallel.

--- a/arch/s390/crc32-vx.c
+++ b/arch/s390/crc32-vx.c
@@ -21,7 +21,7 @@ typedef unsigned char uv16qi __attribute__((vector_size(16)));
 typedef unsigned int uv4si __attribute__((vector_size(16)));
 typedef unsigned long long uv2di __attribute__((vector_size(16)));
 
-static uint32_t crc32_le_vgfm_16(uint32_t crc, const unsigned char *buf, size_t len) {
+static uint32_t crc32_le_vgfm_16(uint32_t crc, const unsigned char *buf, uint64_t len) {
     /*
      * The CRC-32 constant block contains reduction constants to fold and
      * process particular chunks of the input data stream in parallel.

--- a/arch/x86/adler32_avx512_tpl.h
+++ b/arch/x86/adler32_avx512_tpl.h
@@ -14,9 +14,9 @@
 #ifdef X86_AVX512_ADLER32
 
 #ifdef COPY
-Z_INTERNAL uint32_t adler32_fold_copy_avx512(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len) {
+Z_INTERNAL uint32_t adler32_fold_copy_avx512(uint32_t adler, uint8_t *dst, const uint8_t *src, uint64_t len) {
 #else
-Z_INTERNAL uint32_t adler32_avx512(uint32_t adler, const uint8_t *src, size_t len) {
+Z_INTERNAL uint32_t adler32_avx512(uint32_t adler, const uint8_t *src, uint64_t len) {
 #endif
 
     if (src == NULL) return 1L;
@@ -24,7 +24,7 @@ Z_INTERNAL uint32_t adler32_avx512(uint32_t adler, const uint8_t *src, size_t le
 
     uint32_t adler0, adler1;
     adler1 = (adler >> 16) & 0xffff;
-    adler0 = adler & 0xffff; 
+    adler0 = adler & 0xffff;
 
 rem_peel:
     if (len < 64) {
@@ -40,7 +40,7 @@ rem_peel:
 #elif defined(X86_SSSE3_ADLER32)
         return adler32_ssse3(adler, src, len);
 #else
-        return adler32_len_16(adler0, src, len, adler1); 
+        return adler32_len_16(adler0, src, len, adler1);
 #endif
     }
 
@@ -52,7 +52,7 @@ rem_peel:
                                           56, 57, 58, 59, 60, 61, 62, 63, 64);
     const __m512i dot3v = _mm512_set1_epi16(1);
     const __m512i zero = _mm512_setzero_si512();
-    size_t k;
+    uint64_t k;
 
     while (len >= 64) {
         __m512i vs1 = _mm512_zextsi128_si512(_mm_cvtsi32_si128(adler0));
@@ -100,7 +100,7 @@ rem_peel:
         goto rem_peel;
     }
 
-    return adler; 
+    return adler;
 }
 
 #endif

--- a/arch/x86/adler32_avx512_vnni.c
+++ b/arch/x86/adler32_avx512_vnni.c
@@ -18,20 +18,20 @@
 #include "adler32_avx512_p.h"
 #include "adler32_avx2_p.h"
 
-Z_INTERNAL uint32_t adler32_avx512_vnni(uint32_t adler, const uint8_t *src, size_t len) {
+Z_INTERNAL uint32_t adler32_avx512_vnni(uint32_t adler, const uint8_t *src, uint64_t len) {
     if (src == NULL) return 1L;
     if (len == 0) return adler;
 
     uint32_t adler0, adler1;
     adler1 = (adler >> 16) & 0xffff;
-    adler0 = adler & 0xffff; 
+    adler0 = adler & 0xffff;
 
 rem_peel:
     if (len < 32)
 #if defined(X86_SSSE3_ADLER32)
         return adler32_ssse3(adler, src, len);
 #else
-        return adler32_len_16(adler0, src, len, adler1); 
+        return adler32_len_16(adler0, src, len, adler1);
 #endif
 
     if (len < 64)
@@ -40,7 +40,7 @@ rem_peel:
 #elif defined(X86_SSE3_ADLER32)
         return adler32_ssse3(adler, src, len);
 #else
-        return adler32_len_16(adler0, src, len, adler1); 
+        return adler32_len_16(adler0, src, len, adler1);
 #endif
 
     const __m512i dot2v = _mm512_set_epi8(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
@@ -54,7 +54,7 @@ rem_peel:
     while (len >= 64) {
         vs1 = _mm512_zextsi128_si512(_mm_cvtsi32_si128(adler0));
         vs2 = _mm512_zextsi128_si512(_mm_cvtsi32_si128(adler1));
-        size_t k = MIN(len, NMAX);
+        uint64_t k = MIN(len, NMAX);
         k -= k % 64;
         len -= k;
         __m512i vs1_0 = vs1;
@@ -117,16 +117,16 @@ rem_peel:
         goto rem_peel;
     }
 
-    return adler; 
+    return adler;
 }
 
-Z_INTERNAL uint32_t adler32_fold_copy_avx512_vnni(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len) {
+Z_INTERNAL uint32_t adler32_fold_copy_avx512_vnni(uint32_t adler, uint8_t *dst, const uint8_t *src, uint64_t len) {
     if (src == NULL) return 1L;
     if (len == 0) return adler;
 
     uint32_t adler0, adler1;
     adler1 = (adler >> 16) & 0xffff;
-    adler0 = adler & 0xffff; 
+    adler0 = adler & 0xffff;
 
 rem_peel_copy:
     if (len < 32) {
@@ -138,7 +138,7 @@ rem_peel_copy:
 #if defined(X86_SSSE3_ADLER32)
         return adler32_ssse3(adler, src, len);
 #else
-        return adler32_len_16(adler0, src, len, adler1); 
+        return adler32_len_16(adler0, src, len, adler1);
 #endif
     }
 
@@ -151,7 +151,7 @@ rem_peel_copy:
     while (len >= 32) {
         vs1 = _mm256_zextsi128_si256(_mm_cvtsi32_si128(adler0));
         vs2 = _mm256_zextsi128_si256(_mm_cvtsi32_si128(adler1));
-        size_t k = MIN(len, NMAX);
+        uint64_t k = MIN(len, NMAX);
         k -= k % 32;
         len -= k;
         __m256i vs1_0 = vs1;
@@ -219,7 +219,7 @@ rem_peel_copy:
         goto rem_peel_copy;
     }
 
-    return adler; 
+    return adler;
 }
 
 #endif

--- a/arch/x86/adler32_sse42.c
+++ b/arch/x86/adler32_sse42.c
@@ -14,10 +14,10 @@
 
 #ifdef X86_SSE42_ADLER32
 
-Z_INTERNAL uint32_t adler32_fold_copy_sse42(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len) {
+Z_INTERNAL uint32_t adler32_fold_copy_sse42(uint32_t adler, uint8_t *dst, const uint8_t *src, uint64_t len) {
     uint32_t adler0, adler1;
     adler1 = (adler >> 16) & 0xffff;
-    adler0 = adler & 0xffff; 
+    adler0 = adler & 0xffff;
 
 rem_peel:
     if (len < 16) {
@@ -31,7 +31,7 @@ rem_peel:
     const __m128i dot2v = _mm_setr_epi8(32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17);
     const __m128i dot2v_0 = _mm_setr_epi8(16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1);
     const __m128i dot3v = _mm_set1_epi16(1);
-    size_t k;
+    uint64_t k;
 
     while (len >= 16) {
 

--- a/arch/x86/adler32_ssse3.c
+++ b/arch/x86/adler32_ssse3.c
@@ -14,7 +14,7 @@
 
 #include <immintrin.h>
 
-Z_INTERNAL uint32_t adler32_ssse3(uint32_t adler, const unsigned char *buf, uint64_t len) {
+Z_INTERNAL uint32_t adler32_ssse3(uint32_t adler, const uint8_t *buf, uint64_t len) {
     uint32_t sum2;
 
      /* split Adler-32 into component sums */

--- a/arch/x86/adler32_ssse3.c
+++ b/arch/x86/adler32_ssse3.c
@@ -14,7 +14,7 @@
 
 #include <immintrin.h>
 
-Z_INTERNAL uint32_t adler32_ssse3(uint32_t adler, const unsigned char *buf, size_t len) {
+Z_INTERNAL uint32_t adler32_ssse3(uint32_t adler, const unsigned char *buf, uint64_t len) {
     uint32_t sum2;
 
      /* split Adler-32 into component sums */
@@ -46,10 +46,10 @@ Z_INTERNAL uint32_t adler32_ssse3(uint32_t adler, const unsigned char *buf, size
      * additions worthwhile or if it's worth it to just eat the cost of an unaligned
      * load. This is a pretty simple test, just test if 16 - the remainder + len is
      * < 16 */
-    size_t max_iters = NMAX;
-    size_t rem = (uintptr_t)buf & 15;
-    size_t align_offset = 16 - rem;
-    size_t k = 0;
+    uint64_t max_iters = NMAX;
+    uint64_t rem = (uintptr_t)buf & 15;
+    uint64_t align_offset = 16 - rem;
+    uint64_t k = 0;
     if (rem) {
         if (len < 16 + align_offset) {
             /* Let's eat the cost of this one unaligned load so that

--- a/arch/x86/crc32_fold_pclmulqdq.c
+++ b/arch/x86/crc32_fold_pclmulqdq.c
@@ -341,7 +341,7 @@ Z_INTERNAL uint32_t crc32_fold_pclmulqdq_final(crc32_fold *crc) {
     return crc->value;
 }
 
-uint32_t crc32_pclmulqdq(uint32_t crc32, const unsigned char* buf, uint64_t len) {
+uint32_t crc32_pclmulqdq(uint32_t crc32, const uint8_t *buf, uint64_t len) {
     /* For lens < 64, crc32_braid method is faster. The CRC32 instruction for
      * these short lengths might also prove to be effective */
     if (len < 64)

--- a/arch/x86/crc32_fold_pclmulqdq.c
+++ b/arch/x86/crc32_fold_pclmulqdq.c
@@ -32,11 +32,11 @@
 #include <assert.h>
 
 #ifdef X86_VPCLMULQDQ_CRC
-extern size_t fold_16_vpclmulqdq(__m128i *xmm_crc0, __m128i *xmm_crc1,
-    __m128i *xmm_crc2, __m128i *xmm_crc3, const uint8_t *src, size_t len, __m128i init_crc,
+extern uint64_t fold_16_vpclmulqdq(__m128i *xmm_crc0, __m128i *xmm_crc1,
+    __m128i *xmm_crc2, __m128i *xmm_crc3, const uint8_t *src, uint64_t len, __m128i init_crc,
     int32_t first);
-extern size_t fold_16_vpclmulqdq_copy(__m128i *xmm_crc0, __m128i *xmm_crc1,
-    __m128i *xmm_crc2, __m128i *xmm_crc3, uint8_t *dst, const uint8_t *src, size_t len);
+extern uint64_t fold_16_vpclmulqdq_copy(__m128i *xmm_crc0, __m128i *xmm_crc1,
+    __m128i *xmm_crc2, __m128i *xmm_crc3, uint8_t *dst, const uint8_t *src, uint64_t len);
 #endif
 
 static void fold_1(__m128i *xmm_crc0, __m128i *xmm_crc1, __m128i *xmm_crc2, __m128i *xmm_crc3) {
@@ -185,7 +185,7 @@ static const unsigned ALIGNED_(32) pshufb_shf_table[60] = {
     0x0201008f, 0x06050403, 0x0a090807, 0x0e0d0c0b  /* shl  1 (16 -15)/shr15*/
 };
 
-static void partial_fold(const size_t len, __m128i *xmm_crc0, __m128i *xmm_crc1, __m128i *xmm_crc2,
+static void partial_fold(const uint64_t len, __m128i *xmm_crc0, __m128i *xmm_crc1, __m128i *xmm_crc2,
                          __m128i *xmm_crc3, __m128i *xmm_crc_part) {
 
     const __m128i xmm_fold4 = _mm_set_epi32( 0x00000001, 0x54442bd4,

--- a/arch/x86/crc32_fold_pclmulqdq_tpl.h
+++ b/arch/x86/crc32_fold_pclmulqdq_tpl.h
@@ -20,9 +20,9 @@
 #ifdef X86_PCLMULQDQ_CRC
 
 #ifdef COPY
-Z_INTERNAL void crc32_fold_pclmulqdq_copy(crc32_fold *crc, uint8_t *dst, const uint8_t *src, size_t len) {
+Z_INTERNAL void crc32_fold_pclmulqdq_copy(crc32_fold *crc, uint8_t *dst, const uint8_t *src, uint64_t len) {
 #else
-Z_INTERNAL void crc32_fold_pclmulqdq(crc32_fold *crc, const uint8_t *src, size_t len, uint32_t init_crc) {
+Z_INTERNAL void crc32_fold_pclmulqdq(crc32_fold *crc, const uint8_t *src, uint64_t len, uint32_t init_crc) {
 #endif
     unsigned long algn_diff;
     __m128i xmm_t0, xmm_t1, xmm_t2, xmm_t3;
@@ -47,9 +47,9 @@ Z_INTERNAL void crc32_fold_pclmulqdq(crc32_fold *crc, const uint8_t *src, size_t
         if (len == 0)
             return;
 
-        memcpy(partial_buf, src, len);
+        memcpy(partial_buf, src, (size_t)len);
         xmm_crc_part = _mm_load_si128((const __m128i *)partial_buf);
-        memcpy(dst, partial_buf, len);
+        memcpy(dst, partial_buf, (size_t)len);
 #endif
         goto partial;
     }
@@ -82,10 +82,10 @@ Z_INTERNAL void crc32_fold_pclmulqdq(crc32_fold *crc, const uint8_t *src, size_t
 #ifdef X86_VPCLMULQDQ_CRC
     if (x86_cpu_has_vpclmulqdq && x86_cpu_has_avx512 && (len >= 256)) {
 #ifdef COPY
-        size_t n = fold_16_vpclmulqdq_copy(&xmm_crc0, &xmm_crc1, &xmm_crc2, &xmm_crc3, dst, src, len);
+        uint64_t n = fold_16_vpclmulqdq_copy(&xmm_crc0, &xmm_crc1, &xmm_crc2, &xmm_crc3, dst, src, len);
         dst += n;
 #else
-        size_t n = fold_16_vpclmulqdq(&xmm_crc0, &xmm_crc1, &xmm_crc2, &xmm_crc3, src, len,
+        uint64_t n = fold_16_vpclmulqdq(&xmm_crc0, &xmm_crc1, &xmm_crc2, &xmm_crc3, src, len,
             xmm_initial, first);
         first = 0;
 #endif
@@ -176,10 +176,10 @@ Z_INTERNAL void crc32_fold_pclmulqdq(crc32_fold *crc, const uint8_t *src, size_t
 
 partial:
     if (len) {
-        memcpy(&xmm_crc_part, src, len);
+        memcpy(&xmm_crc_part, src, (size_t)len);
 #ifdef COPY
         _mm_storeu_si128((__m128i *)partial_buf, xmm_crc_part);
-        memcpy(dst, partial_buf, len);
+        memcpy(dst, partial_buf, (size_t)len);
 #endif
         partial_fold((size_t)len, &xmm_crc0, &xmm_crc1, &xmm_crc2, &xmm_crc3, &xmm_crc_part);
     }

--- a/arch/x86/crc32_fold_vpclmulqdq_tpl.h
+++ b/arch/x86/crc32_fold_vpclmulqdq_tpl.h
@@ -4,18 +4,18 @@
  */
 
 #ifdef COPY
-size_t fold_16_vpclmulqdq_copy(__m128i *xmm_crc0, __m128i *xmm_crc1,
-    __m128i *xmm_crc2, __m128i *xmm_crc3, uint8_t *dst, const uint8_t *src, size_t len) {
+uint64_t fold_16_vpclmulqdq_copy(__m128i *xmm_crc0, __m128i *xmm_crc1,
+    __m128i *xmm_crc2, __m128i *xmm_crc3, uint8_t *dst, const uint8_t *src, uint64_t len) {
 #else
-size_t fold_16_vpclmulqdq(__m128i *xmm_crc0, __m128i *xmm_crc1,
-    __m128i *xmm_crc2, __m128i *xmm_crc3, const uint8_t *src, size_t len,
+uint64_t fold_16_vpclmulqdq(__m128i *xmm_crc0, __m128i *xmm_crc1,
+    __m128i *xmm_crc2, __m128i *xmm_crc3, const uint8_t *src, uint64_t len,
     __m128i init_crc, int32_t first) {
     __m512i zmm_initial = _mm512_zextsi128_si512(init_crc);
 #endif
     __m512i zmm_t0, zmm_t1, zmm_t2, zmm_t3;
     __m512i zmm_crc0, zmm_crc1, zmm_crc2, zmm_crc3;
     __m512i z0, z1, z2, z3;
-    size_t len_tmp = len;
+    uint64_t len_tmp = len;
     const __m512i zmm_fold4 = _mm512_set4_epi32(
         0x00000001, 0x54442bd4, 0x00000001, 0xc6e41596);
     const __m512i zmm_fold16 = _mm512_set4_epi32(

--- a/cpu_features.h
+++ b/cpu_features.h
@@ -23,29 +23,29 @@
 extern void cpu_check_features(void);
 
 /* adler32 */
-typedef uint32_t (*adler32_func)(uint32_t adler, const unsigned char *buf, uint64_t len);
+typedef uint32_t (*adler32_func)(uint32_t adler, const uint8_t *buf, uint64_t len);
 
-extern uint32_t adler32_c(uint32_t adler, const unsigned char *buf, uint64_t len);
+extern uint32_t adler32_c(uint32_t adler, const uint8_t *buf, uint64_t len);
 #ifdef ARM_NEON_ADLER32
-extern uint32_t adler32_neon(uint32_t adler, const unsigned char *buf, uint64_t len);
+extern uint32_t adler32_neon(uint32_t adler, const uint8_t *buf, uint64_t len);
 #endif
 #ifdef PPC_VMX_ADLER32
-extern uint32_t adler32_vmx(uint32_t adler, const unsigned char *buf, uint64_t len);
+extern uint32_t adler32_vmx(uint32_t adler, const uint8_t *buf, uint64_t len);
 #endif
 #ifdef X86_SSSE3_ADLER32
-extern uint32_t adler32_ssse3(uint32_t adler, const unsigned char *buf, uint64_t len);
+extern uint32_t adler32_ssse3(uint32_t adler, const uint8_t *buf, uint64_t len);
 #endif
 #ifdef X86_AVX2_ADLER32
-extern uint32_t adler32_avx2(uint32_t adler, const unsigned char *buf, uint64_t len);
+extern uint32_t adler32_avx2(uint32_t adler, const uint8_t *buf, uint64_t len);
 #endif
 #ifdef X86_AVX512_ADLER32
-extern uint32_t adler32_avx512(uint32_t adler, const unsigned char *buf, uint64_t len);
+extern uint32_t adler32_avx512(uint32_t adler, const uint8_t *buf, uint64_t len);
 #endif
 #ifdef X86_AVX512VNNI_ADLER32
-extern uint32_t adler32_avx512_vnni(uint32_t adler, const unsigned char *buf, uint64_t len);
+extern uint32_t adler32_avx512_vnni(uint32_t adler, const uint8_t *buf, uint64_t len);
 #endif
 #ifdef POWER8_VSX_ADLER32
-extern uint32_t adler32_power8(uint32_t adler, const unsigned char* buf, uint64_t len);
+extern uint32_t adler32_power8(uint32_t adler, const uint8_t *buf, uint64_t len);
 #endif
 
 /* adler32 folding */
@@ -68,7 +68,7 @@ extern uint32_t crc32_fold_pclmulqdq_reset(crc32_fold *crc);
 extern void     crc32_fold_pclmulqdq_copy(crc32_fold *crc, uint8_t *dst, const uint8_t *src, uint64_t len);
 extern void     crc32_fold_pclmulqdq(crc32_fold *crc, const uint8_t *src, uint64_t len, uint32_t init_crc);
 extern uint32_t crc32_fold_pclmulqdq_final(crc32_fold *crc);
-extern uint32_t crc32_pclmulqdq(uint32_t crc32, const unsigned char* buf, uint64_t len);
+extern uint32_t crc32_pclmulqdq(uint32_t crc32, const uint8_t *buf, uint64_t len);
 #endif
 
 /* memory chunking */
@@ -116,15 +116,15 @@ extern uint8_t* chunkmemset_safe_power8(uint8_t *out, unsigned dist, unsigned le
 #endif
 
 /* CRC32 */
-typedef uint32_t (*crc32_func)(uint32_t crc32, const unsigned char * buf, uint64_t len);
+typedef uint32_t (*crc32_func)(uint32_t crc32, const uint8_t *buf, uint64_t len);
 
-extern uint32_t crc32_braid(uint32_t crc, const unsigned char *buf, uint64_t len);
+extern uint32_t crc32_braid(uint32_t crc, const uint8_t *buf, uint64_t len);
 #ifdef ARM_ACLE_CRC_HASH
-extern uint32_t crc32_acle(uint32_t crc, const unsigned char *buf, uint64_t len);
+extern uint32_t crc32_acle(uint32_t crc, const uint8_t *buf, uint64_t len);
 #elif defined(POWER8_VSX_CRC32)
-extern uint32_t crc32_power8(uint32_t crc, const unsigned char *buf, uint64_t len);
+extern uint32_t crc32_power8(uint32_t crc, const uint8_t *buf, uint64_t len);
 #elif defined(S390_CRC32_VX)
-extern uint32_t PREFIX(s390_crc32_vx)(uint32_t crc, const unsigned char *buf, uint64_t len);
+extern uint32_t PREFIX(s390_crc32_vx)(uint32_t crc, const uint8_t *buf, uint64_t len);
 #endif
 
 /* compare256 */

--- a/cpu_features.h
+++ b/cpu_features.h
@@ -23,43 +23,43 @@
 extern void cpu_check_features(void);
 
 /* adler32 */
-typedef uint32_t (*adler32_func)(uint32_t adler, const unsigned char *buf, size_t len);
+typedef uint32_t (*adler32_func)(uint32_t adler, const unsigned char *buf, uint64_t len);
 
-extern uint32_t adler32_c(uint32_t adler, const unsigned char *buf, size_t len);
+extern uint32_t adler32_c(uint32_t adler, const unsigned char *buf, uint64_t len);
 #ifdef ARM_NEON_ADLER32
-extern uint32_t adler32_neon(uint32_t adler, const unsigned char *buf, size_t len);
+extern uint32_t adler32_neon(uint32_t adler, const unsigned char *buf, uint64_t len);
 #endif
 #ifdef PPC_VMX_ADLER32
-extern uint32_t adler32_vmx(uint32_t adler, const unsigned char *buf, size_t len);
+extern uint32_t adler32_vmx(uint32_t adler, const unsigned char *buf, uint64_t len);
 #endif
 #ifdef X86_SSSE3_ADLER32
-extern uint32_t adler32_ssse3(uint32_t adler, const unsigned char *buf, size_t len);
+extern uint32_t adler32_ssse3(uint32_t adler, const unsigned char *buf, uint64_t len);
 #endif
 #ifdef X86_AVX2_ADLER32
-extern uint32_t adler32_avx2(uint32_t adler, const unsigned char *buf, size_t len);
+extern uint32_t adler32_avx2(uint32_t adler, const unsigned char *buf, uint64_t len);
 #endif
 #ifdef X86_AVX512_ADLER32
-extern uint32_t adler32_avx512(uint32_t adler, const unsigned char *buf, size_t len);
+extern uint32_t adler32_avx512(uint32_t adler, const unsigned char *buf, uint64_t len);
 #endif
 #ifdef X86_AVX512VNNI_ADLER32
-extern uint32_t adler32_avx512_vnni(uint32_t adler, const unsigned char *buf, size_t len);
+extern uint32_t adler32_avx512_vnni(uint32_t adler, const unsigned char *buf, uint64_t len);
 #endif
 #ifdef POWER8_VSX_ADLER32
-extern uint32_t adler32_power8(uint32_t adler, const unsigned char* buf, size_t len);
+extern uint32_t adler32_power8(uint32_t adler, const unsigned char* buf, uint64_t len);
 #endif
 
 /* adler32 folding */
 #ifdef X86_SSE42_ADLER32
-extern uint32_t adler32_fold_copy_sse42(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len);
+extern uint32_t adler32_fold_copy_sse42(uint32_t adler, uint8_t *dst, const uint8_t *src, uint64_t len);
 #endif
 #ifdef X86_AVX2_ADLER32
-extern uint32_t adler32_fold_copy_avx2(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len);
+extern uint32_t adler32_fold_copy_avx2(uint32_t adler, uint8_t *dst, const uint8_t *src, uint64_t len);
 #endif
 #ifdef X86_AVX512_ADLER32
-extern uint32_t adler32_fold_copy_avx512(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len);
+extern uint32_t adler32_fold_copy_avx512(uint32_t adler, uint8_t *dst, const uint8_t *src, uint64_t len);
 #endif
 #ifdef X86_AVX512VNNI_ADLER32
-extern uint32_t adler32_fold_copy_avx512_vnni(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len);
+extern uint32_t adler32_fold_copy_avx512_vnni(uint32_t adler, uint8_t *dst, const uint8_t *src, uint64_t len);
 #endif
 
 /* CRC32 folding */

--- a/cpu_features.h
+++ b/cpu_features.h
@@ -65,8 +65,8 @@ extern uint32_t adler32_fold_copy_avx512_vnni(uint32_t adler, uint8_t *dst, cons
 /* CRC32 folding */
 #ifdef X86_PCLMULQDQ_CRC
 extern uint32_t crc32_fold_pclmulqdq_reset(crc32_fold *crc);
-extern void     crc32_fold_pclmulqdq_copy(crc32_fold *crc, uint8_t *dst, const uint8_t *src, size_t len);
-extern void     crc32_fold_pclmulqdq(crc32_fold *crc, const uint8_t *src, size_t len, uint32_t init_crc);
+extern void     crc32_fold_pclmulqdq_copy(crc32_fold *crc, uint8_t *dst, const uint8_t *src, uint64_t len);
+extern void     crc32_fold_pclmulqdq(crc32_fold *crc, const uint8_t *src, uint64_t len, uint32_t init_crc);
 extern uint32_t crc32_fold_pclmulqdq_final(crc32_fold *crc);
 extern uint32_t crc32_pclmulqdq(uint32_t crc32, const unsigned char* buf, uint64_t len);
 #endif

--- a/crc32_braid.c
+++ b/crc32_braid.c
@@ -111,7 +111,7 @@ static z_word_t crc_word(z_word_t data) {
 #endif /* W */
 
 /* ========================================================================= */
-Z_INTERNAL uint32_t crc32_braid(uint32_t crc, const unsigned char *buf, uint64_t len) {
+Z_INTERNAL uint32_t crc32_braid(uint32_t crc, const uint8_t *buf, uint64_t len) {
     Z_REGISTER uint32_t c;
 
     /* Pre-condition the CRC */

--- a/crc32_braid_p.h
+++ b/crc32_braid_p.h
@@ -45,6 +45,6 @@
 /* CRC polynomial. */
 #define POLY 0xedb88320         /* p(x) reflected, with x^32 implied */
 
-extern uint32_t crc32_braid(uint32_t crc, const unsigned char *buf, uint64_t len);
+extern uint32_t crc32_braid(uint32_t crc, const uint8_t *buf, uint64_t len);
 
 #endif /* CRC32_BRAID_P_H_ */

--- a/crc32_fold.c
+++ b/crc32_fold.c
@@ -12,12 +12,20 @@ Z_INTERNAL uint32_t crc32_fold_reset_c(crc32_fold *crc) {
     return crc->value;
 }
 
-Z_INTERNAL void crc32_fold_copy_c(crc32_fold *crc, uint8_t *dst, const uint8_t *src, size_t len) {
+Z_INTERNAL void crc32_fold_copy_c(crc32_fold *crc, uint8_t *dst, const uint8_t *src, uint64_t len) {
     crc->value = functable.crc32(crc->value, src, len);
-    memcpy(dst, src, len);
+    while (len > SIZE_MAX) {
+        memcpy(dst, src, SIZE_MAX);
+        dst += SIZE_MAX;
+        src += SIZE_MAX;
+        len -= SIZE_MAX;
+    }
+    if (len) {
+        memcpy(dst, src, (size_t)len);
+    }
 }
 
-Z_INTERNAL void crc32_fold_c(crc32_fold *crc, const uint8_t *src, size_t len, uint32_t init_crc) {
+Z_INTERNAL void crc32_fold_c(crc32_fold *crc, const uint8_t *src, uint64_t len, uint32_t init_crc) {
     /* Note: while this is basically the same thing as the vanilla CRC function, we still need
      * a functable entry for it so that we can generically dispatch to this function with the
      * same arguments for the versions that _do_ do a folding CRC but we don't want a copy. The

--- a/crc32_fold.h
+++ b/crc32_fold.h
@@ -14,8 +14,8 @@ typedef struct crc32_fold_s {
 } crc32_fold;
 
 Z_INTERNAL uint32_t crc32_fold_reset_c(crc32_fold *crc);
-Z_INTERNAL void     crc32_fold_copy_c(crc32_fold *crc, uint8_t *dst, const uint8_t *src, size_t len);
-Z_INTERNAL void     crc32_fold_c(crc32_fold *crc, const uint8_t *src, size_t len, uint32_t init_crc);
+Z_INTERNAL void     crc32_fold_copy_c(crc32_fold *crc, uint8_t *dst, const uint8_t *src, uint64_t len);
+Z_INTERNAL void     crc32_fold_c(crc32_fold *crc, const uint8_t *src, uint64_t len, uint32_t init_crc);
 Z_INTERNAL uint32_t crc32_fold_final_c(crc32_fold *crc);
 
 #endif

--- a/functable.c
+++ b/functable.c
@@ -162,7 +162,7 @@ Z_INTERNAL uint32_t longest_match_slow_stub(deflate_state *const s, Pos cur_matc
     return functable.longest_match_slow(s, cur_match);
 }
 
-Z_INTERNAL uint32_t adler32_stub(uint32_t adler, const unsigned char *buf, size_t len) {
+Z_INTERNAL uint32_t adler32_stub(uint32_t adler, const unsigned char *buf, uint64_t len) {
     // Initialize default
     functable.adler32 = &adler32_c;
     cpu_check_features();
@@ -202,7 +202,7 @@ Z_INTERNAL uint32_t adler32_stub(uint32_t adler, const unsigned char *buf, size_
     return functable.adler32(adler, buf, len);
 }
 
-Z_INTERNAL uint32_t adler32_fold_copy_stub(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len) {
+Z_INTERNAL uint32_t adler32_fold_copy_stub(uint32_t adler, uint8_t *dst, const uint8_t *src, uint64_t len) {
     functable.adler32_fold_copy = &adler32_fold_copy_c;
 #if (defined X86_SSE42_ADLER32)
     if (x86_cpu_has_sse42)

--- a/functable.c
+++ b/functable.c
@@ -233,7 +233,7 @@ Z_INTERNAL uint32_t crc32_fold_reset_stub(crc32_fold *crc) {
     return functable.crc32_fold_reset(crc);
 }
 
-Z_INTERNAL void crc32_fold_copy_stub(crc32_fold *crc, uint8_t *dst, const uint8_t *src, size_t len) {
+Z_INTERNAL void crc32_fold_copy_stub(crc32_fold *crc, uint8_t *dst, const uint8_t *src, uint64_t len) {
     functable.crc32_fold_copy = &crc32_fold_copy_c;
     cpu_check_features();
 #ifdef X86_PCLMULQDQ_CRC
@@ -243,7 +243,7 @@ Z_INTERNAL void crc32_fold_copy_stub(crc32_fold *crc, uint8_t *dst, const uint8_
     functable.crc32_fold_copy(crc, dst, src, len);
 }
 
-Z_INTERNAL void crc32_fold_stub(crc32_fold *crc, const uint8_t *src, size_t len, uint32_t init_crc) {
+Z_INTERNAL void crc32_fold_stub(crc32_fold *crc, const uint8_t *src, uint64_t len, uint32_t init_crc) {
     functable.crc32_fold = &crc32_fold_c;
     cpu_check_features();
 #ifdef X86_PCLMULQDQ_CRC

--- a/functable.c
+++ b/functable.c
@@ -162,7 +162,7 @@ Z_INTERNAL uint32_t longest_match_slow_stub(deflate_state *const s, Pos cur_matc
     return functable.longest_match_slow(s, cur_match);
 }
 
-Z_INTERNAL uint32_t adler32_stub(uint32_t adler, const unsigned char *buf, uint64_t len) {
+Z_INTERNAL uint32_t adler32_stub(uint32_t adler, const uint8_t *buf, uint64_t len) {
     // Initialize default
     functable.adler32 = &adler32_c;
     cpu_check_features();
@@ -403,7 +403,7 @@ Z_INTERNAL uint8_t* chunkmemset_safe_stub(uint8_t *out, unsigned dist, unsigned 
     return functable.chunkmemset_safe(out, dist, len, left);
 }
 
-Z_INTERNAL uint32_t crc32_stub(uint32_t crc, const unsigned char *buf, uint64_t len) {
+Z_INTERNAL uint32_t crc32_stub(uint32_t crc, const uint8_t *buf, uint64_t len) {
     Assert(sizeof(uint64_t) >= sizeof(size_t),
            "crc32_z takes size_t but internally we have a uint64_t len");
 

--- a/functable.h
+++ b/functable.h
@@ -11,8 +11,8 @@
 #include "adler32_fold.h"
 
 struct functable_s {
-    uint32_t (* adler32)            (uint32_t adler, const unsigned char *buf, size_t len);
-    uint32_t (* adler32_fold_copy)  (uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len);
+    uint32_t (* adler32)            (uint32_t adler, const unsigned char *buf, uint64_t len);
+    uint32_t (* adler32_fold_copy)  (uint32_t adler, uint8_t *dst, const uint8_t *src, uint64_t len);
     uint32_t (* crc32)              (uint32_t crc, const unsigned char *buf, uint64_t len);
     uint32_t (* crc32_fold_reset)   (crc32_fold *crc);
     void     (* crc32_fold_copy)    (crc32_fold *crc, uint8_t *dst, const uint8_t *src, uint64_t len);

--- a/functable.h
+++ b/functable.h
@@ -15,8 +15,8 @@ struct functable_s {
     uint32_t (* adler32_fold_copy)  (uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len);
     uint32_t (* crc32)              (uint32_t crc, const unsigned char *buf, uint64_t len);
     uint32_t (* crc32_fold_reset)   (crc32_fold *crc);
-    void     (* crc32_fold_copy)    (crc32_fold *crc, uint8_t *dst, const uint8_t *src, size_t len);
-    void     (* crc32_fold)         (crc32_fold *crc, const uint8_t *src, size_t len, uint32_t init_crc);
+    void     (* crc32_fold_copy)    (crc32_fold *crc, uint8_t *dst, const uint8_t *src, uint64_t len);
+    void     (* crc32_fold)         (crc32_fold *crc, const uint8_t *src, uint64_t len, uint32_t init_crc);
     uint32_t (* crc32_fold_final)   (crc32_fold *crc);
     uint32_t (* compare256)         (const uint8_t *src0, const uint8_t *src1);
     uint32_t (* chunksize)          (void);

--- a/functable.h
+++ b/functable.h
@@ -11,9 +11,9 @@
 #include "adler32_fold.h"
 
 struct functable_s {
-    uint32_t (* adler32)            (uint32_t adler, const unsigned char *buf, uint64_t len);
+    uint32_t (* adler32)            (uint32_t adler, const uint8_t *buf, uint64_t len);
     uint32_t (* adler32_fold_copy)  (uint32_t adler, uint8_t *dst, const uint8_t *src, uint64_t len);
-    uint32_t (* crc32)              (uint32_t crc, const unsigned char *buf, uint64_t len);
+    uint32_t (* crc32)              (uint32_t crc, const uint8_t *buf, uint64_t len);
     uint32_t (* crc32_fold_reset)   (crc32_fold *crc);
     void     (* crc32_fold_copy)    (crc32_fold *crc, uint8_t *dst, const uint8_t *src, uint64_t len);
     void     (* crc32_fold)         (crc32_fold *crc, const uint8_t *src, uint64_t len, uint32_t init_crc);

--- a/test/benchmarks/benchmark_adler32_copy.cc
+++ b/test/benchmarks/benchmark_adler32_copy.cc
@@ -18,7 +18,7 @@ extern "C" {
 #define MAX_RANDOM_INTS (1024 * 1024)
 #define MAX_RANDOM_INTS_SIZE (MAX_RANDOM_INTS * sizeof(uint32_t))
 
-typedef uint32_t (*adler32_cpy_func)(uint32_t adler, unsigned char *dst, const unsigned char *buf, uint64_t len);
+typedef uint32_t (*adler32_cpy_func)(uint32_t adler, unsigned char *dst, const uint8_t *buf, uint64_t len);
 
 class adler32_copy: public benchmark::Fixture {
 private:
@@ -75,7 +75,7 @@ public:
             state.SkipWithError("CPU does not support " #name); \
         } \
         Bench(state, [](uint32_t init_sum, unsigned char *dst, \
-                        const unsigned char *buf, uint64_t len) -> uint32_t { \
+                        const uint8_t *buf, uint64_t len) -> uint32_t { \
             memcpy(dst, buf, len); \
             return fptr(init_sum, buf, len); \
         }); \

--- a/test/benchmarks/benchmark_adler32_copy.cc
+++ b/test/benchmarks/benchmark_adler32_copy.cc
@@ -18,7 +18,7 @@ extern "C" {
 #define MAX_RANDOM_INTS (1024 * 1024)
 #define MAX_RANDOM_INTS_SIZE (MAX_RANDOM_INTS * sizeof(uint32_t))
 
-typedef uint32_t (*adler32_cpy_func)(uint32_t adler, unsigned char *dst, const unsigned char *buf, size_t len);
+typedef uint32_t (*adler32_cpy_func)(uint32_t adler, unsigned char *dst, const unsigned char *buf, uint64_t len);
 
 class adler32_copy: public benchmark::Fixture {
 private:
@@ -75,7 +75,7 @@ public:
             state.SkipWithError("CPU does not support " #name); \
         } \
         Bench(state, [](uint32_t init_sum, unsigned char *dst, \
-                        const unsigned char *buf, size_t len) -> uint32_t { \
+                        const unsigned char *buf, uint64_t len) -> uint32_t { \
             memcpy(dst, buf, len); \
             return fptr(init_sum, buf, len); \
         }); \


### PR DESCRIPTION
```
arch\x86\crc32_fold_pclmulqdq.c(604,43): warning C4244: 'function':
conversion from 'uint64_t' to 'size_t', possible loss of data
```

Another option we can do is to change `crc32_fold_pclmulqdq` to use `uint64_t len` instead of `size_t len`.