### PR TITLE
Make directory for output files

### DIFF
--- a/cmake/run-and-compare.cmake
+++ b/cmake/run-and-compare.cmake
@@ -16,6 +16,10 @@ if(NOT DEFINED OUTPUT OR NOT DEFINED COMPARE OR NOT DEFINED COMMAND)
     message(FATAL_ERROR "Run and compare arguments missing")
 endif()
 
+# Ensure directory exists for output files
+get_filename_component(OUTPUT_DIR "${OUTPUT}" DIRECTORY)
+file(MAKE_DIRECTORY "${OUTPUT_DIR}")
+
 if(INPUT)
     # Run command with stdin input and redirect stdout to output
     execute_process(COMMAND ${CMAKE_COMMAND}


### PR DESCRIPTION
If zlib-ng is added to the CMake project via ``add_subdirectory`` then the ``${CMAKE_CURRENT_BINARY_DIR}/Testing/Temporary`` directory may not exist when the tests are run.

CMake creates a ``Testing/Temporary`` directory only for the top project (``${CMAKE_BINARY_DIR}/Testing/Temporary``).