### PR TITLE
Fixed incorrect case for __clang__ preprocessor macro in zbuild.h.

### DIFF
--- a/zbuild.h
+++ b/zbuild.h
@@ -100,7 +100,7 @@
 #  define ZSWAP32(q) _byteswap_ulong(q)
 #  define ZSWAP64(q) _byteswap_uint64(q)
 
-#elif defined(__Clang__) || (defined(__GNUC__) && \
+#elif defined(__clang__) || (defined(__GNUC__) && \
         (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)))
 #  define ZSWAP16(q) __builtin_bswap16(q)
 #  define ZSWAP32(q) __builtin_bswap32(q)
@@ -144,7 +144,7 @@
 #endif
 
 /* Only enable likely/unlikely if the compiler is known to support it */
-#if (defined(__GNUC__) && (__GNUC__ >= 3)) || defined(__INTEL_COMPILER) || defined(__Clang__)
+#if (defined(__GNUC__) && (__GNUC__ >= 3)) || defined(__INTEL_COMPILER) || defined(__clang__)
 #  define LIKELY_NULL(x)        __builtin_expect((x) != 0, 0)
 #  define LIKELY(x)             __builtin_expect(!!(x), 1)
 #  define UNLIKELY(x)           __builtin_expect(!!(x), 0)


### PR DESCRIPTION
_I think_ I ran into an issue where it was not using builtins for AppleClang.