### PR TITLE
Use ZLIB_INCLUDE_DIRS from FindZLIB instead of ZLIB_INCLUDE_DIR.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -210,7 +210,7 @@ if(WITH_GTEST)
             -fsanitize-memory-track-origins)
     endif()
 
-    if(NOT ZLIB_COMPAT AND DEFINED ZLIB_LIBRARIES AND DEFINED ZLIB_INCLUDE_DIR)
+    if(NOT ZLIB_COMPAT AND DEFINED ZLIB_LIBRARIES AND DEFINED ZLIB_INCLUDE_DIRS)
         if(NOT IS_ABSOLUTE ${ZLIB_LIBRARIES})
             get_filename_component(ZLIB_ABSOLUTE_PATH
                 "${CMAKE_CURRENT_SOURCE_DIR}/${ZLIB_LIBRARIES}"
@@ -222,11 +222,11 @@ if(WITH_GTEST)
         add_library(external_zlib STATIC IMPORTED)
         set_property(TARGET external_zlib PROPERTY IMPORTED_LOCATION ${ZLIB_ABSOLUTE_PATH})
         message(STATUS "Added dual linking tests against zlib")
-        message(STATUS "  Zlib include dir: ${ZLIB_INCLUDE_DIR}")
+        message(STATUS "  Zlib include dirs: ${ZLIB_INCLUDE_DIRS}")
         message(STATUS "  Zlib libraries: ${ZLIB_ABSOLUTE_PATH}")
 
         target_sources(gtest_zlib PRIVATE test_compress_dual.cc)
-        target_include_directories(gtest_zlib PRIVATE ${ZLIB_INCLUDE_DIR})
+        target_include_directories(gtest_zlib PRIVATE ${ZLIB_INCLUDE_DIRS})
         target_link_libraries(gtest_zlib external_zlib)
     endif()
 


### PR DESCRIPTION
`ZLIB_INCLUDE_DIRS` is set by FindZLIB if `ZLIB_INCLUDE_DIR` is set on the command line.