### PR TITLE
Clean up detection on ARM variants and allow ACLE on all ARM archs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -548,7 +548,20 @@ if(WITH_OPTIM)
     if(BASEARCH_ARM_FOUND)
         add_definitions(-DARM_FEATURES)
         if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-            if(NOT "${ARCH}" MATCHES "aarch64")
+            if("${ARCH}" MATCHES "aarch64")
+                check_c_source_compiles(
+                    "#include <sys/auxv.h>
+                    int main() {
+                        return (getauxval(AT_HWCAP) & HWCAP_CRC32);
+                    }"
+                    ARM_AUXV_HAS_CRC32
+                )
+                if(ARM_AUXV_HAS_CRC32)
+                    add_definitions(-DARM_AUXV_HAS_CRC32)
+                else()
+                   message(STATUS "HWCAP_CRC32 not present in sys/auxv.h; cannot detect support at runtime.")
+                endif()
+            else()
                 check_c_source_compiles(
                     "#include <sys/auxv.h>
                     int main() {
@@ -573,21 +586,6 @@ if(WITH_OPTIM)
                         message(STATUS "HWCAP2_CRC32 not present in sys/auxv.h; cannot detect support at runtime.")
                     endif()
                 endif()
-            else()
-                check_c_source_compiles(
-                    "#include <sys/auxv.h>
-                    int main() {
-                        return (getauxval(AT_HWCAP) & HWCAP_CRC32);
-                    }"
-                    ARM_AUXV_HAS_CRC32
-                )
-                if(ARM_AUXV_HAS_CRC32)
-                    add_definitions(-DARM_AUXV_HAS_CRC32)
-                else()
-                   message(STATUS "HWCAP_CRC32 not present in sys/auxv.h; cannot detect support at runtime.")
-                endif()
-            endif()
-            if(NOT "${ARCH}" MATCHES "aarch64")
                 check_c_source_compiles(
                     "#include <sys/auxv.h>
                     int main() {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -615,7 +615,7 @@ if(WITH_OPTIM)
         endif()
         list(APPEND ZLIB_ARCH_HDRS ${ARCHDIR}/arm_features.h)
         list(APPEND ZLIB_ARCH_SRCS ${ARCHDIR}/arm_features.c)
-        if(WITH_ACLE AND NOT "${ARCH}" MATCHES "armv[2-7]")
+        if(WITH_ACLE)
             check_acle_compiler_flag()
             if(HAVE_ACLE_FLAG)
                 add_definitions(-DARM_ACLE)
@@ -715,7 +715,7 @@ if(WITH_OPTIM)
                 add_definitions(-DRISCV_RVV)
                 list(APPEND ZLIB_ARCH_HDRS ${ARCHDIR}/riscv_features.h)
                 list(APPEND ZLIB_ARCH_SRCS ${ARCHDIR}/riscv_features.c)
-                # FIXME: we will not set compile flags for riscv_features.c when 
+                # FIXME: we will not set compile flags for riscv_features.c when
                 # the kernels update hwcap or hwprobe for riscv
                 set(RVV_SRCS ${ARCHDIR}/riscv_features.c ${ARCHDIR}/adler32_rvv.c ${ARCHDIR}/compare256_rvv.c ${ARCHDIR}/slide_hash_rvv.c)
                 list(APPEND ZLIB_ARCH_SRCS ${RVV_SRCS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -631,7 +631,7 @@ if(WITH_OPTIM)
         endif()
         if(WITH_NEON)
             check_neon_compiler_flag()
-            if(MFPU_NEON_AVAILABLE)
+            if(NEON_AVAILABLE)
                 add_definitions(-DARM_NEON)
                 set(NEON_SRCS ${ARCHDIR}/adler32_neon.c ${ARCHDIR}/chunkset_neon.c
                     ${ARCHDIR}/compare256_neon.c ${ARCHDIR}/slide_hash_neon.c)

--- a/cmake/detect-intrinsics.cmake
+++ b/cmake/detect-intrinsics.cmake
@@ -193,7 +193,7 @@ macro(check_neon_compiler_flag)
         #  include <arm_neon.h>
         #endif
         int main() { return 0; }"
-        MFPU_NEON_AVAILABLE FAIL_REGEX "not supported")
+        NEON_AVAILABLE FAIL_REGEX "not supported")
     set(CMAKE_REQUIRED_FLAGS)
 endmacro()
 

--- a/configure
+++ b/configure
@@ -317,17 +317,9 @@ if test "$gcc" -eq 1 && ($cc $CFLAGS -c $test.c) >> configure.log 2>&1; then
         ARCH=$CC_ARCH
       fi ;;
     arm | armeb)
-        ARCH=arm
+      ARCH=arm
       if test "${uname}" = "eabi"; then
-        # No ACLE support
         uname=arm
-        if test $buildacle -eq 1; then
-          echo ACLE support not available
-          buildacle=0
-        fi
-      fi
-      if test $buildacle -eq 1; then
-        ARCH=armv8-a+crc
       fi ;;
     armv8l)
       ARCH=armv8-a ;;
@@ -1153,14 +1145,13 @@ EOF
     if try $CC -c $CFLAGS -march=armv8-a+crc $test.c; then
         ACLE_AVAILABLE=1
         echo "Check whether -march=armv8-a+crc works ... Yes." | tee -a configure.log
+        acleflag="-march=armv8-a+crc"
     else
         echo "Check whether -march=armv8-a+crc works ... No." | tee -a configure.log
         if try $CC -c $CFLAGS -march=armv8-a+crc+simd $test.c; then
             ACLE_AVAILABLE=1
             echo "Check whether -march=armv8-a+crc+simd works ... Yes." | tee -a configure.log
-            if test "$ARCH" = "armv8-a+crc"; then
-                ARCH=armv8-a+crc+simd
-            fi
+            acleflag="-march=armv8-a+crc+simd"
         else
             ACLE_AVAILABLE=0
             echo "Check whether -march=armv8-a+crc+simd works ... No." | tee -a configure.log
@@ -1169,7 +1160,12 @@ EOF
 }
 
 check_neon_compiler_flag() {
-    # Check whether -mfpu=neon is available on ARM processors.
+    if test "$ARCH" = "aarch64"; then
+        neonflag="-march=armv8-a+simd"
+    else
+        neonflag="-mfpu=neon"
+    fi
+    # Check whether neon flag is available on ARM processors.
     cat > $test.c << EOF
 #if defined(_M_ARM64) || defined(_M_ARM64EC)
  #  include <arm64_neon.h>
@@ -1178,23 +1174,16 @@ check_neon_compiler_flag() {
 #endif
 int main() { return 0; }
 EOF
-    if try $CC -c $CFLAGS -mfpu=neon $test.c; then
-        MFPU_NEON_AVAILABLE=1
-        echo "Check whether -mfpu=neon is available ... Yes." | tee -a configure.log
+    if try $CC -c $CFLAGS $neonflag $test.c; then
+        NEON_AVAILABLE=1
+        echo "Check whether $neonflag is available ... Yes." | tee -a configure.log
     else
-        MFPU_NEON_AVAILABLE=0
-        echo "Check whether -mfpu=neon is available ... No." | tee -a configure.log
+        NEON_AVAILABLE=0
+        echo "Check whether $neonflag is available ... No." | tee -a configure.log
     fi
 }
 
 check_neon_ld4_intrinsics() {
-    if test $buildneon -eq 1; then
-        if test "$CC_ARCH" = "aarch64" || test "$CC_ARCH" = "aarch64_be" || test "$CC_ARCH" = "arm64"; then
-            neonflag="-march=armv8-a+simd"
-        elif test $MFPU_NEON_AVAILABLE -eq 1; then
-            neonflag="-mfpu=neon"
-        fi
-    fi
     cat > $test.c << EOF
 #if defined(_M_ARM64) || defined(_M_ARM64EC)
 #  include <arm64_neon.h>
@@ -1612,8 +1601,16 @@ case "${ARCH}" in
     ;;
 
     # ARM specific optimizations
-    arm*)
-        [ ! -z $CROSS_PREFIX ] && QEMU_ARCH=arm
+    arm* | aarch64)
+      case "${ARCH}" in
+            arm*)
+                [ ! -z $CROSS_PREFIX ] && QEMU_ARCH=arm
+            ;;
+            aarch64)
+                [ ! -z $CROSS_PREFIX ] && QEMU_ARCH=aarch64
+            ;;
+        esac
+
         ARCHDIR=arch/arm
 
         if test $without_optimizations -eq 0; then
