### PR TITLE
In compatibility mode, always define z_crc_t as uint32_t for backwards compatibility.

### DIFF
--- a/configure
+++ b/configure
@@ -874,6 +874,7 @@ echo >> configure.log
 
 # Check for ANSI C compliant compiler
 cat > $test.c <<EOF
+#include <stdint.h>
 #include <stdio.h>
 #include <stdarg.h>
 #include "zconf${SUFFIX}.h"

--- a/zconf-ng.h.in
+++ b/zconf-ng.h.in
@@ -116,7 +116,6 @@ typedef PTRDIFF_TYPE ptrdiff_t;
 #endif
 
 #include <sys/types.h>      /* for off_t */
-#include <stdarg.h>         /* for va_list */
 
 #include <stddef.h>         /* for wchar_t and NULL */
 

--- a/zconf.h.in
+++ b/zconf.h.in
@@ -127,6 +127,8 @@ typedef void const *voidpc;
 typedef void       *voidpf;
 typedef void       *voidp;
 
+typedef uint32_t z_crc_t;
+
 #ifdef HAVE_UNISTD_H    /* may be set to #if 1 by configure/cmake/etc */
 #  define Z_HAVE_UNISTD_H
 #endif
@@ -136,7 +138,6 @@ typedef PTRDIFF_TYPE ptrdiff_t;
 #endif
 
 #include <sys/types.h>      /* for off_t */
-#include <stdarg.h>         /* for va_list */
 
 #include <stddef.h>         /* for wchar_t and NULL */
 

--- a/zlib-ng.h.in
+++ b/zlib-ng.h.in
@@ -34,9 +34,10 @@
 #endif
 
 #ifndef RC_INVOKED
-#include "zconf-ng.h"
-
 #include <stdint.h>
+#include <stdarg.h>
+
+#include "zconf-ng.h"
 
 #ifndef ZCONFNG_H
 #  error Missing zconf-ng.h add binary output directory to include directories

--- a/zlib.h.in
+++ b/zlib.h.in
@@ -35,10 +35,10 @@
 #endif
 
 #ifndef RC_INVOKED
-#include "zconf.h"
-
 #include <stdint.h>
 #include <stdarg.h>
+
+#include "zconf.h"
 
 #ifndef ZCONF_H
 #  error Missing zconf.h add binary output directory to include directories


### PR DESCRIPTION
Also move include for stdint.h/stdarg.h out of zconf.h/zconf-ng.h as stdint.h must be included first.

See #1296 