### PR TITLE
Functable cleanup

### DIFF
--- a/functable.c
+++ b/functable.c
@@ -150,6 +150,7 @@ static void init_functable(void) {
     // ARM - NEON
 #if defined(ARM_NEON) && defined(HAVE_BUILTIN_CTZLL)
     if (arm_cpu_has_neon) {
+        ft.compare256 = &compare256_neon;
         ft.longest_match = &longest_match_neon;
         ft.longest_match_slow = &longest_match_slow_neon;
     }

--- a/functable.c
+++ b/functable.c
@@ -56,27 +56,24 @@ static void init_functable(void) {
     // Select arch-optimized functions
 
     // X86 - SSE2
-#ifdef X86_SSE2
+#if defined(X86_SSE2) || defined(X86_SSE2_CHUNKSET)
 #  if !defined(__x86_64__) && !defined(_M_X64) && !defined(X86_NOCHECK_SSE2)
     if (x86_cpu_has_sse2)
 #  endif
+    {
+#  ifdef X86_SSE2
         ft.slide_hash = &slide_hash_sse2;
-#endif
-#if defined(X86_SSE2) && defined(HAVE_BUILTIN_CTZ)
-    if (x86_cpu_has_sse2) {
+#    ifdef HAVE_BUILTIN_CTZ
         ft.longest_match = &longest_match_sse2;
         ft.longest_match_slow = &longest_match_slow_sse2;
         ft.compare256 = &compare256_sse2;
-    }
-#endif
-#ifdef X86_SSE2_CHUNKSET
-# if !defined(__x86_64__) && !defined(_M_X64) && !defined(X86_NOCHECK_SSE2)
-    if (x86_cpu_has_sse2)
-# endif
-    {
+#    endif
+#  endif
+#  ifdef X86_SSE2_CHUNKSET
         ft.chunksize = &chunksize_sse2;
         ft.chunkmemset_safe = &chunkmemset_safe_sse2;
         ft.inflate_fast = &inflate_fast_sse2;
+#  endif
     }
 #endif
     // X86 - SSSE3
@@ -121,14 +118,13 @@ static void init_functable(void) {
     }
 #endif
 #ifdef X86_AVX2
-    if (x86_cpu_has_avx2)
-        ft.slide_hash = &slide_hash_avx2;
-#endif
-#if defined(X86_AVX2) && defined(HAVE_BUILTIN_CTZ)
     if (x86_cpu_has_avx2) {
+        ft.slide_hash = &slide_hash_avx2;
+#  ifdef HAVE_BUILTIN_CTZ
         ft.longest_match = &longest_match_avx2;
         ft.longest_match_slow = &longest_match_slow_avx2;
         ft.compare256 = &compare256_avx2;
+#  endif
     }
 #endif
 #ifdef X86_AVX2_ADLER32


### PR DESCRIPTION
- Simplified functable.c
- Combined checks that were identical and rewritten some that were not identical but were closely related.
- Made longest_match and compare256 use the X86_NOCHECK_SSE2 override, thus now those are also automatically enabled on x86_64.

There is no easy way to do this, but I tried to split the changes into two commits. Easiest for review is to just look at the resulting file.
I think I have gotten the ordering/priority of the checks right, but please verify if you can.

There is still a whole lot of separate defines that probably could be combined. Just some examples: `ARM_NEON`, `ARM_NEON_ADLER32`, `ARM_NEON_SLIDEHASH` and `ARM_NEON_CHUNKSET`.
I bet those could all have used `ARM_NEON` instead. If we want to have the ability to specifically disable specific optimized functions, I'd have preferred we just use `ARM_NEON` and then check for `ifndef DISABLE_NEON_CHUNKSET` so they don't need to be set by the build system, but can be added manually if someone wanted to disable specifics.
I might make a separate PR for that.