### PR TITLE
Fix warning: comparison of integer expressions of different signednes…

### DIFF
--- a/test/gh1235.c
+++ b/test/gh1235.c
@@ -7,7 +7,7 @@ int main(void) {
     unsigned char plain[32];
     unsigned char compressed[130];
     PREFIX3(stream) strm;
-    int bound;
+    z_size_t bound;
     z_size_t bytes;
 
     for (int i = 0; i <= 32; i++) {
@@ -21,7 +21,7 @@ int main(void) {
         strm.avail_out = sizeof(compressed);
         if (PREFIX(deflate)(&strm, Z_FINISH) != Z_STREAM_END) return -1;
         if (strm.avail_in != 0) return -1;
-        printf("bytes = %2i, deflateBound = %2i, total_out = %2zi\n", i, bound, strm.total_out);
+        printf("bytes = %2i, deflateBound = %2zi, total_out = %2zi\n", i, (size_t)bound, (size_t)strm.total_out);
         if (bound < strm.total_out) return -1;
         if (PREFIX(deflateEnd)(&strm) != Z_OK) return -1;
     }
@@ -32,7 +32,7 @@ int main(void) {
         }
         bound = PREFIX(compressBound)(i);
         if (PREFIX(compress2)(compressed, &bytes, plain, i, 1) != Z_OK) return -1;
-        printf("bytes = %2i, compressBound = %2i, total_out = %2zi\n", i, bound, (size_t)bytes);
+        printf("bytes = %2i, compressBound = %2zi, total_out = %2zi\n", i, (size_t)bound, (size_t)bytes);
         if (bytes > bound) return -1;
     }
     return 0;


### PR DESCRIPTION
…s: 'size_t' {aka 'long unsigned int'} and 'int' [-Wsign-compare]


Warning from CI:

```
gcc -O2  -std=c11 -Wall -Wextra -DNDEBUG -D_LARGEFILE64_SOURCE=1 -DHAVE_POSIX_MEMALIGN -DHAVE_ALIGNED_ALLOC -DHAVE_SYS_AUXV_H -DWITH_GZFILEOP -DHAVE_VISIBILITY_HIDDEN -DHAVE_VISIBILITY_INTERNAL -DHAVE_THREAD_LOCAL -DHAVE_BUILTIN_CTZ -DHAVE_BUILTIN_CTZLL -DS390_FEATURES -DS390_DFLTCC_DEFLATE -DS390_DFLTCC_INFLATE -DS390_CRC32_VX -I.. -I/home/actions-runner/_work/zlib-ng/zlib-ng -o gh1235 /home/actions-runner/_work/zlib-ng/zlib-ng/test/gh1235.c -L.. ../libz-ng.a


/home/actions-runner/_work/zlib-ng/zlib-ng/test/gh1235.c: In function 'main':
/home/actions-runner/_work/zlib-ng/zlib-ng/test/gh1235.c:25:19: warning: comparison of integer expressions of different signedness: 'int' and 'size_t' {aka 'long unsigned int'} [-Wsign-compare]
   25 |         if (bound < strm.total_out) return -1;
      |                   ^
/home/actions-runner/_work/zlib-ng/zlib-ng/test/gh1235.c:36:19: warning: comparison of integer expressions of different signedness: 'size_t' {aka 'long unsigned int'} and 'int' [-Wsign-compare]
   36 |         if (bytes > bound) return -1;
      |                   ^
./gh1235
```
