### PR TITLE
Add distclean target to arch/generic/Makefile.in

### DIFF
--- a/arch/generic/Makefile.in
+++ b/arch/generic/Makefile.in
@@ -19,3 +19,6 @@ clean:
 	rm -f *.o *.lo *~ \
 	rm -rf objs
 	rm -f *.gcda *.gcno *.gcov
+
+distclean: clean
+	rm -f Makefile


### PR DESCRIPTION
Fixes issue when `make distclean` fails on unsupported targets.