### PR TITLE
Fix compilation on OpenBSD

### DIFF
--- a/zbuild.h
+++ b/zbuild.h
@@ -8,6 +8,9 @@
 #ifndef _ISOC11_SOURCE
 #  define _ISOC11_SOURCE 1 /* aligned_alloc */
 #endif
+#ifdef __OpenBSD__
+#  define _BSD_SOURCE 1
+#endif
 
 #include <stddef.h>
 #include <string.h>


### PR DESCRIPTION
On OpenBSD for Non-POSIX functions (like `vasprintf()` and `swap16()`) to be defined,
it requires defining `_BSD_SOURCE`.

Otherwise the build fails to compile, or compiles successfully and fails when linking against zlib-ng.