### PR TITLE
Fix the value of ZLIBNG_VER_STATUS

### DIFF
--- a/zlib.h.in
+++ b/zlib.h.in
@@ -54,7 +54,7 @@ extern "C" {
 #define ZLIBNG_VER_MAJOR 2
 #define ZLIBNG_VER_MINOR 1
 #define ZLIBNG_VER_REVISION 3
-#define ZLIBNG_VER_STATUS F         /* 0=devel, 1-E=beta, F=Release */
+#define ZLIBNG_VER_STATUS 0xF         /* 0=devel, 1-E=beta, F=Release */
 #define ZLIBNG_VER_MODIFIED 0       /* non-zero if modified externally from zlib-ng */
 
 #define ZLIB_VERSION "1.3.0.zlib-ng"


### PR DESCRIPTION
On C, the value F is usually interpreted as an identifier (e.g. name of a variable, function, etc.).
Force the hexadecimal 0xF in order to avoid compiler errors such as:

    F undeclared (first use in this function)