### PR TITLE
Fixed benchmarks not building

### DIFF
--- a/test/benchmarks/CMakeLists.txt
+++ b/test/benchmarks/CMakeLists.txt
@@ -12,13 +12,23 @@ find_package(benchmark QUIET)
 if(NOT benchmark_FOUND)
     # Fetch google benchmark source code from official repository
     set(BENCHMARK_ENABLE_TESTING OFF)
+
+    # Allow specifying alternative Google benchmark repository
+    if(NOT DEFINED GBENCHMARK_REPOSITORY)
+        set(GBENCHMARK_REPOSITORY https://github.com/google/benchmark.git)
+    endif()
+    if(NOT DEFINED GBENCHMARK_TAG)
+        set(GBENCHMARK_TAG v1.7.0)
+    endif()
+
     FetchContent_Declare(benchmark
-        GIT_REPOSITORY https://github.com/google/benchmark.git)
+        GIT_REPOSITORY ${GBENCHMARK_REPOSITORY}
+        GIT_TAG ${GBENCHMARK_TAG})
 
     FetchContent_GetProperties(benchmark)
     if(NOT benchmark_POPULATED)
         FetchContent_Populate(benchmark)
-        add_subdirectory(${benchmark_SOURCE_DIR} ${benchmark_BINARY_DIR})
+        add_subdirectory(${benchmark_SOURCE_DIR} ${benchmark_BINARY_DIR} EXCLUDE_FROM_ALL)
     endif()
 endif()
 
@@ -31,6 +41,7 @@ add_executable(benchmark_zlib
     benchmark_slidehash.cc
     )
 
+target_compile_definitions(benchmark_zlib PRIVATE -DBENCHMARK_STATIC_DEFINE)
 target_include_directories(benchmark_zlib PRIVATE
     ${PROJECT_SOURCE_DIR}
     ${PROJECT_BINARY_DIR}

--- a/test/benchmarks/benchmark_adler32_copy.cc
+++ b/test/benchmarks/benchmark_adler32_copy.cc
@@ -36,7 +36,8 @@ public:
          * control the _consistency_ of the results */
         random_ints_src = (uint32_t *)zng_alloc(MAX_RANDOM_INTS_SIZE);
         random_ints_dst = (uint32_t *)zng_alloc(MAX_RANDOM_INTS_SIZE);
-        assert(random_ints != NULL);
+        assert(random_ints_src != NULL);
+        assert(random_ints_dst != NULL);
 
         for (int32_t i = 0; i < MAX_RANDOM_INTS; i++) {
             random_ints_src[i] = rand();

--- a/test/benchmarks/benchmark_adler32_copy.cc
+++ b/test/benchmarks/benchmark_adler32_copy.cc
@@ -77,7 +77,7 @@ public:
         } \
         Bench(state, [](uint32_t init_sum, unsigned char *dst, \
                         const uint8_t *buf, uint64_t len) -> uint32_t { \
-            memcpy(dst, buf, len); \
+            memcpy(dst, buf, (size_t)len); \
             return fptr(init_sum, buf, len); \
         }); \
     } \


### PR DESCRIPTION
This fixes **Ubuntu GCC Benchmark** CI.

Google benchmark repository removed the `master` tag. I think CMake FetchContent defaults to `GIT_TAG=master` so that is possibly why the failures.