### PR TITLE
Remove `CMAKE_MACOSX_RPATH`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,6 @@ else()
 endif()
 message(STATUS "Using CMake version ${CMAKE_VERSION}")
 
-set(CMAKE_MACOSX_RPATH 1)
-
 # If not specified on the command line, enable C11 as the default
 # Configuration items that affect the global compiler environment standards
 # should be issued before the "project" command.


### PR DESCRIPTION
This is ON by default since CMake 3.0