### PR TITLE
Fix definition of z_size_t to match documentation of legacy zlib API.

### DIFF
--- a/PORTING.md
+++ b/PORTING.md
@@ -43,7 +43,8 @@ certain value will need to be updated.
 - Static library is *libz.a* on Unix and macOS, or *zlib.lib* on Windows
 - Shared library is *libz.so* on Unix, *libz.dylib* on macOS, or *zlib1.dll*
   on Windows
-- Type `z_size_t` is *unsigned long*
+- Type `z_size_t` is *unsigned __int64* on 64-bit Windows, and *unsigned long* on 32-bit Windows, Unix and macOS
+- Type `z_uintmax_t` is *unsigned long* in zlib-compat mode, and *size_t* with zlib-ng API
 
 zlib-ng native mode
 -------------------

--- a/compress.c
+++ b/compress.c
@@ -28,8 +28,8 @@
    memory, Z_BUF_ERROR if there was not enough room in the output buffer,
    Z_STREAM_ERROR if the level parameter is invalid.
 */
-int Z_EXPORT PREFIX(compress2)(unsigned char *dest, z_size_t *destLen, const unsigned char *source,
-                        z_size_t sourceLen, int level) {
+int Z_EXPORT PREFIX(compress2)(unsigned char *dest, z_uintmax_t *destLen, const unsigned char *source,
+                        z_uintmax_t sourceLen, int level) {
     PREFIX3(stream) stream;
     int err;
     const unsigned int max = (unsigned int)-1;
@@ -63,14 +63,14 @@ int Z_EXPORT PREFIX(compress2)(unsigned char *dest, z_size_t *destLen, const uns
         err = PREFIX(deflate)(&stream, sourceLen ? Z_NO_FLUSH : Z_FINISH);
     } while (err == Z_OK);
 
-    *destLen = (z_size_t)stream.total_out;
+    *destLen = stream.total_out;
     PREFIX(deflateEnd)(&stream);
     return err == Z_STREAM_END ? Z_OK : err;
 }
 
 /* ===========================================================================
  */
-int Z_EXPORT PREFIX(compress)(unsigned char *dest, z_size_t *destLen, const unsigned char *source, z_size_t sourceLen) {
+int Z_EXPORT PREFIX(compress)(unsigned char *dest, z_uintmax_t *destLen, const unsigned char *source, z_uintmax_t sourceLen) {
     return PREFIX(compress2)(dest, destLen, source, sourceLen, Z_DEFAULT_COMPRESSION);
 }
 
@@ -78,8 +78,8 @@ int Z_EXPORT PREFIX(compress)(unsigned char *dest, z_size_t *destLen, const unsi
    If the default memLevel or windowBits for deflateInit() is changed, then
    this function needs to be updated.
  */
-z_size_t Z_EXPORT PREFIX(compressBound)(z_size_t sourceLen) {
-    z_size_t complen = DEFLATE_BOUND_COMPLEN(sourceLen);
+z_uintmax_t Z_EXPORT PREFIX(compressBound)(z_uintmax_t sourceLen) {
+    z_uintmax_t complen = DEFLATE_BOUND_COMPLEN(sourceLen);
 
     if (complen > 0)
         /* Architecture-specific code provided an upper bound. */

--- a/inflate.c
+++ b/inflate.c
@@ -1292,8 +1292,8 @@ int32_t Z_EXPORT PREFIX(inflateSync)(PREFIX3(stream) *strm) {
     in = strm->total_in;
     out = strm->total_out;
     PREFIX(inflateReset)(strm);
-    strm->total_in = (z_size_t)in;
-    strm->total_out = (z_size_t)out;
+    strm->total_in = (z_uintmax_t)in; /* Can't use z_size_t here as it will overflow on 64-bit Windows */
+    strm->total_out = (z_uintmax_t)out;
     state->flags = flags;
     state->mode = TYPE;
     return Z_OK;

--- a/test/example.c
+++ b/test/example.c
@@ -26,13 +26,13 @@ static unsigned long dictId = 0; /* Adler32 value of the dictionary */
 #define MAX_DICTIONARY_SIZE 32768
 
 
-void test_compress      (unsigned char *compr, z_size_t comprLen,unsigned char *uncompr, z_size_t uncomprLen);
+void test_compress      (unsigned char *compr, z_uintmax_t comprLen, unsigned char *uncompr, z_uintmax_t uncomprLen);
 void test_gzio          (const char *fname, unsigned char *uncompr, z_size_t uncomprLen);
 void test_deflate       (unsigned char *compr, size_t comprLen);
 void test_inflate       (unsigned char *compr, size_t comprLen, unsigned char *uncompr, size_t uncomprLen);
 void test_large_deflate (unsigned char *compr, size_t comprLen, unsigned char *uncompr, size_t uncomprLen, int zng_params);
 void test_large_inflate (unsigned char *compr, size_t comprLen, unsigned char *uncompr, size_t uncomprLen);
-void test_flush         (unsigned char *compr, z_size_t *comprLen);
+void test_flush         (unsigned char *compr, z_uintmax_t *comprLen);
 void test_sync          (unsigned char *compr, size_t comprLen, unsigned char *uncompr, size_t uncomprLen);
 void test_dict_deflate  (unsigned char *compr, size_t comprLen);
 void test_dict_inflate  (unsigned char *compr, size_t comprLen, unsigned char *uncompr, size_t uncomprLen);
@@ -63,11 +63,11 @@ void error(const char *format, ...) {
 /* ===========================================================================
  * Test compress() and uncompress()
  */
-void test_compress(unsigned char *compr, z_size_t comprLen, unsigned char *uncompr, z_size_t uncomprLen) {
+void test_compress(unsigned char *compr, z_uintmax_t comprLen, unsigned char *uncompr, z_uintmax_t uncomprLen) {
     int err;
-    size_t len = strlen(hello)+1;
+    unsigned int len = (unsigned int)strlen(hello)+1;
 
-    err = PREFIX(compress)(compr, &comprLen, (const unsigned char*)hello, (z_size_t)len);
+    err = PREFIX(compress)(compr, &comprLen, (const unsigned char*)hello, len);
     CHECK_ERR(err, "compress");
 
     strcpy((char*)uncompr, "garbage");
@@ -402,7 +402,7 @@ void test_large_inflate(unsigned char *compr, size_t comprLen, unsigned char *un
 /* ===========================================================================
  * Test deflate() with full flush
  */
-void test_flush(unsigned char *compr, z_size_t *comprLen) {
+void test_flush(unsigned char *compr, z_uintmax_t *comprLen) {
     PREFIX3(stream) c_stream; /* compression stream */
     int err;
     unsigned int len = (unsigned int)strlen(hello)+1;
@@ -953,8 +953,8 @@ void test_deflate_tune(unsigned char *compr, size_t comprLen) {
  */
 int main(int argc, char *argv[]) {
     unsigned char *compr, *uncompr;
-    z_size_t comprLen = 10000*sizeof(int); /* don't overflow on MSDOS */
-    z_size_t uncomprLen = comprLen;
+    z_uintmax_t comprLen = 10000*sizeof(int); /* don't overflow on MSDOS */
+    z_uintmax_t uncomprLen = comprLen;
     static const char* myVersion = PREFIX2(VERSION);
 
     if (zVersion()[0] != myVersion[0]) {

--- a/test/test_compress.cc
+++ b/test/test_compress.cc
@@ -18,7 +18,7 @@
 
 TEST(compress, basic) {
     uint8_t compr[128], uncompr[128];
-    z_size_t compr_len = sizeof(compr), uncompr_len = sizeof(uncompr);
+    z_uintmax_t compr_len = sizeof(compr), uncompr_len = sizeof(uncompr);
     int err;
 
     err = PREFIX(compress)(compr, &compr_len, (const unsigned char *)hello, hello_len);

--- a/test/test_compress_bound.cc
+++ b/test/test_compress_bound.cc
@@ -35,7 +35,7 @@ public:
         }
 
         for (z_size_t i = 0; i < MAX_LENGTH; i++) {
-            z_size_t dest_len = sizeof(dest);
+            z_uintmax_t dest_len = sizeof(dest);
 
             /* calculate actual output length */
             estimate_len = PREFIX(compressBound)(i);

--- a/uncompr.c
+++ b/uncompr.c
@@ -22,11 +22,11 @@
    Z_DATA_ERROR if the input data was corrupted, including if the input data is
    an incomplete zlib stream.
 */
-int Z_EXPORT PREFIX(uncompress2)(unsigned char *dest, z_size_t *destLen, const unsigned char *source, z_size_t *sourceLen) {
+int Z_EXPORT PREFIX(uncompress2)(unsigned char *dest, z_uintmax_t *destLen, const unsigned char *source, z_uintmax_t *sourceLen) {
     PREFIX3(stream) stream;
     int err;
     const unsigned int max = (unsigned int)-1;
-    z_size_t len, left;
+    z_uintmax_t len, left;
     unsigned char buf[1];    /* for detection of incomplete stream when *destLen == 0 */
 
     len = *sourceLen;
@@ -75,6 +75,6 @@ int Z_EXPORT PREFIX(uncompress2)(unsigned char *dest, z_size_t *destLen, const u
            err;
 }
 
-int Z_EXPORT PREFIX(uncompress)(unsigned char *dest, z_size_t *destLen, const unsigned char *source, z_size_t sourceLen) {
+int Z_EXPORT PREFIX(uncompress)(unsigned char *dest, z_uintmax_t *destLen, const unsigned char *source, z_uintmax_t sourceLen) {
     return PREFIX(uncompress2)(dest, destLen, source, &sourceLen);
 }

--- a/zbuild.h
+++ b/zbuild.h
@@ -85,7 +85,11 @@
 #  define PREFIX3(x) z_ ## x
 #  define PREFIX4(x) x ## 64
 #  define zVersion zlibVersion
-#  define z_size_t unsigned long
+#  if defined(_WIN64)
+#    define z_size_t unsigned __int64
+#  else
+#    define z_size_t unsigned long
+#  endif
 #else
 #  define PREFIX(x) zng_ ## x
 #  define PREFIX2(x) ZLIBNG_ ## x
@@ -93,6 +97,13 @@
 #  define PREFIX4(x) zng_ ## x
 #  define zVersion zlibng_version
 #  define z_size_t size_t
+#endif
+
+/* In zlib-compat some functions and types use unsigned long, but zlib-ng use size_t */
+#if defined(ZLIB_COMPAT)
+#  define z_uintmax_t unsigned long
+#else
+#  define z_uintmax_t size_t
 #endif
 
 /* Minimum of a and b. */


### PR DESCRIPTION
Legacy zlib changed definition of `z_size_t` to smallest unsigned type that can hold a pointer value after we forked, but this was never merged in.

We currently avoid including standard headers in our own headers as some standard headers must be included in specific order, otherwise we could just include `stddef.h` in `zbuild.h`.

Some of the function parameters and return types, and struct members are still limited to `unsigned long` when `ZLIB_COMPAT` is defined.

Blocks: #1356