### PR TITLE
Improve performance of crc32_acle on 32-bit ARM

### DIFF
--- a/arch/arm/crc32_acle.c
+++ b/arch/arm/crc32_acle.c
@@ -17,34 +17,40 @@ Z_INTERNAL uint32_t crc32_acle(uint32_t crc, const uint8_t *buf, size_t len) {
     Z_REGISTER uint32_t c;
     Z_REGISTER const uint16_t *buf2;
     Z_REGISTER const uint32_t *buf4;
+    Z_REGISTER const uint64_t *buf8;
 
     c = ~crc;
-    if (len && ((ptrdiff_t)buf & 1)) {
-        c = __crc32b(c, *buf++);
-        len--;
-    }
 
-    if ((len >= sizeof(uint16_t)) && ((ptrdiff_t)buf & sizeof(uint16_t))) {
-        buf2 = (const uint16_t *) buf;
-        c = __crc32h(c, *buf2++);
-        len -= sizeof(uint16_t);
-        buf4 = (const uint32_t *) buf2;
-    } else {
-        buf4 = (const uint32_t *) buf;
-    }
-
-#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
-    if ((len >= sizeof(uint32_t)) && ((ptrdiff_t)buf & sizeof(uint32_t))) {
-        c = __crc32w(c, *buf4++);
-        len -= sizeof(uint32_t);
-    }
-
-    if (len == 0) {
+    if (UNLIKELY(len == 1)) {
+        c = __crc32b(c, *buf);
         c = ~c;
         return c;
     }
 
-    const uint64_t *buf8 = (const uint64_t *) buf4;
+    if ((ptrdiff_t)buf & (sizeof(uint64_t) - 1)) {
+        if (len && ((ptrdiff_t)buf & 1)) {
+            c = __crc32b(c, *buf++);
+            len--;
+        }
+
+        if ((len >= sizeof(uint16_t)) && ((ptrdiff_t)buf & sizeof(uint16_t))) {
+            buf2 = (const uint16_t *) buf;
+            c = __crc32h(c, *buf2++);
+            len -= sizeof(uint16_t);
+            buf4 = (const uint32_t *) buf2;
+        } else {
+            buf4 = (const uint32_t *) buf;
+        }
+
+        if ((len >= sizeof(uint32_t)) && ((ptrdiff_t)buf & sizeof(uint32_t))) {
+            c = __crc32w(c, *buf4++);
+            len -= sizeof(uint32_t);
+        }
+
+        buf8 = (const uint64_t *) buf4;
+    } else {
+        buf8 = (const uint64_t *) buf;
+    }
 
     while (len >= sizeof(uint64_t)) {
         c = __crc32d(c, *buf8++);
@@ -66,28 +72,6 @@ Z_INTERNAL uint32_t crc32_acle(uint32_t crc, const uint8_t *buf, size_t len) {
     }
 
     buf = (const unsigned char *) buf2;
-#else /* __aarch64__ */
-
-    if (len == 0) {
-        c = ~c;
-        return c;
-    }
-
-    while (len >= sizeof(uint32_t)) {
-        c = __crc32w(c, *buf4++);
-        len -= sizeof(uint32_t);
-    }
-
-    if (len >= sizeof(uint16_t)) {
-        buf2 = (const uint16_t *) buf4;
-        c = __crc32h(c, *buf2++);
-        len -= sizeof(uint16_t);
-        buf = (const unsigned char *) buf2;
-    } else {
-        buf = (const unsigned char *) buf4;
-    }
-#endif /* __aarch64__ */
-
     if (len) {
         c = __crc32b(c, *buf);
     }


### PR DESCRIPTION
This does a few things:
- `__crc32d` is called even on AArch32, where it expands to two `__crc32w` instructions.
- ~The number of intermediate variables is reduced, which makes modern GCC more likely to use `ldrd` or `ldm` instead of two `ldr` instructions.~ This wasn't as beneficial as I'd hoped.
- ~`size_t` is used for the length to avoid 64-bit comparisons and subtractions in the inner loop. This can be simplified once PR #1356 is merged.~
- The alignment checks are simplified so that most of them are skipped if the buffer is already aligned.
- A special case is added when the length is 1.


Results from `benchmark_zlib` on a Raspberry Pi 400 (outdated) - Before:
```
----------------------------------------------------------------------------------
Benchmark                                        Time             CPU   Iterations
----------------------------------------------------------------------------------
crc32/acle/1                                  6.22 ns         6.22 ns    112505190
crc32/acle/8                                  25.9 ns         25.9 ns     27547565
crc32/acle/64                                 37.8 ns         37.8 ns     18518587
crc32/acle/512                                 235 ns          235 ns      2977104
crc32/acle/4096                               1730 ns         1729 ns       404738
crc32/acle/32768                             13968 ns        13967 ns        50177
crc32/acle/262144                           110440 ns       110436 ns         6327
crc32/acle/2097152                          984960 ns       984810 ns          707
crc32/acle/4194304                         1966942 ns      1966880 ns          355
```

After:
```
----------------------------------------------------------------------------------
Benchmark                                        Time             CPU   Iterations
----------------------------------------------------------------------------------
crc32/acle/1                                  11.7 ns         11.7 ns     59957221
crc32/acle/8                                  16.7 ns         16.7 ns     41973016
crc32/acle/64                                 27.8 ns         27.8 ns     25184196
crc32/acle/512                                99.0 ns         98.9 ns      7074500
crc32/acle/4096                                597 ns          597 ns      1171412
crc32/acle/32768                              5081 ns         5080 ns       134381
crc32/acle/262144                            38645 ns        38641 ns        18111
crc32/acle/2097152                          559192 ns       559120 ns         1238
crc32/acle/4194304                         1118589 ns      1118471 ns          623
```