### PR TITLE
Add linter workflow for whitespace errors. 

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,17 @@
+name: Lint
+on: [pull_request]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Whitespace errors
+      run: |
+        git config core.whitespace tab-in-indent,blank-at-eol
+        git diff --color --check ${{ github.event.pull_request.base.sha }}

--- a/test/minideflate.c
+++ b/test/minideflate.c
@@ -168,7 +168,7 @@ void inflate_params(FILE *fin, FILE *fout, int32_t read_buf_size, int32_t write_
         do {
             err = PREFIX(inflate)(&d_stream, flush);
 
-            /* Ignore Z_BUF_ERROR if we are finishing and read buffer size is 
+            /* Ignore Z_BUF_ERROR if we are finishing and read buffer size is
              * purposefully limited */
             if (flush == Z_FINISH && err == Z_BUF_ERROR && read_buf_size != BUFSIZE)
                 err = Z_OK;


### PR DESCRIPTION
zlib-ng/zlib-ng#1190

Example of a failure run:
https://github.com/nmoinvaz/zlib-ng/actions/runs/7332708222/job/19967228971