### PR TITLE
use dash not bash for portability

### DIFF
--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # configure script for zlib.
 #
 # Normally configure builds both a static and a shared library.
@@ -243,7 +243,7 @@ int main() {return getchar();}
 EOF
 
 cc=${CC-${CROSS_PREFIX}gcc}
-echo -n "Checking for compiler... " | tee -a configure.log
+printf "Checking for compiler... " | tee -a configure.log
 case "$cc" in
   *gcc*) gcc=1 ;;
   *clang*) gcc=1 ;;
@@ -361,7 +361,7 @@ if test "$gcc" -eq 1 && ($cc $CFLAGS -c $test.c) >> configure.log 2>&1; then
     SFLAGS="${SFLAGS} -DNDEBUG"
   fi
   if test -z "$uname"; then
-    uname=$((uname -s || echo unknown) 2>/dev/null)
+    uname=$( (uname -s || echo unknown) 2>/dev/null)
   fi
   case "$uname" in
   Linux* | linux* | GNU | GNU/* | solaris*)
@@ -443,7 +443,7 @@ if test "$gcc" -eq 1 && ($cc $CFLAGS -c $test.c) >> configure.log 2>&1; then
         fi
         RC="${CROSS_PREFIX}windres"
         RCFLAGS="-I ${BUILDDIR}"
-        if [ "$CC" == "mingw32-gcc" ]; then
+        if [ "$CC" = "mingw32-gcc" ]; then
           case $ARCH in
           i386 | i486 | i586 | i686) RCFLAGS="${RCFLAGS} -F pe-i386";;
           esac;
@@ -458,7 +458,7 @@ if test "$gcc" -eq 1 && ($cc $CFLAGS -c $test.c) >> configure.log 2>&1; then
   HP-UX*)
          LDSHARED=${LDSHARED-"$cc"}
          LDSHAREDFLAGS="-shared"
-         case $((uname -m || echo unknown) 2>/dev/null) in
+         case $( (uname -m || echo unknown) 2>/dev/null) in
          ia64)
                  shared_ext='.so'
                  SHAREDLIB='${LIBNAME}.so' ;;
@@ -494,14 +494,14 @@ else
   gcc=0
   echo "$CC" | tee -a configure.log
   if test -z "$uname"; then
-    uname=$((uname -sr || echo unknown) 2>/dev/null)
+    uname=$( (uname -sr || echo unknown) 2>/dev/null)
   fi
   case "$uname" in
   HP-UX*)    SFLAGS=${CFLAGS-"-O +z"}
              CFLAGS=${CFLAGS-"-O"}
              LDSHARED=${LDSHARED-"ld"}
              LDSHAREDFLAGS="-b"
-         case $((uname -m || echo unknown) 2>/dev/null) in
+         case $( (uname -m || echo unknown) 2>/dev/null) in
          ia64)
              shared_ext='.so'
              SHAREDLIB='${LIBNAME}.so' ;;
@@ -598,7 +598,7 @@ extern int getchar();
 int hello() {return getchar();}
 EOF
 if test $shared -eq 1; then
-  echo -n "Checking for shared library support... " | tee -a configure.log
+  printf "Checking for shared library support... " | tee -a configure.log
   # we must test in two steps (cc then ld), required at least on SunOS 4.x
   if try $CC -w -c $SFLAGS $test.c &&
      try $LDSHARED $LDSHAREDFLAGS $LDFLAGS -o $test$shared_ext $test.o $LDSHAREDLIBC; then
@@ -755,7 +755,7 @@ fi
 # Rename @ZLIB_SYMBOL_PREFIX@ to $symbol_prefix in gzread.c, zlib.h and zlib_name_mangling.h
 sed < $SRCDIR/gzread.c.in "s/@ZLIB_SYMBOL_PREFIX@/$symbol_prefix/g" > gzread.c
 sed < $SRCDIR/zlib${SUFFIX}.h.in "s/@ZLIB_SYMBOL_PREFIX@/$symbol_prefix/g" > zlib${SUFFIX}.h
-if [[ ! -z $symbol_prefix ]]; then
+if [ ! -z "$symbol_prefix" ]; then
   sed < $SRCDIR/zlib_name_mangling${SUFFIX}.h.in "s/@ZLIB_SYMBOL_PREFIX@/$symbol_prefix/g" > zlib_name_mangling${SUFFIX}.h
 else
   # symbol_prefix is not set, copy the empty mangling header
@@ -785,7 +785,7 @@ fi
 echo >> configure.log
 
 # check for ptrdiff_t and save result in zconf.h
-echo -n "Checking for ptrdiff_t... " | tee -a configure.log
+printf "Checking for ptrdiff_t... " | tee -a configure.log
 cat > $test.c <<EOF
 #include <stddef.h>
 int fun(ptrdiff_t *a) { (void)a; return 0; }
@@ -797,7 +797,7 @@ else
     sed < zconf${SUFFIX}.h "/^#ifdef NEED_PTRDIFF_T.* may be/s/def NEED_PTRDIFF_T\(.*\) may be/ 1\1 was/" > zconf${SUFFIX}.temp.h
     mv zconf${SUFFIX}.temp.h zconf${SUFFIX}.h
 
-    echo -n "Checking for sizeof(void *)... " | tee -a configure.log
+    printf "Checking for sizeof(void *)... " | tee -a configure.log
     cat > $test.c <<EOF
 #include <stdint.h>
 #define COMPILE_TIME_ASSERT(pred) struct s { int x: (pred) ? 1 : -1; }
@@ -835,7 +835,7 @@ if test $compat -eq 1; then
   esac
 fi
 
-if [[ ! -z $DEFFILE ]]; then
+if [ ! -z "$DEFFILE" ]; then
   mkdir -p win32
   sed < $SRCDIR/$DEFFILE.in "s/@ZLIB_SYMBOL_PREFIX@/$symbol_prefix/g" > $DEFFILE
 fi
@@ -1447,14 +1447,14 @@ EOF
 
 check_vgfma_intrinsics() {
     # Check whether "VECTOR GALOIS FIELD MULTIPLY SUM AND ACCUMULATE" intrinsic is available
-    echo -n "Checking for -mzarch... " | tee -a configure.log
+    printf "Checking for -mzarch... " | tee -a configure.log
     if try $CC -x c -c /dev/null -o /dev/null -mzarch; then
         echo Yes. | tee -a configure.log
         vgfmaflag="${vgfmaflag} -mzarch"
     else
         echo No. | tee -a configure.log
     fi
-    echo -n "Checking for -fzvector... " | tee -a configure.log
+    printf "Checking for -fzvector... " | tee -a configure.log
     if try $CC -x c -c /dev/null -o /dev/null -fzvector; then
         echo Yes. | tee -a configure.log
         vgfmaflag="${vgfmaflag} -fzvector"
@@ -1471,7 +1471,7 @@ int main(void) {
     return c[0];
 }
 EOF
-    echo -n "Checking for VGFMA support... " | tee -a configure.log
+    printf "Checking for VGFMA support... " | tee -a configure.log
     if try $CC -c $CFLAGS $vgfmaflag $test.c; then
         HAVE_VGFMA_INTRIN=1
         echo "Yes." | tee -a configure.log
@@ -2111,11 +2111,11 @@ for file in $SRCDIR/*.c $SRCDIR/test/*.c $SRCDIR/test/fuzz/*.c $SRCDIR/$ARCHDIR/
                    # Check that the include file exists in the current dir,
                    # otherwise it may be one of the system include header.
                    if test -e $SRCDIR/$i; then
-                       echo -n " \$(SRCDIR)/$i"
+                       printf " \$(SRCDIR)/$i"
                    fi
                    # We also need to check whether the include file is in the ARCHDIR.
                    if test -e $SRCDIR/$ARCHDIR/$i; then
-                       echo -n " \$(SRCDIR)/$ARCHDIR/$i"
+                       printf " \$(SRCDIR)/$ARCHDIR/$i"
                    fi
                done)
     obj=$(basename $(echo $file | sed -e 's/\.c/\.o/g' -e 's#^\./##g'))
@@ -2188,11 +2188,11 @@ for file in $SRCDIR/$ARCHDIR/*.c; do
                    # Check that the include file exists in the current dir,
                    # otherwise it may be one of the system include header.
                    if test -e $SRCDIR/$i; then
-                       echo -n " \$(SRCTOP)/$i"
+                       printf " \$(SRCTOP)/$i"
                    fi
                    # We also need to check whether the include file is in the ARCHDIR.
                    if test -e $SRCDIR/$ARCHDIR/$i; then
-                       echo -n " \$(SRCDIR)/$i"
+                       printf " \$(SRCDIR)/$i"
                    fi
                done)
     obj=$(basename $(echo $file | sed -e 's/\.c/\.o/g' -e 's#^\./##g'))

--- a/configure
+++ b/configure
@@ -563,7 +563,7 @@ if ($CC -c $CFLAGS $test.c) 2>/dev/null; then
   try()
   {
     show $*
-    test "$(\( $* \) 2>&1 | tee -a configure.log)" = ""
+    test "$( ($*) 2>&1 | tee -a configure.log)" = ""
   }
   echo - using any output from compiler to indicate an error >> configure.log
 else

--- a/configure
+++ b/configure
@@ -227,13 +227,13 @@ test=ztest$$
 # put arguments in log, also put test file in log if used in arguments
 show()
 {
-  case "$*" in
+  case "$@" in
     *$test.c*)
       echo "=== $test.c ===" >> configure.log
       cat $test.c >> configure.log
       echo "===" >> configure.log;;
   esac
-  echo $* >> configure.log
+  echo "$@" >> configure.log
 }
 
 # check for gcc vs. cc and set compile and link flags based on the system identified by uname
@@ -562,15 +562,15 @@ EOF
 if ($CC -c $CFLAGS $test.c) 2>/dev/null; then
   try()
   {
-    show $*
-    test "$( ($*) 2>&1 | tee -a configure.log)" = ""
+    show "$@"
+    test "$( ("$@") 2>&1 | tee -a configure.log)" = ""
   }
   echo - using any output from compiler to indicate an error >> configure.log
 else
   try()
   {
-    show $*
-    ( $* ) >> configure.log 2>&1
+    show "$@"
+    ( "$@" ) >> configure.log 2>&1
     ret=$?
     if test $ret -ne 0; then
       echo "(exit code $ret)" >> configure.log


### PR DESCRIPTION
Use `#!/bin/sh` in configure script, since `bash` is not universal.
For example Alpine Linux only has dash aka `/bin/sh` by default.
Also the zlib configure script itself is using `/bin/sh` as shebang.

Also use `"$@"` instead of `$*` so that you could in principle pass
args that contain whitespace. For example

```sh
try ${CC} '-DMY_DEFINE="a b c"' $test.c
```

now invokes the compiler with `'-DMY_DEFINE="a b c"`
literally instead of `'-DMY_DEFINE="a' 'b' 'c'`.