### PR TITLE
IBM Z DFLTCC: Fix updating strm.adler with inflate()

### DIFF
--- a/arch/s390/dfltcc_inflate.c
+++ b/arch/s390/dfltcc_inflate.c
@@ -115,7 +115,7 @@ dfltcc_inflate_action Z_INTERNAL PREFIX(dfltcc_inflate)(PREFIX3(streamp) strm, i
     state->bits = param->sbb;
     state->whave = param->hl;
     state->wnext = (param->ho + param->hl) & ((1 << HB_BITS) - 1);
-    state->check = state->flags ? ZSWAP32(param->cv) : param->cv;
+    strm->adler = state->check = state->flags ? ZSWAP32(param->cv) : param->cv;
     if (cc == DFLTCC_CC_OP2_CORRUPT && param->oesc != 0) {
         /* Report an error if stream is corrupted */
         state->mode = BAD;

--- a/test/test_inflate_adler32.cc
+++ b/test/test_inflate_adler32.cc
@@ -41,6 +41,8 @@ TEST(inflate, adler32) {
     err = PREFIX(inflate)(&strm, Z_NO_FLUSH);
     EXPECT_EQ(err, Z_STREAM_END);
 
+    EXPECT_EQ(strm.adler, 0x6b931030);
+
     err = PREFIX(inflateEnd)(&strm);
     EXPECT_EQ(err, Z_OK);
 


### PR DESCRIPTION
inflate() does not update strm.adler with DFLTCC.
Add a missing assignment to dfltcc_inflate() to fix this.
Note that deflate() is not affected.
Also add a test to prevent regressions.