### PR TITLE
Remove references to TLS code

### DIFF
--- a/functable.c
+++ b/functable.c
@@ -13,7 +13,7 @@
 
 #include "cpu_features.h"
 
-Z_INTERNAL Z_TLS struct functable_s functable;
+Z_INTERNAL struct functable_s functable;
 
 /* stub functions */
 Z_INTERNAL uint32_t update_hash_stub(deflate_state *const s, uint32_t h, uint32_t val) {
@@ -427,7 +427,7 @@ Z_INTERNAL uint32_t compare256_stub(const uint8_t *src0, const uint8_t *src1) {
 }
 
 /* functable init */
-Z_INTERNAL Z_TLS struct functable_s functable = {
+Z_INTERNAL struct functable_s functable = {
     adler32_stub,
     crc32_stub,
     crc32_fold_reset_stub,

--- a/functable.h
+++ b/functable.h
@@ -30,6 +30,6 @@ struct functable_s {
     uint32_t (* update_hash)        (deflate_state *const s, uint32_t h, uint32_t val);
 };
 
-Z_INTERNAL extern Z_TLS struct functable_s functable;
+Z_INTERNAL extern struct functable_s functable;
 
 #endif

--- a/zbuild.h
+++ b/zbuild.h
@@ -25,20 +25,6 @@
 #  endif
 #endif
 
-/* Determine compiler support for TLS */
-#ifndef Z_TLS
-#  if defined(STDC11) && !defined(__STDC_NO_THREADS__)
-#    define Z_TLS _Thread_local
-#  elif defined(__GNUC__) || defined(__SUNPRO_C)
-#    define Z_TLS __thread
-#  elif defined(_WIN32) && (defined(_MSC_VER) || defined(__ICL))
-#    define Z_TLS __declspec(thread)
-#  else
-#    warning Unable to detect Thread Local Storage support.
-#    define Z_TLS
-#  endif
-#endif
-
 /* This has to be first include that defines any types */
 #if defined(_MSC_VER)
 #  if defined(_WIN64)


### PR DESCRIPTION
This TLS code was pure nonsense,  added by 16b6cda67be0038327b416e5fa5c7243ed138e21 with zero explanation why at all this was needed in the first place.
There is no library out there that uses similar function pointers and also uses TLS for these pointer (example: ffmpeg/libav/libavcodec).
My wild guess the code was added was to "handle" possibility to have different cores (like hi-pef vs low-power cores). In case if there is any doubt that the code wasn't needed, then obviously there is a problem with the TLS code if execution moving between cores, which certainly does happen all the time.
