### PR TITLE
Fix warnings in benchmarks

### DIFF
--- a/test/benchmarks/benchmark_compare256.cc
+++ b/test/benchmarks/benchmark_compare256.cc
@@ -33,7 +33,7 @@ public:
 
     void Bench(benchmark::State& state, compare256_func compare256) {
         int32_t match_len = (int32_t)state.range(0) - 1;
-        uint32_t len;
+        uint32_t len = 0;
 
         str2[match_len] = 0;
         for (auto _ : state) {

--- a/test/benchmarks/benchmark_slidehash.cc
+++ b/test/benchmarks/benchmark_slidehash.cc
@@ -26,7 +26,7 @@ public:
     void SetUp(const ::benchmark::State& state) {
         l0 = (uint16_t *)zng_alloc(HASH_SIZE * sizeof(uint16_t));
 
-        for (int32_t i = 0; i < HASH_SIZE; i++) {
+        for (uint32_t i = 0; i < HASH_SIZE; i++) {
             l0[i] = rand();
         }
 


### PR DESCRIPTION
1. Initialize len in benchmark_compare256.cc.

```
In function ‘typename std::enable_if<(std::is_trivially_copyable<_Tp>::value && (sizeof (Tp) <= sizeof (Tp*)))>::type benchmark::DoNotOptimize(Tp&) [with Tp = unsigned int]’,
    inlined from ‘void compare256::Bench(benchmark::State&, compare256_func)’ at /zlib-ng/test/benchmarks/benchmark_compare256.cc:44:33,
    inlined from ‘virtual void compare256_c_Benchmark::BenchmarkCase(benchmark::State&)’ at /zlib-ng/test/benchmarks/benchmark_compare256.cc:62:1:
/zlib-ng/_deps/benchmark-src/include/benchmark/benchmark.h:480:3: warning: ‘len’ may be used uninitialized [-Wmaybe-uninitialized]
  480 |   asm volatile("" : "+m,r"(value) : : "memory");
      |   ^~~
/zlib-ng/test/benchmarks/benchmark_compare256.cc: In member function ‘virtual void compare256_c_Benchmark::BenchmarkCase(benchmark::State&)’:
/zlib-ng/test/benchmarks/benchmark_compare256.cc:36:18: note: ‘len’ was declared here
   36 |         uint32_t len;
      |                  ^~~
```

2. Make the loop counter unsigned in benchmark_slidehash.cc.

```
/zlib-ng/test/benchmarks/benchmark_slidehash.cc: In member function ‘virtual void slide_hash::SetUp(const benchmark::State&)’:
/zlib-ng/test/benchmarks/benchmark_slidehash.cc:29:31: warning: comparison of integer expressions of different signedness: ‘int32_t’ {aka ‘int’} and ‘unsigned int’ [-Wsign-compare]
   29 |         for (int32_t i = 0; i < HASH_SIZE; i++) {
```