### PR TITLE
Fix inflateBack to detect invalid input with distances too far.

### DIFF
--- a/infback.c
+++ b/infback.c
@@ -55,6 +55,7 @@ int32_t ZNG_CONDEXPORT PREFIX(inflateBackInit)(PREFIX3(stream) *strm, int32_t wi
     state->window = window;
     state->wnext = 0;
     state->whave = 0;
+    state->sane = 1;
     state->chunksize = functable.chunksize();
     return Z_OK;
 }


### PR DESCRIPTION
Original commit: https://github.com/madler/zlib/commit/2333419cd76cb9ae5f15c9b240b16a2052b27691