### PR TITLE
Add CPack capability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1250,3 +1250,20 @@ endif()
 add_feature_info(INSTALL_UTILS INSTALL_UTILS "Copy minigzip and minideflate during install")
 
 FEATURE_SUMMARY(WHAT ALL INCLUDE_QUIET_PACKAGES)
+
+#============================================================================
+# CPack
+#============================================================================
+set(CPACK_GENERATOR "TGZ")
+set(CPACK_SOURCE_GENERATOR "TGZ")
+set(CPACK_SOURCE_IGNORE_FILES .git/ _CPack_Packages/ "${PROJECT_BINARY_DIR}/")
+
+set(CPACK_PACKAGE_NAME "zlib${SUFFIX}")
+set(CPACK_PACKAGE_VERSION ${ZLIB_FULL_VERSION})
+set(CPACK_PACKAGE_DIRECTORY "${PROJECT_BINARY_DIR}/package")
+
+if("${PROJECT_BINARY_DIR}" STREQUAL "${PROJECT_SOURCE_DIR}")
+    message(WARNING "Building to source folder is not recommended. Cpack will be unable to generate source package.")
+endif()
+
+include(CPack)


### PR DESCRIPTION
Inspired by #1336, but needed some changes to properly support our zlib compat and zlib-ng switching.

Tested building source, binary tgz and binary rpm packages locally.

I am not sure there is much value in using this in the release.yml workflow, unless we wanted to provide rpm/deb/nsis packages as well.