### PR TITLE
IBM zSystems: Use HWCAP_S390_VXRS

### DIFF
--- a/arch/s390/s390_features.c
+++ b/arch/s390/s390_features.c
@@ -5,6 +5,10 @@
 #  include <sys/auxv.h>
 #endif
 
+#ifndef HWCAP_S390_VXRS
+#define HWCAP_S390_VXRS HWCAP_S390_VX
+#endif
+
 void Z_INTERNAL s390_check_features(struct s390_cpu_features *features) {
-    features->has_vx = getauxval(AT_HWCAP) & HWCAP_S390_VX;
+    features->has_vx = getauxval(AT_HWCAP) & HWCAP_S390_VXRS;
 }

--- a/cmake/detect-intrinsics.cmake
+++ b/cmake/detect-intrinsics.cmake
@@ -344,8 +344,11 @@ endmacro()
 macro(check_s390_intrinsics)
     check_c_source_compiles(
         "#include <sys/auxv.h>
+        #ifndef HWCAP_S390_VXRS
+        #define HWCAP_S390_VXRS HWCAP_S390_VX
+        #endif
         int main() {
-            return (getauxval(AT_HWCAP) & HWCAP_S390_VX);
+            return (getauxval(AT_HWCAP) & HWCAP_S390_VXRS);
         }"
         HAVE_S390_INTRIN
     )


### PR DESCRIPTION
glibc defines HWCAP_S390_VX and, since v2.33, its alias HWCAP_S390_VXRS; musl has only HWCAP_S390_VXRS.

Use the common HWCAP_S390_VXRS, define it as HWCAP_S390_VX if necessary.