### PR TITLE
Enable the `Sponsor` button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: zlib-ng


### PR DESCRIPTION
Adds the required `FUNDING.yml` file for enabling the `Sponsor` button to appear when viewing the repo.

If we are lucky, we might get enough funds to acquire and set up some dedicated machines that are fast enough to offload some of the CI jobs onto real metal instead of cloud+qemu (Arm64 first and foremost I think).