### PR TITLE
pkgconfig file: propagate WITH_GZFILEOP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1159,6 +1159,9 @@ else()
 endif()
 
 set(ZLIB_PC ${CMAKE_CURRENT_BINARY_DIR}/zlib${SUFFIX}.pc)
+if(WITH_GZFILEOP)
+    set(PKG_CONFIG_CFLAGS "-DWITH_GZFILEOP")
+endif()
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/zlib.pc.cmakein
     ${ZLIB_PC} @ONLY)
 configure_file(${CMAKE_CURRENT_BINARY_DIR}/zconf${SUFFIX}.h.cmakein

--- a/zlib.pc.cmakein
+++ b/zlib.pc.cmakein
@@ -11,4 +11,4 @@ Version: @ZLIB_FULL_VERSION@
 
 Requires:
 Libs: -L${libdir} -L${sharedlibdir} -lz@SUFFIX@
-Cflags: -I${includedir}
+Cflags: -I${includedir} @PKG_CONFIG_CFLAGS@


### PR DESCRIPTION
if you compile with `WITH_GZFILEOP` you currently manually have to define `WITH_GZFILEOP` again. This should not be needed. Fixes https://github.com/microsoft/vcpkg/discussions/34886

An alternative would be to use `#cmakedefine01 WITH_GZFILEOP` in `zlib_name_mangling-ng.h.in`, but this does not work with Makefiles