### PR TITLE
CVE-2022-37434

### DIFF
--- a/inflate.c
+++ b/inflate.c
@@ -552,9 +552,11 @@ int32_t Z_EXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int32_t flush) {
                 if (copy) {
                     if (state->head != NULL && state->head->extra != NULL) {
                         len = state->head->extra_len - state->length;
-                        memcpy(state->head->extra + len, next,
-                                len + copy > state->head->extra_max ?
-                                state->head->extra_max - len : copy);
+                        if (len < state->head->extra_max) {
+                            memcpy(state->head->extra + len, next,
+                                    len + copy > state->head->extra_max ?
+                                    state->head->extra_max - len : copy);
+                        }
                     }
                     if ((state->flags & 0x0200) && (state->wrap & 4)) {
                         state->check = PREFIX(crc32)(state->check, next, copy);

--- a/test/infcover.c
+++ b/test/infcover.c
@@ -669,6 +669,10 @@ static void cover_fast(void) {
         Z_STREAM_END);
 }
 
+static void cover_cve_2022_37434(void) {
+    inf("1f 8b 08 04 61 62 63 64 61 62 52 51 1f 8b 08 04 61 62 63 64 61 62 52 51 1f 8b 08 04 61 62 63 64 61 62 52 51 1f 8b 08 04 61 62 63 64 61 62 52 51", "wtf", 13, 47, 12, Z_OK);
+}
+
 int main(void) {
     fprintf(stderr, "%s\n", zVersion());
     cover_support();
@@ -677,5 +681,6 @@ int main(void) {
     cover_inflate();
     cover_trees();
     cover_fast();
+    cover_cve_2022_37434();
     return 0;
 }


### PR DESCRIPTION
If the extra field was larger than the space the user provided with
inflateGetHeader(), and if multiple calls of inflate() delivered
the extra header data, then there could be a buffer overflow of the
provided space. This commit assures that provided space is not
exceeded.

See #1323.