### PR TITLE
Improve Microsoft Visual Studio CI & fix build on MSVC 2015,2017

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -348,15 +348,45 @@ jobs:
             packages:  ninja-build llvm-11-tools
             gcov-exec: llvm-cov-11 gcov
 
-          - name: Windows MSVC Win32
+          - name: Windows MSVC 2022 v143 Win32
             os: windows-latest
             compiler: cl
-            cmake-args: -A Win32
+            cmake-args: -G "Visual Studio 17 2022" -A Win32 -T v143
 
-          - name: Windows MSVC Win64
+          - name: Windows MSVC 2022 v143 Win64
             os: windows-latest
             compiler: cl
-            cmake-args: -A x64
+            cmake-args: -G "Visual Studio 17 2022" -A x64 -T v143
+
+          - name: Windows MSVC 2022 v142 Win32
+            os: windows-latest
+            compiler: cl
+            cmake-args: -G "Visual Studio 17 2022" -A Win32 -T v142
+
+          - name: Windows MSVC 2022 v142 Win64
+            os: windows-latest
+            compiler: cl
+            cmake-args: -G "Visual Studio 17 2022" -A x64 -T v142
+
+          - name: Windows MSVC 2022 v141 Win32
+            os: windows-latest
+            compiler: cl
+            cmake-args: -G "Visual Studio 17 2022" -A Win32 -T v141
+
+          - name: Windows MSVC 2022 v141 Win64
+            os: windows-latest
+            compiler: cl
+            cmake-args: -G "Visual Studio 17 2022" -A x64 -T v141
+
+          - name: Windows MSVC 2019 v140 Win32
+            os: windows-2019
+            compiler: cl
+            cmake-args: -G "Visual Studio 16 2019" -A Win32 -T v140
+
+          - name: Windows MSVC 2019 v140 Win64
+            os: windows-2019
+            compiler: cl
+            cmake-args: -G "Visual Studio 16 2019" -A x64 -T v140
 
           - name: Windows MSVC ARM No Test
             os: windows-latest

--- a/arch/x86/adler32_ssse3_p.h
+++ b/arch/x86/adler32_ssse3_p.h
@@ -12,7 +12,7 @@
 #include <stdint.h>
 
 static inline uint32_t partial_hsum(__m128i x) {
-    __m128i second_int = _mm_bsrli_si128(x, 8);
+    __m128i second_int = _mm_srli_si128(x, 8);
     __m128i sum = _mm_add_epi32(x, second_int);
     return _mm_cvtsi128_si32(sum);
 }

--- a/arch/x86/crc32_fold_pclmulqdq.c
+++ b/arch/x86/crc32_fold_pclmulqdq.c
@@ -238,17 +238,18 @@ static inline void crc32_fold_load(__m128i *fold, __m128i *fold0, __m128i *fold1
     *fold3 = _mm_load_si128(fold + 3);
 }
 
-static inline void crc32_fold_save(__m128i *fold, __m128i fold0, __m128i fold1, __m128i fold2, __m128i fold3) {
-    _mm_storeu_si128(fold + 0, fold0);
-    _mm_storeu_si128(fold + 1, fold1);
-    _mm_storeu_si128(fold + 2, fold2);
-    _mm_storeu_si128(fold + 3, fold3);
+static inline void crc32_fold_save(__m128i *fold, const __m128i *fold0, const __m128i *fold1,
+                                   const __m128i *fold2, const __m128i *fold3) {
+    _mm_storeu_si128(fold + 0, *fold0);
+    _mm_storeu_si128(fold + 1, *fold1);
+    _mm_storeu_si128(fold + 2, *fold2);
+    _mm_storeu_si128(fold + 3, *fold3);
 }
 
 Z_INTERNAL uint32_t crc32_fold_pclmulqdq_reset(crc32_fold *crc) {
     __m128i xmm_crc0 = _mm_cvtsi32_si128(0x9db42487);
     __m128i xmm_zero = _mm_setzero_si128();
-    crc32_fold_save((__m128i *)crc->fold, xmm_crc0, xmm_zero, xmm_zero, xmm_zero);
+    crc32_fold_save((__m128i *)crc->fold, &xmm_crc0, &xmm_zero, &xmm_zero, &xmm_zero);
     return 0;
 }
 

--- a/arch/x86/crc32_fold_pclmulqdq_tpl.h
+++ b/arch/x86/crc32_fold_pclmulqdq_tpl.h
@@ -184,6 +184,6 @@ partial:
         partial_fold((size_t)len, &xmm_crc0, &xmm_crc1, &xmm_crc2, &xmm_crc3, &xmm_crc_part);
     }
 
-    crc32_fold_save((__m128i *)crc->fold, xmm_crc0, xmm_crc1, xmm_crc2, xmm_crc3);
+    crc32_fold_save((__m128i *)crc->fold, &xmm_crc0, &xmm_crc1, &xmm_crc2, &xmm_crc3);
 }
 #endif

--- a/cmake/detect-intrinsics.cmake
+++ b/cmake/detect-intrinsics.cmake
@@ -132,6 +132,8 @@ macro(check_avx2_intrinsics)
         if(NOT NATIVEFLAG)
             set(AVX2FLAG "-mavx2")
         endif()
+    elseif(MSVC)
+        set(AVX2FLAG "/arch:AVX2")
     endif()
     # Check whether compiler supports AVX2 intrinics
     set(CMAKE_REQUIRED_FLAGS "${AVX2FLAG} ${NATIVEFLAG}")

--- a/fallback_builtins.h
+++ b/fallback_builtins.h
@@ -71,4 +71,22 @@ static inline __m512i _mm512_zextsi128_si512(__m128i a) {
 
 #endif // __AVX2__
 
+/* Missing zero-extension AVX and AVX512 intrinsics.
+ * Fixed in Microsoft Visual Studio 2017 version 15.7
+ * https://developercommunity.visualstudio.com/t/missing-zero-extension-avx-and-avx512-intrinsics/175737
+ */
+#if defined(_MSC_VER) && _MSC_VER < 1914
+#ifdef __AVX2__
+static inline __m256i _mm256_zextsi128_si256(__m128i a) {
+    return _mm256_inserti128_si256(_mm256_setzero_si256(), a, 0);
+}
+#endif // __AVX2__
+
+#ifdef __AVX512F__
+static inline __m512i _mm512_zextsi128_si512(__m128i a) {
+    return _mm512_inserti32x4(_mm512_setzero_si512(), a, 0);
+}
+#endif // __AVX512F__
+#endif // defined(_MSC_VER) && _MSC_VER < 1914
+
 #endif // include guard FALLBACK_BUILTINS_H


### PR DESCRIPTION
New CI:
- Toolset Visual Studio 2015 (Win32, x64)
- Toolset Visual Studio 2017 (Win32, x64)
- Toolset Visual Studio 2019 (Win32, x64)
- Toolset Visual Studio 2022 (Win32, x64)

Fix build errors on MSVC 2015,2017.

cc @mtl1979