### PR TITLE
Fix several cases of wrongly exported functions and errors in the version scripts.

### DIFF
--- a/arch/arm/adler32_neon.c
+++ b/arch/arm/adler32_neon.c
@@ -141,7 +141,7 @@ static void NEON_handle_tail(uint32_t *pair, const uint8_t *buf, size_t len) {
     }
 }
 
-uint32_t adler32_neon(uint32_t adler, const uint8_t *buf, size_t len) {
+Z_INTERNAL uint32_t adler32_neon(uint32_t adler, const uint8_t *buf, size_t len) {
     /* split Adler-32 into component sums */
     uint32_t sum2 = (adler >> 16) & 0xffff;
     adler &= 0xffff;

--- a/arch/arm/crc32_acle.c
+++ b/arch/arm/crc32_acle.c
@@ -13,7 +13,7 @@
 #endif
 #include "../../zbuild.h"
 
-uint32_t crc32_acle(uint32_t crc, const uint8_t *buf, size_t len) {
+Z_INTERNAL uint32_t crc32_acle(uint32_t crc, const uint8_t *buf, size_t len) {
     Z_REGISTER uint32_t c;
     Z_REGISTER const uint16_t *buf2;
     Z_REGISTER const uint32_t *buf4;

--- a/arch/power/adler32_power8.c
+++ b/arch/power/adler32_power8.c
@@ -52,7 +52,7 @@ static inline vector unsigned int vec_sumsu(vector unsigned int __a, vector unsi
     return __a;
 }
 
-uint32_t adler32_power8(uint32_t adler, const uint8_t *buf, size_t len) {
+Z_INTERNAL uint32_t adler32_power8(uint32_t adler, const uint8_t *buf, size_t len) {
     uint32_t s1 = adler & 0xffff;
     uint32_t s2 = (adler >> 16) & 0xffff;
 

--- a/arch/power/adler32_vmx.c
+++ b/arch/power/adler32_vmx.c
@@ -113,7 +113,7 @@ static void vmx_accum32(uint32_t *s, const uint8_t *buf, size_t len) {
     vec_ste(s2acc, 0, s+1);
 }
 
-uint32_t adler32_vmx(uint32_t adler, const uint8_t *buf, size_t len) {
+Z_INTERNAL uint32_t adler32_vmx(uint32_t adler, const uint8_t *buf, size_t len) {
     uint32_t sum2;
     uint32_t pair[16] ALIGNED_(16);
     memset(&pair[2], 0, 14);

--- a/deflate.c
+++ b/deflate.c
@@ -202,11 +202,11 @@ int32_t ZNG_CONDEXPORT PREFIX(deflateInit2)(PREFIX3(stream) *strm, int32_t level
 
     strm->msg = NULL;
     if (strm->zalloc == NULL) {
-        strm->zalloc = PREFIX3(calloc);
+        strm->zalloc = PREFIX(zcalloc);
         strm->opaque = NULL;
     }
     if (strm->zfree == NULL)
-        strm->zfree = PREFIX3(cfree);
+        strm->zfree = PREFIX(zcfree);
 
     if (level == Z_DEFAULT_COMPRESSION)
         level = 6;

--- a/infback.c
+++ b/infback.c
@@ -38,11 +38,11 @@ int32_t ZNG_CONDEXPORT PREFIX(inflateBackInit)(PREFIX3(stream) *strm, int32_t wi
         return Z_STREAM_ERROR;
     strm->msg = NULL;                   /* in case we return an error */
     if (strm->zalloc == NULL) {
-        strm->zalloc = PREFIX3(calloc);
+        strm->zalloc = PREFIX(zcalloc);
         strm->opaque = NULL;
     }
     if (strm->zfree == NULL)
-        strm->zfree = PREFIX3(cfree);
+        strm->zfree = PREFIX(zcfree);
     state = ZALLOC_INFLATE_STATE(strm);
     if (state == NULL)
         return Z_MEM_ERROR;

--- a/inflate.c
+++ b/inflate.c
@@ -146,11 +146,11 @@ int32_t ZNG_CONDEXPORT PREFIX(inflateInit2)(PREFIX3(stream) *strm, int32_t windo
         return Z_STREAM_ERROR;
     strm->msg = NULL;                   /* in case we return an error */
     if (strm->zalloc == NULL) {
-        strm->zalloc = PREFIX3(calloc);
+        strm->zalloc = PREFIX(zcalloc);
         strm->opaque = NULL;
     }
     if (strm->zfree == NULL)
-        strm->zfree = PREFIX3(cfree);
+        strm->zfree = PREFIX(zcfree);
     state = ZALLOC_INFLATE_STATE(strm);
     if (state == NULL)
         return Z_MEM_ERROR;

--- a/zlib-ng.map
+++ b/zlib-ng.map
@@ -5,12 +5,12 @@ ZLIB_NG_2.1.0 {
     zng_inflateBackInit;
     zng_inflateInit;
     zng_inflateInit2;
+    zlibng_version;
 };
 
 ZLIB_NG_2.0.0 {
   global:
     zng_adler32;
-    zng_adler32_c;
     zng_adler32_combine;
     zng_adler32_z;
     zng_compress;
@@ -64,17 +64,14 @@ ZLIB_NG_2.0.0 {
     zng_uncompress2;
     zng_zError;
     zng_zlibCompileFlags;
-    zng_zlibng_string;
-    zng_version;
+    zng_vstring;
   local:
     zng_deflate_copyright;
     zng_inflate_copyright;
-    zng_inflate_fast;
-    zng_inflate_table;
     zng_zcalloc;
     zng_zcfree;
     zng_z_errmsg;
-    zng_gz_error;
+    gz_error;
     _*;
 };
 
@@ -95,20 +92,20 @@ ZLIB_NG_GZ_2.0.0 {
     zng_gzgetc;
     zng_gzgets;
     zng_gzoffset;
-    zng_gzoffset64;
     zng_gzopen;
-    zng_gzopen64;
     zng_gzprintf;
     zng_gzputc;
     zng_gzputs;
     zng_gzread;
     zng_gzrewind;
     zng_gzseek;
-    zng_gzseek64;
     zng_gzsetparams;
     zng_gztell;
-    zng_gztell64;
     zng_gzungetc;
     zng_gzvprintf;
     zng_gzwrite;
+};
+
+FAIL {
+  local: *;
 };

--- a/zlib.map
+++ b/zlib.map
@@ -9,8 +9,6 @@ ZLIB_1.2.0 {
   local:
     deflate_copyright;
     inflate_copyright;
-    inflate_fast;
-    inflate_table;
     zcalloc;
     zcfree;
     z_errmsg;

--- a/zlib_name_mangling-ng.h.in
+++ b/zlib_name_mangling-ng.h.in
@@ -125,10 +125,8 @@
 #  define zng_uncompress2           @ZLIB_SYMBOL_PREFIX@zng_uncompress2
 #endif
 #define zng_zError                @ZLIB_SYMBOL_PREFIX@zng_zError
-#ifndef Z_SOLO
-#  define zng_zcalloc               @ZLIB_SYMBOL_PREFIX@zng_zcalloc
-#  define zng_zcfree                @ZLIB_SYMBOL_PREFIX@zng_zcfree
-#endif
+#define zng_zcalloc               @ZLIB_SYMBOL_PREFIX@zng_zcalloc
+#define zng_zcfree                @ZLIB_SYMBOL_PREFIX@zng_zcfree
 #define zng_zlibCompileFlags      @ZLIB_SYMBOL_PREFIX@zng_zlibCompileFlags
 #define zng_zlibVersion           @ZLIB_SYMBOL_PREFIX@zng_zlibVersion
 
@@ -171,8 +169,6 @@
 #define zng_zError             @ZLIB_SYMBOL_PREFIX@zng_zError
 
 #define zng_alloc_aligned      @ZLIB_SYMBOL_PREFIX@zng_alloc_aligned
-#define zng_calloc             @ZLIB_SYMBOL_PREFIX@zng_calloc
-#define zng_cfree              @ZLIB_SYMBOL_PREFIX@zng_cfree
 #define zng_free_aligned       @ZLIB_SYMBOL_PREFIX@zng_free_aligned
 #define zng_get_crc_table      @ZLIB_SYMBOL_PREFIX@zng_get_crc_table
 #define zng_inflateSyncPoint   @ZLIB_SYMBOL_PREFIX@zng_inflateSyncPoint

--- a/zlib_name_mangling-ng.h.in
+++ b/zlib_name_mangling-ng.h.in
@@ -18,11 +18,9 @@
 #define zng_adler32_combine       @ZLIB_SYMBOL_PREFIX@zng_adler32_combine
 #define zng_adler32_combine64     @ZLIB_SYMBOL_PREFIX@zng_adler32_combine64
 #define zng_adler32_z             @ZLIB_SYMBOL_PREFIX@zng_adler32_z
-#ifndef Z_SOLO
-#  define zng_compress              @ZLIB_SYMBOL_PREFIX@zng_compress
-#  define zng_compress2             @ZLIB_SYMBOL_PREFIX@zng_compress2
-#  define zng_compressBound         @ZLIB_SYMBOL_PREFIX@zng_compressBound
-#endif
+#define zng_compress              @ZLIB_SYMBOL_PREFIX@zng_compress
+#define zng_compress2             @ZLIB_SYMBOL_PREFIX@zng_compress2
+#define zng_compressBound         @ZLIB_SYMBOL_PREFIX@zng_compressBound
 #define zng_crc32                 @ZLIB_SYMBOL_PREFIX@zng_crc32
 #define zng_crc32_combine         @ZLIB_SYMBOL_PREFIX@zng_crc32_combine
 #define zng_crc32_combine64       @ZLIB_SYMBOL_PREFIX@zng_crc32_combine64
@@ -52,7 +50,7 @@
 #define zng_fixedtables           @ZLIB_SYMBOL_PREFIX@zng_fixedtables
 #define zng_flush_pending         @ZLIB_SYMBOL_PREFIX@zng_flush_pending
 #define zng_get_crc_table         @ZLIB_SYMBOL_PREFIX@zng_get_crc_table
-#ifndef Z_SOLO
+#ifdef WITH_GZFILEOP
 #  define zng_gz_error              @ZLIB_SYMBOL_PREFIX@zng_gz_error
 #  define zng_gz_strwinerror        @ZLIB_SYMBOL_PREFIX@zng_gz_strwinerror
 #  define zng_gzbuffer              @ZLIB_SYMBOL_PREFIX@zng_gzbuffer
@@ -120,10 +118,8 @@
 #define zng_inflate_fast          @ZLIB_SYMBOL_PREFIX@zng_inflate_fast
 #define zng_inflate_table         @ZLIB_SYMBOL_PREFIX@zng_inflate_table
 #define zng_read_buf              @ZLIB_SYMBOL_PREFIX@zng_read_buf
-#ifndef Z_SOLO
-#  define zng_uncompress            @ZLIB_SYMBOL_PREFIX@zng_uncompress
-#  define zng_uncompress2           @ZLIB_SYMBOL_PREFIX@zng_uncompress2
-#endif
+#define zng_uncompress            @ZLIB_SYMBOL_PREFIX@zng_uncompress
+#define zng_uncompress2           @ZLIB_SYMBOL_PREFIX@zng_uncompress2
 #define zng_zError                @ZLIB_SYMBOL_PREFIX@zng_zError
 #define zng_zcalloc               @ZLIB_SYMBOL_PREFIX@zng_zcalloc
 #define zng_zcfree                @ZLIB_SYMBOL_PREFIX@zng_zcfree
@@ -136,7 +132,7 @@
 #define alloc_func            @ZLIB_SYMBOL_PREFIX@alloc_func
 #define charf                 @ZLIB_SYMBOL_PREFIX@charf
 #define free_func             @ZLIB_SYMBOL_PREFIX@free_func
-#ifndef Z_SOLO
+#ifdef WITH_GZFILEOP
 #  define gzFile                @ZLIB_SYMBOL_PREFIX@gzFile
 #endif
 #define gz_header             @ZLIB_SYMBOL_PREFIX@gz_header
@@ -156,9 +152,6 @@
 #define zng_gz_header_s           @ZLIB_SYMBOL_PREFIX@zng_gz_header_s
 #define internal_state            @ZLIB_SYMBOL_PREFIX@internal_state
 
-/* all zlib structs in zutil.h */
-#define zlibng_string             @ZLIB_SYMBOL_PREFIX@zlibng_string
-
 /* zlib-ng specific symbols */
 #define zng_deflate_param         @ZLIB_SYMBOL_PREFIX@zng_deflate_param
 #define zng_deflate_param_value   @ZLIB_SYMBOL_PREFIX@zng_deflate_param_value
@@ -166,6 +159,7 @@
 #define zng_deflateGetParams      @ZLIB_SYMBOL_PREFIX@zng_deflateGetParams
 
 #define zlibng_version         @ZLIB_SYMBOL_PREFIX@zlibng_version
+#define zng_vstring            @ZLIB_SYMBOL_PREFIX@zng_vstring
 #define zng_zError             @ZLIB_SYMBOL_PREFIX@zng_zError
 
 #define zng_alloc_aligned      @ZLIB_SYMBOL_PREFIX@zng_alloc_aligned

--- a/zlib_name_mangling.h.in
+++ b/zlib_name_mangling.h.in
@@ -160,11 +160,11 @@
 
 /* all zlib structs in zutil.h */
 #define z_errmsg              @ZLIB_SYMBOL_PREFIX@z_errmsg
-#define zlibng_string         @ZLIB_SYMBOL_PREFIX@zlibng_string
+#define z_vstring             @ZLIB_SYMBOL_PREFIX@z_vstring
 #define zlibng_version        @ZLIB_SYMBOL_PREFIX@zlibng_version
 
 /* zlib-ng specific symbols */
-#define zng_alloc_aligned      @ZLIB_SYMBOL_PREFIX@zng_alloc_aligned
-#define zng_free_aligned       @ZLIB_SYMBOL_PREFIX@zng_free_aligned
+#define zng_alloc_aligned     @ZLIB_SYMBOL_PREFIX@zng_alloc_aligned
+#define zng_free_aligned      @ZLIB_SYMBOL_PREFIX@zng_free_aligned
 
 #endif /* ZLIB_NAME_MANGLING_H */

--- a/zlib_name_mangling.h.in
+++ b/zlib_name_mangling.h.in
@@ -165,8 +165,6 @@
 
 /* zlib-ng specific symbols */
 #define zng_alloc_aligned      @ZLIB_SYMBOL_PREFIX@zng_alloc_aligned
-#define zng_calloc             @ZLIB_SYMBOL_PREFIX@zng_calloc
-#define zng_cfree              @ZLIB_SYMBOL_PREFIX@zng_cfree
 #define zng_free_aligned       @ZLIB_SYMBOL_PREFIX@zng_free_aligned
 
 #endif /* ZLIB_NAME_MANGLING_H */

--- a/zutil.c
+++ b/zutil.c
@@ -100,12 +100,12 @@ const char * Z_EXPORT PREFIX(zError)(int err) {
     return ERR_MSG(err);
 }
 
-void Z_INTERNAL *PREFIX3(calloc)(void *opaque, unsigned items, unsigned size) {
+void Z_INTERNAL *PREFIX(zcalloc)(void *opaque, unsigned items, unsigned size) {
     Z_UNUSED(opaque);
     return zng_alloc((size_t)items * (size_t)size);
 }
 
-void Z_INTERNAL PREFIX3(cfree)(void *opaque, void *ptr) {
+void Z_INTERNAL PREFIX(zcfree)(void *opaque, void *ptr) {
     Z_UNUSED(opaque);
     zng_free(ptr);
 }
@@ -118,8 +118,8 @@ void Z_INTERNAL *PREFIX3(alloc_aligned)(zng_calloc_func zalloc, void *opaque, un
     void *ptr;
 
     /* If no custom calloc function used then call zlib-ng's aligned calloc */
-    if (zalloc == PREFIX3(calloc))
-        return PREFIX3(calloc)(opaque, items, size);
+    if (zalloc == PREFIX(zcalloc))
+        return PREFIX(zcalloc)(opaque, items, size);
 
     /* Allocate enough memory for proper alignment and to store the original memory pointer */
     alloc_size = sizeof(void *) + (items * size) + align;
@@ -143,8 +143,8 @@ void Z_INTERNAL *PREFIX3(alloc_aligned)(zng_calloc_func zalloc, void *opaque, un
 
 void Z_INTERNAL PREFIX3(free_aligned)(zng_cfree_func zfree, void *opaque, void *ptr) {
     /* If no custom cfree function used then call zlib-ng's aligned cfree */
-    if (zfree == PREFIX3(cfree)) {
-        PREFIX3(cfree)(opaque, ptr);
+    if (zfree == PREFIX(zcfree)) {
+        PREFIX(zcfree)(opaque, ptr);
         return;
     }
     if (!ptr)

--- a/zutil.c
+++ b/zutil.c
@@ -20,14 +20,14 @@ z_const char * const PREFIX(z_errmsg)[10] = {
     (z_const char *)""
 };
 
+const char PREFIX3(vstring)[] =
+    " zlib-ng 2.1.0.devel forked from zlib";
+
 #ifdef ZLIB_COMPAT
 const char * Z_EXPORT zlibVersion(void) {
     return ZLIB_VERSION;
 }
 #else
-const char zlibng_string[] =
-    " zlib-ng 2.1.0.devel forked from zlib";
-
 const char * Z_EXPORT zlibng_version(void) {
     return ZLIBNG_VERSION;
 }

--- a/zutil.h
+++ b/zutil.h
@@ -126,8 +126,8 @@ extern z_const char * const PREFIX(z_errmsg)[10]; /* indexed by 2-zlib_error */
 
          /* memory allocation functions */
 
-void Z_INTERNAL *PREFIX3(calloc)(void *opaque, unsigned items, unsigned size);
-void Z_INTERNAL  PREFIX3(cfree)(void *opaque, void *ptr);
+void Z_INTERNAL *PREFIX(zcalloc)(void *opaque, unsigned items, unsigned size);
+void Z_INTERNAL  PREFIX(zcfree)(void *opaque, void *ptr);
 
 typedef void *zng_calloc_func(void *opaque, unsigned items, unsigned size);
 typedef void  zng_cfree_func(void *opaque, void *ptr);


### PR DESCRIPTION
- Add missing Z_INTERNAL to some functions that should not be exported.
- Introduced PREFIX5() macro.
- Fixed calloc/cfree prefixing.
- Fixed several errors in the version scripts.
- Fixed several problems with name mangling.

Resolves #1427 