### PR TITLE
Fix buffer overflow in compare256_rle benchmark

### DIFF
--- a/test/benchmarks/benchmark_compare256_rle.cc
+++ b/test/benchmarks/benchmark_compare256_rle.cc
@@ -33,7 +33,7 @@ public:
     }
 
     void Bench(benchmark::State& state, compare256_rle_func compare256_rle) {
-        int32_t match_len = (int32_t)state.range(0);
+        int32_t match_len = (int32_t)state.range(0) - 1;
         uint32_t len;
 
         str2[match_len] = 0;


### PR DESCRIPTION
Fix buffer overflow in compare256_rle benchmark.

Segmentation fault on Apple M1 (arm64):

```
compare256_rle/c/1                           0.468 ns        0.468 ns   1000000000
compare256_rle/c/8                            1.72 ns         1.72 ns    409029024
compare256_rle/c/64                           11.8 ns         11.8 ns     59611503
zsh: segmentation fault  ./test/benchmarks/benchmark_zlib
phprus@mbp b % ./test/benchmarks/benchmark_zlib
```

@Dead2 