### PR TITLE
Pin Google Benchmark to v1.7.1 to fix the upstream issue https://github.com/google/benchmark/issues/1454.

### DIFF
--- a/test/benchmarks/CMakeLists.txt
+++ b/test/benchmarks/CMakeLists.txt
@@ -18,7 +18,7 @@ if(NOT benchmark_FOUND)
         set(GBENCHMARK_REPOSITORY https://github.com/google/benchmark.git)
     endif()
     if(NOT DEFINED GBENCHMARK_TAG)
-        set(GBENCHMARK_TAG v1.7.0)
+        set(GBENCHMARK_TAG v1.7.1)
     endif()
 
     FetchContent_Declare(benchmark


### PR DESCRIPTION
CMake command:
```
cmake -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=Release -DWITH_BENCHMARKS=ON ..
```

Error:
```
Run Build Command(s):/usr/bin/make -f Makefile cmTC_eb0c4/fast && /Applications/Xcode.app/Contents/Developer/usr/bin/make  -f CMakeFiles/cmTC_eb0c4.dir/build.make CMakeFiles/cmTC_eb0c4.dir/build
Building CXX object CMakeFiles/cmTC_eb0c4.dir/thread_safety_attributes.cpp.o
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++   -std=c++11  -Wall  -Wextra  -Wshadow  -Wfloat-equal  -Wsuggest-override  -pedantic  -pedantic-errors  -Wshorten-64-to-32  -fstrict-aliasing  -Wno-deprecated-declarations  -Wstrict-aliasing  -Wthread-safety  -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk -mmacosx-version-min=12.6 -MD -MT CMakeFiles/cmTC_eb0c4.dir/thread_safety_attributes.cpp.o -MF CMakeFiles/cmTC_eb0c4.dir/thread_safety_attributes.cpp.o.d -o CMakeFiles/cmTC_eb0c4.dir/thread_safety_attributes.cpp.o -c /Users/phprus/Devel/phprus/zlib-ng/build/_deps/benchmark-src/cmake/thread_safety_attributes.cpp
In file included from /Users/phprus/Devel/phprus/zlib-ng/build/_deps/benchmark-src/cmake/thread_safety_attributes.cpp:2:
In file included from /Users/phprus/Devel/phprus/zlib-ng/build/_deps/benchmark-src/cmake/../src/mutex.h:7:
/Users/phprus/Devel/phprus/zlib-ng/build/_deps/benchmark-src/cmake/../src/check.h:8:10: fatal error: 'benchmark/export.h' file not found
#include "benchmark/export.h"
         ^~~~~~~~~~~~~~~~~~~~
1 error generated.
make[1]: *** [CMakeFiles/cmTC_eb0c4.dir/thread_safety_attributes.cpp.o] Error 1
make: *** [cmTC_eb0c4/fast] Error 2
```


Upstream issue: https://github.com/google/benchmark/issues/1454
Upstream PR: https://github.com/google/benchmark/pull/1456
Fixed in release: https://github.com/google/benchmark/releases/tag/v1.7.1