### PR TITLE
Ensure that unaligned compare256 variants are only used on little endian systems

### DIFF
--- a/compare256.c
+++ b/compare256.c
@@ -56,7 +56,7 @@ Z_INTERNAL uint32_t compare256_c(const uint8_t *src0, const uint8_t *src1) {
 
 #include "match_tpl.h"
 
-#ifdef UNALIGNED_OK
+#if defined(UNALIGNED_OK) && BYTE_ORDER == LITTLE_ENDIAN
 /* 16-bit unaligned integer comparison */
 static inline uint32_t compare256_unaligned_16_static(const uint8_t *src0, const uint8_t *src1) {
     uint32_t len = 0;

--- a/cpu_features.h
+++ b/cpu_features.h
@@ -155,7 +155,7 @@ extern uint32_t crc32_s390_vx(uint32_t crc, const uint8_t *buf, size_t len);
 typedef uint32_t (*compare256_func)(const uint8_t *src0, const uint8_t *src1);
 
 extern uint32_t compare256_c(const uint8_t *src0, const uint8_t *src1);
-#ifdef UNALIGNED_OK
+#if defined(UNALIGNED_OK) && BYTE_ORDER == LITTLE_ENDIAN
 extern uint32_t compare256_unaligned_16(const uint8_t *src0, const uint8_t *src1);
 #ifdef HAVE_BUILTIN_CTZ
 extern uint32_t compare256_unaligned_32(const uint8_t *src0, const uint8_t *src1);
@@ -188,7 +188,7 @@ extern void insert_string_acle(deflate_state *const s, const uint32_t str, uint3
 
 /* longest_match */
 extern uint32_t longest_match_c(deflate_state *const s, Pos cur_match);
-#ifdef UNALIGNED_OK
+#if defined(UNALIGNED_OK) && BYTE_ORDER == LITTLE_ENDIAN
 extern uint32_t longest_match_unaligned_16(deflate_state *const s, Pos cur_match);
 #ifdef HAVE_BUILTIN_CTZ
 extern uint32_t longest_match_unaligned_32(deflate_state *const s, Pos cur_match);
@@ -212,7 +212,7 @@ extern uint32_t longest_match_power9(deflate_state *const s, Pos cur_match);
 
 /* longest_match_slow */
 extern uint32_t longest_match_slow_c(deflate_state *const s, Pos cur_match);
-#ifdef UNALIGNED_OK
+#if defined(UNALIGNED_OK) && BYTE_ORDER == LITTLE_ENDIAN
 extern uint32_t longest_match_slow_unaligned_16(deflate_state *const s, Pos cur_match);
 extern uint32_t longest_match_slow_unaligned_32(deflate_state *const s, Pos cur_match);
 #ifdef UNALIGNED64_OK

--- a/functable.c
+++ b/functable.c
@@ -33,7 +33,7 @@ static void init_functable(void) {
     ft.slide_hash = &slide_hash_c;
     ft.update_hash = &update_hash_c;
 
-#ifdef UNALIGNED_OK
+#if defined(UNALIGNED_OK) && BYTE_ORDER == LITTLE_ENDIAN
 #  if defined(UNALIGNED64_OK) && defined(HAVE_BUILTIN_CTZLL)
     ft.longest_match = &longest_match_unaligned_64;
     ft.longest_match_slow = &longest_match_slow_unaligned_64;

--- a/test/benchmarks/benchmark_compare256.cc
+++ b/test/benchmarks/benchmark_compare256.cc
@@ -61,7 +61,7 @@ public:
 
 BENCHMARK_COMPARE256(c, compare256_c, 1);
 
-#ifdef UNALIGNED_OK
+#if defined(UNALIGNED_OK) && BYTE_ORDER == LITTLE_ENDIAN
 BENCHMARK_COMPARE256(unaligned_16, compare256_unaligned_16, 1);
 #ifdef HAVE_BUILTIN_CTZ
 BENCHMARK_COMPARE256(unaligned_32, compare256_unaligned_32, 1);

--- a/test/test_compare256.cc
+++ b/test/test_compare256.cc
@@ -60,7 +60,7 @@ static inline void compare256_match_check(compare256_func compare256) {
 
 TEST_COMPARE256(c, compare256_c, 1)
 
-#ifdef UNALIGNED_OK
+#if defined(UNALIGNED_OK) && BYTE_ORDER == LITTLE_ENDIAN
 TEST_COMPARE256(unaligned_16, compare256_unaligned_16, 1)
 #ifdef HAVE_BUILTIN_CTZ
 TEST_COMPARE256(unaligned_32, compare256_unaligned_32, 1)


### PR DESCRIPTION
With this change it should be possible to enable `UNALIGNED_OK` on big endian PowerPC targets, although I've only been able to test this with QEMU.