### PR TITLE
Prefix shared functions to prevent symbol conflict when linking

### DIFF
--- a/arch/s390/crc32-vx.c
+++ b/arch/s390/crc32-vx.c
@@ -202,12 +202,12 @@ uint32_t Z_INTERNAL PREFIX(s390_crc32_vx)(uint32_t crc, const unsigned char *buf
     uint64_t prealign, aligned, remaining;
 
     if (len < VX_MIN_LEN + VX_ALIGN_MASK)
-        return crc32_braid(crc, buf, len);
+        return PREFIX(crc32_braid)(crc, buf, len);
 
     if ((uintptr_t)buf & VX_ALIGN_MASK) {
         prealign = VX_ALIGNMENT - ((uintptr_t)buf & VX_ALIGN_MASK);
         len -= prealign;
-        crc = crc32_braid(crc, buf, prealign);
+        crc = PREFIX(crc32_braid)(crc, buf, prealign);
         buf += prealign;
     }
     aligned = len & ~VX_ALIGN_MASK;
@@ -216,7 +216,7 @@ uint32_t Z_INTERNAL PREFIX(s390_crc32_vx)(uint32_t crc, const unsigned char *buf
     crc = crc32_le_vgfm_16(crc ^ 0xffffffff, buf, (size_t)aligned) ^ 0xffffffff;
 
     if (remaining)
-        crc = crc32_braid(crc, buf + aligned, remaining);
+        crc = PREFIX(crc32_braid)(crc, buf + aligned, remaining);
 
     return crc;
 }

--- a/arch/x86/crc32_fold_pclmulqdq.c
+++ b/arch/x86/crc32_fold_pclmulqdq.c
@@ -346,7 +346,7 @@ uint32_t crc32_pclmulqdq(uint32_t crc32, const uint8_t *buf, uint64_t len) {
     /* For lens < 64, crc32_braid method is faster. The CRC32 instruction for
      * these short lengths might also prove to be effective */
     if (len < 64)
-        return crc32_braid(crc32, buf, len);
+        return PREFIX(crc32_braid)(crc32, buf, len);
 
     crc32_fold ALIGNED_(16) crc_state;
     crc32_fold_pclmulqdq_reset(&crc_state);

--- a/cpu_features.h
+++ b/cpu_features.h
@@ -113,7 +113,7 @@ extern uint8_t* chunkmemset_safe_power8(uint8_t *out, unsigned dist, unsigned le
 /* CRC32 */
 typedef uint32_t (*crc32_func)(uint32_t crc32, const uint8_t *buf, uint64_t len);
 
-extern uint32_t crc32_braid(uint32_t crc, const uint8_t *buf, uint64_t len);
+extern uint32_t PREFIX(crc32_braid)(uint32_t crc, const uint8_t *buf, uint64_t len);
 #ifdef ARM_ACLE_CRC_HASH
 extern uint32_t crc32_acle(uint32_t crc, const uint8_t *buf, uint64_t len);
 #elif defined(POWER8_VSX_CRC32)

--- a/crc32_braid.c
+++ b/crc32_braid.c
@@ -111,7 +111,7 @@ static z_word_t crc_word(z_word_t data) {
 #endif /* W */
 
 /* ========================================================================= */
-Z_INTERNAL uint32_t crc32_braid(uint32_t crc, const uint8_t *buf, uint64_t len) {
+Z_INTERNAL uint32_t PREFIX(crc32_braid)(uint32_t crc, const uint8_t *buf, uint64_t len) {
     Z_REGISTER uint32_t c;
 
     /* Pre-condition the CRC */

--- a/crc32_braid_p.h
+++ b/crc32_braid_p.h
@@ -45,6 +45,6 @@
 /* CRC polynomial. */
 #define POLY 0xedb88320         /* p(x) reflected, with x^32 implied */
 
-extern uint32_t crc32_braid(uint32_t crc, const uint8_t *buf, uint64_t len);
+extern uint32_t PREFIX(crc32_braid)(uint32_t crc, const uint8_t *buf, uint64_t len);
 
 #endif /* CRC32_BRAID_P_H_ */

--- a/deflate.c
+++ b/deflate.c
@@ -202,11 +202,11 @@ int32_t ZNG_CONDEXPORT PREFIX(deflateInit2)(PREFIX3(stream) *strm, int32_t level
 
     strm->msg = NULL;
     if (strm->zalloc == NULL) {
-        strm->zalloc = zng_calloc;
+        strm->zalloc = PREFIX3(calloc);
         strm->opaque = NULL;
     }
     if (strm->zfree == NULL)
-        strm->zfree = zng_cfree;
+        strm->zfree = PREFIX3(cfree);
 
     if (level == Z_DEFAULT_COMPRESSION)
         level = 6;
@@ -400,14 +400,14 @@ int32_t Z_EXPORT PREFIX(deflateSetDictionary)(PREFIX3(stream) *strm, const uint8
     next = strm->next_in;
     strm->avail_in = dictLength;
     strm->next_in = (z_const unsigned char *)dictionary;
-    fill_window(s);
+    PREFIX(fill_window)(s);
     while (s->lookahead >= STD_MIN_MATCH) {
         str = s->strstart;
         n = s->lookahead - (STD_MIN_MATCH - 1);
         s->insert_string(s, str, n);
         s->strstart = str + n;
         s->lookahead = STD_MIN_MATCH - 1;
-        fill_window(s);
+        PREFIX(fill_window)(s);
     }
     s->strstart += s->lookahead;
     s->block_start = (int)s->strstart;
@@ -1090,7 +1090,7 @@ int32_t Z_EXPORT PREFIX(deflateCopy)(PREFIX3(stream) *dest, PREFIX3(stream) *sou
  * allocating a large strm->next_in buffer and copying from it.
  * (See also flush_pending()).
  */
-Z_INTERNAL unsigned read_buf(PREFIX3(stream) *strm, unsigned char *buf, unsigned size) {
+Z_INTERNAL unsigned PREFIX(read_buf)(PREFIX3(stream) *strm, unsigned char *buf, unsigned size) {
     uint32_t len = strm->avail_in;
 
     len = MIN(len, size);
@@ -1175,7 +1175,7 @@ static void lm_init(deflate_state *s) {
  *    option -- not supported here).
  */
 
-void Z_INTERNAL fill_window(deflate_state *s) {
+void Z_INTERNAL PREFIX(fill_window)(deflate_state *s) {
     unsigned n;
     unsigned int more;    /* Amount of free space at the end of the window. */
     unsigned int wsize = s->w_size;
@@ -1219,7 +1219,7 @@ void Z_INTERNAL fill_window(deflate_state *s) {
          */
         Assert(more >= 2, "more < 2");
 
-        n = read_buf(s->strm, s->window + s->strstart + s->lookahead, more);
+        n = PREFIX(read_buf)(s->strm, s->window + s->strstart + s->lookahead, more);
         s->lookahead += n;
 
         /* Initialize the hash value now that we have some input: */

--- a/deflate.h
+++ b/deflate.h
@@ -373,7 +373,7 @@ static inline void put_uint64(deflate_state *s, uint64_t lld) {
    memory checker errors from longest match routines */
 
 
-void Z_INTERNAL fill_window(deflate_state *s);
+void Z_INTERNAL PREFIX(fill_window)(deflate_state *s);
 void Z_INTERNAL slide_hash_c(deflate_state *s);
 
         /* in trees.c */

--- a/deflate_fast.c
+++ b/deflate_fast.c
@@ -29,7 +29,7 @@ Z_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
          * string following the next match.
          */
         if (s->lookahead < MIN_LOOKAHEAD) {
-            fill_window(s);
+            PREFIX(fill_window)(s);
             if (UNLIKELY(s->lookahead < MIN_LOOKAHEAD && flush == Z_NO_FLUSH)) {
                 return need_more;
             }

--- a/deflate_huff.c
+++ b/deflate_huff.c
@@ -19,7 +19,7 @@ Z_INTERNAL block_state deflate_huff(deflate_state *s, int flush) {
     for (;;) {
         /* Make sure that we have a literal to write. */
         if (s->lookahead == 0) {
-            fill_window(s);
+            PREFIX(fill_window)(s);
             if (s->lookahead == 0) {
                 if (flush == Z_NO_FLUSH)
                     return need_more;

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -179,7 +179,7 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
          * string following the next current_match.
          */
         if (s->lookahead < MIN_LOOKAHEAD) {
-            fill_window(s);
+            PREFIX(fill_window)(s);
             if (s->lookahead < MIN_LOOKAHEAD && flush == Z_NO_FLUSH) {
                 return need_more;
             }

--- a/deflate_p.h
+++ b/deflate_p.h
@@ -48,7 +48,7 @@ static inline void check_match(deflate_state *s, Pos start, Pos match, int lengt
 #endif
 
 Z_INTERNAL void PREFIX(flush_pending)(PREFIX3(stream) *strm);
-Z_INTERNAL unsigned read_buf(PREFIX3(stream) *strm, unsigned char *buf, unsigned size);
+Z_INTERNAL unsigned PREFIX(read_buf)(PREFIX3(stream) *strm, unsigned char *buf, unsigned size);
 
 /* ===========================================================================
  * Save the match info and tally the frequency counts. Return true if

--- a/deflate_quick.c
+++ b/deflate_quick.c
@@ -70,7 +70,7 @@ Z_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
         }
 
         if (UNLIKELY(s->lookahead < MIN_LOOKAHEAD)) {
-            fill_window(s);
+            PREFIX(fill_window)(s);
             if (UNLIKELY(s->lookahead < MIN_LOOKAHEAD && flush == Z_NO_FLUSH)) {
                 return need_more;
             }

--- a/deflate_rle.c
+++ b/deflate_rle.c
@@ -26,7 +26,7 @@ Z_INTERNAL block_state deflate_rle(deflate_state *s, int flush) {
          * for the longest run, plus one for the unrolled loop.
          */
         if (s->lookahead <= STD_MAX_MATCH) {
-            fill_window(s);
+            PREFIX(fill_window)(s);
             if (s->lookahead <= STD_MAX_MATCH && flush == Z_NO_FLUSH)
                 return need_more;
             if (s->lookahead == 0)

--- a/deflate_slow.c
+++ b/deflate_slow.c
@@ -34,7 +34,7 @@ Z_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
          * string following the next match.
          */
         if (s->lookahead < MIN_LOOKAHEAD) {
-            fill_window(s);
+            PREFIX(fill_window)(s);
             if (UNLIKELY(s->lookahead < MIN_LOOKAHEAD && flush == Z_NO_FLUSH)) {
                 return need_more;
             }

--- a/deflate_stored.c
+++ b/deflate_stored.c
@@ -94,7 +94,7 @@ Z_INTERNAL block_state deflate_stored(deflate_state *s, int flush) {
          * the check value.
          */
         if (len) {
-            read_buf(s->strm, s->strm->next_out, len);
+            PREFIX(read_buf)(s->strm, s->strm->next_out, len);
             s->strm->next_out += len;
             s->strm->avail_out -= len;
             s->strm->total_out += len;
@@ -157,7 +157,7 @@ Z_INTERNAL block_state deflate_stored(deflate_state *s, int flush) {
 
     have = MIN(have, s->strm->avail_in);
     if (have) {
-        read_buf(s->strm, s->window + s->strstart, have);
+        PREFIX(read_buf)(s->strm, s->window + s->strstart, have);
         s->strstart += have;
         s->insert += MIN(have, s->w_size - s->insert);
     }

--- a/functable.c
+++ b/functable.c
@@ -407,7 +407,7 @@ Z_INTERNAL uint32_t crc32_stub(uint32_t crc, const uint8_t *buf, uint64_t len) {
     Assert(sizeof(uint64_t) >= sizeof(size_t),
            "crc32_z takes size_t but internally we have a uint64_t len");
 
-    functable.crc32 = &crc32_braid;
+    functable.crc32 = &PREFIX(crc32_braid);
     cpu_check_features();
 #ifdef ARM_ACLE_CRC_HASH
     if (arm_cpu_has_crc32)

--- a/infback.c
+++ b/infback.c
@@ -39,11 +39,11 @@ int32_t ZNG_CONDEXPORT PREFIX(inflateBackInit)(PREFIX3(stream) *strm, int32_t wi
         return Z_STREAM_ERROR;
     strm->msg = NULL;                   /* in case we return an error */
     if (strm->zalloc == NULL) {
-        strm->zalloc = zng_calloc;
+        strm->zalloc = PREFIX3(calloc);
         strm->opaque = NULL;
     }
     if (strm->zfree == NULL)
-        strm->zfree = zng_cfree;
+        strm->zfree = PREFIX3(cfree);
     state = ZALLOC_INFLATE_STATE(strm);
     if (state == NULL)
         return Z_MEM_ERROR;
@@ -192,7 +192,7 @@ int32_t Z_EXPORT PREFIX(inflateBack)(PREFIX3(stream) *strm, in_func in, void *in
                 state->mode = STORED;
                 break;
             case 1:                             /* fixed block */
-                fixedtables(state);
+                PREFIX(fixedtables)(state);
                 Tracev((stderr, "inflate:     fixed codes block%s\n", state->last ? " (last)" : ""));
                 state->mode = LEN;              /* decode codes */
                 break;

--- a/inflate.c
+++ b/inflate.c
@@ -147,11 +147,11 @@ int32_t ZNG_CONDEXPORT PREFIX(inflateInit2)(PREFIX3(stream) *strm, int32_t windo
         return Z_STREAM_ERROR;
     strm->msg = NULL;                   /* in case we return an error */
     if (strm->zalloc == NULL) {
-        strm->zalloc = zng_calloc;
+        strm->zalloc = PREFIX3(calloc);
         strm->opaque = NULL;
     }
     if (strm->zfree == NULL)
-        strm->zfree = zng_cfree;
+        strm->zfree = PREFIX3(cfree);
     state = ZALLOC_INFLATE_STATE(strm);
     if (state == NULL)
         return Z_MEM_ERROR;
@@ -214,7 +214,7 @@ int32_t Z_EXPORT PREFIX(inflatePrime)(PREFIX3(stream) *strm, int32_t bits, int32
    fixed code decoding.  This returns fixed tables from inffixed_tbl.h.
  */
 
-void Z_INTERNAL fixedtables(struct inflate_state *state) {
+void Z_INTERNAL PREFIX(fixedtables)(struct inflate_state *state) {
     state->lencode = lenfix;
     state->lenbits = 9;
     state->distcode = distfix;
@@ -677,7 +677,7 @@ int32_t Z_EXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int32_t flush) {
                 state->mode = STORED;
                 break;
             case 1:                             /* fixed block */
-                fixedtables(state);
+                PREFIX(fixedtables)(state);
                 Tracev((stderr, "inflate:     fixed codes block%s\n", state->last ? " (last)" : ""));
                 state->mode = LEN_;             /* decode codes */
                 if (flush == Z_TREES) {

--- a/inflate.h
+++ b/inflate.h
@@ -135,6 +135,6 @@ struct inflate_state {
 };
 
 int Z_INTERNAL PREFIX(inflate_ensure_window)(struct inflate_state *state);
-void Z_INTERNAL fixedtables(struct inflate_state *state);
+void Z_INTERNAL PREFIX(fixedtables)(struct inflate_state *state);
 
 #endif /* INFLATE_H_ */

--- a/test/benchmarks/benchmark_crc32.cc
+++ b/test/benchmarks/benchmark_crc32.cc
@@ -55,7 +55,7 @@ public:
     } \
     BENCHMARK_REGISTER_F(crc32, name)->Range(1, MAX_RANDOM_INTS_SIZE);
 
-BENCHMARK_CRC32(braid, crc32_braid, 1);
+BENCHMARK_CRC32(braid, PREFIX(crc32_braid), 1);
 
 #ifdef ARM_ACLE_CRC_HASH
 BENCHMARK_CRC32(acle, crc32_acle, arm_cpu_has_crc32);

--- a/test/test_aligned_alloc.cc
+++ b/test/test_aligned_alloc.cc
@@ -41,8 +41,8 @@ void zng_cfree_unaligned(void *opaque, void *ptr) {
 }
 
 TEST(zalloc, aligned_64) {
-    void *return_ptr = zng_alloc_aligned(zng_calloc_unaligned, 0, 1, 100, 64);
+    void *return_ptr = PREFIX3(alloc_aligned)(zng_calloc_unaligned, 0, 1, 100, 64);
     ASSERT_TRUE(return_ptr != NULL);
     EXPECT_EQ((intptr_t)return_ptr % 64, 0);
-    zng_free_aligned(zng_cfree_unaligned, 0, return_ptr);
+    PREFIX3(free_aligned)(zng_cfree_unaligned, 0, return_ptr);
 }

--- a/test/test_crc32.cc
+++ b/test/test_crc32.cc
@@ -206,7 +206,7 @@ INSTANTIATE_TEST_SUITE_P(crc32, crc32_variant, testing::ValuesIn(tests));
         hash(GetParam(), func); \
     }
 
-TEST_CRC32(braid, crc32_braid, 1)
+TEST_CRC32(braid, PREFIX(crc32_braid), 1)
 
 #ifdef ARM_ACLE_CRC_HASH
 TEST_CRC32(acle, crc32_acle, arm_cpu_has_crc32)

--- a/zutil.c
+++ b/zutil.c
@@ -20,18 +20,18 @@ z_const char * const PREFIX(z_errmsg)[10] = {
     (z_const char *)""
 };
 
-const char zlibng_string[] =
-    " zlib-ng 2.1.0.devel forked from zlib";
-
 #ifdef ZLIB_COMPAT
 const char * Z_EXPORT zlibVersion(void) {
     return ZLIB_VERSION;
 }
-#endif
+#else
+const char zlibng_string[] =
+    " zlib-ng 2.1.0.devel forked from zlib";
 
 const char * Z_EXPORT zlibng_version(void) {
     return ZLIBNG_VERSION;
 }
+#endif
 
 unsigned long Z_EXPORT PREFIX(zlibCompileFlags)(void) {
     unsigned long flags;
@@ -100,26 +100,26 @@ const char * Z_EXPORT PREFIX(zError)(int err) {
     return ERR_MSG(err);
 }
 
-void Z_INTERNAL *zng_calloc(void *opaque, unsigned items, unsigned size) {
+void Z_INTERNAL *PREFIX3(calloc)(void *opaque, unsigned items, unsigned size) {
     Z_UNUSED(opaque);
     return zng_alloc((size_t)items * (size_t)size);
 }
 
-void Z_INTERNAL zng_cfree(void *opaque, void *ptr) {
+void Z_INTERNAL PREFIX3(cfree)(void *opaque, void *ptr) {
     Z_UNUSED(opaque);
     zng_free(ptr);
 }
 
 /* Since we support custom memory allocators, some which might not align memory as we expect,
  * we have to ask for extra memory and return an aligned pointer. */
-void Z_INTERNAL *zng_alloc_aligned(zng_calloc_func zalloc, void *opaque, unsigned items, unsigned size, unsigned align) {
+void Z_INTERNAL *PREFIX3(alloc_aligned)(zng_calloc_func zalloc, void *opaque, unsigned items, unsigned size, unsigned align) {
     uintptr_t return_ptr, original_ptr;
     uint32_t alloc_size, align_diff;
     void *ptr;
 
     /* If no custom calloc function used then call zlib-ng's aligned calloc */
-    if (zalloc == zng_calloc)
-        return zng_calloc(opaque, items, size);
+    if (zalloc == PREFIX3(calloc))
+        return PREFIX3(calloc)(opaque, items, size);
 
     /* Allocate enough memory for proper alignment and to store the original memory pointer */
     alloc_size = sizeof(void *) + (items * size) + align;
@@ -141,10 +141,10 @@ void Z_INTERNAL *zng_alloc_aligned(zng_calloc_func zalloc, void *opaque, unsigne
     return (void *)return_ptr;
 }
 
-void Z_INTERNAL zng_free_aligned(zng_cfree_func zfree, void *opaque, void *ptr) {
+void Z_INTERNAL PREFIX3(free_aligned)(zng_cfree_func zfree, void *opaque, void *ptr) {
     /* If no custom cfree function used then call zlib-ng's aligned cfree */
-    if (zfree == zng_cfree) {
-        zng_cfree(opaque, ptr);
+    if (zfree == PREFIX3(cfree)) {
+        PREFIX3(cfree)(opaque, ptr);
         return;
     }
     if (!ptr)

--- a/zutil.h
+++ b/zutil.h
@@ -126,17 +126,17 @@ extern z_const char * const PREFIX(z_errmsg)[10]; /* indexed by 2-zlib_error */
 
          /* memory allocation functions */
 
-void Z_INTERNAL *zng_calloc(void *opaque, unsigned items, unsigned size);
-void Z_INTERNAL   zng_cfree(void *opaque, void *ptr);
+void Z_INTERNAL *PREFIX3(calloc)(void *opaque, unsigned items, unsigned size);
+void Z_INTERNAL  PREFIX3(cfree)(void *opaque, void *ptr);
 
 typedef void *zng_calloc_func(void *opaque, unsigned items, unsigned size);
 typedef void  zng_cfree_func(void *opaque, void *ptr);
 
-void Z_INTERNAL *zng_alloc_aligned(zng_calloc_func zalloc, void *opaque, unsigned items, unsigned size, unsigned align);
-void Z_INTERNAL  zng_free_aligned(zng_cfree_func zfree, void *opaque, void *ptr);
+void Z_INTERNAL *PREFIX3(alloc_aligned)(zng_calloc_func zalloc, void *opaque, unsigned items, unsigned size, unsigned align);
+void Z_INTERNAL  PREFIX3(free_aligned)(zng_cfree_func zfree, void *opaque, void *ptr);
 
-#define ZALLOC(strm, items, size) zng_alloc_aligned((strm)->zalloc, (strm)->opaque, (items), (size), 64)
-#define ZFREE(strm, addr)         zng_free_aligned((strm)->zfree, (strm)->opaque, (void *)(addr))
+#define ZALLOC(strm, items, size) PREFIX3(alloc_aligned)((strm)->zalloc, (strm)->opaque, (items), (size), 64)
+#define ZFREE(strm, addr)         PREFIX3(free_aligned)((strm)->zfree, (strm)->opaque, (void *)(addr))
 
 #define TRY_FREE(s, p)            {if (p) ZFREE(s, p);}
 


### PR DESCRIPTION
Prevents symbol conflict when linking native API against compatibility API. See #1279.
```
crc32_braid.c:(.text+0x60): multiple definition of `crc32_braid'; ../../compat/libz.a(crc32_braid.c.o):crc32_braid.c:(.text+0x70): first defined here
deflate.c:(.text+0x1a50): multiple definition of `read_buf'; ../../compat/libz.a(deflate.c.o):deflate.c:(.text+0x1a40): first defined here
deflate.c:(.text+0x1ae0): multiple definition of `fill_window'; ../../compat/libz.a(deflate.c.o):deflate.c:(.text+0x1ae0): first defined here
inflate.c:(.text+0x460): multiple definition of `fixedtables'; ../../compat/libz.a(inflate.c.o):inflate.c:(.text+0x450): first defined here
zutil.c:(.text+0x0): multiple definition of `zng_calloc'; ../../compat/libz.a(zutil.c.o):zutil.c:(.text+0x0): first defined here
zutil.c:(.text+0x60): multiple definition of `zng_cfree'; ../../compat/libz.a(zutil.c.o):zutil.c:(.text+0x60): first defined here
zutil.c:(.text+0x70): multiple definition of `zlibng_version'; ../../compat/libz.a(zutil.c.o):zutil.c:(.text+0x80): first defined here
zutil.c:(.text+0xb0): multiple definition of `zng_alloc_aligned'; ../../compat/libz.a(zutil.c.o):zutil.c:(.text+0xc0): first defined here
zutil.c:(.text+0x160): multiple definition of `zng_free_aligned'; ../../compat/libz.a(zutil.c.o):zutil.c:(.text+0x170): first defined here
/usr/bin/ld: ../libz-ng.a(zutil.c.o):(.rodata+0x0): multiple definition of `zlibng_string'; ../../compat/libz.a(zutil.c.o):(.rodata+0x0): first defined here
```