### PR TITLE
Inflate: Unconditional refill and fastpath for literals

### DIFF
--- a/inffast.h
+++ b/inffast.h
@@ -12,7 +12,7 @@
 
 void Z_INTERNAL zng_inflate_fast(PREFIX3(stream) *strm, unsigned long start);
 
-#define INFLATE_FAST_MIN_HAVE 8
-#define INFLATE_FAST_MIN_LEFT 258
+#define INFLATE_FAST_MIN_HAVE 15
+#define INFLATE_FAST_MIN_LEFT 260
 
 #endif /* INFFAST_H_ */


### PR DESCRIPTION
This is the second of a series of optimisation changes [described on my blog](https://dougallj.wordpress.com/2022/08/20/faster-zlib-deflate-decompression-on-the-apple-m1-and-x86/).