### PR TITLE
IBM Z DFLTCC: Test with MSan

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -252,6 +252,12 @@ jobs:
             ldflags: -static
             codecov: ubuntu_gcc_s390x_dfltcc_compat
 
+          - name: Ubuntu Clang S390X DFLTCC MSAN
+            os: z15
+            compiler: clang-11
+            cxx-compiler: clang++-11
+            cmake-args: -GNinja -DWITH_DFLTCC_DEFLATE=ON -DWITH_DFLTCC_INFLATE=ON -DWITH_SANITIZER=Memory
+
           - name: Ubuntu MinGW i686
             os: ubuntu-latest
             cmake-args: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-mingw-i686.cmake

--- a/arch/s390/dfltcc_detail.h
+++ b/arch/s390/dfltcc_detail.h
@@ -1,7 +1,5 @@
-#include <stddef.h>
-#include <stdint.h>
+#include "../../zbuild.h"
 #include <stdio.h>
-#include <string.h>
 
 #ifdef HAVE_SYS_SDT_H
 #include <sys/sdt.h>

--- a/arch/s390/dfltcc_detail.h
+++ b/arch/s390/dfltcc_detail.h
@@ -27,74 +27,6 @@
 #endif
 
 /*
-   C wrapper for the DEFLATE CONVERSION CALL instruction.
- */
-typedef enum {
-    DFLTCC_CC_OK = 0,
-    DFLTCC_CC_OP1_TOO_SHORT = 1,
-    DFLTCC_CC_OP2_TOO_SHORT = 2,
-    DFLTCC_CC_OP2_CORRUPT = 2,
-    DFLTCC_CC_AGAIN = 3,
-} dfltcc_cc;
-
-#define DFLTCC_QAF 0
-#define DFLTCC_GDHT 1
-#define DFLTCC_CMPR 2
-#define DFLTCC_XPND 4
-#define HBT_CIRCULAR (1 << 7)
-#define HB_BITS 15
-#define HB_SIZE (1 << HB_BITS)
-#define DFLTCC_FACILITY 151
-
-static inline dfltcc_cc dfltcc(int fn, void *param,
-                               unsigned char **op1, size_t *len1, z_const unsigned char **op2, size_t *len2, void *hist) {
-    unsigned char *t2 = op1 ? *op1 : NULL;
-    size_t t3 = len1 ? *len1 : 0;
-    z_const unsigned char *t4 = op2 ? *op2 : NULL;
-    size_t t5 = len2 ? *len2 : 0;
-    Z_REGISTER int r0 __asm__("r0") = fn;
-    Z_REGISTER void *r1 __asm__("r1") = param;
-    Z_REGISTER unsigned char *r2 __asm__("r2") = t2;
-    Z_REGISTER size_t r3 __asm__("r3") = t3;
-    Z_REGISTER z_const unsigned char *r4 __asm__("r4") = t4;
-    Z_REGISTER size_t r5 __asm__("r5") = t5;
-    int cc;
-
-    __asm__ volatile(
-#ifdef HAVE_SYS_SDT_H
-                     STAP_PROBE_ASM(zlib, dfltcc_entry, STAP_PROBE_ASM_TEMPLATE(5))
-#endif
-                     ".insn rrf,0xb9390000,%[r2],%[r4],%[hist],0\n"
-#ifdef HAVE_SYS_SDT_H
-                     STAP_PROBE_ASM(zlib, dfltcc_exit, STAP_PROBE_ASM_TEMPLATE(5))
-#endif
-                     "ipm %[cc]\n"
-                     : [r2] "+r" (r2)
-                     , [r3] "+r" (r3)
-                     , [r4] "+r" (r4)
-                     , [r5] "+r" (r5)
-                     , [cc] "=r" (cc)
-                     : [r0] "r" (r0)
-                     , [r1] "r" (r1)
-                     , [hist] "r" (hist)
-#ifdef HAVE_SYS_SDT_H
-                     , STAP_PROBE_ASM_OPERANDS(5, r2, r3, r4, r5, hist)
-#endif
-                     : "cc", "memory");
-    t2 = r2; t3 = r3; t4 = r4; t5 = r5;
-
-    if (op1)
-        *op1 = t2;
-    if (len1)
-        *len1 = t3;
-    if (op2)
-        *op2 = t4;
-    if (len2)
-        *len2 = t5;
-    return (cc >> 28) & 3;
-}
-
-/*
    Parameter Block for Query Available Functions.
  */
 #define static_assert(c, msg) __attribute__((unused)) static char static_assert_failed_ ## msg[c ? 1 : -1]