@@ -1623,52 +1620,69 @@ case "${ARCH}" in
             ARCH_SHARED_OBJS="${ARCH_SHARED_OBJS} arm_features.lo"
 
             if test $LINUX -eq 1; then
-                cat > $test.c <<EOF
+                if test "$ARCH" != "aarch64"; then
+                    cat > $test.c <<EOF
 #include <sys/auxv.h>
 int main() {
     return (getauxval(AT_HWCAP2) & HWCAP2_CRC32);
 }
 EOF
-                if try $CC -c $CFLAGS $test.c; then
-                    CFLAGS="${CFLAGS} -DARM_AUXV_HAS_CRC32"
-                    SFLAGS="${SFLAGS} -DARM_AUXV_HAS_CRC32"
-                else
-                    cat > $test.c <<EOF
+                    if try $CC -c $CFLAGS $test.c; then
+                        CFLAGS="${CFLAGS} -DARM_AUXV_HAS_CRC32"
+                        SFLAGS="${SFLAGS} -DARM_AUXV_HAS_CRC32"
+                    else
+                        cat > $test.c <<EOF
 #include <sys/auxv.h>
 #include <asm/hwcap.h>
 int main() {
     return (getauxval(AT_HWCAP2) & HWCAP2_CRC32);
 }
 EOF
