### PR TITLE
Add member to cpu_features struct if empty

### DIFF
--- a/cpu_features.h
+++ b/cpu_features.h
@@ -29,6 +29,8 @@ struct cpu_features {
     struct power_cpu_features power;
 #elif defined(S390_FEATURES)
     struct s390_cpu_features s390;
+#else
+    char empty;
 #endif
 };
 


### PR DESCRIPTION
When WITH_OPTIM is off, the cpu_features struct is empty. This is not allowed in standard C and causes a build failure with various compilers, including MSVC.

This adds a dummy char member to the struct if it would otherwise be empty.