### PR TITLE
Get rid of relative #includes in the arch/ code

### DIFF
--- a/arch/arm/adler32_neon.c
+++ b/arch/arm/adler32_neon.c
@@ -7,8 +7,8 @@
  */
 #ifdef ARM_NEON
 #include "neon_intrins.h"
-#include "../../zbuild.h"
-#include "../../adler32_p.h"
+#include "zbuild.h"
+#include "adler32_p.h"
 
 static void NEON_accum32(uint32_t *s, const uint8_t *buf, size_t len) {
     static const uint16_t ALIGNED_(16) taps[64] = {

--- a/arch/arm/arm_features.c
+++ b/arch/arm/arm_features.c
@@ -1,4 +1,4 @@
-#include "../../zbuild.h"
+#include "zbuild.h"
 #include "arm_features.h"
 
 #if defined(__linux__) && defined(HAVE_SYS_AUXV_H)

--- a/arch/arm/chunkset_neon.c
+++ b/arch/arm/chunkset_neon.c
@@ -4,7 +4,7 @@
 
 #ifdef ARM_NEON
 #include "neon_intrins.h"
-#include "../../zbuild.h"
+#include "zbuild.h"
 #include "../generic/chunk_permute_table.h"
 
 typedef uint8x16_t chunk_t;

--- a/arch/arm/compare256_neon.c
+++ b/arch/arm/compare256_neon.c
@@ -3,7 +3,7 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-#include "../../zbuild.h"
+#include "zbuild.h"
 
 #include "fallback_builtins.h"
 

--- a/arch/arm/crc32_acle.c
+++ b/arch/arm/crc32_acle.c
@@ -11,7 +11,7 @@
 #else
 #  include <arm_acle.h>
 #endif
-#include "../../zbuild.h"
+#include "zbuild.h"
 
 Z_INTERNAL uint32_t crc32_acle(uint32_t crc, const uint8_t *buf, size_t len) {
     Z_REGISTER uint32_t c;

--- a/arch/arm/insert_string_acle.c
+++ b/arch/arm/insert_string_acle.c
@@ -9,8 +9,8 @@
 #ifndef _MSC_VER
 #  include <arm_acle.h>
 #endif
-#include "../../zbuild.h"
-#include "../../deflate.h"
+#include "zbuild.h"
+#include "deflate.h"
 
 #define HASH_CALC(s, h, val) \
     h = __crc32w(0, val)
@@ -22,5 +22,5 @@
 #define INSERT_STRING       insert_string_acle
 #define QUICK_INSERT_STRING quick_insert_string_acle
 
-#include "../../insert_string_tpl.h"
+#include "insert_string_tpl.h"
 #endif

--- a/arch/arm/slide_hash_neon.c
+++ b/arch/arm/slide_hash_neon.c
@@ -10,8 +10,8 @@
 
 #ifdef ARM_NEON
 #include "neon_intrins.h"
-#include "../../zbuild.h"
-#include "../../deflate.h"
+#include "zbuild.h"
+#include "deflate.h"
 
 /* SIMD version of hash_chain rebase */
 static inline void slide_hash_chain(Pos *table, uint32_t entries, uint16_t wsize) {

--- a/arch/power/chunkset_power8.c
+++ b/arch/power/chunkset_power8.c
@@ -4,7 +4,7 @@
 
 #ifdef POWER8_VSX
 #include <altivec.h>
-#include "../../zbuild.h"
+#include "zbuild.h"
 
 typedef vector unsigned char chunk_t;
 

--- a/arch/power/compare256_power9.c
+++ b/arch/power/compare256_power9.c
@@ -5,8 +5,8 @@
 
 #ifdef POWER9
 #include <altivec.h>
-#include "../../zbuild.h"
-#include "../../zendian.h"
+#include "zbuild.h"
+#include "zendian.h"
 
 /* Older versions of GCC misimplemented semantics for these bit counting builtins.
  * https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;h=3f30f2d1dbb3228b8468b26239fe60c2974ce2ac */

--- a/arch/power/power_features.c
+++ b/arch/power/power_features.c
@@ -10,7 +10,7 @@
 #ifdef __FreeBSD__
 #  include <machine/cpu.h>
 #endif
-#include "../../zbuild.h"
+#include "zbuild.h"
 #include "power_features.h"
 
 void Z_INTERNAL power_check_features(struct power_cpu_features *features) {

--- a/arch/riscv/compare256_rvv.c
+++ b/arch/riscv/compare256_rvv.c
@@ -6,7 +6,7 @@
 
 #ifdef RISCV_RVV
 
-#include "../../zbuild.h"
+#include "zbuild.h"
 #include "fallback_builtins.h"
 
 #include <riscv_vector.h>

--- a/arch/riscv/riscv_features.c
+++ b/arch/riscv/riscv_features.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "../../zbuild.h"
+#include "zbuild.h"
 #include "riscv_features.h"
 
 /* TODO: detect risc-v cpu info at runtime when the kernel updates hwcap or hwprobe for risc-v */

--- a/arch/riscv/slide_hash_rvv.c
+++ b/arch/riscv/slide_hash_rvv.c
@@ -8,8 +8,8 @@
 
 #include <riscv_vector.h>
 
-#include "../../zbuild.h"
-#include "../../deflate.h"
+#include "zbuild.h"
+#include "deflate.h"
 
 static inline void slide_hash_chain(Pos *table, uint32_t entries, uint16_t wsize) {
     size_t vl;

--- a/arch/s390/crc32-vx.c
+++ b/arch/s390/crc32-vx.c
@@ -12,7 +12,7 @@
  * relicensed under the zlib license.
  */
 
-#include "../../zbuild.h"
+#include "zbuild.h"
 #include "crc32_braid_p.h"
 
 #include <vecintrin.h>

--- a/arch/s390/dfltcc_detail.h
+++ b/arch/s390/dfltcc_detail.h
@@ -1,4 +1,4 @@
-#include "../../zbuild.h"
+#include "zbuild.h"
 #include <stdio.h>
 
 #ifdef HAVE_SYS_SDT_H

--- a/arch/s390/s390_features.c
+++ b/arch/s390/s390_features.c
@@ -1,4 +1,4 @@
-#include "../../zbuild.h"
+#include "zbuild.h"
 #include "s390_features.h"
 
 #ifdef HAVE_SYS_AUXV_H

--- a/arch/x86/adler32_avx2_tpl.h
+++ b/arch/x86/adler32_avx2_tpl.h
@@ -3,11 +3,11 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-#include "../../zbuild.h"
+#include "zbuild.h"
 #include <immintrin.h>
-#include "../../adler32_fold.h"
-#include "../../adler32_p.h"
-#include "../../fallback_builtins.h"
+#include "adler32_fold.h"
+#include "adler32_p.h"
+#include "fallback_builtins.h"
 #include "adler32_avx2_p.h"
 
 #ifdef X86_SSE42

--- a/arch/x86/adler32_avx512_tpl.h
+++ b/arch/x86/adler32_avx512_tpl.h
@@ -3,11 +3,11 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-#include "../../zbuild.h"
-#include "../../adler32_p.h"
-#include "../../adler32_fold.h"
-#include "../../cpu_features.h"
-#include "../../fallback_builtins.h"
+#include "zbuild.h"
+#include "adler32_p.h"
+#include "adler32_fold.h"
+#include "cpu_features.h"
+#include "fallback_builtins.h"
 #include <immintrin.h>
 #include "adler32_avx512_p.h"
 

--- a/arch/x86/adler32_avx512_vnni.c
+++ b/arch/x86/adler32_avx512_vnni.c
@@ -9,12 +9,12 @@
 
 #ifdef X86_AVX512VNNI
 
-#include "../../zbuild.h"
-#include "../../adler32_p.h"
-#include "../../cpu_features.h"
-#include "../../fallback_builtins.h"
+#include "zbuild.h"
+#include "adler32_p.h"
+#include "cpu_features.h"
+#include "fallback_builtins.h"
 #include <immintrin.h>
-#include "../../adler32_fold.h"
+#include "adler32_fold.h"
 #include "adler32_avx512_p.h"
 #include "adler32_avx2_p.h"
 

--- a/arch/x86/adler32_sse42.c
+++ b/arch/x86/adler32_sse42.c
@@ -6,9 +6,9 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-#include "../../zbuild.h"
-#include "../../adler32_p.h"
-#include "../../adler32_fold.h"
+#include "zbuild.h"
+#include "adler32_p.h"
+#include "adler32_fold.h"
 #include "adler32_ssse3_p.h"
 #include <immintrin.h>
 

--- a/arch/x86/adler32_ssse3.c
+++ b/arch/x86/adler32_ssse3.c
@@ -6,8 +6,8 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-#include "../../zbuild.h"
-#include "../../adler32_p.h"
+#include "zbuild.h"
+#include "adler32_p.h"
 #include "adler32_ssse3_p.h"
 
 #ifdef X86_SSSE3

--- a/arch/x86/compare256_avx2.c
+++ b/arch/x86/compare256_avx2.c
@@ -3,7 +3,7 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-#include "../../zbuild.h"
+#include "zbuild.h"
 
 #include "fallback_builtins.h"
 

--- a/arch/x86/compare256_sse2.c
+++ b/arch/x86/compare256_sse2.c
@@ -3,7 +3,7 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-#include "../../zbuild.h"
+#include "zbuild.h"
 
 #include "fallback_builtins.h"
 

--- a/arch/x86/crc32_pclmulqdq_tpl.h
+++ b/arch/x86/crc32_pclmulqdq_tpl.h
@@ -17,7 +17,7 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-#include "../../zbuild.h"
+#include "zbuild.h"
 
 #include <immintrin.h>
 #include <wmmintrin.h>
@@ -26,9 +26,9 @@
 #  include <immintrin.h>
 #endif
 
-#include "../../crc32_fold.h"
-#include "../../crc32_braid_p.h"
-#include "../../fallback_builtins.h"
+#include "crc32_fold.h"
+#include "crc32_braid_p.h"
+#include "fallback_builtins.h"
 #include <assert.h>
 
 #ifdef X86_VPCLMULQDQ

--- a/arch/x86/insert_string_sse42.c
+++ b/arch/x86/insert_string_sse42.c
@@ -5,12 +5,12 @@
  *
  */
 
-#include "../../zbuild.h"
+#include "zbuild.h"
 #include <immintrin.h>
 #ifdef _MSC_VER
 #  include <nmmintrin.h>
 #endif
-#include "../../deflate.h"
+#include "deflate.h"
 
 #ifdef X86_SSE42_CRC_INTRIN
 #  ifdef _MSC_VER

--- a/arch/x86/slide_hash_avx2.c
+++ b/arch/x86/slide_hash_avx2.c
@@ -9,8 +9,8 @@
  *
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
-#include "../../zbuild.h"
-#include "../../deflate.h"
+#include "zbuild.h"
+#include "deflate.h"
 
 #include <immintrin.h>
 

--- a/arch/x86/slide_hash_sse2.c
+++ b/arch/x86/slide_hash_sse2.c
@@ -8,8 +8,8 @@
  *
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
-#include "../../zbuild.h"
-#include "../../deflate.h"
+#include "zbuild.h"
+#include "deflate.h"
 
 #include <immintrin.h>
 #include <assert.h>

--- a/arch/x86/x86_features.c
+++ b/arch/x86/x86_features.c
@@ -7,7 +7,7 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-#include "../../zbuild.h"
+#include "zbuild.h"
 #include "x86_features.h"
 
 #ifdef _WIN32


### PR DESCRIPTION
The arch/ code is built with "-I$SRCDIR".
Remove the ugly ../.. prefixes from #includes.