-                    if try $CC -c $CFLAGS $test.c; then
-                        CFLAGS="${CFLAGS} -DARM_AUXV_HAS_CRC32 -DARM_ASM_HWCAP"
-                        SFLAGS="${SFLAGS} -DARM_AUXV_HAS_CRC32 -DARM_ASM_HWCAP"
-                    else
-                        echo "HWCAP2_CRC32 not present in sys/auxv.h; cannot detect support at runtime." | tee -a configure.log
+                        if try $CC -c $CFLAGS $test.c; then
+                            CFLAGS="${CFLAGS} -DARM_AUXV_HAS_CRC32 -DARM_ASM_HWCAP"
+                            SFLAGS="${SFLAGS} -DARM_AUXV_HAS_CRC32 -DARM_ASM_HWCAP"
+                        else
+                            echo "HWCAP2_CRC32 not present in sys/auxv.h; cannot detect support at runtime." | tee -a configure.log
+                        fi
                     fi
-                fi
-
-                cat > $test.c <<EOF
-#include <sys/auxv.h>
-int main() {
-    return (getauxval(AT_HWCAP) & HWCAP_ARM_NEON);
-}
-EOF
-                if try $CC -c $CFLAGS $test.c; then
-                    CFLAGS="${CFLAGS} -DARM_AUXV_HAS_NEON"
-                    SFLAGS="${SFLAGS} -DARM_AUXV_HAS_NEON"
                 else
                     cat > $test.c <<EOF
 #include <sys/auxv.h>
 int main() {
-    return (getauxval(AT_HWCAP) & HWCAP_NEON);
+    return (getauxval(AT_HWCAP) & HWCAP_CRC32);
+}
+EOF
+                    if try $CC -c $CFLAGS $test.c; then
+                        CFLAGS="${CFLAGS} -DARM_AUXV_HAS_CRC32"
+                        SFLAGS="${SFLAGS} -DARM_AUXV_HAS_CRC32"
+                    else
+                        echo "HWCAP_CRC32 not present in sys/auxv.h; cannot detect support at runtime." | tee -a configure.log
+                    fi
+                fi
+
+                if test "$ARCH" != "aarch64"; then
+                    cat > $test.c <<EOF
+#include <sys/auxv.h>
+int main() {
+    return (getauxval(AT_HWCAP) & HWCAP_ARM_NEON);
 }
 EOF
                     if try $CC -c $CFLAGS $test.c; then
                         CFLAGS="${CFLAGS} -DARM_AUXV_HAS_NEON"
                         SFLAGS="${SFLAGS} -DARM_AUXV_HAS_NEON"
                     else
