### PR TITLE
Remove extra CMake messages from ARM toolchains.

### DIFF
--- a/cmake/toolchain-aarch64.cmake
+++ b/cmake/toolchain-aarch64.cmake
@@ -2,8 +2,6 @@ set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR aarch64)
 set(CMAKE_SYSTEM_VERSION 1)
 
-message(STATUS "Using cross-compile toolchain: ${CROSS_COMPILE_TOOLCHAIN}")
-
 set(CMAKE_C_COMPILER_TARGET "aarch64-linux-gnu")
 set(CMAKE_CXX_COMPILER_TARGET "aarch64-linux-gnu")
 

--- a/cmake/toolchain-arm.cmake
+++ b/cmake/toolchain-arm.cmake
@@ -2,8 +2,6 @@ set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR arm)
 set(CMAKE_SYSTEM_VERSION 1)
 
-message(STATUS "Using cross-compile toolchain: ${CROSS_COMPILE_TOOLCHAIN}")
-
 if(NOT DEFINED CMAKE_C_COMPILER_TARGET)
     set(CMAKE_C_COMPILER_TARGET arm-linux-gnueabi)
 endif()

--- a/cmake/toolchain-armhf.cmake
+++ b/cmake/toolchain-armhf.cmake
@@ -2,8 +2,6 @@ set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR arm)
 set(CMAKE_SYSTEM_VERSION 1)
 
-message(STATUS "Using cross-compile toolchain: ${CROSS_COMPILE_TOOLCHAIN}")
-
 set(CMAKE_C_COMPILER_TARGET arm-linux-gnueabihf)
 set(CMAKE_CXX_COMPILER_TARGET arm-linux-gnueabihf)
 


### PR DESCRIPTION
These seem to only be in the arm toolchain files and only end up printing out empty values. Anyways it is duplicate message that is already in: https://github.com/zlib-ng/zlib-ng/blob/02d10b252cc54159f7c33823048daec4b023fb22/CMakeLists.txt#L57
