### PR TITLE
Relocatable pkg config files, `@rpath/<libraryname>` install name on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -951,36 +951,8 @@ if(NOT CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR)
     endif()
 endif()
 
-# Refer to prefix symbolically to ease relocation by end user,
-# as Makefile-generated .pc file does.
-string(FIND "${CMAKE_INSTALL_INCLUDEDIR}" "${CMAKE_INSTALL_PREFIX}/" INCLUDEDIR_POS)
-string(FIND "${CMAKE_INSTALL_LIBDIR}" "${CMAKE_INSTALL_PREFIX}/" LIBDIR_POS)
-string(LENGTH "${CMAKE_INSTALL_PREFIX}/" INSTALL_PREFIX_LEN)
-
-if(NOT IS_ABSOLUTE "${CMAKE_INSTALL_INCLUDEDIR}")
-  set(PC_INC_INSTALL_DIR "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
-elseif(INCLUDEDIR_POS EQUAL 0)
-  string(SUBSTRING "${CMAKE_INSTALL_INCLUDEDIR}" "${INSTALL_PREFIX_LEN}" "-1" INCLUDEDIR_RELATIVE)
-  set(PC_INC_INSTALL_DIR "\${prefix}/${INCLUDEDIR_RELATIVE}")
-else()
-  set(PC_INC_INSTALL_DIR "${CMAKE_INSTALL_INCLUDEDIR}")
-endif()
-
-if(APPLE)
-  option(WITH_RPATH "Enable RPATH for shared library" OFF)
-endif()
-if(NOT IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}")
-  if(APPLE AND WITH_RPATH)
-    set(PC_LIB_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}")
-  else()
-    set(PC_LIB_INSTALL_DIR "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
-  endif()
-elseif(LIBDIR_POS EQUAL 0)
-  string(SUBSTRING "${CMAKE_INSTALL_LIBDIR}" "${INSTALL_PREFIX_LEN}" "-1" LIBDIR_RELATIVE)
-  set(PC_LIB_INSTALL_DIR "\${exec_prefix}/${LIBDIR_RELATIVE}")
-else()
-  set(PC_LIB_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}")
-endif()
+set(PC_INC_INSTALL_DIR "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
+set(PC_LIB_INSTALL_DIR "${CMAKE_INSTALL_FULL_LIBDIR}")
 
 #============================================================================
 # zlib
@@ -1142,11 +1114,6 @@ if(NOT DEFINED BUILD_SHARED_LIBS OR BUILD_SHARED_LIBS)
         if(NOT APPLE)
             set_target_properties(zlib PROPERTIES LINK_FLAGS
                 "-Wl,--version-script,\"${CMAKE_CURRENT_SOURCE_DIR}/zlib${SUFFIX}.map\"")
-        elseif(IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}" OR NOT WITH_RPATH)
-            # Match configure/make's behavior (i.e. don't use @rpath on mac when using absolute path).
-            set_target_properties(zlib PROPERTIES INSTALL_NAME_DIR "@rpath/${CMAKE_INSTALL_FULL_LIBDIR}")
-        else()
-            set_target_properties(zlib PROPERTIES INSTALL_NAME_DIR "@rpath/${CMAKE_INSTALL_LIBDIR}")
         endif()
     endif()
     if(MSYS)
@@ -1182,11 +1149,6 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/zlib${SUFFIX}.h.in
     ${CMAKE_CURRENT_BINARY_DIR}/zlib${SUFFIX}.h @ONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/gzread.c.in
     ${CMAKE_CURRENT_BINARY_DIR}/gzread.c @ONLY)
-
-# Fix install directory after generating zlib.pc/zlib-ng.pc
-if (NOT IS_ABSOLUTE CMAKE_INSTALL_LIBDIR AND WITH_RPATH)
-    set(CMAKE_INSTALL_LIBDIR "/${CMAKE_INSTALL_LIBDIR}")
-endif()
 
 if (NOT ZLIB_SYMBOL_PREFIX STREQUAL "")
     add_feature_info(ZLIB_SYMBOL_PREFIX ON "Publicly exported symbols have a custom prefix")
@@ -1285,9 +1247,5 @@ elseif(BASEARCH_X86_FOUND)
 endif()
 
 add_feature_info(INSTALL_UTILS INSTALL_UTILS "Copy minigzip and minideflate during install")
-
-if(APPLE)
-    add_feature_info(WITH_RPATH WITH_RPATH "Enable RPATH for shared library")
-endif()
 
 FEATURE_SUMMARY(WHAT ALL INCLUDE_QUIET_PACKAGES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -951,8 +951,19 @@ if(NOT CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR)
     endif()
 endif()
 
-set(PC_INC_INSTALL_DIR "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
-set(PC_LIB_INSTALL_DIR "${CMAKE_INSTALL_FULL_LIBDIR}")
+# The user is allowed (but discouraged) to set absolute CMAKE_INSTALL_*DIR paths.
+# If they do, we copy these non-relocatable paths into the pkg-config file.
+if(IS_ABSOLUTE "${CMAKE_INSTALL_INCLUDEDIR}")
+    set(PC_INC_INSTALL_DIR "${CMAKE_INSTALL_INCLUDEDIR}")
+else()
+    set(PC_INC_INSTALL_DIR "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+endif()
+
+if(IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}")
+    set(PC_LIB_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}")
+else()
+    set(PC_LIB_INSTALL_DIR "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
+endif()
 
 #============================================================================
 # zlib

--- a/configure
+++ b/configure
@@ -513,12 +513,7 @@ if test "$gcc" -eq 1 && ($cc $CFLAGS -c $test.c) >> configure.log 2>&1; then
              SHAREDLIBM=${LIBNAME}.$VER1$shared_ext
              SHAREDTARGET=$SHAREDLIBV
              LDSHARED=${LDSHARED-"$cc"}
-             case ${libdir} in
-             /*)
-                 LDSHAREDFLAGS="-dynamiclib -install_name ${libdir}/${SHAREDLIBM} -compatibility_version ${VER1} -current_version ${VER3}" ;;
-             *)
-                 LDSHAREDFLAGS="-dynamiclib -install_name @rpath/${libdir}/${SHAREDLIBM} -compatibility_version ${VER1} -current_version ${VER3}" ;;
-             esac
+             LDSHAREDFLAGS="-dynamiclib -install_name @rpath/${SHAREDLIBM} -compatibility_version ${VER1} -current_version ${VER3}"
              if libtool -V 2>&1 | grep Apple > /dev/null; then
                  AR="libtool"
              else

--- a/test/pkgcheck.sh
+++ b/test/pkgcheck.sh
@@ -81,11 +81,6 @@ Darwin)
   sysctl -n machdep.cpu.features
   sysctl -n machdep.cpu.leaf7_features
   sysctl -n machdep.cpu.extfeatures
-  CMAKE_ARGS="-DCMAKE_INSTALL_LIBDIR=lib ${CMAKE_ARGS}"
-  CONFIGURE_ARGS="--libdir=lib ${CONFIGURE_ARGS}"
-  ;;
-*)
-  CMAKE_ARGS="-DCMAKE_INSTALL_LIBDIR=lib ${CMAKE_ARGS}"
   ;;
 esac
 

--- a/test/pkgcheck.sh
+++ b/test/pkgcheck.sh
@@ -81,7 +81,7 @@ Darwin)
   sysctl -n machdep.cpu.features
   sysctl -n machdep.cpu.leaf7_features
   sysctl -n machdep.cpu.extfeatures
-  CMAKE_ARGS="-DCMAKE_INSTALL_LIBDIR=lib -DPKGCONFIG_INSTALL_DIR=/lib/pkgconfig -DWITH_RPATH=on ${CMAKE_ARGS}"
+  CMAKE_ARGS="-DCMAKE_INSTALL_LIBDIR=lib ${CMAKE_ARGS}"
   CONFIGURE_ARGS="--libdir=lib ${CONFIGURE_ARGS}"
   ;;
 *)


### PR DESCRIPTION
Closes #1523 

1. Make the install name `@rpath/<libz.dylib>` on macOS for CMake and configure. This is what [CMake 3.0+ does by default (CMP0042)](https://cmake.org/cmake/help/latest/policy/CMP0042.html)[^1] and is a very sensible.

2. When using GNUInstallDirs, there's `CMAKE_INSTALL_*` for relative paths, and `CMAKE_INSTALL_FULL_*` for absolute paths (joined with `CMAKE_INSTALL_PREFIX` + some special rules for multi-arch systems). Absolute paths in `CMAKE_INSTALL_*DIR` are allowed but discouraged, since that makes things non-relocatable. This PR drops the complexity of generating relocatable pc files when using absolute paths in those variables. If you want a custom layout, but a relocatable install, use e.g. `CMAKE_INSTALL_[LIB|INCLUDE]DIR=relative/path`, it's as simple as that.

3. In contrast to `CMake` + `GNUInstallDirs`, the configure script expects absolute paths for `--libdir` (or `./configure '--libdir=${prefix}/lib'` literally?). I'm not familiar enough with autotools, but looks like it's standard: [Standard Directory Variables](https://www.gnu.org/software/automake/manual/html_node/Standard-Directory-Variables.html). Or maybe this is to mimic upstream zlib? In any case, with this PR, both the generated autotools & cmake pc file are relocatable by default, unless `--libdir=/absolute/path` or `CMAKE_INSTALL_LIBDIR=/absolute/path` is given.

[^1]: For what it's worth, there are two approaches to make libraries easily locatable in non-standard directories, both are rather hacky:
    
    1. Set the install name to `@rpath/libfoo.dylib` instead of `libfoo.dylib`, so that dependent libraries end up with a load command of `@rpath/libfoo.dylib` after linking, and rpaths can be used automatically.
    2. Set the install name to `/absolute/path/of/libfoo.dylib` so that dependent libraries end up with a load command of `/absolute/path/of/libfoo.dylib`, meaning that the dynamic linker doesn't have to search but can immediately open it.
    
    As far as I know, the second option is the most hacky and non-relocatable (using an absolute path as a library name...), the first option is the default of CMake. Option 1 is very common.