### PR TITLE
Fix ambiguous shift warning in inflateCopy.

### DIFF
--- a/inflate.c
+++ b/inflate.c
@@ -1352,7 +1352,7 @@ int32_t Z_EXPORT PREFIX(inflateCopy)(PREFIX3(stream) *dest, PREFIX3(stream) *sou
     }
     copy->next = copy->codes + (state->next - state->codes);
     if (window != NULL) {
-        ZCOPY_WINDOW(window, state->window, 1U << state->wbits);
+        ZCOPY_WINDOW(window, state->window, (size_t)1U << state->wbits);
     }
     copy->window = window;
     dest->state = (struct internal_state *)copy;


### PR DESCRIPTION
Microsoft Visual C++ gives warning if result of 32-bit shift is passed as function parameter expecting 64-bit type.

Separated from #1377.
Fixes #1389. 