### PR TITLE
fix off-by-one bug in crc32_acle.c

### DIFF
--- a/arch/arm/crc32_acle.c
+++ b/arch/arm/crc32_acle.c
@@ -22,7 +22,7 @@ uint32_t crc32_acle(uint32_t crc, const unsigned char *buf, uint64_t len) {
         len--;
     }
 
-    if ((len > sizeof(uint16_t)) && ((ptrdiff_t)buf & sizeof(uint16_t))) {
+    if ((len >= sizeof(uint16_t)) && ((ptrdiff_t)buf & sizeof(uint16_t))) {
         buf2 = (const uint16_t *) buf;
         c = __crc32h(c, *buf2++);
         len -= sizeof(uint16_t);
@@ -32,7 +32,7 @@ uint32_t crc32_acle(uint32_t crc, const unsigned char *buf, uint64_t len) {
     }
 
 #if defined(__aarch64__)
-    if ((len > sizeof(uint32_t)) && ((ptrdiff_t)buf & sizeof(uint32_t))) {
+    if ((len >= sizeof(uint32_t)) && ((ptrdiff_t)buf & sizeof(uint32_t))) {
         c = __crc32w(c, *buf4++);
         len -= sizeof(uint32_t);
     }

--- a/arch/arm/crc32_acle.c
+++ b/arch/arm/crc32_acle.c
@@ -37,6 +37,11 @@ uint32_t crc32_acle(uint32_t crc, const unsigned char *buf, uint64_t len) {
         len -= sizeof(uint32_t);
     }
 
+    if (len == 0) {
+        c = ~c;
+        return c;
+    }
+
     const uint64_t *buf8 = (const uint64_t *) buf4;
 
     while (len >= sizeof(uint64_t)) {
@@ -60,6 +65,11 @@ uint32_t crc32_acle(uint32_t crc, const unsigned char *buf, uint64_t len) {
 
     buf = (const unsigned char *) buf2;
 #else /* __aarch64__ */
+
+    if (len == 0) {
+        c = ~c;
+        return c;
+    }
 
     while (len >= sizeof(uint32_t)) {
         c = __crc32w(c, *buf4++);

--- a/arch/arm/crc32_acle.c
+++ b/arch/arm/crc32_acle.c
@@ -39,16 +39,6 @@ uint32_t crc32_acle(uint32_t crc, const unsigned char *buf, uint64_t len) {
 
     const uint64_t *buf8 = (const uint64_t *) buf4;
 
-#ifdef UNROLL_MORE
-    while (len >= 4 * sizeof(uint64_t)) {
-        c = __crc32d(c, *buf8++);
-        c = __crc32d(c, *buf8++);
-        c = __crc32d(c, *buf8++);
-        c = __crc32d(c, *buf8++);
-        len -= 4 * sizeof(uint64_t);
-    }
-#endif
-
     while (len >= sizeof(uint64_t)) {
         c = __crc32d(c, *buf8++);
         len -= sizeof(uint64_t);
@@ -70,20 +60,6 @@ uint32_t crc32_acle(uint32_t crc, const unsigned char *buf, uint64_t len) {
 
     buf = (const unsigned char *) buf2;
 #else /* __aarch64__ */
-
-#  ifdef UNROLL_MORE
-    while (len >= 8 * sizeof(uint32_t)) {
-        c = __crc32w(c, *buf4++);
-        c = __crc32w(c, *buf4++);
-        c = __crc32w(c, *buf4++);
-        c = __crc32w(c, *buf4++);
-        c = __crc32w(c, *buf4++);
-        c = __crc32w(c, *buf4++);
-        c = __crc32w(c, *buf4++);
-        c = __crc32w(c, *buf4++);
-        len -= 8 * sizeof(uint32_t);
-    }
-#  endif
 
     while (len >= sizeof(uint32_t)) {
         c = __crc32w(c, *buf4++);


### PR DESCRIPTION
would be doing unaligned memory reads on very small buffers