### PR TITLE
Add z_size_t to zconf

### DIFF
--- a/zbuild.h
+++ b/zbuild.h
@@ -88,11 +88,6 @@
 #  define PREFIX3(x) z_ ## x
 #  define PREFIX4(x) x ## 64
 #  define zVersion zlibVersion
-#  if defined(_WIN64)
-#    define z_size_t unsigned __int64
-#  else
-#    define z_size_t unsigned long
-#  endif
 #else
 #  define PREFIX(x) zng_ ## x
 #  define PREFIX2(x) ZLIBNG_ ## x

--- a/zconf.h.in
+++ b/zconf.h.in
@@ -25,6 +25,8 @@
 #  define z_const
 #endif
 
+typedef size_t z_size_t;
+
 /* Maximum value for memLevel in deflateInit2 */
 #ifndef MAX_MEM_LEVEL
 #  define MAX_MEM_LEVEL 9

--- a/zlib-ng.h.in
+++ b/zlib-ng.h.in
@@ -1411,9 +1411,7 @@ size_t zng_gzfread(void *buf, size_t size, size_t nitems, gzFile file);
 /*
      Read and decompress up to nitems items of size size from file into buf,
    otherwise operating as gzread() does.  This duplicates the interface of
-   stdio's fread(), with size_t request and return types.  If the library
-   defines size_t, then z_size_t is identical to size_t.  If not, then z_size_t
-   is an unsigned integer type that can contain a pointer.
+   stdio's fread(), with size_t request and return types.
 
      gzfread() returns the number of full items read of size size, or zero if
    the end of the file was reached and a full item could not be read, or if


### PR DESCRIPTION
Fix z_size_t definition:
- Zlib Compat: Move definition of `z_size_t` to `zconf.h`, so it is exported to applications.
               Always defined as `size_t` to follow zlib 1.2.13 behavior with STDC compilers.
- Zlib-NG: Keeps internal definition of `z_size_t` in `zbuild.h`

- Remove references to `z_size_t` from `zlib-ng.h`, since we use size_t directly.

This changes our behavior for zlib-compat builds.

Fixes #1485 