### PR TITLE
Actually run `configure` CI on macOS with GCC

### DIFF
--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -178,17 +178,17 @@ jobs:
 
           - name: macOS GCC Symbol Prefix
             os: macOS-latest
-            compiler: gcc
+            compiler: gcc-9
             configure-args: --sprefix=zTest_
 
           - name: macOS GCC Symbol Prefix & Compat
             os: macOS-latest
-            compiler: gcc
+            compiler: gcc-9
             configure-args: --zlib-compat --sprefix=zTest_
 
           - name: macOS GCC
             os: macOS-latest
-            compiler: gcc
+            compiler: gcc-9
             configure-args: --warn
 
     steps:


### PR DESCRIPTION
`gcc` is an alias for Apple Clang on macOS.  See for example https://github.com/zlib-ng/zlib-ng/runs/7963904948?check_suite_focus=true
```
gcc -O2  -std=c11 -Wall -fPIC -DNDEBUG -DHAVE_POSIX_MEMALIGN -DWITH_GZFILEOP -fno-semantic-interposition -DHAVE_VISIBILITY_HIDDEN -DHAVE_VISIBILITY_INTERNAL -DHAVE_BUILTIN_CTZ -DHAVE_BUILTIN_CTZLL -DX86_FEATURES -DX86_AVX2 -DX86_AVX2_ADLER32 -DX86_AVX_CHUNKSET -DX86_AVX512 -DX86_AVX512_ADLER32 -DX86_MASK_INTRIN -DX86_AVX512VNNI -DX86_AVX512VNNI_ADLER32 -DX86_SSE41 -DX86_SSE42_CRC_HASH -DX86_SSE42_ADLER32 -DX86_SSE42_CRC_INTRIN -DX86_SSE2 -DX86_SSE2_CHUNKSET -DX86_SSSE3 -DX86_SSSE3_ADLER32 -DX86_PCLMULQDQ_CRC -DPIC -I/Users/runner/work/zlib-ng/zlib-ng -c -o adler32.lo /Users/runner/work/zlib-ng/zlib-ng/adler32.c
clang: warning: argument unused during compilation: '-fno-semantic-interposition' [-Wunused-command-line-argument]
```

In order to use the real GCC you have to call `gcc-9`, `gcc-10`, or `gcc-11`: https://github.com/actions/runner-images/blob/06dd4c14e4aa8c14febdd8d6cf123b8d770b4e4a/images/macos/macos-11-Readme.md#language-and-runtime.