### PR TITLE
Fix building benchmarks on 32-bit PowerPC.

### DIFF
--- a/test/benchmarks/benchmark_crc32.cc
+++ b/test/benchmarks/benchmark_crc32.cc
@@ -59,7 +59,7 @@ BENCHMARK_CRC32(braid, PREFIX(crc32_braid), 1);
 
 #ifdef ARM_ACLE
 BENCHMARK_CRC32(acle, crc32_acle, test_cpu_features.arm.has_crc32);
-#elif defined(POWER8_VSX)
+#elif defined(POWER8_VSX_CRC32)
 BENCHMARK_CRC32(power8, crc32_power8, test_cpu_features.power.has_arch_2_07);
 #elif defined(S390_CRC32_VX)
 BENCHMARK_CRC32(vx, crc32_s390_vx, test_cpu_features.s390.has_vx);


### PR DESCRIPTION
32-bit compiler for PowerPC might know about POWER8, but the CPU doesn't support it, so we disable the benchmark to avoid linker error.