### PR TITLE
detect intrinsics: ensure intrinsics are not optimized out before assembler is run

### DIFF
--- a/cmake/detect-intrinsics.cmake
+++ b/cmake/detect-intrinsics.cmake
@@ -507,7 +507,7 @@ macro(check_xsave_intrinsics)
         #else
         #  include <x86gprintrin.h>
         #endif
-        unsigned int f(unsigned int a) { return _xgetbv(a); }
+        unsigned int f(unsigned int a) { return (int) _xgetbv(a); }
         int main(void) { return 0; }"
         HAVE_XSAVE_INTRIN FAIL_REGEX "not supported")
     set(CMAKE_REQUIRED_FLAGS)

--- a/cmake/detect-intrinsics.cmake
+++ b/cmake/detect-intrinsics.cmake
@@ -73,28 +73,19 @@ macro(check_avx512_intrinsics)
     set(CMAKE_REQUIRED_FLAGS "${AVX512FLAG} ${NATIVEFLAG}")
     check_c_source_compile_or_run(
         "#include <immintrin.h>
-        int main(void) {
-            __m512i x = _mm512_set1_epi8(2);
-            const __m512i y = _mm512_set_epi32(0x1020304, 0x5060708, 0x90a0b0c, 0xd0e0f10,
-                                               0x11121314, 0x15161718, 0x191a1b1c, 0x1d1e1f20,
-                                               0x21222324, 0x25262728, 0x292a2b2c, 0x2d2e2f30,
-                                               0x31323334, 0x35363738, 0x393a3b3c, 0x3d3e3f40);
-            x = _mm512_sub_epi8(x, y);
-            (void)x;
-            return 0;
-        }"
+        __m512i f(__m512i y) {
+          __m512i x = _mm512_set1_epi8(2);
+          return _mm512_sub_epi8(x, y);
+        }
+        int main(void) { return 0; }"
         HAVE_AVX512_INTRIN
     )
 
     # Evidently both GCC and clang were late to implementing these
     check_c_source_compile_or_run(
         "#include <immintrin.h>
-        int main(void) {
-            __mmask16 a = 0xFF;
-            a = _knot_mask16(a);
-            (void)a;
-            return 0;
-        }"
+        __mmask16 f(__mmask16 x) { return _knot_mask16(x); }
+        int main(void) { return 0; }"
         HAVE_MASK_INTRIN
     )
     set(CMAKE_REQUIRED_FLAGS)
@@ -128,17 +119,11 @@ macro(check_avx512vnni_intrinsics)
     set(CMAKE_REQUIRED_FLAGS "${AVX512VNNIFLAG} ${NATIVEFLAG}")
     check_c_source_compile_or_run(
         "#include <immintrin.h>
-        int main(void) {
-            __m512i x = _mm512_set1_epi8(2);
-            const __m512i y = _mm512_set_epi8(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
-                                              20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37,
-                                              38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55,
-                                              56, 57, 58, 59, 60, 61, 62, 63, 64);
+        __m512i f(__m512i x, __m512i y) {
             __m512i z = _mm512_setzero_epi32();
-            z = _mm512_dpbusd_epi32(z, x, y);
-            (void)z;
-            return 0;
-        }"
+            return _mm512_dpbusd_epi32(z, x, y);
+        }
+        int main(void) { return 0; }"
         HAVE_AVX512VNNI_INTRIN
     )
     set(CMAKE_REQUIRED_FLAGS)
@@ -162,13 +147,11 @@ macro(check_avx2_intrinsics)
     set(CMAKE_REQUIRED_FLAGS "${AVX2FLAG} ${NATIVEFLAG}")
     check_c_source_compile_or_run(
         "#include <immintrin.h>
-        int main(void) {
-            __m256i x = _mm256_set1_epi16(2);
+        __m256i f(__m256i x) {
             const __m256i y = _mm256_set1_epi16(1);
-            x = _mm256_subs_epu16(x, y);
-            (void)x;
-            return 0;
-        }"
+            return _mm256_subs_epu16(x, y);
+        }
+        int main(void) { return 0; }"
         HAVE_AVX2_INTRIN
     )
     set(CMAKE_REQUIRED_FLAGS)
