### PR TITLE
Update actions package dependencies

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -12,8 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Ubuntu 18.04 GCC
-            os: ubuntu-18.04
+          - name: Ubuntu 20.04 GCC
+            os: ubuntu-20.04
             compiler: gcc
             cxx-compiler: g++
 
@@ -281,8 +281,8 @@ jobs:
              # Limit parallel test jobs to prevent wine errors
             parallels-jobs: 1
 
-          - name: Ubuntu 18.04 Clang
-            os: ubuntu-18.04
+          - name: Ubuntu 20.04 Clang
+            os: ubuntu-20.04
             compiler: clang-6.0
             cxx-compiler: clang++-6.0
             packages: clang-6.0

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -548,7 +548,7 @@ jobs:
           --xml --output coverage.xml
 
     - name: Upload coverage report
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       if: matrix.codecov && (env.CODECOV_TOKEN != '' || github.repository == 'zlib-ng/zlib-ng')
       with:
         token: ${{ secrets.CODECOV_TOKEN || 'e4fdf847-f541-4ab1-9d50-3d27e5913906' }}
@@ -561,7 +561,7 @@ jobs:
         CODECOV_TOKEN: "${{secrets.CODECOV_TOKEN}}"
 
     - name: Upload build errors
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: ${{ matrix.name }} (cmake)

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -482,7 +482,7 @@ jobs:
 
     - name: Install Emscripten
       if: contains(matrix.name, 'WASM32')
-      uses: mymindstorm/setup-emsdk@v11
+      uses: mymindstorm/setup-emsdk@v12
 
     - name: Initialize Wine
       # Prevent parallel test jobs from initializing Wine at the same time

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -220,7 +220,7 @@ jobs:
       working-directory: ${{ matrix.build-dir }}
 
     - name: Upload build errors
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: ${{ matrix.name }} (configure)

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -196,7 +196,7 @@ jobs:
 
     - name: Install Emscripten
       if: contains(matrix.name, 'WASM32')
-      uses: mymindstorm/setup-emsdk@v11
+      uses: mymindstorm/setup-emsdk@v12
 
     - name: Generate project files
       run: |

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -13,8 +13,8 @@ jobs:
             compiler: gcc
             configure-args: --warn
 
-          - name: Ubuntu 18.04 GCC
-            os: ubuntu-18.04
+          - name: Ubuntu 20.04 GCC
+            os: ubuntu-20.04
             compiler: gcc
             configure-args: --warn
 

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -29,7 +29,7 @@ jobs:
         dry-run: false
 
     - name: Upload Crash
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: artifacts

--- a/.github/workflows/link.yml
+++ b/.github/workflows/link.yml
@@ -27,7 +27,7 @@ jobs:
       run: cmake --build native --config Release
 
     - name: Upload build errors
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: Link zlib (CMake Logs)
@@ -56,7 +56,7 @@ jobs:
       run: cmake --build native --config Release
 
     - name: Upload build errors
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: Link zlib-ng compat (CMake Logs)

--- a/.github/workflows/nmake.yml
+++ b/.github/workflows/nmake.yml
@@ -51,7 +51,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Setup development environment
-      uses: ilammy/msvc-dev-cmd@v1.10.0
+      uses: ilammy/msvc-dev-cmd@v1.12.1
       with:
         arch: ${{ matrix.arch }}
 

--- a/.github/workflows/pigz.yml
+++ b/.github/workflows/pigz.yml
@@ -111,7 +111,7 @@ jobs:
         CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
 
     - name: Upload build errors
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: ${{ matrix.name }} (cmake)

--- a/.github/workflows/pigz.yml
+++ b/.github/workflows/pigz.yml
@@ -99,7 +99,7 @@ jobs:
           --xml --output coverage.xml
 
     - name: Upload coverage report
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       if: matrix.codecov && (env.CODECOV_TOKEN != '' || github.repository == 'zlib-ng/zlib-ng')
       with:
         token: ${{ secrets.CODECOV_TOKEN || 'e4fdf847-f541-4ab1-9d50-3d27e5913906' }}

--- a/.github/workflows/pkgcheck.yml
+++ b/.github/workflows/pkgcheck.yml
@@ -153,7 +153,7 @@ jobs:
         LDFLAGS: ${{ matrix.ldflags }}
 
     - name: Upload build errors
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: ${{ matrix.name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
       working-directory: out
 
     - name: Upload release (Windows)
-      uses: svenstaro/upload-release-action@v1-release
+      uses: svenstaro/upload-release-action@v2
       if: runner.os == 'Windows'
       with:
         asset_name: zlib-ng-${{ matrix.deploy-name }}.zip


### PR DESCRIPTION
This hopefully gets rid of the various deprecation warnings we have been seeing lately.
They were up to 56 warnings just for the cmake workflow.
Possibly faster to install when they are all using the same version of Node? IDK.
Some bugs have also been fixed, as well as some new features that we are not yet using.

Notable features I noticed while reading changelogs:
- VS version is selectable https://github.com/ilammy/msvc-dev-cmd/pull/52
- Release uploader now allows setting release name, etc
- Codecov xcode argument support https://github.com/codecov/codecov-action/pull/699
- Codecov gcov argument support https://github.com/codecov/codecov-action/pull/688