### PR TITLE
Update to GoogleTest 1.12.1

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -143,7 +143,7 @@ if(WITH_GTEST)
             if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS_EQUAL 5.3)
                 set(GTEST_TAG release-1.10.0)
             else()
-                set(GTEST_TAG release-1.11.0)
+                set(GTEST_TAG release-1.12.1)
             endif()
         endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -148,6 +148,7 @@ if(WITH_GTEST)
         endif()
 
         # Fetch Google test source code from official repository
+        message(STATUS "Git checking out GoogleTest ${GTEST_TAG}")
         FetchContent_Declare(googletest
             GIT_REPOSITORY ${GTEST_REPOSITORY}
             GIT_TAG ${GTEST_TAG})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -94,16 +94,11 @@ endif()
 
 if(WITH_GTEST OR WITH_BENCHMARKS)
     if(CMAKE_VERSION VERSION_LESS 3.12)
-        message(WARNING "Minimum cmake version of 3.12 not met for GoogleTest or benchmarks!")
-
-        set(WITH_GTEST OFF)
-        set(WITH_GTEST OFF PARENT_SCOPE)
-
+        message(WARNING "Minimum cmake version of 3.12 not met for Google benchmark!")
         set(WITH_BENCHMARKS OFF)
         set(WITH_BENCHMARKS OFF PARENT_SCOPE)
-    else()
-        enable_language(CXX)
     endif()
+    enable_language(CXX)
 endif()
 
 if(WITH_BENCHMARKS)
@@ -127,7 +122,7 @@ if(WITH_GTEST)
         find_package(GTest)
     endif()
 
-    if(NOT TARGET GTest::GTest)
+    if(NOT TARGET GTest::GTest AND NOT CMAKE_VERSION VERSION_LESS 3.11)
         include(FetchContent)
 
         # Prevent overriding the parent project's compiler/linker settings for Windows


### PR DESCRIPTION
- Update to GoogleTest 1.12.1
  - Fixes a warning from newer CMake versions about GoogleTest 1.11.0 specifying a CMake version that has been deprecated.
- Add a status message when we start the git download.
- Don't disable GoogleTest when CMake is older than 3.12

GoogleTest 1.12.1 requires minimum CMake 3.5 and C++11, this matches nicely with the zlib-ng 2.1.x requirements of CMake 3.5.1 and C11.