### PR TITLE
Use Ubuntu 20.04 images for SPARC64 and PPC64LE tests

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -212,7 +212,7 @@ jobs:
             codecov: ubuntu_gcc_ppc64
 
           - name: Ubuntu GCC PPC64LE
-            os: ubuntu-latest
+            os: ubuntu-20.04
             cmake-args: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-powerpc64le.cmake
             packages: qemu qemu-user gcc-powerpc64le-linux-gnu g++-powerpc64le-linux-gnu libc-dev-ppc64el-cross
             codecov: ubuntu_gcc_ppc64le

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -218,7 +218,7 @@ jobs:
             codecov: ubuntu_gcc_ppc64le
 
           - name: Ubuntu GCC SPARC64
-            os: ubuntu-latest
+            os: ubuntu-20.04
             cmake-args: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-sparc64.cmake
             packages: qemu qemu-user gcc-sparc64-linux-gnu g++-sparc64-linux-gnu libc-dev-sparc64-cross
             ldflags: -static


### PR DESCRIPTION
I suspect that qemu or gcc or whatever must be buggy. See #1378 and #1379.