### PR TITLE
Adjust thread counts for compiles and tests

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -49,7 +49,7 @@ jobs:
         CI: true
 
     - name: Compile source code
-      run: cmake --build . --config Release > /dev/null
+      run: cmake --build . -j2 --config Release > /dev/null
 
   Clang:
     runs-on: ubuntu-latest
@@ -75,4 +75,4 @@ jobs:
     - name: Compile source code
       run: |
         scan-build --status-bugs \
-          cmake --build . --config Release > /dev/null
+          cmake --build . -j2 --config Release > /dev/null

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -231,6 +231,8 @@ jobs:
             packages: qemu qemu-user gcc-s390x-linux-gnu g++-s390x-linux-gnu libc-dev-s390x-cross
             ldflags: -static
             codecov: ubuntu_gcc_s390x
+            # The dedicated test VM has 4 cores
+            parallels-jobs: 4
 
           - name: Ubuntu GCC S390X No vectorized CRC32 ASAN
             os: ubuntu-latest
@@ -239,6 +241,8 @@ jobs:
             packages: qemu qemu-user gcc-s390x-linux-gnu g++-s390x-linux-gnu libc-dev-s390x-cross
             ldflags: -static
             codecov: ubuntu_gcc_s390x_no_crc32
+            # The dedicated test VM has 4 cores
+            parallels-jobs: 4
 
           - name: Ubuntu GCC S390X DFLTCC ASAN
             os: z15
@@ -248,6 +252,8 @@ jobs:
             asan-options: detect_leaks=0
             ldflags: -static
             codecov: ubuntu_gcc_s390x_dfltcc
+            # The dedicated test VM has 4 cores
+            parallels-jobs: 4
 
           - name: Ubuntu GCC S390X DFLTCC Compat UBSAN
             os: z15
@@ -256,12 +262,16 @@ jobs:
             cmake-args: -DZLIB_COMPAT=ON -DWITH_DFLTCC_DEFLATE=ON -DWITH_DFLTCC_INFLATE=ON -DWITH_SANITIZER=Undefined
             ldflags: -static
             codecov: ubuntu_gcc_s390x_dfltcc_compat
+            # The dedicated test VM has 4 cores
+            parallels-jobs: 4
 
           - name: Ubuntu Clang S390X DFLTCC MSAN
             os: z15
             compiler: clang-11
             cxx-compiler: clang++-11
             cmake-args: -GNinja -DWITH_DFLTCC_DEFLATE=ON -DWITH_DFLTCC_INFLATE=ON -DWITH_SANITIZER=Memory
+            # The dedicated test VM has 4 cores
+            parallels-jobs: 4
 
           - name: Ubuntu MinGW i686
             os: ubuntu-22.04
@@ -524,7 +534,7 @@ jobs:
           -DLLVM_ENABLE_PROJECTS="libcxx;libcxxabi" \
           -DLLVM_USE_SANITIZER=MemoryWithOrigins \
           -DLLVM_LIBC_ENABLE_LINTING=OFF
-        cmake --build llvm-project/build -- cxx cxxabi
+        cmake --build llvm-project/build -j2 -- cxx cxxabi
         echo "LLVM_BUILD_DIR=`pwd`/llvm-project/build" >> $GITHUB_ENV
       env:
         CC: ${{ matrix.compiler }}
@@ -548,12 +558,12 @@ jobs:
         CI: true
 
     - name: Compile source code
-      run: cmake --build ${{ matrix.build-dir || '.' }} --config ${{ matrix.build-config || 'Release' }}
+      run: cmake --build ${{ matrix.build-dir || '.' }} -j2 --config ${{ matrix.build-config || 'Release' }}
 
     - name: Run test cases
       # Don't run tests on Windows ARM
       if: runner.os != 'Windows' || contains(matrix.name, 'ARM') == false
-      run: ctest --verbose -C Release --output-on-failure --max-width 120 -j ${{ matrix.parallels-jobs || '6' }}
+      run: ctest --verbose -C Release --output-on-failure --max-width 120 -j ${{ matrix.parallels-jobs || '3' }}
       working-directory: ${{ matrix.build-dir || '.' }}
       env:
         ASAN_OPTIONS: ${{ matrix.asan-options || 'verbosity=0' }}:abort_on_error=1:halt_on_error=1

