### PR TITLE
distclean target in test directory should depend on clean target.

### DIFF
--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -78,5 +78,5 @@ clean:
 	rm -f *.o *.gcda *.gcno *.gcov
 	rm -f switchlevels$(EXE) gh1235$(EXE)
 
-distclean:
+distclean: clean
 	rm -f Makefile


### PR DESCRIPTION
`make distclean` should remove all generated files, not just `Makefile`.