### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,14 +161,16 @@ To install zlib-ng system-wide using the configure script:
 make install
 ```
 
-Alternatively, you can build and install zlib-ng using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+### vcpkg
+
+Alternatively, you can build and install zlib-ng using the [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
 
 ```sh or powershell
-    git clone https://github.com/Microsoft/vcpkg.git
-    cd vcpkg
-    ./bootstrap-vcpkg.sh # "./bootstrap-vcpkg.bat" for powershell
-    ./vcpkg integrate install
-    ./vcpkg install zlib-ng
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh # "./bootstrap-vcpkg.bat" for powershell
+./vcpkg integrate install
+./vcpkg install zlib-ng
 ```
 
 The zlib-ng port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.

--- a/README.md
+++ b/README.md
@@ -161,6 +161,18 @@ To install zlib-ng system-wide using the configure script:
 make install
 ```
 
+Alternatively, you can build and install zlib-ng using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+```sh or powershell
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh # "./bootstrap-vcpkg.bat" for powershell
+    ./vcpkg integrate install
+    ./vcpkg install zlib-ng
+```
+
+The zlib-ng port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 Contributing
 ------------
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ To install zlib-ng system-wide using the configure script:
 make install
 ```
 
-### vcpkg
+### Vcpkg
 
 Alternatively, you can build and install zlib-ng using the [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
 


### PR DESCRIPTION
`zlib-ng` is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `zlib-ng` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `zlib-ng`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/zlib-ng/portfile.cmake). We try to keep the library maintained as close as possible to the original library. :)