### PR TITLE
Remove duplicate enable tests option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1205,7 +1205,6 @@ endif()
 # Example binaries
 #============================================================================
 
-option(ZLIB_ENABLE_TESTS "Build test binaries" ON)
 if(ZLIB_ENABLE_TESTS)
     enable_testing()
 


### PR DESCRIPTION
There are two identical ZLIB_ENABLE_TESTS option in CMakeLists.txt which means the latter one is meaningless. This issue is introduced in https://github.com/zlib-ng/zlib-ng/commit/ce1a64b5147b874a2dd32920765be333f54e7095 which adds the option to top but forgets to remove the original one.