### PR TITLE
MinGW32 build fixes

### DIFF
--- a/arch/x86/x86_features.c
+++ b/arch/x86/x86_features.c
@@ -10,7 +10,7 @@
 #include "../../zbuild.h"
 #include "x86_features.h"
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #  include <intrin.h>
 #else
 // Newer versions of GCC and clang come with cpuid.h
@@ -20,7 +20,7 @@
 #include <string.h>
 
 static inline void cpuid(int info, unsigned* eax, unsigned* ebx, unsigned* ecx, unsigned* edx) {
-#ifdef _WIN32
+#ifdef _MSC_VER
     unsigned int registers[4];
     __cpuid((int *)registers, info);
 
@@ -34,7 +34,7 @@ static inline void cpuid(int info, unsigned* eax, unsigned* ebx, unsigned* ecx, 
 }
 
 static inline void cpuidex(int info, int subinfo, unsigned* eax, unsigned* ebx, unsigned* ecx, unsigned* edx) {
-#ifdef _WIN32
+#ifdef _MSC_VER
     unsigned int registers[4];
     __cpuidex((int *)registers, info, subinfo);
 
@@ -48,7 +48,7 @@ static inline void cpuidex(int info, int subinfo, unsigned* eax, unsigned* ebx, 
 }
 
 static inline uint64_t xgetbv(unsigned int xcr) {
-#ifdef _WIN32
+#ifdef _MSC_VER
     return _xgetbv(xcr);
 #else
     uint32_t eax, edx;

--- a/cmake/detect-intrinsics.cmake
+++ b/cmake/detect-intrinsics.cmake
@@ -502,7 +502,7 @@ macro(check_xsave_intrinsics)
     endif()
     set(CMAKE_REQUIRED_FLAGS "${XSAVEFLAG} ${NATIVEFLAG}")
     check_c_source_compiles(
-        "#ifdef _WIN32
+        "#ifdef _MSC_VER
         #  include <intrin.h>
         #else
         #  include <x86gprintrin.h>

--- a/configure
+++ b/configure
@@ -1217,7 +1217,7 @@ EOF
 check_xsave_intrinsics() {
    # Check whether compiler supports XSAVE intrinsics
    cat > $test.c << EOF
-#ifdef _WIN32
+#ifdef _MSC_VER
 #  include <intrin.h>
 #else
 #  include <x86gprintrin.h>

--- a/test/minideflate.c
+++ b/test/minideflate.c
@@ -13,14 +13,16 @@
 #if defined(_WIN32) || defined(__CYGWIN__)
 #  include <fcntl.h>
 #  include <io.h>
-#  include <string.h>
 #  define SET_BINARY_MODE(file) setmode(fileno(file), O_BINARY)
-#  ifdef _MSC_VER
-#    define strcasecmp _stricmp
-#  endif
+#else
+#  define SET_BINARY_MODE(file)
+#endif
+
+#ifdef _MSC_VER
+#  include <string.h>
+#  define strcasecmp _stricmp
 #else
 #  include <strings.h>
-#  define SET_BINARY_MODE(file)
 #endif
 
 #define CHECK_ERR(err, msg) { \


### PR DESCRIPTION
- MinGW-w64 provides a version of `intrin.h`, but MinGW32 doesn't. The GCC cpuid intrinsics are now used for both toolchains.
- `strings.h` is now included for `strcasecmp`.
- ~~C++11 threads are only available in pthread-based MinGW-w64 toolchains, so [mingw-std-threads](https://github.com/meganz/mingw-std-threads.git) is used instead. This should benefit Win32-based MinGW-w64 toolchains as well.~~ See PR #1573.
- There are still some warnings in the test programs regarding `fileno`, but I've [opened an issue](https://osdn.net/projects/mingw/ticket/48055) for this in MinGW32 instead of working around it here.
- The benchmarks don't compile yet, but that requires updating the benchmark library to use mingw-std-threads. All other tests pass.
