### PR TITLE
Fix deflate() with Z_BEST_COMPRESSION ignoring the dictionary

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -404,7 +404,7 @@ int32_t Z_EXPORT PREFIX(deflateSetDictionary)(PREFIX3(stream) *strm, const uint8
     while (s->lookahead >= STD_MIN_MATCH) {
         str = s->strstart;
         n = s->lookahead - (STD_MIN_MATCH - 1);
-        functable.insert_string(s, str, n);
+        s->insert_string(s, str, n);
         s->strstart = str + n;
         s->lookahead = STD_MIN_MATCH - 1;
         fill_window(s);


### PR DESCRIPTION
Hi!

While working on a DFLTCC improvement, I noticed that using software compression level 9 causes dictionary to be ignored.
I tracked this down to usage of different hashing algorithms.
This patch fixes the issue, but I'm not 100% sure it's correct, in particular:

* Is it safe to mix different hashing algorithms in the same hash table?
* Is it safe to count to `n` here, or do I need to subtract `WANT_MIN_MATCH` or something along these lines?

The problematic test is here: https://github.com/iii-i/zlib-ng/blob/dfltcc-inflate-small-window-20221020/test/test_small_window.cc

Best regards,
Ilya

---

deflate_slow() uses s->quick_insert_string(), while deflateSetDictionary() uses functable.insert_string(). These functions use different hashing algorithms, which leads to deflate_slow() ignoring the dictionary.

Fix by using both functions in deflateSetDictionary().