### PR TITLE
Add one extra byte to return value of compressBound and deflateBound …

### DIFF
--- a/compress.c
+++ b/compress.c
@@ -92,6 +92,8 @@ z_size_t Z_EXPORT PREFIX(compressBound)(z_size_t sourceLen) {
 
 #ifndef NO_QUICK_STRATEGY
     return sourceLen                       /* The source size itself */
+      + (sourceLen == 0 ? 1 : 0)           /* Always at least one byte for any input */
+      + (sourceLen < 9 ? 1 : 0)            /* One extra byte for lengths less than 9 */
       + DEFLATE_QUICK_OVERHEAD(sourceLen)  /* Source encoding overhead, padded to next full byte */
       + DEFLATE_BLOCK_OVERHEAD             /* Deflate block overhead bytes */
       + ZLIB_WRAPLEN;                      /* zlib wrapper */

--- a/deflate.c
+++ b/deflate.c
@@ -723,6 +723,8 @@ unsigned long Z_EXPORT PREFIX(deflateBound)(PREFIX3(stream) *strm, unsigned long
 
 #ifndef NO_QUICK_STRATEGY
     return sourceLen                       /* The source size itself */
+      + (sourceLen == 0 ? 1 : 0)           /* Always at least one byte for any input */
+      + (sourceLen < 9 ? 1 : 0)            /* One extra byte for lengths less than 9 */
       + DEFLATE_QUICK_OVERHEAD(sourceLen)  /* Source encoding overhead, padded to next full byte */
       + DEFLATE_BLOCK_OVERHEAD             /* Deflate block overhead bytes */
       + wraplen;                           /* none, zlib or gzip wrapper */


### PR DESCRIPTION
…for small lengths due to shift returning 0.

* Treat 0 byte input as 1 byte input when calculating compressBound and deflateBound

Fixes:  #1391 

(cherry picked from commit 4fadf3c49e3dc98c5e1c0b86401324061d951d9f)