### PR TITLE
Replace __WIN__ with X86_FEATURES

### DIFF
--- a/zbuild.h
+++ b/zbuild.h
@@ -187,7 +187,7 @@
 #  define PREFETCH_L1(addr)     __builtin_prefetch(addr, 0, 3)
 #  define PREFETCH_L2(addr)     __builtin_prefetch(addr, 0, 2)
 #  define PREFETCH_RW(addr)     __builtin_prefetch(addr, 1, 2)
-#elif defined(__WIN__)
+#elif defined(X86_FEATURES)
 #  include <xmmintrin.h>
 #  define LIKELY_NULL(x)        x
 #  define LIKELY(x)             x


### PR DESCRIPTION
The ``__WIN__`` macro is not standard.