-                        echo "Neither HWCAP_ARM_NEON or HWCAP_NEON present in sys/auxv.h; cannot detect support at runtime." | tee -a configure.log
+                        cat > $test.c <<EOF
+#include <sys/auxv.h>
+int main() {
+    return (getauxval(AT_HWCAP) & HWCAP_NEON);
+}
+EOF
+                        if try $CC -c $CFLAGS $test.c; then
+                            CFLAGS="${CFLAGS} -DARM_AUXV_HAS_NEON"
+                            SFLAGS="${SFLAGS} -DARM_AUXV_HAS_NEON"
+                        else
+                            echo "Neither HWCAP_ARM_NEON or HWCAP_NEON present in sys/auxv.h; cannot detect support at runtime." | tee -a configure.log
+                        fi
                     fi
                 fi
             fi
@@ -1697,169 +1711,37 @@ EOF
         fi
 
         if test $without_optimizations -eq 0; then
-            check_acle_compiler_flag
-            check_neon_compiler_flag
-            check_neon_ld4_intrinsics
-        fi
-
-        case "${ARCH}" in
-            armv[345]*)
-                if test $without_optimizations -eq 0; then
-                    if test $buildacle -eq 1; then
-                        echo ACLE support not available
-                    fi
-
-                    if test $buildneon -eq 1; then
-                        echo NEON support not available
-                    fi
-                fi
-            ;;
-            armv6l | armv6hl)
-                if test $without_optimizations -eq 0; then
-                    if test $buildacle -eq 1; then
-                        echo ACLE support not available
-                    fi
-
-                    if test $buildneon -eq 1; then
-                        echo NEON support not available
-                    fi
-                fi
-            ;;
-            arm | armv7*)
-                if test $without_optimizations -eq 0; then
-                    if test $buildacle -eq 1; then
-                        echo ACLE support not available
-                    fi
-
-                    if test $buildneon -eq 1; then
-                        CFLAGS="${CFLAGS} -DARM_NEON"
-                        SFLAGS="${SFLAGS} -DARM_NEON"
-
-                        if test $MFPU_NEON_AVAILABLE -eq 1; then
-                            neonflag="-mfpu=neon"
-                        fi
-
-                        if test $NEON_HAS_LD4 -eq 1; then
-                            CFLAGS="${CFLAGS} -DARM_NEON_HASLD4"
-                            SFLAGS="${SFLAGS} -DARM_NEON_HASLD4"
-                        fi
-
-                        ARCH_STATIC_OBJS="${ARCH_STATIC_OBJS} adler32_neon.o chunkset_neon.o compare256_neon.o slide_hash_neon.o"
-                        ARCH_SHARED_OBJS="${ARCH_SHARED_OBJS} adler32_neon.lo chunkset_neon.lo compare256_neon.lo slide_hash_neon.lo"
-                    fi
-                fi
-            ;;
-            armv8-a | armv8-a+simd)
-                if test $without_optimizations -eq 0; then
-                    if test $buildacle -eq 1; then
-                        echo ACLE support not available
-                    fi
-
-                    if test $buildneon -eq 1; then
-                        CFLAGS="${CFLAGS} -DARM_NEON"
-                        SFLAGS="${SFLAGS} -DARM_NEON"
-
-                        if test $MFPU_NEON_AVAILABLE -eq 1;then
-                            neonflag="-mfpu=neon"
-                        fi
-
-                        if test $NEON_HAS_LD4 -eq 1; then
-                            CFLAGS="${CFLAGS} -DARM_NEON_HASLD4"
-                            SFLAGS="${SFLAGS} -DARM_NEON_HASLD4"
-                        fi
-
-                        ARCH_STATIC_OBJS="${ARCH_STATIC_OBJS} adler32_neon.o chunkset_neon.o compare256_neon.o slide_hash_neon.o"
-                        ARCH_SHARED_OBJS="${ARCH_SHARED_OBJS} adler32_neon.lo chunkset_neon.lo compare256_neon.lo slide_hash_neon.lo"
-                    fi
-                fi
-            ;;
-            armv8-a+crc | armv8-a+crc+simd | armv8.[1234]-a | armv8.[1234]-a+simd)
-                acleflag="-march=${ARCH}"
-
-                if test $without_optimizations -eq 0; then
-                    if test $ACLE_AVAILABLE -eq 1; then
-                        CFLAGS="${CFLAGS} -DARM_ACLE"
-                        SFLAGS="${SFLAGS} -DARM_ACLE"
-
-                        ARCH_STATIC_OBJS="${ARCH_STATIC_OBJS} crc32_acle.o insert_string_acle.o"
-                        ARCH_SHARED_OBJS="${ARCH_SHARED_OBJS} crc32_acle.lo insert_string_acle.lo"
-                    fi
-
-                    if test $buildneon -eq 1; then
-                        CFLAGS="${CFLAGS} -DARM_NEON"
-                        SFLAGS="${SFLAGS} -DARM_NEON"
-
-                        if test $MFPU_NEON_AVAILABLE -eq 1;then
-                            neonflag="-mfpu=neon"
-                        fi
-
-                        if test $NEON_HAS_LD4 -eq 1; then
-                            CFLAGS="${CFLAGS} -DARM_NEON_HASLD4"
-                            SFLAGS="${SFLAGS} -DARM_NEON_HASLD4"
-                        fi
-
-                        ARCH_STATIC_OBJS="${ARCH_STATIC_OBJS} adler32_neon.o chunkset_neon.o compare256_neon.o slide_hash_neon.o"
-                        ARCH_SHARED_OBJS="${ARCH_SHARED_OBJS} adler32_neon.lo chunkset_neon.lo compare256_neon.lo slide_hash_neon.lo"
-                    fi
-                fi
-            ;;
-        esac
-
-    ;;
-    # 64-bit ARM specific optimizations
-    aarch64)
-        [ ! -z $CROSS_PREFIX ] && QEMU_ARCH=aarch64
-        ARCHDIR=arch/arm
-
-        ARCH="armv8-a"
-
-        if test $without_optimizations -eq 0; then
-            check_neon_ld4_intrinsics
-
-            CFLAGS="${CFLAGS} -DARM_FEATURES"
-            SFLAGS="${SFLAGS} -DARM_FEATURES"
-            ARCH_STATIC_OBJS="${ARCH_STATIC_OBJS} arm_features.o"
-            ARCH_SHARED_OBJS="${ARCH_SHARED_OBJS} arm_features.lo"
-
-            if test $LINUX -eq 1; then
-                cat > $test.c <<EOF
-#include <sys/auxv.h>
-int main() {
-    return (getauxval(AT_HWCAP) & HWCAP_CRC32);
-}
-EOF
-                if try $CC -c $CFLAGS $test.c; then
-                    CFLAGS="${CFLAGS} -DARM_AUXV_HAS_CRC32"
-                    SFLAGS="${SFLAGS} -DARM_AUXV_HAS_CRC32"
-                else
-                    echo "HWCAP_CRC32 not present in sys/auxv.h; cannot detect support at runtime." | tee -a configure.log
-                fi
-            fi
-
-            if test $NEON_HAS_LD4 -eq 1; then
-                CFLAGS="${CFLAGS} -DARM_NEON_HASLD4"
-                SFLAGS="${SFLAGS} -DARM_NEON_HASLD4"
-            fi
-
             if test $buildacle -eq 1; then
