### PR TITLE
Fix a bug when getting a gzip header extra field with inflate().

### DIFF
--- a/inflate.c
+++ b/inflate.c
@@ -550,8 +550,8 @@ int32_t Z_EXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int32_t flush) {
                 if (copy > have)
                     copy = have;
                 if (copy) {
-                    if (state->head != NULL && state->head->extra != NULL) {
-                        len = state->head->extra_len - state->length;
+                    len = state->head->extra_len - state->length;
+                    if (state->head != NULL && state->head->extra != NULL && len < state->head->extra_max) {
                         memcpy(state->head->extra + len, next,
                                 len + copy > state->head->extra_max ?
                                 state->head->extra_max - len : copy);


### PR DESCRIPTION
If the extra field was larger than the space the user provided with
inflateGetHeader(), and if multiple calls of inflate() delivered
the extra header data, then there could be a buffer overflow of the
provided space. This commit assures that provided space is not
exceeded.