### PR TITLE
Fixed functions declared without a prototype warning in tools.

### DIFF
--- a/tools/makecrct.c
+++ b/tools/makecrct.c
@@ -62,7 +62,7 @@ static void write_table64(const z_word_t *table, int k);
   information needed to generate CRCs on data a byte at a time for all
   combinations of CRC register values and incoming bytes.
 */
-static void make_crc_table() {
+static void make_crc_table(void) {
     unsigned i, j, n;
     uint32_t p;
 

--- a/tools/maketrees.c
+++ b/tools/maketrees.c
@@ -98,7 +98,7 @@ static void tr_static_init(void) {
       ((i) == (last)? "\n};\n\n" :    \
        ((i) % (width) == (width)-1 ? ",\n" : ", "))
 
-static void gen_trees_header() {
+static void gen_trees_header(void) {
     int i;
 
     printf("#ifndef TREES_TBL_H_\n");


### PR DESCRIPTION
```
  tools/maketrees.c:101:29: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
static void gen_trees_header()

  tools/makecrct.c:65:27: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
static void make_crc_table()
```