@@ -106,7 +38,8 @@ struct dfltcc_qaf_param {
     char reserved2[6];
 };
 
-static_assert(sizeof(struct dfltcc_qaf_param) == 32, sizeof_struct_dfltcc_qaf_param_is_32);
+#define DFLTCC_SIZEOF_QAF 32
+static_assert(sizeof(struct dfltcc_qaf_param) == DFLTCC_SIZEOF_QAF, qaf);
 
 static inline int is_bit_set(const char *bits, int n) {
     return bits[n / 8] & (1 << (7 - (n % 8)));
@@ -115,6 +48,8 @@ static inline int is_bit_set(const char *bits, int n) {
 static inline void clear_bit(char *bits, int n) {
     bits[n / 8] &= ~(1 << (7 - (n % 8)));
 }
+
+#define DFLTCC_FACILITY 151
 
 static inline int is_dfltcc_enabled(void) {
     uint64_t facilities[(DFLTCC_FACILITY / 64) + 1];
@@ -189,12 +124,16 @@ struct dfltcc_param_v0 {
     uint16_t cdhtl : 12;               /* Compressed-Dynamic-Huffman Table
                                           Length */
     uint8_t reserved464[6];
-    uint8_t cdht[288];
-    uint8_t reserved[32];
-    uint8_t csb[1152];
+    uint8_t cdht[288];                 /* Compressed-Dynamic-Huffman Table */
+    uint8_t reserved[24];
+    uint8_t ribm2[8];                  /* Reserved for IBM use */
+    uint8_t csb[1152];                 /* Continuation-State Buffer */
 };
 
-static_assert(sizeof(struct dfltcc_param_v0) == 1536, sizeof_struct_dfltcc_param_v0_is_1536);
+#define DFLTCC_SIZEOF_GDHT_V0 384
+#define DFLTCC_SIZEOF_CMPR_XPND_V0 1536
+static_assert(offsetof(struct dfltcc_param_v0, csb) == DFLTCC_SIZEOF_GDHT_V0, gdht_v0);
+static_assert(sizeof(struct dfltcc_param_v0) == DFLTCC_SIZEOF_CMPR_XPND_V0, cmpr_xpnd_v0);
 
 static inline z_const char *oesc_msg(char *buf, int oesc) {
     if (oesc == 0x00)
@@ -203,6 +142,97 @@ static inline z_const char *oesc_msg(char *buf, int oesc) {
         sprintf(buf, "Operation-Ending-Supplemental Code is 0x%.2X", oesc);
         return buf;
     }
+}
+
+/*
+   C wrapper for the DEFLATE CONVERSION CALL instruction.
+ */
+typedef enum {
+    DFLTCC_CC_OK = 0,
+    DFLTCC_CC_OP1_TOO_SHORT = 1,
+    DFLTCC_CC_OP2_TOO_SHORT = 2,
+    DFLTCC_CC_OP2_CORRUPT = 2,
+    DFLTCC_CC_AGAIN = 3,
+} dfltcc_cc;
+
+#define DFLTCC_QAF 0
+#define DFLTCC_GDHT 1
+#define DFLTCC_CMPR 2
+#define DFLTCC_XPND 4
+#define HBT_CIRCULAR (1 << 7)
+#define DFLTCC_FN_MASK ((1 << 7) - 1)
+#define HB_BITS 15
+#define HB_SIZE (1 << HB_BITS)
+
+static inline dfltcc_cc dfltcc(int fn, void *param,
+                               unsigned char **op1, size_t *len1,
+                               z_const unsigned char **op2, size_t *len2, void *hist) {
+    unsigned char *t2 = op1 ? *op1 : NULL;
+#ifdef Z_MEMORY_SANITIZER
+    unsigned char *orig_t2 = t2;
+#endif
+    size_t t3 = len1 ? *len1 : 0;
+    z_const unsigned char *t4 = op2 ? *op2 : NULL;
+    size_t t5 = len2 ? *len2 : 0;
+    Z_REGISTER int r0 __asm__("r0") = fn;
+    Z_REGISTER void *r1 __asm__("r1") = param;
+    Z_REGISTER unsigned char *r2 __asm__("r2") = t2;
+    Z_REGISTER size_t r3 __asm__("r3") = t3;
+    Z_REGISTER z_const unsigned char *r4 __asm__("r4") = t4;
+    Z_REGISTER size_t r5 __asm__("r5") = t5;
+    int cc;
+
+    __asm__ volatile(
+#ifdef HAVE_SYS_SDT_H
+                     STAP_PROBE_ASM(zlib, dfltcc_entry, STAP_PROBE_ASM_TEMPLATE(5))
+#endif
+                     ".insn rrf,0xb9390000,%[r2],%[r4],%[hist],0\n"
+#ifdef HAVE_SYS_SDT_H
+                     STAP_PROBE_ASM(zlib, dfltcc_exit, STAP_PROBE_ASM_TEMPLATE(5))
+#endif
+                     "ipm %[cc]\n"
+                     : [r2] "+r" (r2)
+                     , [r3] "+r" (r3)
+                     , [r4] "+r" (r4)
+                     , [r5] "+r" (r5)
+                     , [cc] "=r" (cc)
+                     : [r0] "r" (r0)
+                     , [r1] "r" (r1)
+                     , [hist] "r" (hist)
+#ifdef HAVE_SYS_SDT_H
+                     , STAP_PROBE_ASM_OPERANDS(5, r2, r3, r4, r5, hist)
+#endif
+                     : "cc", "memory");
+    t2 = r2; t3 = r3; t4 = r4; t5 = r5;
+
+#ifdef Z_MEMORY_SANITIZER
+    switch (fn & DFLTCC_FN_MASK) {
+    case DFLTCC_QAF:
+        __msan_unpoison(param, DFLTCC_SIZEOF_QAF);
+        break;
+    case DFLTCC_GDHT:
+        __msan_unpoison(param, DFLTCC_SIZEOF_GDHT_V0);
+        break;
+    case DFLTCC_CMPR:
+        __msan_unpoison(param, DFLTCC_SIZEOF_CMPR_XPND_V0);
+        __msan_unpoison(orig_t2, t2 - orig_t2 + (((struct dfltcc_param_v0 *)param)->sbb == 0 ? 0 : 1));
+        break;
+    case DFLTCC_XPND:
+        __msan_unpoison(param, DFLTCC_SIZEOF_CMPR_XPND_V0);
+        __msan_unpoison(orig_t2, t2 - orig_t2);
+        break;
+    }
+#endif
+
+    if (op1)
+        *op1 = t2;
+    if (len1)
+        *len1 = t3;
+    if (op2)
+        *op2 = t4;
+    if (len2)
+        *len2 = t5;
+    return (cc >> 28) & 3;
 }
 
 /*

--- a/arch/s390/self-hosted-builder/actions-runner.Dockerfile
+++ b/arch/s390/self-hosted-builder/actions-runner.Dockerfile
@@ -11,6 +11,7 @@ FROM s390x/ubuntu:20.04
 # Packages for zlib-ng testing.
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get -y install \
+        clang-11 \
         cmake \
         curl \
         gcc \
@@ -18,6 +19,7 @@ RUN apt-get update && apt-get -y install \
         jq \
         libxml2-dev \
         libxslt-dev \
+        llvm-11-tools \
         ninja-build \
         python-is-python3 \
         python3 \


### PR DESCRIPTION
* Add a CI job.
* Do not collect coverage: LLVM's gcov support (part of compiler-rt)
  cannot be built with the MSan instrumentation, which means that
  whenever it's called (in particular, in order to write the results to
  a file at the end), there is a risk of false positives.
* Add __msan_unpoison() calls to DFLTCC inline assembly.
* Make parameter block sizes symbolic constants.
* Move dfltcc() definition after struct dfltcc_param_v0 definition.