@@ -215,12 +198,8 @@ macro(check_neon_ld4_intrinsics)
         #else
         #  include <arm_neon.h>
         #endif
-        int main(void) {
-            int stack_var[16];
-            int32x4x4_t v = vld1q_s32_x4(stack_var);
-            (void)v;
-            return 0;
-        }"
+        int32x4x4_t f(int var[16]) { return vld1q_s32_x4(var); }
+        int main(void) { return 0; }"
         NEON_HAS_LD4)
     set(CMAKE_REQUIRED_FLAGS)
 endmacro()
@@ -237,13 +216,9 @@ macro(check_pclmulqdq_intrinsics)
         set(CMAKE_REQUIRED_FLAGS "${PCLMULFLAG} ${NATIVEFLAG}")
         check_c_source_compile_or_run(
             "#include <immintrin.h>
-            int main(void) {
-                __m128i a = _mm_setzero_si128();
-                __m128i b = _mm_setzero_si128();
-                __m128i c = _mm_clmulepi64_si128(a, b, 0x10);
-                (void)c;
-                return 0;
-            }"
+            #include <wmmintrin.h>
+            __m128i f(__m128i a, __m128i b) { return _mm_clmulepi64_si128(a, b, 0x10); }
+            int main(void) { return 0; }"
             HAVE_PCLMULQDQ_INTRIN
         )
         set(CMAKE_REQUIRED_FLAGS)
@@ -263,13 +238,12 @@ macro(check_vpclmulqdq_intrinsics)
         set(CMAKE_REQUIRED_FLAGS "${VPCLMULFLAG} ${NATIVEFLAG}")
         check_c_source_compile_or_run(
             "#include <immintrin.h>
-            int main(void) {
-                __m512i a = _mm512_setzero_si512();
+            #include <wmmintrin.h>
+            __m512i f(__m512i a) {
                 __m512i b = _mm512_setzero_si512();
-                __m512i c = _mm512_clmulepi64_epi128(a, b, 0x10);
-                (void)c;
-                return 0;
-            }"
+                return _mm512_clmulepi64_epi128(a, b, 0x10);
+            }
+            int main(void) { return 0; }"
             HAVE_VPCLMULQDQ_INTRIN
         )
         set(CMAKE_REQUIRED_FLAGS)
@@ -442,11 +416,8 @@ macro(check_sse2_intrinsics)
     set(CMAKE_REQUIRED_FLAGS "${SSE2FLAG} ${NATIVEFLAG}")
     check_c_source_compile_or_run(
         "#include <immintrin.h>
-        int main(void) {
-            __m128i zero = _mm_setzero_si128();
-            (void)zero;
-            return 0;
-        }"
+        __m128i f(__m128i x, __m128i y) { return _mm_sad_epu8(x, y); }
+        int main(void) { return 0; }"
         HAVE_SSE2_INTRIN
     )
     set(CMAKE_REQUIRED_FLAGS)
@@ -468,14 +439,11 @@ macro(check_ssse3_intrinsics)
     set(CMAKE_REQUIRED_FLAGS "${SSSE3FLAG} ${NATIVEFLAG}")
     check_c_source_compile_or_run(
         "#include <immintrin.h>
-        int main(void) {
-            __m128i u, v, w;
-            u = _mm_set1_epi32(1);
-            v = _mm_set1_epi32(2);
-            w = _mm_hadd_epi32(u, v);
-            (void)w;
-            return 0;
-        }"
+        __m128i f(__m128i u) {
+          __m128i v = _mm_set1_epi32(1);
+          return _mm_hadd_epi32(u, v);
+        }
+        int main(void) { return 0; }"
         HAVE_SSSE3_INTRIN
     )
 endmacro()
