### PR TITLE
Narrow down the amount of packages installed for Wine in MinGW CI runs.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -276,7 +276,7 @@ jobs:
           - name: Ubuntu MinGW i686
             os: ubuntu-22.04
             cmake-args: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-mingw-i686.cmake
-            packages: wine32 gcc-mingw-w64-i686 g++-mingw-w64-i686 libpcre2-8-0=10.39-3ubuntu0.1 libpcre2-8-0:i386=10.39-3ubuntu0.1 libodbc1=2.3.9-5 libodbc1:i386=2.3.9-5 libwine:i386=6.0.3~repack-1 libgphoto2-6:i386=2.5.27-1build2 libsane:i386=1.1.1-5 libgd3=2.3.0-2ubuntu2 libgd3:i386=2.3.0-2ubuntu2
+            packages: wine wine32 gcc-mingw-w64-i686 g++-mingw-w64-i686 libpcre2-8-0=10.39-3ubuntu0.1 libpcre2-8-0:i386=10.39-3ubuntu0.1 libodbc1=2.3.9-5 libodbc1:i386=2.3.9-5 libwine:i386=6.0.3~repack-1 libgphoto2-6:i386=2.5.27-1build2 libsane:i386=1.1.1-5 libgd3=2.3.0-2ubuntu2 libgd3:i386=2.3.0-2ubuntu2
             ldflags: -static
             codecov: ubuntu_gcc_mingw_i686
             # Limit parallel test jobs to prevent wine errors
@@ -285,7 +285,7 @@ jobs:
           - name: Ubuntu MinGW x86_64
             os: ubuntu-latest
             cmake-args: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-mingw-x86_64.cmake
-            packages: wine-stable gcc-mingw-w64 g++-mingw-w64
+            packages: wine wine64 gcc-mingw-w64 g++-mingw-w64
             ldflags: -static
             codecov: ubuntu_gcc_mingw_x86_64
              # Limit parallel test jobs to prevent wine errors
@@ -485,7 +485,7 @@ jobs:
         path: test/data/corpora
 
     - name: Add repositories (Wine)
-      if: contains(matrix.packages, 'wine')
+      if: contains(matrix.packages, 'wine32')
       run: sudo dpkg --add-architecture i386
 
     - name: Add ubuntu mirrors
@@ -500,7 +500,7 @@ jobs:
       if: runner.os == 'Linux' && matrix.packages
       run: |
         sudo apt-get update
-        sudo apt-get install -y --allow-downgrades ${{ matrix.packages }}
+        sudo apt-get install -y --allow-downgrades --no-install-recommends ${{ matrix.packages }}
 
     - name: Install packages (Windows)
       if: runner.os == 'Windows'


### PR DESCRIPTION
Before:
```
# x86
12 upgraded, 265 newly installed, 0 to remove and 40 not upgraded.
Need to get 354 MB of archives.
After this operation, 1626 MB of additional disk space will be used.

# x86-64
12 upgraded, 296 newly installed, 0 to remove and 40 not upgraded.
Need to get 545 MB of archives.
After this operation, 2703 MB of additional disk space will be used.
```

After:
```
# x86
2 upgraded, 167 newly installed, 0 to remove and 28 not upgraded.
Need to get 254 MB of archives.
After this operation, 1239 MB of additional disk space will be used.

#x86-64
0 upgraded, 48 newly installed, 0 to remove and 30 not upgraded.
Need to get 318 MB of archives.
After this operation, 1710 MB of additional disk space will be used.
```

This should shave off some of the time spent installing packages, but the variation between runs is too great to see how much. This CI has so far both of the fastest wine install runs I have seen. (Faster by 12sec, 1min, 10min, etc.)