--- a/.github/workflows/libpng.yml
+++ b/.github/workflows/libpng.yml
@@ -21,7 +21,7 @@ jobs:
         CI: true
 
     - name: Compile source code (zlib-ng)
-      run: cmake --build . --config Release
+      run: cmake --build . -j2 --config Release
 
     - name: Checkout repository (libpng)
       uses: actions/checkout@v3
@@ -43,9 +43,9 @@ jobs:
         CI: true
 
     - name: Compile source code (libpng)
-      run: cmake --build . --config Release
+      run: cmake --build . -j2 --config Release
       working-directory: libpng
 
     - name: Run test cases (libpng)
-      run: ctest -C Release --output-on-failure --max-width 120
+      run: ctest -j2 -C Release --output-on-failure --max-width 120
       working-directory: libpng

--- a/.github/workflows/link.yml
+++ b/.github/workflows/link.yml
@@ -18,13 +18,13 @@ jobs:
       run: cmake -S zlib -B zlib/build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF
 
     - name: Compile source code (zlib)
-      run: cmake --build zlib/build --config Release
+      run: cmake --build zlib/build -j2 --config Release
 
     - name: Generate project files (native)
       run: cmake -S . -B native -DZLIB_COMPAT=OFF -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DZLIB_LIBRARIES=../zlib/build/libz.a -DZLIB_INCLUDE_DIR="../zlib/build;../zlib"
 
     - name: Compile source code (native)
-      run: cmake --build native --config Release
+      run: cmake --build native -j2 --config Release
 
     - name: Upload build errors
       uses: actions/upload-artifact@v3
@@ -47,13 +47,13 @@ jobs:
       run: cmake -S . -B compat -DZLIB_COMPAT=ON -DZLIB_ENABLE_TESTS=OFF -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DWITH_MAINTAINER_WARNINGS=ON
 
     - name: Compile source code (compat)
-      run: cmake --build compat --config Release
+      run: cmake --build compat -j2 --config Release
 
     - name: Generate project files (native)
       run: cmake -S . -B native -DZLIB_COMPAT=OFF -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DZLIB_LIBRARIES=../compat/libz.a -DZLIB_INCLUDE_DIR=../compat
 
     - name: Compile source code (native)
-      run: cmake --build native --config Release
+      run: cmake --build native -j2 --config Release
 
     - name: Upload build errors
       uses: actions/upload-artifact@v3

--- a/.github/workflows/pigz.yml
+++ b/.github/workflows/pigz.yml
@@ -89,11 +89,11 @@ jobs:
         CI: true
 
     - name: Compile source code
-      run: cmake --build . --config ${{ matrix.build-config || 'Release' }}
+      run: cmake --build . -j2 --config ${{ matrix.build-config || 'Release' }}
       working-directory: test/pigz
 
     - name: Run test cases
-      run: ctest --verbose -C Release --output-on-failure --max-width 120 -j ${{ matrix.parallels-jobs || '2' }}
+      run: ctest --verbose -C Release --output-on-failure --max-width 120 -j ${{ matrix.parallels-jobs || '3' }}
       working-directory: test/pigz
 
     - name: Generate coverage report

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
         CI: true
 
     - name: Compile source code
-      run: cmake --build . --config Release --target install
+      run: cmake --build . -j2 --config Release --target install
 
     - name: Package release (Windows)
       if: runner.os == 'Windows'

--- a/test/pkgcheck.sh
+++ b/test/pkgcheck.sh
@@ -125,7 +125,7 @@ cd btmp1
     ;;
   esac
   ../configure $CONFIGURE_ARGS
-  make
+  make -j2
   make install
 cd ..
 


### PR DESCRIPTION
Adjust thread counts for compiles and tests to avoid under-utilization and congestion.
The free Github Actions VMs have 2 cores, the dedicated s390x VM has 4 cores.

This will hopefully shave off a little of the wait time for each PR to complete its CI runs.