### PR TITLE
Relax AVX512 requirements for older GCC support

### DIFF
--- a/cmake/detect-intrinsics.cmake
+++ b/cmake/detect-intrinsics.cmake
@@ -46,7 +46,13 @@ macro(check_avx512_intrinsics)
             # instruction scheduling unless you specify a reasonable -mtune= target
             set(AVX512FLAG "-mavx512f -mavx512dq -mavx512bw -mavx512vl")
             if(NOT CMAKE_GENERATOR_TOOLSET MATCHES "ClangCl")
-                set(AVX512FLAG "${AVX512FLAG} -mtune=cascadelake")
+                check_c_compiler_flag("-mtune=cascadelake" HAVE_CASCADE_LAKE)
+                if(HAVE_CASCADE_LAKE)
+                    set(AVX512FLAG "${AVX512FLAG} -mtune=cascadelake")
+                else()
+                    set(AVX512FLAG "${AVX512FLAG} -mtune=skylake-avx512")
+                endif()
+                unset(HAVE_CASCADE_LAKE)
             endif()
         endif()
     elseif(MSVC)
@@ -58,10 +64,10 @@ macro(check_avx512_intrinsics)
         "#include <immintrin.h>
         int main(void) {
             __m512i x = _mm512_set1_epi8(2);
-            const __m512i y = _mm512_set_epi8(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
-                                              20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37,
-                                              38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55,
-                                              56, 57, 58, 59, 60, 61, 62, 63, 64);
+            const __m512i y = _mm512_set_epi32(0x1020304, 0x5060708, 0x90a0b0c, 0xd0e0f10,
+                                               0x11121314, 0x15161718, 0x191a1b1c, 0x1d1e1f20,
+                                               0x21222324, 0x25262728, 0x292a2b2c, 0x2d2e2f30,
+                                               0x31323334, 0x35363738, 0x393a3b3c, 0x3d3e3f40);
             x = _mm512_sub_epi8(x, y);
             (void)x;
             return 0;

--- a/configure
+++ b/configure
@@ -105,7 +105,7 @@ native=0
 forcesse2=0
 # For CPUs that can benefit from AVX512, it seems GCC generates suboptimal
 # instruction scheduling unless you specify a reasonable -mtune= target
-avx512flag="-mavx512f -mavx512dq -mavx512bw -mavx512vl -mtune=cascadelake"
+avx512flag="-mavx512f -mavx512dq -mavx512bw -mavx512vl"
 avx512vnniflag="-mavx512vnni ${avx512flag}"
 avx2flag="-mavx2"
 sse2flag="-msse2"
@@ -1063,10 +1063,10 @@ check_avx512_intrinsics() {
 #include <immintrin.h>
 int main(void) {
     __m512i x = _mm512_set1_epi8(2);
-    const __m512i y = _mm512_set_epi8(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
-                                      20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37,
-                                      38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55,
-                                      56, 57, 58, 59, 60, 61, 62, 63, 64);
+    const __m512i y = _mm512_set_epi32(0x1020304, 0x5060708, 0x90a0b0c, 0xd0e0f10,
+                                       0x11121314, 0x15161718, 0x191a1b1c, 0x1d1e1f20,
+                                       0x21222324, 0x25262728, 0x292a2b2c, 0x2d2e2f30,
+                                       0x31323334, 0x35363738, 0x393a3b3c, 0x3d3e3f40);
     x = _mm512_sub_epi8(x, y);
     (void)x;
     return 0;
@@ -1078,6 +1078,35 @@ EOF
     else
         echo "Checking for AVX512 intrinsics ... No." | tee -a configure.log
         HAVE_AVX512_INTRIN=0
+    fi
+}
+
+check_mtune_skylake_avx512_compiler_flag() {
+    # Check whether -mtune=skylake-avx512 works correctly
+    cat > $test.c << EOF
+int main() { return 0; }
+EOF
+    if try $CC -c $CFLAGS -mtune=skylake-avx512 $test.c; then
+        MTUNE_SKYLAKE_AVX512_AVAILABLE=1
+        echo "Check whether -mtune=skylake-avx512 works ... Yes." | tee -a configure.log
+    else
+        echo "Check whether -mtune=skylake-avx512 works ... No." | tee -a configure.log
+        MTUNE_SKYLAKE_AVX512_AVAILABLE=0
+    fi
+}
+
+check_mtune_cascadelake_compiler_flag() {
+    # Check whether -mtune=cascadelake works correctly
+    cat > $test.c << EOF
+int main() { return 0; }
+EOF
+    if try $CC -c $CFLAGS -mtune=cascadelake $test.c; then
+        MTUNE_CASCADELAKE_AVAILABLE=1
+        echo "Check whether -mtune=cascadelake works ... Yes." | tee -a configure.log
+    else
+        echo "Check whether -mtune=cascadelake works ... No." | tee -a configure.log
+        MTUNE_CASCADELAKE_AVAILABLE=0
+        check_mtune_skylake_avx512_compiler_flag
     fi
 }
 
@@ -1564,6 +1593,16 @@ case "${ARCH}" in
                 if test ${HAVE_MASK_INTRIN} -eq 1; then
                     CFLAGS="${CFLAGS} -DX86_MASK_INTRIN"
                     SFLAGS="${SFLAGS} -DX86_MASK_INTRIN"
+                fi
+            fi
+
+            check_mtune_cascadelake_compiler_flag
+
+            if test ${MTUNE_CASCADELAKE_AVAILABLE} -eq 1; then
+                avx512flag="${avx512flag} -mtune=cascadelake"
+            else
+                if test ${MTUNE_SKYLAKE_AVX512_AVAILABLE} -eq 1; then
+                    avx512flag="${avx512flag} -mtune=skylake-avx512"
                 fi
             fi
 

--- a/fallback_builtins.h
+++ b/fallback_builtins.h
@@ -72,6 +72,46 @@ static inline __m512i _mm512_zextsi128_si512(__m128i a) {
 
 #endif // __AVX2__
 
+/* GCC <9 is missing some AVX512 intrinsics.
+ */
+#ifdef __AVX512F__
+#if (!defined(__clang__) && defined(__GNUC__) && __GNUC__ < 9)
+#include <immintrin.h>
+
+#define PACK(c0, c1, c2, c3) (((int)(unsigned char)(c0) << 24) | ((int)(unsigned char)(c1) << 16) | \
+                              ((int)(unsigned char)(c2) << 8) | ((int)(unsigned char)(c3)))
+
+static inline __m512i _mm512_set_epi8(char __q63, char __q62, char __q61, char __q60,
+                                      char __q59, char __q58, char __q57, char __q56,
+                                      char __q55, char __q54, char __q53, char __q52,
+                                      char __q51, char __q50, char __q49, char __q48,
+                                      char __q47, char __q46, char __q45, char __q44,
+                                      char __q43, char __q42, char __q41, char __q40,
+                                      char __q39, char __q38, char __q37, char __q36,
+                                      char __q35, char __q34, char __q33, char __q32,
+                                      char __q31, char __q30, char __q29, char __q28,
+                                      char __q27, char __q26, char __q25, char __q24,
+                                      char __q23, char __q22, char __q21, char __q20,
+                                      char __q19, char __q18, char __q17, char __q16,
+                                      char __q15, char __q14, char __q13, char __q12,
+                                      char __q11, char __q10, char __q09, char __q08,
+                                      char __q07, char __q06, char __q05, char __q04,
+                                      char __q03, char __q02, char __q01, char __q00) {
+    return _mm512_set_epi32(PACK(__q63, __q62, __q61, __q60), PACK(__q59, __q58, __q57, __q56),
+                            PACK(__q55, __q54, __q53, __q52), PACK(__q51, __q50, __q49, __q48),
+                            PACK(__q47, __q46, __q45, __q44), PACK(__q43, __q42, __q41, __q40),
+                            PACK(__q39, __q38, __q37, __q36), PACK(__q35, __q34, __q33, __q32),
+                            PACK(__q31, __q30, __q29, __q28), PACK(__q27, __q26, __q25, __q24),
+                            PACK(__q23, __q22, __q21, __q20), PACK(__q19, __q18, __q17, __q16),
+                            PACK(__q15, __q14, __q13, __q12), PACK(__q11, __q10, __q09, __q08),
+                            PACK(__q07, __q06, __q05, __q04), PACK(__q03, __q02, __q01, __q00));
+}
+
+#undef PACK
+
+#endif // gcc version test
+#endif // __AVX512F__
+
 /* Missing zero-extension AVX and AVX512 intrinsics.
  * Fixed in Microsoft Visual Studio 2017 version 15.7
  * https://developercommunity.visualstudio.com/t/missing-zero-extension-avx-and-avx512-intrinsics/175737


### PR DESCRIPTION
'_mm512_set_epi8' intrinsic is missing in GCC <9. However, its usage can be easily eliminated in favor of '_mm512_set_epi32' with no loss in performance enabling older GCC to benefit from AVX512-optimized codepaths.