### PR TITLE
Fix memcpy() overflow in adler32_fold.c and crc32_fold.c

### DIFF
--- a/adler32_fold.c
+++ b/adler32_fold.c
@@ -7,14 +7,19 @@
 #include "functable.h"
 #include "adler32_fold.h"
 
+#include <limits.h>
+
 Z_INTERNAL uint32_t adler32_fold_copy_c(uint32_t adler, uint8_t *dst, const uint8_t *src, uint64_t len) {
     adler = functable.adler32(adler, src, len);
-    while (len > SIZE_MAX) {
-        memcpy(dst, src, SIZE_MAX);
-        dst += SIZE_MAX;
-        src += SIZE_MAX;
-        len -= SIZE_MAX;
+/* Test that we don't try to copy more than actually fits in available address space */
+#if INTPTR_MAX > SSIZE_MAX
+    while (len > SSIZE_MAX) {
+        memcpy(dst, src, SSIZE_MAX);
+        dst += SSIZE_MAX;
+        src += SSIZE_MAX;
+        len -= SSIZE_MAX;
     }
+#endif
     if (len) {
         memcpy(dst, src, (size_t)len);
     }

--- a/crc32_fold.c
+++ b/crc32_fold.c
@@ -7,6 +7,8 @@
 
 #include "crc32_fold.h"
 
+#include <limits.h>
+
 Z_INTERNAL uint32_t crc32_fold_reset_c(crc32_fold *crc) {
     crc->value = CRC32_INITIAL_VALUE;
     return crc->value;
@@ -14,12 +16,15 @@ Z_INTERNAL uint32_t crc32_fold_reset_c(crc32_fold *crc) {
 
 Z_INTERNAL void crc32_fold_copy_c(crc32_fold *crc, uint8_t *dst, const uint8_t *src, uint64_t len) {
     crc->value = functable.crc32(crc->value, src, len);
-    while (len > SIZE_MAX) {
-        memcpy(dst, src, SIZE_MAX);
-        dst += SIZE_MAX;
-        src += SIZE_MAX;
-        len -= SIZE_MAX;
+/* Test that we don't try to copy more than actually fits in available address space */
+#if INTPTR_MAX > SSIZE_MAX
+    while (len > SSIZE_MAX) {
+        memcpy(dst, src, SSIZE_MAX);
+        dst += SSIZE_MAX;
+        src += SSIZE_MAX;
+        len -= SSIZE_MAX;
     }
+#endif
     if (len) {
         memcpy(dst, src, (size_t)len);
     }

--- a/zbuild.h
+++ b/zbuild.h
@@ -46,6 +46,12 @@
 #  else
     typedef long ssize_t;
 #  endif
+
+#  if defined(_WIN64)
+    #define SSIZE_MAX _I64_MAX
+#  else
+    #define SSIZE_MAX LONG_MAX
+#  endif
 #endif
 
 /* MS Visual Studio does not allow inline in C, only C++.


### PR DESCRIPTION
* On 32-bit platforms, last parameter of memcpy() is limited to SSIZE_MAX, but is likely to overlap if used