### PR TITLE
Remove architecture dependent endian header locations

### DIFF
--- a/zendian.h
+++ b/zendian.h
@@ -34,7 +34,7 @@
 #  endif
 #elif defined(__linux__)
 #  include <endian.h>
-#elif defined(__APPLE__) || defined(__arm__) || defined(__aarch64__)
+#elif defined(__APPLE__)
 #  include <machine/endian.h>
 #elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__bsdi__) || defined(__DragonFly__)
 #  include <sys/endian.h>


### PR DESCRIPTION
The header locations are OS specific and not architecture specific. The previous behaviour was to always include machine/endian.h for ARM and AArch64 architectures on non-Windows and non-Linux OSs, causing build failures if the OS uses other locations defined further down the conditional block.