### PR TITLE
Fixed inflate size conversion warning in chunkcopy_safe.

### DIFF
--- a/inflate_p.h
+++ b/inflate_p.h
@@ -130,16 +130,16 @@
     } while (0)
 
 /* Behave like chunkcopy, but avoid writing beyond of legal output. */
-static inline uint8_t* chunkcopy_safe(uint8_t *out, uint8_t *from, size_t len, uint8_t *safe) {
-    uint32_t safelen = (uint32_t)((safe - out) + 1);
+static inline uint8_t* chunkcopy_safe(uint8_t *out, uint8_t *from, uint64_t len, uint8_t *safe) {
+    uint64_t safelen = (safe - out) + 1;
     len = MIN(len, safelen);
     int32_t olap_src = from >= out && from < out + len;
     int32_t olap_dst = out >= from && out < from + len;
-    size_t tocopy;
+    uint64_t tocopy;
 
     /* For all cases without overlap, memcpy is ideal */
     if (!(olap_src || olap_dst)) {
-        memcpy(out, from, len);
+        memcpy(out, from, (size_t)len);
         return out + len;
     }
 
@@ -148,9 +148,9 @@ static inline uint8_t* chunkcopy_safe(uint8_t *out, uint8_t *from, size_t len, u
      * initial bulk memcpy of the nonoverlapping region. Then, we can leverage the size of this to determine the safest
      * atomic memcpy size we can pick such that we have non-overlapping regions. This effectively becomes a safe look
      * behind or lookahead distance. */
-    size_t non_olap_size = llabs(from - out); // llabs vs labs for compatibility with windows
+    uint64_t non_olap_size = llabs(from - out); // llabs vs labs for compatibility with windows
 
-    memcpy(out, from, non_olap_size);
+    memcpy(out, from, (size_t)non_olap_size);
     out += non_olap_size;
     from += non_olap_size;
     len -= non_olap_size;


### PR DESCRIPTION
Using `-A Win32 -D WITH_MAINTAINER_WARNINGS=ON`.
```
  inflate_p.h(142,27): warning C4244: 'function': conversion from 'uint64_t' to 'size_t', possible loss of data
```
Here I just move the cast from `uint64_t` to `size_t` to the call to `memcpy`.