-                ARCH="${ARCH}+crc"
-                CFLAGS="${CFLAGS} -DARM_ACLE"
-                SFLAGS="${SFLAGS} -DARM_ACLE"
-                ARCH_STATIC_OBJS="${ARCH_STATIC_OBJS} crc32_acle.o insert_string_acle.o"
-                ARCH_SHARED_OBJS="${ARCH_SHARED_OBJS} crc32_acle.lo insert_string_acle.lo"
+                check_acle_compiler_flag
+
+                if test $ACLE_AVAILABLE -eq 1; then
+                    CFLAGS="${CFLAGS} -DARM_ACLE"
+                    SFLAGS="${SFLAGS} -DARM_ACLE"
+
+                    ARCH_STATIC_OBJS="${ARCH_STATIC_OBJS} crc32_acle.o insert_string_acle.o"
+                    ARCH_SHARED_OBJS="${ARCH_SHARED_OBJS} crc32_acle.lo insert_string_acle.lo"
+                fi
             fi
 
             if test $buildneon -eq 1; then
-                ARCH="${ARCH}+simd"
-                CFLAGS="${CFLAGS} -DARM_NEON"
-                SFLAGS="${SFLAGS} -DARM_NEON"
-                ARCH_STATIC_OBJS="${ARCH_STATIC_OBJS} adler32_neon.o chunkset_neon.o compare256_neon.o slide_hash_neon.o"
-                ARCH_SHARED_OBJS="${ARCH_SHARED_OBJS} adler32_neon.lo chunkset_neon.lo compare256_neon.lo slide_hash_neon.lo"
+                check_neon_compiler_flag
+
+                if test $NEON_AVAILABLE -eq 1; then
+                    CFLAGS="${CFLAGS} -DARM_NEON"
+                    SFLAGS="${SFLAGS} -DARM_NEON"
+
+                    check_neon_ld4_intrinsics
+
+                    if test $NEON_HAS_LD4 -eq 1; then
+                        CFLAGS="${CFLAGS} -DARM_NEON_HASLD4"
+                        SFLAGS="${SFLAGS} -DARM_NEON_HASLD4"
+                    fi
+
+                    ARCH_STATIC_OBJS="${ARCH_STATIC_OBJS} adler32_neon.o chunkset_neon.o compare256_neon.o slide_hash_neon.o"
+                    ARCH_SHARED_OBJS="${ARCH_SHARED_OBJS} adler32_neon.lo chunkset_neon.lo compare256_neon.lo slide_hash_neon.lo"
+                fi
             fi
         fi