@@ -496,13 +464,8 @@ macro(check_sse42_intrinsics)
     set(CMAKE_REQUIRED_FLAGS "${SSE42FLAG} ${NATIVEFLAG}")
     check_c_source_compile_or_run(
         "#include <nmmintrin.h>
-        int main(void) {
-            unsigned crc = 0;
-            char c = 'c';
-            crc = _mm_crc32_u32(crc, c);
-            (void)crc;
-            return 0;
-        }"
+        unsigned int f(unsigned int a, unsigned int b) { return _mm_crc32_u32(a, b); }
+        int main(void) { return 0; }"
         HAVE_SSE42_INTRIN
     )
     set(CMAKE_REQUIRED_FLAGS)
@@ -540,13 +503,12 @@ macro(check_xsave_intrinsics)
     set(CMAKE_REQUIRED_FLAGS "${XSAVEFLAG} ${NATIVEFLAG}")
     check_c_source_compiles(
         "#ifdef _WIN32
-         #  include <intrin.h>
-         #else
-         #  include <x86gprintrin.h>
-         #endif
-         int main(void) {
-             return _xgetbv(0);
-         }"
+        #  include <intrin.h>
+        #else
+        #  include <x86gprintrin.h>
+        #endif
+        unsigned int f(unsigned int a) { return _xgetbv(a); }
+        int main(void) { return 0; }"
         HAVE_XSAVE_INTRIN FAIL_REGEX "not supported")
     set(CMAKE_REQUIRED_FLAGS)
 endmacro()

