### PR TITLE
distclean target should depend on clean target in arch directories.

### DIFF
--- a/arch/arm/Makefile.in
+++ b/arch/arm/Makefile.in
@@ -73,5 +73,5 @@ clean:
 	rm -rf objs
 	rm -f *.gcda *.gcno *.gcov
 
-distclean:
+distclean: clean
 	rm -f Makefile

--- a/arch/power/Makefile.in
+++ b/arch/power/Makefile.in
@@ -89,5 +89,5 @@ clean:
 	rm -rf objs
 	rm -f *.gcda *.gcno *.gcov
 
-distclean:
+distclean: clean
 	rm -f Makefile

--- a/arch/s390/Makefile.in
+++ b/arch/s390/Makefile.in
@@ -50,5 +50,5 @@ clean:
 	rm -rf objs
 	rm -f *.gcda *.gcno *.gcov
 
-distclean:
+distclean: clean
 	rm -f Makefile

--- a/arch/x86/Makefile.in
+++ b/arch/x86/Makefile.in
@@ -143,5 +143,5 @@ clean:
 	rm -rf objs
 	rm -f *.gcda *.gcno *.gcov
 
-distclean:
+distclean: clean
 	rm -f Makefile


### PR DESCRIPTION
Makes sure all generated files are deleted with `make distclean` except for RISC-V which is missing support for configure.