### PR TITLE
Only read version information from zlib.h.in

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,8 @@ if(NOT CMAKE_C_STANDARD IN_LIST VALID_C_STANDARDS)
     MESSAGE(FATAL_ERROR "CMAKE_C_STANDARD:STRING=${CMAKE_C_STANDARD} not in known standards list\n ${VALID_C_STANDARDS}")
 endif()
 
-# Parse the full version number from zlib.h and include in ZLIB_FULL_VERSION
-file(READ ${CMAKE_CURRENT_SOURCE_DIR}/zlib${SUFFIX}.h.in _zlib_h_contents)
+# Parse the full version number from zlib.h.in and include in ZLIB_FULL_VERSION
+file(READ ${CMAKE_CURRENT_SOURCE_DIR}/zlib.h.in _zlib_h_contents)
 string(REGEX REPLACE ".*#define[ \t]+ZLIB_VERSION[ \t]+\"([0-9]+.[0-9]+.[0-9]+).*\".*"
         "\\1" ZLIB_HEADER_VERSION ${_zlib_h_contents})
 string(REGEX REPLACE ".*#define[ \t]+ZLIBNG_VERSION[ \t]+\"([-0-9A-Za-z.]+)\".*"


### PR DESCRIPTION
This is a patch for https://github.com/zlib-ng/zlib-ng/commit/cd458c79c7923e76ffdd0e2638bf2a0eed4f3996 As the commit message says: "Add code to extract version information for both ZLIB and ZLIBNG variants from the zlib.h file."

The logic of ${SUFFIX} is that zlib-ng reads version information after parse ZLIB_COMPAT before the commit mentioned above. ${SUFFIX} will only be set by ZLIB_COMPAT and is meaningless before ZLIB_COMPAT.