### PR TITLE
Tell scan-build ASSERT_TRUE() behaves like assert().

### DIFF
--- a/test/test_aligned_alloc.cc
+++ b/test/test_aligned_alloc.cc
@@ -11,6 +11,8 @@ extern "C" {
 
 #include <gtest/gtest.h>
 
+#include "test_shared.h"
+
 void *zng_calloc_unaligned(void *opaque, unsigned items, unsigned size) {
     uint8_t *pointer = (uint8_t *)calloc(1, (items * size) + 2);
     Z_UNUSED(opaque);

--- a/test/test_compare256.cc
+++ b/test/test_compare256.cc
@@ -15,7 +15,10 @@ extern "C" {
 
 #include <gtest/gtest.h>
 
+#include "test_shared.h"
+
 #define MAX_COMPARE_SIZE (256)
+
 
 /* Ensure that compare256 returns the correct match length */
 static inline void compare256_match_check(compare256_func compare256) {

--- a/test/test_compress_bound.cc
+++ b/test/test_compress_bound.cc
@@ -12,9 +12,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "test_shared.h"
-
 #include <gtest/gtest.h>
+
+#include "test_shared.h"
 
 #define MAX_LENGTH (32)
 

--- a/test/test_deflate_bound.cc
+++ b/test/test_deflate_bound.cc
@@ -12,9 +12,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "test_shared.h"
-
 #include <gtest/gtest.h>
+
+#include "test_shared.h"
 
 #define MAX_LENGTH (32)
 

--- a/test/test_deflate_dict.cc
+++ b/test/test_deflate_dict.cc
@@ -12,9 +12,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "test_shared.h"
-
 #include <gtest/gtest.h>
+
+#include "test_shared.h"
 
 TEST(deflate, dictionary) {
     PREFIX3(stream) c_stream;

--- a/test/test_deflate_header.cc
+++ b/test/test_deflate_header.cc
@@ -12,9 +12,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "test_shared.h"
-
 #include <gtest/gtest.h>
+
+#include "test_shared.h"
 
 TEST(deflate, header) {
     PREFIX3(stream) c_stream;

--- a/test/test_deflate_params.cc
+++ b/test/test_deflate_params.cc
@@ -16,9 +16,9 @@
 
 #include "deflate.h"
 
-#include "test_shared.h"
-
 #include <gtest/gtest.h>
+
+#include "test_shared.h"
 
 #define COMPR_BUFFER_SIZE (48 * 1024)
 #define UNCOMPR_BUFFER_SIZE (64 * 1024)

--- a/test/test_deflate_pending.cc
+++ b/test/test_deflate_pending.cc
@@ -12,9 +12,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "test_shared.h"
-
 #include <gtest/gtest.h>
+
+#include "test_shared.h"
 
 TEST(deflate, pending) {
     PREFIX3(stream) c_stream;

--- a/test/test_gzio.cc
+++ b/test/test_gzio.cc
@@ -12,9 +12,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "test_shared.h"
-
 #include <gtest/gtest.h>
+
+#include "test_shared.h"
 
 #define TESTFILE "foo.gz"
 

--- a/test/test_large_buffers.cc
+++ b/test/test_large_buffers.cc
@@ -13,9 +13,9 @@
 #include <string.h>
 #include <time.h>
 
-#include "test_shared.h"
-
 #include <gtest/gtest.h>
+
+#include "test_shared.h"
 
 #define COMPR_BUFFER_SIZE (48 * 1024)
 #define UNCOMPR_BUFFER_SIZE (32 * 1024)

--- a/test/test_shared.h
+++ b/test/test_shared.h
@@ -9,4 +9,10 @@
 static const char hello[] = "hello, hello!";
 static const int hello_len = sizeof(hello);
 
+/* Clang static analyzer doesn't understand googletest's ASSERT_TRUE, so we need to tell that it's like assert() */
+#ifdef __clang_analyzer__
+#  undef  ASSERT_TRUE
+#  define ASSERT_TRUE assert
+#endif
+
 #endif


### PR DESCRIPTION
Fixes false positives with unix.Malloc check.