### PR TITLE
Add support for __attribute__((__target__(...))) to overcome limitations of -march=native.

### DIFF
--- a/arch/arm/acle_intrins.h
+++ b/arch/arm/acle_intrins.h
@@ -8,6 +8,14 @@
 #  include <arm_acle.h>
 #endif
 
+#ifdef ARM_ACLE
+#if defined(__aarch64__)
+#  define Z_TARGET_CRC Z_TARGET("+crc")
+#else
+#  define Z_TARGET_CRC
+#endif
+#endif
+
 #ifdef ARM_SIMD
 #ifdef _MSC_VER
 typedef uint32_t uint16x2_t;

--- a/arch/arm/crc32_acle.c
+++ b/arch/arm/crc32_acle.c
@@ -6,14 +6,10 @@
 */
 
 #ifdef ARM_ACLE
-#ifdef _MSC_VER
-#  include <intrin.h>
-#else
-#  include <arm_acle.h>
-#endif
+#include "acle_intrins.h"
 #include "../../zbuild.h"
 
-Z_INTERNAL uint32_t crc32_acle(uint32_t crc, const uint8_t *buf, size_t len) {
+Z_INTERNAL Z_TARGET_CRC uint32_t crc32_acle(uint32_t crc, const uint8_t *buf, size_t len) {
     Z_REGISTER uint32_t c;
     Z_REGISTER const uint16_t *buf2;
     Z_REGISTER const uint32_t *buf4;

--- a/arch/arm/insert_string_acle.c
+++ b/arch/arm/insert_string_acle.c
@@ -6,9 +6,7 @@
  */
 
 #ifdef ARM_ACLE
-#ifndef _MSC_VER
-#  include <arm_acle.h>
-#endif
+#include "acle_intrins.h"
 #include "../../zbuild.h"
 #include "../../deflate.h"
 
@@ -18,9 +16,9 @@
 #define HASH_CALC_VAR       h
 #define HASH_CALC_VAR_INIT  uint32_t h = 0
 
-#define UPDATE_HASH         update_hash_acle
-#define INSERT_STRING       insert_string_acle
-#define QUICK_INSERT_STRING quick_insert_string_acle
+#define UPDATE_HASH         Z_TARGET_CRC update_hash_acle
+#define INSERT_STRING       Z_TARGET_CRC insert_string_acle
+#define QUICK_INSERT_STRING Z_TARGET_CRC quick_insert_string_acle
 
 #include "../../insert_string_tpl.h"
 #endif

--- a/zbuild.h
+++ b/zbuild.h
@@ -61,6 +61,14 @@
 #  endif
 #endif
 
+#ifndef Z_TARGET
+#  if Z_HAS_ATTRIBUTE(__target__)
+#    define Z_TARGET(x) __attribute__((__target__(x)))
+#  else
+#    define Z_TARGET(x)
+#  endif
+#endif
+
 /* This has to be first include that defines any types */
 #if defined(_MSC_VER)
 #  if defined(_WIN64)


### PR DESCRIPTION
Support for -march=native for AArch64 is still new, so it doesn't detect all CPU extensions.

Implicitly telling gcc/clang to enable "crc" extension when using -march=native will allow compiling functions with ACLE CRC32 intrinsics.