### PR TITLE
Update wine32 dependencies for Ubuntu 22.04

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -264,9 +264,9 @@ jobs:
             cmake-args: -GNinja -DWITH_DFLTCC_DEFLATE=ON -DWITH_DFLTCC_INFLATE=ON -DWITH_SANITIZER=Memory
 
           - name: Ubuntu MinGW i686
-            os: ubuntu-latest
+            os: ubuntu-22.04
             cmake-args: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-mingw-i686.cmake
-            packages: wine32 gcc-mingw-w64-i686 g++-mingw-w64-i686 libpcre2-8-0=10.34-7 libpcre2-8-0:i386=10.34-7 libodbc1=2.3.6-0.1build1 libodbc1:i386=2.3.6-0.1build1 libwine:i386=5.0-3ubuntu1 libgphoto2-6:i386=2.5.25-0ubuntu0.1 libsane:i386=1.0.29-0ubuntu5.2 libgd3=2.2.5-5.2ubuntu2.1 libgd3:i386=2.2.5-5.2ubuntu2.1
+            packages: wine32 gcc-mingw-w64-i686 g++-mingw-w64-i686 libpcre2-8-0=10.39-3ubuntu0.1 libpcre2-8-0:i386=10.39-3ubuntu0.1 libodbc1=2.3.9-5 libodbc1:i386=2.3.9-5 libwine:i386=6.0.3~repack-1 libgphoto2-6:i386=2.5.27-1build2 libsane:i386=1.1.1-5 libgd3=2.3.0-2ubuntu2 libgd3:i386=2.3.0-2ubuntu2
             ldflags: -static
             codecov: ubuntu_gcc_mingw_i686
             # Limit parallel test jobs to prevent wine errors


### PR DESCRIPTION
GitHub will use either Ubuntu 20.04 or 22.04 for "ubuntu-latest" and that will cause apt to not always find correct versions for dependencies.

Specifying "ubuntu-22.04" explicitly will allow apt to find correct versions and avoid constant updating of the dependency versions. Ubuntu 22.04 should be supported for at least 4 years from now, up to March 2027.

We specify exact versions we want as apt currently can't match dependency versions across architectures.