### PR TITLE
Fixed conversion warnings for wsize in slide_hash_c.

### DIFF
--- a/slide_hash.c
+++ b/slide_hash.c
@@ -45,7 +45,7 @@ static inline void slide_hash_c_chain(Pos *table, uint32_t entries, uint16_t wsi
 }
 
 Z_INTERNAL void slide_hash_c(deflate_state *s) {
-    unsigned int wsize = s->w_size;
+    uint16_t wsize = (uint16_t)s->w_size;
 
     slide_hash_c_chain(s->head, HASH_SIZE, wsize);
     slide_hash_c_chain(s->prev, wsize, wsize);


### PR DESCRIPTION
These occur with MSVC when running `-D WITH_MAINTAINER_WARNINGS=ON`.
```
  slide_hash.c(50,44): warning C4244: 'function': conversion from 'unsigned int' to 'uint16_t', possible loss of data
  slide_hash.c(51,40): warning C4244: 'function': conversion from 'unsigned int' to 'uint16_t', possible loss of data
```

Other slide_hash variants cast in the same manor.