### PR TITLE
[Compat] Don't use uint32_t for z_crc_t

### DIFF
--- a/zconf.h.in
+++ b/zconf.h.in
@@ -111,7 +111,7 @@
 #  define ZEXPORTVA Z_EXPORTVA
 #endif
 
-/* Fallback for something that includes us. */
+/* Legacy zlib typedefs for backwards compatibility. Don't assume stdint.h is defined. */
 typedef unsigned char Byte;
 typedef Byte Bytef;
 
@@ -127,7 +127,7 @@ typedef void const *voidpc;
 typedef void       *voidpf;
 typedef void       *voidp;
 
-typedef uint32_t z_crc_t;
+typedef unsigned int z_crc_t;
 
 #ifdef HAVE_UNISTD_H    /* may be set to #if 1 by configure/cmake/etc */
 #  define Z_HAVE_UNISTD_H


### PR DESCRIPTION
* We don't include stdint.h as it must be included before stdarg.h and other headers might include stdarg.h before us

See #1342