### PR TITLE
Bump _POSIX_C_SOURCE to 200809 for strdup()

### DIFF
--- a/test/minideflate.c
+++ b/test/minideflate.c
@@ -3,10 +3,11 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
+#include "zbuild.h"
+
 #include <stdio.h>
 #include <assert.h>
 
-#include "zbuild.h"
 #include "zutil.h"
 
 #if defined(_WIN32) || defined(__CYGWIN__)

--- a/zbuild.h
+++ b/zbuild.h
@@ -3,7 +3,7 @@
 
 #define _POSIX_SOURCE 1  /* fileno */
 #ifndef _POSIX_C_SOURCE
-#  define _POSIX_C_SOURCE 200112L /* snprintf, posix_memalign */
+#  define _POSIX_C_SOURCE 200809L /* snprintf, posix_memalign, strdup */
 #endif
 
 #include <stddef.h>


### PR DESCRIPTION
Google Test uses strdup(), which makes building tests fail on a fresh
MSYS2 setup:

```
In file included from zlib-ng/_deps/googletest-src/googletest/include/gtest/internal/gtest-internal.h:40,
                 from zlib-ng/_deps/googletest-src/googletest/include/gtest/gtest.h:62,
                 from zlib-ng/test/test_compress.cc:17:
zlib-ng/_deps/googletest-src/googletest/include/gtest/internal/gtest-port.h: In function ‘char* testing::internal::posix::StrDup(const char*)’:
zlib-ng/_deps/googletest-src/googletest/include/gtest/internal/gtest-port.h:2046:47: error: ‘strdup’ was not declared in this scope; did you mean ‘StrDup’?
 2046 | inline char* StrDup(const char* src) { return strdup(src); }
      |                                               ^~~~~~
      |                                               StrDup
```

Bump _POSIX_C_SOURCE to enable this function. An alternative solution
would be to define _POSIX_C_SOURCE in test/CMakeLists.txt, but having a
bigger value for zlib-ng itself should not hurt.

Include zbuild.h earlier in minideflate.c in order to make the new
setting take effect for this file.