### PR TITLE
Ubuntu 22.04 CI image doesn't have clang-11 installed.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -291,7 +291,7 @@ jobs:
             os: ubuntu-latest
             compiler: clang-11
             cxx-compiler: clang++-11
-            packages: llvm-11-tools
+            packages: clang-11 llvm-11-tools
             gcov-exec: llvm-cov-11 gcov
             codecov: ubuntu_clang
 
@@ -300,7 +300,7 @@ jobs:
             compiler: clang-11
             cxx-compiler: clang++-11
             cmake-args: -DWITH_INFLATE_STRICT=ON
-            packages: llvm-11-tools
+            packages: clang-11 llvm-11-tools
             gcov-exec: llvm-cov-11 gcov
             codecov: ubuntu_clang_inflate_strict
 
@@ -309,7 +309,7 @@ jobs:
             compiler: clang-11
             cxx-compiler: clang++-11
             cmake-args: -DWITH_INFLATE_ALLOW_INVALID_DIST=ON
-            packages: llvm-11-tools
+            packages: clang-11 llvm-11-tools
             gcov-exec: llvm-cov-11 gcov
             codecov: ubuntu_clang_inflate_allow_invalid_dist
 
@@ -318,7 +318,7 @@ jobs:
             compiler: clang-11
             cxx-compiler: clang++-11
             cmake-args: -DWITH_REDUCED_MEM=ON
-            packages: llvm-11-tools
+            packages: clang-11 llvm-11-tools
             gcov-exec: llvm-cov-11 gcov
             codecov: ubuntu_clang_reduced_mem
 
@@ -327,7 +327,7 @@ jobs:
             compiler: clang-11
             cxx-compiler: clang++-11
             cflags: -DUSE_MMAP
-            packages: llvm-11-tools
+            packages: clang-11 llvm-11-tools
             gcov-exec: llvm-cov-11 gcov
             codecov: ubuntu_clang_mmap
 
@@ -335,7 +335,7 @@ jobs:
             os: ubuntu-latest
             compiler: clang-11
             cxx-compiler: clang++-11
-            packages: llvm-11-tools
+            packages: clang-11 llvm-11-tools
             gcov-exec: llvm-cov-11 gcov
             codecov: ubuntu_clang_debug
             build-config: Debug
@@ -345,7 +345,7 @@ jobs:
             compiler: clang-11
             cxx-compiler: clang++-11
             cmake-args: -GNinja -DWITH_SANITIZER=Memory
-            packages:  ninja-build llvm-11-tools
+            packages:  ninja-build clang-11 llvm-11-tools
             gcov-exec: llvm-cov-11 gcov
 
           - name: Windows MSVC 2022 v143 Win32


### PR DESCRIPTION
"ubuntu-latest" will use either "ubuntu-20.04" or "ubuntu-22.04" images, but "ubuntu-22.04" doesn't have clang-11 installed, so cmake can't find compiler.