### PR TITLE
Shared libraries on cygwin can be named with their version number

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1102,7 +1102,7 @@ if(NOT DEFINED BUILD_SHARED_LIBS OR BUILD_SHARED_LIBS)
             set_target_properties(zlib PROPERTIES INSTALL_NAME_DIR "${LIB_INSTALL_DIR}")
         endif()
     endif()
-    if(MSYS OR CYGWIN)
+    if(MSYS)
         # Suppress version number from shared library name
         set(CMAKE_SHARED_LIBRARY_NAME_WITH_VERSION 0)
     elseif(WIN32)


### PR DESCRIPTION
Shared libraries on cygwin can be named with their version number.

See https://github.com/Kitware/CMake/blob/v3.25.3/Modules/Platform/CYGWIN.cmake#L61

This fix will build `cygz-ng-2.dll`.
