### PR TITLE
Remove unused chunkcopy_safe function prototypes.

### DIFF
--- a/arch/arm/chunkset_neon.c
+++ b/arch/arm/chunkset_neon.c
@@ -38,7 +38,6 @@ static inline void chunkmemset_8(uint8_t *from, chunk_t *chunk) {
 
 #define CHUNKSIZE        chunksize_neon
 #define CHUNKCOPY        chunkcopy_neon
-#define CHUNKCOPY_SAFE   chunkcopy_safe_neon
 #define CHUNKUNROLL      chunkunroll_neon
 #define CHUNKMEMSET      chunkmemset_neon
 #define CHUNKMEMSET_SAFE chunkmemset_safe_neon

--- a/arch/power/chunkset_power8.c
+++ b/arch/power/chunkset_power8.c
@@ -34,7 +34,6 @@ static inline void chunkmemset_8(uint8_t *from, chunk_t *chunk) {
 
 #define CHUNKSIZE        chunksize_power8
 #define CHUNKCOPY        chunkcopy_power8
-#define CHUNKCOPY_SAFE   chunkcopy_safe_power8
 #define CHUNKUNROLL      chunkunroll_power8
 #define CHUNKMEMSET      chunkmemset_power8
 #define CHUNKMEMSET_SAFE chunkmemset_safe_power8

--- a/arch/x86/chunkset_avx.c
+++ b/arch/x86/chunkset_avx.c
@@ -122,7 +122,6 @@ static inline chunk_t GET_CHUNK_MAG(uint8_t *buf, uint32_t *chunk_rem, uint32_t 
 
 #define CHUNKSIZE        chunksize_avx
 #define CHUNKCOPY        chunkcopy_avx
-#define CHUNKCOPY_SAFE   chunkcopy_safe_avx
 #define CHUNKUNROLL      chunkunroll_avx
 #define CHUNKMEMSET      chunkmemset_avx
 #define CHUNKMEMSET_SAFE chunkmemset_safe_avx

--- a/arch/x86/chunkset_sse2.c
+++ b/arch/x86/chunkset_sse2.c
@@ -43,7 +43,6 @@ static inline void storechunk(uint8_t *out, chunk_t *chunk) {
 
 #define CHUNKSIZE        chunksize_sse2
 #define CHUNKCOPY        chunkcopy_sse2
-#define CHUNKCOPY_SAFE   chunkcopy_safe_sse2
 #define CHUNKUNROLL      chunkunroll_sse2
 #define CHUNKMEMSET      chunkmemset_sse2
 #define CHUNKMEMSET_SAFE chunkmemset_safe_sse2

--- a/chunkset.c
+++ b/chunkset.c
@@ -31,7 +31,6 @@ static inline void storechunk(uint8_t *out, chunk_t *chunk) {
 
 #define CHUNKSIZE        chunksize_c
 #define CHUNKCOPY        chunkcopy_c
-#define CHUNKCOPY_SAFE   chunkcopy_safe_c
 #define CHUNKUNROLL      chunkunroll_c
 #define CHUNKMEMSET      chunkmemset_c
 #define CHUNKMEMSET_SAFE chunkmemset_safe_c

--- a/cpu_features.h
+++ b/cpu_features.h
@@ -74,14 +74,12 @@ extern uint32_t crc32_pclmulqdq(uint32_t crc32, const unsigned char* buf, uint64
 /* memory chunking */
 extern uint32_t chunksize_c(void);
 extern uint8_t* chunkcopy_c(uint8_t *out, uint8_t const *from, unsigned len);
-extern uint8_t* chunkcopy_safe_c(uint8_t *out, uint8_t const *from, unsigned len, uint8_t *safe);
 extern uint8_t* chunkunroll_c(uint8_t *out, unsigned *dist, unsigned *len);
 extern uint8_t* chunkmemset_c(uint8_t *out, unsigned dist, unsigned len);
 extern uint8_t* chunkmemset_safe_c(uint8_t *out, unsigned dist, unsigned len, unsigned left);
 #ifdef X86_SSE2_CHUNKSET
 extern uint32_t chunksize_sse2(void);
 extern uint8_t* chunkcopy_sse2(uint8_t *out, uint8_t const *from, unsigned len);
-extern uint8_t* chunkcopy_safe_sse2(uint8_t *out, uint8_t const *from, unsigned len, uint8_t *safe);
 extern uint8_t* chunkunroll_sse2(uint8_t *out, unsigned *dist, unsigned *len);
 extern uint8_t* chunkmemset_sse2(uint8_t *out, unsigned dist, unsigned len);
 extern uint8_t* chunkmemset_safe_sse2(uint8_t *out, unsigned dist, unsigned len, unsigned left);
@@ -93,7 +91,6 @@ extern uint8_t* chunkmemset_safe_sse41(uint8_t *out, unsigned dist, unsigned len
 #ifdef X86_AVX_CHUNKSET
 extern uint32_t chunksize_avx(void);
 extern uint8_t* chunkcopy_avx(uint8_t *out, uint8_t const *from, unsigned len);
-extern uint8_t* chunkcopy_safe_avx(uint8_t *out, uint8_t const *from, unsigned len, uint8_t *safe);
 extern uint8_t* chunkunroll_avx(uint8_t *out, unsigned *dist, unsigned *len);
 extern uint8_t* chunkmemset_avx(uint8_t *out, unsigned dist, unsigned len);
 extern uint8_t* chunkmemset_safe_avx(uint8_t *out, unsigned dist, unsigned len, unsigned left);
@@ -101,7 +98,6 @@ extern uint8_t* chunkmemset_safe_avx(uint8_t *out, unsigned dist, unsigned len, 
 #ifdef ARM_NEON_CHUNKSET
 extern uint32_t chunksize_neon(void);
 extern uint8_t* chunkcopy_neon(uint8_t *out, uint8_t const *from, unsigned len);
-extern uint8_t* chunkcopy_safe_neon(uint8_t *out, uint8_t const *from, unsigned len, uint8_t *safe);
 extern uint8_t* chunkunroll_neon(uint8_t *out, unsigned *dist, unsigned *len);
 extern uint8_t* chunkmemset_neon(uint8_t *out, unsigned dist, unsigned len);
 extern uint8_t* chunkmemset_safe_neon(uint8_t *out, unsigned dist, unsigned len, unsigned left);
@@ -109,7 +105,6 @@ extern uint8_t* chunkmemset_safe_neon(uint8_t *out, unsigned dist, unsigned len,
 #ifdef POWER8_VSX_CHUNKSET
 extern uint32_t chunksize_power8(void);
 extern uint8_t* chunkcopy_power8(uint8_t *out, uint8_t const *from, unsigned len);
-extern uint8_t* chunkcopy_safe_power8(uint8_t *out, uint8_t const *from, unsigned len, uint8_t *safe);
 extern uint8_t* chunkunroll_power8(uint8_t *out, unsigned *dist, unsigned *len);
 extern uint8_t* chunkmemset_power8(uint8_t *out, unsigned dist, unsigned len);
 extern uint8_t* chunkmemset_safe_power8(uint8_t *out, unsigned dist, unsigned len, unsigned left);


### PR DESCRIPTION
`chunkcopy_safe` was moved to static function inside `inflate_p.h`.