### PR TITLE
Fix regex for visibility attribute tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,7 +374,7 @@ check_c_source_compiles(
     int main() {
         return 0;
     }"
-    HAVE_ATTRIBUTE_VISIBILITY_HIDDEN FAIL_REGEX "not supported")
+    HAVE_ATTRIBUTE_VISIBILITY_HIDDEN FAIL_REGEX "visibility")
 if(HAVE_ATTRIBUTE_VISIBILITY_HIDDEN)
     add_definitions(-DHAVE_VISIBILITY_HIDDEN)
 endif()
@@ -388,7 +388,7 @@ check_c_source_compiles(
     int main() {
         return 0;
     }"
-    HAVE_ATTRIBUTE_VISIBILITY_INTERNAL FAIL_REGEX "not supported")
+    HAVE_ATTRIBUTE_VISIBILITY_INTERNAL FAIL_REGEX "visibility")
 if(HAVE_ATTRIBUTE_VISIBILITY_INTERNAL)
     add_definitions(-DHAVE_VISIBILITY_INTERNAL)
 endif()


### PR DESCRIPTION
The previous regex of `not supported` was very specific to a particular compiler (Clang 3.4+). As Clang isn't the only compiler that throws a warning (but otherwise succeeds) when a visibility isn't supported, make the regex more generic to hit all such cases.

Testing on Compiler Explorer shows that looking for the string `visibility` has a better hit rate. `attribute` is perhaps more dangerously generic, and `hidden`/`internal` doesn't always show up in warning messages when the visibility attribute itself isn't available.