### PR TITLE
[ARM] We need to include NEON headers when testing for -mfpu=neon.

### DIFF
--- a/cmake/detect-intrinsics.cmake
+++ b/cmake/detect-intrinsics.cmake
@@ -152,7 +152,12 @@ macro(check_neon_compiler_flag)
     # Check whether compiler supports NEON flag
     set(CMAKE_REQUIRED_FLAGS "${NEONFLAG} ${NATIVEFLAG}")
     check_c_source_compiles(
-        "int main() { return 0; }"
+        "#ifdef _M_ARM64
+        #  include <arm64_neon.h>
+        #else
+        #  include <arm_neon.h>
+        #endif
+        int main() { return 0; }"
         MFPU_NEON_AVAILABLE FAIL_REGEX "not supported")
     set(CMAKE_REQUIRED_FLAGS)
 endmacro()

--- a/configure
+++ b/configure
@@ -1106,6 +1106,11 @@ EOF
 check_neon_compiler_flag() {
     # Check whether -mfpu=neon is available on ARM processors.
     cat > $test.c << EOF
+#ifdef _M_ARM64
+ #  include <arm64_neon.h>
+ #else
+ #  include <arm_neon.h>
+#endif
 int main() { return 0; }
 EOF
     if try $CC -c $CFLAGS -mfpu=neon $test.c; then


### PR DESCRIPTION
* If -mfpu is already specified in C_FLAGS, it can disable NEON support.