-
-        neonflag="-march=${ARCH}"
-        acleflag="-march=${ARCH}"
     ;;
     powerpc*)
         case "${ARCH}" in

--- a/configure
+++ b/configure
@@ -1613,6 +1613,28 @@ case "${ARCH}" in
 
         ARCHDIR=arch/arm
 
+        cat > $test.c << EOF
+int main() { return 0; }
+EOF
+        if try $CC -w -c $SFLAGS $test.c -mfloat-abi=softfp &&
+           try $LDSHARED $LDSHAREDFLAGS $LDFLAGS -o $test$shared_ext $test.o $LDSHAREDLIBC; then
+            floatabi="-mfloat-abi=softfp"
+        else
+            if try $CC -w -c $SFLAGS $test.c -mfloat-abi=hard &&
+               try $LDSHARED $LDSHAREDFLAGS $LDFLAGS -o $test$shared_ext $test.o $LDSHAREDLIBC; then
+                floatabi="-mfloat-abi=hard"
+            fi
+        fi
+
+        if [ -z $floatabi ]; then
+            echo "ARM floating point arch not auto-detected" | tee -a configure.log
+        else
+            echo "ARM floating point arch: ${floatabi}" | tee -a configure.log
+
+            CFLAGS="${CFLAGS} ${floatabi}"
+            SFLAGS="${SFLAGS} ${floatabi}"
+        fi
+
         if test $without_optimizations -eq 0; then
             CFLAGS="${CFLAGS} -DARM_FEATURES"
             SFLAGS="${SFLAGS} -DARM_FEATURES"
