### PR TITLE
Check attribute aligned compiler support in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -392,6 +392,20 @@ if(HAVE_ATTRIBUTE_VISIBILITY_INTERNAL)
 endif()
 
 #
+# Check for __attribute__((aligned(x))) support in the compiler
+#
+check_c_source_compiles(
+    "int main(void) {
+        __attribute__((aligned(8))) int test = 0;
+        (void)test;
+        return 0;
+    }"
+    HAVE_ATTRIBUTE_ALIGNED FAIL_REGEX "aligned")
+if(HAVE_ATTRIBUTE_ALIGNED)
+    add_definitions(-DHAVE_ATTRIBUTE_ALIGNED)
+endif()
+
+#
 # check for _Thread_local() support in the compiler
 #
 check_c_source_compiles(

--- a/configure
+++ b/configure
@@ -985,6 +985,22 @@ EOF
   fi
 fi
 
+# Check for attribute(aligned) support in compiler
+cat > $test.c << EOF
+int main(void) {
+  __attribute__((aligned(8))) int test = 0;
+  (void)test;
+  return 0;
+}
+EOF
+if try ${CC} ${CFLAGS} $test.c $LDSHAREDLIBC; then
+    echo "Checking for attribute(aligned) ... Yes." | tee -a configure.log
+    CFLAGS="$CFLAGS -DHAVE_ATTRIBUTE_ALIGNED"
+    SFLAGS="$SFLAGS -DHAVE_ATTRIBUTE_ALIGNED"
+else
+    echo "Checking for attribute(aligned) ... No." | tee -a configure.log
+fi
+
 # Check for _Thread_local support in compiler
 cat > $test.c << EOF
 _Thread_local int test;

--- a/zbuild.h
+++ b/zbuild.h
@@ -190,7 +190,7 @@
 #  define UNLIKELY(x)           x
 #endif /* (un)likely */
 
-#if defined(__clang__) || defined(__GNUC__)
+#if defined(HAVE_ATTRIBUTE_ALIGNED)
 #  define ALIGNED_(x) __attribute__ ((aligned(x)))
 #elif defined(_MSC_VER)
 #  define ALIGNED_(x) __declspec(align(x))


### PR DESCRIPTION
This allows ALIGNED_ to be defined for more compilers so that more than just Clang, GCC and MSVC can build the project.