### PR TITLE
Detect the availability of _Thread_local using a configure check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -384,6 +384,21 @@ if(HAVE_ATTRIBUTE_VISIBILITY_INTERNAL)
 endif()
 
 #
+# check for _Thread_local() support in the compiler
+#
+check_c_source_compiles(
+    "_Thread_local int test;
+    int main(void) {
+        (void)test;
+        return 0;
+    }"
+    HAVE_THREAD_LOCAL
+)
+if(HAVE_THREAD_LOCAL)
+    add_definitions(-DHAVE_THREAD_LOCAL)
+endif()
+
+#
 # check for __builtin_ctz() support in the compiler
 #
 check_c_source_compiles(
@@ -398,6 +413,7 @@ check_c_source_compiles(
 if(HAVE_BUILTIN_CTZ)
     add_definitions(-DHAVE_BUILTIN_CTZ)
 endif()
+
 #
 # check for __builtin_ctzll() support in the compiler
 #

--- a/configure
+++ b/configure
@@ -942,6 +942,22 @@ EOF
   fi
 fi
 
+# Check for _Thread_local support in compiler
+cat > $test.c << EOF
+_Thread_local int test;
+int main(void) {
+    (void)test;
+    return 0;
+}
+EOF
+if try ${CC} ${CFLAGS} $test.c $LDSHAREDLIBC; then
+    echo "Checking for _Thread_local ... Yes." | tee -a configure.log
+    CFLAGS="$CFLAGS -DHAVE_THREAD_LOCAL"
+    SFLAGS="$SFLAGS -DHAVE_THREAD_LOCAL"
+else
+    echo "Checking for _Thread_local ... No." | tee -a configure.log
+fi
+
 # Check for __builtin_ctz() support in compiler
 cat > $test.c << EOF
 int main(void) {

--- a/zbuild.h
+++ b/zbuild.h
@@ -27,7 +27,7 @@
 
 /* Determine compiler support for TLS */
 #ifndef Z_TLS
-#  if defined(STDC11) && !defined(__STDC_NO_THREADS__)
+#  ifdef HAVE_THREAD_LOCAL
 #    define Z_TLS _Thread_local
 #  elif defined(__GNUC__) || defined(__SUNPRO_C)
 #    define Z_TLS __thread


### PR DESCRIPTION
`_Thread_local` was first added to GCC in version 4.9. The previous check didn't work because `__STDC_NO_THREADS__` wasn't defined, and [this bug report](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53769) suggests that the define is meant to define the availability of threading support in the standard library rather than the compiler.