--- a/configure
+++ b/configure
@@ -1210,13 +1210,11 @@ check_vpclmulqdq_intrinsics() {
     cat > $test.c << EOF
 #include <immintrin.h>
 #include <wmmintrin.h>
-int main(void) {
-    __m512i a = _mm512_setzero_si512();
+__m512i f(__m512i a) {
     __m512i b = _mm512_setzero_si512();
-    __m512i c = _mm512_clmulepi64_epi128(a, b, 0x10);
-    (void)c;
-    return 0;
+    return _mm512_clmulepi64_epi128(a, b, 0x10);
 }
+int main(void) { return 0; }
 EOF
     if try ${CC} ${CFLAGS} ${vpclmulflag} $test.c; then
         echo "Checking for VPCLMULQDQ intrinsics ... Yes." | tee -a configure.log

--- a/configure
+++ b/configure
@@ -1233,7 +1233,7 @@ check_xsave_intrinsics() {
 #else
 #  include <x86gprintrin.h>
 #endif
-unsigned int f(unsigned int a) { return _xgetbv(a); }
+unsigned int f(unsigned int a) { return (int) _xgetbv(a); }
 int main(void) { return 0; }
 EOF
     if try ${CC} ${CFLAGS} ${xsaveflag} $test.c; then

--- a/configure
+++ b/configure
@@ -994,12 +994,8 @@ fi
 
 # Check for __builtin_ctz() support in compiler
 cat > $test.c << EOF
-int main(void) {
-    unsigned int zero = 0;
-    long test = __builtin_ctz(zero);
-    (void)test;
-    return 0;
-}
+long f(unsigned int x) { return __builtin_ctz(x); }
+int main(void) { return 0; }
 EOF
 if try ${CC} ${CFLAGS} $test.c $LDSHAREDLIBC; then
     echo "Checking for __builtin_ctz ... Yes." | tee -a configure.log
@@ -1011,12 +1007,8 @@ fi
 
 # Check for __builtin_ctzll() support in compiler
 cat > $test.c << EOF
-int main(void) {
-    unsigned long long zero = 0;
-    long test = __builtin_ctzll(zero);
-    (void)test;
-    return 0;
-}
+long f(unsigned long long x) { return __builtin_ctzll(x); }
+int main(void) { return 0; }
 EOF
 if try ${CC} ${CFLAGS} $test.c $LDSHAREDLIBC; then
     echo "Checking for __builtin_ctzll ... Yes." | tee -a configure.log
@@ -1030,13 +1022,11 @@ check_avx2_intrinsics() {
     # Check whether compiler supports AVX2 intrinsics
     cat > $test.c << EOF
 #include <immintrin.h>
-int main(void) {
-    __m256i x = _mm256_set1_epi16(2);
+__m256i f(__m256i x) {
     const __m256i y = _mm256_set1_epi16(1);
-    x = _mm256_subs_epu16(x, y);
-    (void)x;
-    return 0;
+    return _mm256_subs_epu16(x, y);
 }
+int main(void) { return 0; }
 EOF
     if try ${CC} ${CFLAGS} ${avx2flag} $test.c; then
         echo "Checking for AVX2 intrinsics ... Yes." | tee -a configure.log
@@ -1051,16 +1041,11 @@ check_avx512_intrinsics() {
     # Check whether compiler supports AVX512 intrinsics
     cat > $test.c << EOF
 #include <immintrin.h>
-int main(void) {
-    __m512i x = _mm512_set1_epi8(2);
-    const __m512i y = _mm512_set_epi32(0x1020304, 0x5060708, 0x90a0b0c, 0xd0e0f10,
-                                       0x11121314, 0x15161718, 0x191a1b1c, 0x1d1e1f20,
-                                       0x21222324, 0x25262728, 0x292a2b2c, 0x2d2e2f30,
-                                       0x31323334, 0x35363738, 0x393a3b3c, 0x3d3e3f40);
-    x = _mm512_sub_epi8(x, y);
-    (void)x;
-    return 0;
+__m512i f(__m512i y) {
+  __m512i x = _mm512_set1_epi8(2);
+  return _mm512_sub_epi8(x, y);
 }
+int main(void) { return 0; }
 EOF
     if try ${CC} ${CFLAGS} ${avx512flag} $test.c; then
         echo "Checking for AVX512 intrinsics ... Yes." | tee -a configure.log
@@ -1104,17 +1089,11 @@ check_avx512vnni_intrinsics() {
     # Check whether compiler supports AVX512-VNNI intrinsics
     cat > $test.c << EOF
 #include <immintrin.h>
-int main(void) {
-    __m512i x = _mm512_set1_epi8(2);
-    const __m512i y = _mm512_set_epi8(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
-                                      20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37,
-                                      38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55,
-                                      56, 57, 58, 59, 60, 61, 62, 63, 64);
+__m512i f(__m512i x, __m512i y) {
     __m512i z = _mm512_setzero_epi32();
-    z = _mm512_dpbusd_epi32(z, x, y);
-    (void)z;
-    return 0;
+    return _mm512_dpbusd_epi32(z, x, y);
 }
+int main(void) { return 0; }
 EOF
     if try ${CC} ${CFLAGS} ${avx512vnniflag} $test.c; then
         echo "Checking for AVX512VNNI intrinsics ... Yes." | tee -a configure.log
@@ -1129,12 +1108,8 @@ check_mask_intrinsics() {
     # Check whether compiler supports AVX512 k-mask intrinsics
     cat > $test.c << EOF
 #include <immintrin.h>
-int main(void) {
-    __mmask16 a = 0xFF;
-    a = _knot_mask16(a);
-    (void)a;
-    return 0;
-}
+__mmask16 f(__mmask16 x) { return _knot_mask16(x); }
+int main(void) { return 0; }
 EOF
     if try ${CC} ${CFLAGS} ${avx512flag} $test.c; then
         echo "Checking for AVX512 k-mask intrinsics ... Yes." | tee -a configure.log
@@ -1201,12 +1176,8 @@ check_neon_ld4_intrinsics() {
 #else
 #  include <arm_neon.h>
 #endif
-int main(void) {
-    int stack_var[16];
-    int32x4x4_t v = vld1q_s32_x4(stack_var);
-    (void)v;
-    return 0;
-}
+int32x4x4_t f(int var[16]) { return vld1q_s32_x4(var); }
+int main(void) { return 0; }
 EOF
     if try $CC -c $CFLAGS $neonflag $test.c; then
         NEON_HAS_LD4=1
@@ -1222,13 +1193,8 @@ check_pclmulqdq_intrinsics() {
     cat > $test.c << EOF
 #include <immintrin.h>
 #include <wmmintrin.h>
-int main(void) {
-    __m128i a = _mm_setzero_si128();
-    __m128i b = _mm_setzero_si128();
-    __m128i c = _mm_clmulepi64_si128(a, b, 0x10);
-    (void)c;
-    return 0;
-}
+__m128i f(__m128i a, __m128i b) { return _mm_clmulepi64_si128(a, b, 0x10); }
+int main(void) { return 0; }
 EOF
     if try ${CC} ${CFLAGS} ${pclmulflag} $test.c; then
         echo "Checking for PCLMULQDQ intrinsics ... Yes." | tee -a configure.log
@@ -1269,9 +1235,8 @@ check_xsave_intrinsics() {
 #else
 #  include <x86gprintrin.h>
 #endif
-int main(void) {
-    return _xgetbv(0);
-}
+unsigned int f(unsigned int a) { return _xgetbv(a); }
+int main(void) { return 0; }
 EOF
     if try ${CC} ${CFLAGS} ${xsaveflag} $test.c; then
         echo "Checking for XSAVE intrinsics ... Yes." | tee -a configure.log
@@ -1386,11 +1351,8 @@ check_sse2_intrinsics() {
     # Check whether compiler supports SSE2 intrinsics
     cat > $test.c << EOF
 #include <immintrin.h>
-int main(void) {
-    __m128i zero = _mm_setzero_si128();
-    (void)zero;
-    return 0;
-}
+__m128i f(__m128i x, __m128i y) { return _mm_sad_epu8(x, y); }
+int main(void) { return 0; }
 EOF
     if try ${CC} ${CFLAGS} ${sse2flag} $test.c; then
         echo "Checking for SSE2 intrinsics ... Yes." | tee -a configure.log
@@ -1405,13 +1367,8 @@ check_sse42_intrinsics() {
     # Check whether compiler supports SSE4.2 intrinsics
     cat > $test.c << EOF
 #include <nmmintrin.h>
-int main(void) {
-    unsigned crc = 0;
-    char c = 'c';
-    crc = _mm_crc32_u32(crc, c);
-    (void)crc;
-    return 0;
-}
+unsigned int f(unsigned int a, unsigned int b) { return _mm_crc32_u32(a, b); }
+int main(void) { return 0; }
 EOF
     if try ${CC} ${CFLAGS} ${sse42flag} $test.c; then
         echo "Checking for SSE4.2 intrinsics ... Yes." | tee -a configure.log
@@ -1426,15 +1383,11 @@ check_ssse3_intrinsics() {
     # Check whether compiler supports SSSE3 intrinsics
     cat > $test.c << EOF
 #include <immintrin.h>
-int main(void)
-{
-    __m128i u, v, w;
-    u = _mm_set1_epi32(1);
-    v = _mm_set1_epi32(2);
-    w = _mm_hadd_epi32(u, v);
-    (void)w;
-    return 0;
+__m128i f(__m128i u) {
+  __m128i v = _mm_set1_epi32(1);
+  return _mm_hadd_epi32(u, v);
 }
+int main(void) { return 0; }
 EOF
     if try ${CC} ${CFLAGS} ${ssse3flag} $test.c; then
         echo "Checking for SSSE3 intrinsics ... Yes." | tee -a configure.log


### PR DESCRIPTION
Closes #1559 

Old binutils may have an assembler that does not support vector instructions
generated by `gcc`.

Although it's recommended to use an up-to-date assembler with gcc, it's happens
in practice that new gcc and old binutils are mixed.

The problem with the current configure script is that it runs tests with `-O2`
cflags, which causes the test inside `main() { ... }` to be optimized out
entirely, and the assembler won't see any of the vector instructions, leading
to false positives in tests.

This PR ensures that most configure tests use a separate function, taking and
returning some `__mm*` type, to avoid optimizations, so that the assembler will
error on seeing unsupported instructions.

Alternatively, `-O0` could be passed, but I don't think that is always
sufficient, since some compilers cannot *not* optimize ;p I believe nvhpc is
one of those.

