### PR TITLE
Fix Coverity warnings

### DIFF
--- a/deflate_quick.c
+++ b/deflate_quick.c
@@ -99,6 +99,8 @@ Z_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
                     if (match_len >= WANT_MIN_MATCH) {
                         if (UNLIKELY(match_len > s->lookahead))
                             match_len = s->lookahead;
+                        if (UNLIKELY(match_len > STD_MAX_MATCH))
+                            match_len = STD_MAX_MATCH;
 
                         check_match(s, s->strstart, hash_head, match_len);
 

--- a/deflate_rle.c
+++ b/deflate_rle.c
@@ -47,6 +47,7 @@ Z_INTERNAL block_state deflate_rle(deflate_state *s, int flush) {
                          scan < strend);
                 match_len = STD_MAX_MATCH - (unsigned int)(strend - scan);
                 match_len = MIN(match_len, s->lookahead);
+                match_len = MIN(match_len, STD_MAX_MATCH);
             }
             Assert(scan <= s->window + s->window_size - 1, "wild scan");
         }


### PR DESCRIPTION
Fix defects detected by coverity scan.

Personally I think these are corner cases that happen only if the match is very long.