### PR TITLE
IBM zSystems: Fix calling deflateBound() before deflateInit()

### DIFF
--- a/arch/s390/dfltcc_deflate.h
+++ b/arch/s390/dfltcc_deflate.h
@@ -45,7 +45,7 @@ int Z_INTERNAL PREFIX(dfltcc_deflate_get_dictionary)(PREFIX3(streamp) strm, unsi
 
 #define DEFLATE_BOUND_ADJUST_COMPLEN(strm, complen, source_len) \
     do { \
-        if (PREFIX(dfltcc_can_deflate)((strm))) \
+        if (deflateStateCheck((strm)) || PREFIX(dfltcc_can_deflate)((strm))) \
             (complen) = DEFLATE_BOUND_COMPLEN(source_len); \
     } while (0)
 


### PR DESCRIPTION
Even though zlib officialy forbids calling deflateBound() before
deflateInit(), Firefox does this anyway, and it happens to work [1],
but unfortunately not with DFLTCC [2], because the DFLTCC code assumes
that the deflate state is allocated, and segfaults when it isn't.

Bow down before Hyrum's Law and add deflateStateCheck() to
DEFLATE_BOUND_ADJUST_COMPLEN().

Extend the deflate_bound test accordingly.

[1] https://searchfox.org/mozilla-esr102/source/dom/script/ScriptCompression.cpp#97
[2] https://bugzilla.suse.com/show_bug.cgi?id=1210593