### PR TITLE
Initialize functable earlier, during DeflateInit

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -194,6 +194,9 @@ int32_t ZNG_CONDEXPORT PREFIX(deflateInit2)(PREFIX3(stream) *strm, int32_t level
     deflate_state *s;
     int wrap = 1;
 
+    /* Force initialization functable, because deflate captures function pointers from functable. */
+    functable.force_init();
+
     if (strm == NULL)
         return Z_STREAM_ERROR;
 

--- a/functable.c
+++ b/functable.c
@@ -11,6 +11,10 @@
 #include "functable.h"
 #include "cpu_features.h"
 
+static void force_init_empty(void) {
+    // empty
+}
+
 static void init_functable(void) {
     struct functable_s ft;
     struct cpu_features cf;
@@ -18,6 +22,7 @@ static void init_functable(void) {
     cpu_check_features(&cf);
 
     // Generic code
+    ft.force_init = &force_init_empty;
     ft.adler32 = &adler32_c;
     ft.adler32_fold_copy = &adler32_fold_copy_c;
     ft.chunkmemset_safe = &chunkmemset_safe_c;
@@ -234,6 +239,7 @@ static void init_functable(void) {
 #endif
 
     // Assign function pointers individually for atomic operation
+    functable.force_init = ft.force_init;
     functable.adler32 = ft.adler32;
     functable.adler32_fold_copy = ft.adler32_fold_copy;
     functable.chunkmemset_safe = ft.chunkmemset_safe;
@@ -254,6 +260,10 @@ static void init_functable(void) {
 }
 
 /* stub functions */
+static void force_init_stub(void) {
+    init_functable();
+}
+
 static uint32_t adler32_stub(uint32_t adler, const uint8_t* buf, size_t len) {
     init_functable();
     return functable.adler32(adler, buf, len);
@@ -341,6 +351,7 @@ static uint32_t update_hash_stub(deflate_state* const s, uint32_t h, uint32_t va
 
 /* functable init */
 Z_INTERNAL Z_TLS struct functable_s functable = {
+    force_init_stub,
     adler32_stub,
     adler32_fold_copy_stub,
     chunkmemset_safe_stub,

--- a/functable.h
+++ b/functable.h
@@ -17,6 +17,7 @@ typedef struct zng_stream_s zng_stream;
 #endif
 
 struct functable_s {
+    void     (* force_init)         (void);
     uint32_t (* adler32)            (uint32_t adler, const uint8_t *buf, size_t len);
     uint32_t (* adler32_fold_copy)  (uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len);
     uint8_t* (* chunkmemset_safe)   (uint8_t *out, unsigned dist, unsigned len, unsigned left);

--- a/inflate.c
+++ b/inflate.c
@@ -139,6 +139,9 @@ int32_t ZNG_CONDEXPORT PREFIX(inflateInit2)(PREFIX3(stream) *strm, int32_t windo
     int32_t ret;
     struct inflate_state *state;
 
+    /* Initialize functable earlier. */
+    functable.force_init();
+
     if (strm == NULL)
         return Z_STREAM_ERROR;
     strm->msg = NULL;                   /* in case we return an error */


### PR DESCRIPTION
``deflate`` captures pointers to stub functions:


1:

https://github.com/zlib-ng/zlib-ng/blob/2baed9faa9437fcd1d0a106da87a540073ad851f/deflate.c#L1125-L1127

Call chain:
```
deflateInit2 -> deflateReset -> lm_init -> lm_set_level
```

If ``deflateInit2`` is called first from zlib-ng, pointers to the stub will be captured.

2:

https://github.com/zlib-ng/zlib-ng/blob/2baed9faa9437fcd1d0a106da87a540073ad851f/deflate_slow.c#L24-L27


This PR should speed up ``deflate``.
