### PR TITLE
Add public compile definition for zlib-ng API 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1037,6 +1037,9 @@ else()
 endif()
 
 foreach(ZLIB_INSTALL_LIBRARY ${ZLIB_INSTALL_LIBRARIES})
+    if(NOT ZLIB_COMPAT)
+        target_compile_definitions(${ZLIB_INSTALL_LIBRARY} PUBLIC ZLIBNG_NATIVE_API)
+    endif()
     target_include_directories(${ZLIB_INSTALL_LIBRARY} PUBLIC
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR};${CMAKE_CURRENT_SOURCE_DIR}>"
         "$<INSTALL_INTERFACE:include>")


### PR DESCRIPTION
This is so that other projects that use CMake and link against the zlib project can easily determine whether or not to include "zlib-ng.h" or "zlib.h". They would do this in order to support zlib compatibility.I am open to the different naming.

Any consumer project that uses `target_link_libraries(${PROJECT_NAME} zlibstatic)` (zlib or zlibstatic) can use:
```
#ifdef ZLIBNG_NATIVE_API
#  include "zlib-ng.h"
#  define ZLIB_PREFIX(x) zng_ ## x
   typedef zng_stream zlib_stream;
#else
#  include "zlib.h"
#  define ZLIB_PREFIX(x) x
   typedef z_stream zlib_stream;
#endif
```
They would do this in order to also support zlib compatibility. https://github.com/zlib-ng/minizip-ng/blob/47b8449fec2c7a575a506ecbe6399ad0603b5992/mz_strm_zlib.c#L16