@@ -1686,31 +1708,7 @@ EOF
                     fi
                 fi
             fi
-        fi
 
-        cat > $test.c << EOF
-int main() { return 0; }
-EOF
-        if try $CC -w -c $SFLAGS $test.c -mfloat-abi=softfp &&
-           try $LDSHARED $LDSHAREDFLAGS $LDFLAGS -o $test$shared_ext $test.o $LDSHAREDLIBC; then
-            floatabi="-mfloat-abi=softfp"
-        else
-            if try $CC -w -c $SFLAGS $test.c -mfloat-abi=hard &&
-               try $LDSHARED $LDSHAREDFLAGS $LDFLAGS -o $test$shared_ext $test.o $LDSHAREDLIBC; then
-                floatabi="-mfloat-abi=hard"
-            fi
-        fi
-
-        if [ -z $floatabi ]; then
-            echo "ARM floating point arch not auto-detected" | tee -a configure.log
-        else
-            echo "ARM floating point arch: ${floatabi}" | tee -a configure.log
-
-            CFLAGS="${CFLAGS} ${floatabi}"
-            SFLAGS="${SFLAGS} ${floatabi}"
-        fi
-
-        if test $without_optimizations -eq 0; then
             if test $buildacle -eq 1; then
                 check_acle_compiler_flag
 

--- a/configure
+++ b/configure
@@ -1642,7 +1642,20 @@ EOF
             ARCH_SHARED_OBJS="${ARCH_SHARED_OBJS} arm_features.lo"
 
             if test $LINUX -eq 1; then
-                if test "$ARCH" != "aarch64"; then
+                if test "$ARCH" = "aarch64"; then
+                    cat > $test.c <<EOF
+#include <sys/auxv.h>
+int main() {
+    return (getauxval(AT_HWCAP) & HWCAP_CRC32);
+}
+EOF
+                    if try $CC -c $CFLAGS $test.c; then
+                        CFLAGS="${CFLAGS} -DARM_AUXV_HAS_CRC32"
+                        SFLAGS="${SFLAGS} -DARM_AUXV_HAS_CRC32"
+                    else
+                        echo "HWCAP_CRC32 not present in sys/auxv.h; cannot detect support at runtime." | tee -a configure.log
+                    fi
+                else
                     cat > $test.c <<EOF
 #include <sys/auxv.h>
 int main() {
@@ -1667,22 +1680,7 @@ EOF
                             echo "HWCAP2_CRC32 not present in sys/auxv.h; cannot detect support at runtime." | tee -a configure.log
                         fi
                     fi
-                else
-                    cat > $test.c <<EOF
-#include <sys/auxv.h>
-int main() {
-    return (getauxval(AT_HWCAP) & HWCAP_CRC32);
-}
-EOF
-                    if try $CC -c $CFLAGS $test.c; then
-                        CFLAGS="${CFLAGS} -DARM_AUXV_HAS_CRC32"
-                        SFLAGS="${SFLAGS} -DARM_AUXV_HAS_CRC32"
-                    else
-                        echo "HWCAP_CRC32 not present in sys/auxv.h; cannot detect support at runtime." | tee -a configure.log
-                    fi
-                fi
 
-                if test "$ARCH" != "aarch64"; then
                     cat > $test.c <<EOF
 #include <sys/auxv.h>
 int main() {


### PR DESCRIPTION
In this PR, I've tried to simplify compiler flag detection for ARM variants, using #1399 as a base.

In `configure` script, the ARM detection section is now similar to X86 and PPC sections. Essentially what I have tried to do is make the ARM detection more similar to what CMake does and I've used CMake as the basis for the changes.