### PR TITLE
Deprecate ZLIBNG_VER_STATUS, add new variant ZLIBNG_VER_STATUSH

### DIFF
--- a/zlib-ng.h.in
+++ b/zlib-ng.h.in
@@ -53,7 +53,8 @@ extern "C" {
 #define ZLIBNG_VER_MAJOR 2
 #define ZLIBNG_VER_MINOR 1
 #define ZLIBNG_VER_REVISION 3
-#define ZLIBNG_VER_STATUS F         /* 0=devel, 1-E=beta, F=Release */
+#define ZLIBNG_VER_STATUS F         /* 0=devel, 1-E=beta, F=Release (DEPRECATED) */
+#define ZLIBNG_VER_STATUSH 0xF      /* Hex values: 0=devel, 1-E=beta, F=Release */
 #define ZLIBNG_VER_MODIFIED 0       /* non-zero if modified externally from zlib-ng */
 
 /*

--- a/zlib.h.in
+++ b/zlib.h.in
@@ -54,7 +54,8 @@ extern "C" {
 #define ZLIBNG_VER_MAJOR 2
 #define ZLIBNG_VER_MINOR 1
 #define ZLIBNG_VER_REVISION 3
-#define ZLIBNG_VER_STATUS F         /* 0=devel, 1-E=beta, F=Release */
+#define ZLIBNG_VER_STATUS F         /* 0=devel, 1-E=beta, F=Release (DEPRECATED) */
+#define ZLIBNG_VER_STATUSH 0xF      /* Hex values: 0=devel, 1-E=beta, F=Release */
 #define ZLIBNG_VER_MODIFIED 0       /* non-zero if modified externally from zlib-ng */
 
 #define ZLIB_VERSION "1.3.0.zlib-ng"


### PR DESCRIPTION
Fixes the problem of the value not being defined as hex, and thus causing problems for example with the value F not being easily interpreted correctly by applications.