### PR TITLE
Fix behavior change in inflateCopy that resulted in data corruption in our application

### DIFF
--- a/inflate.c
+++ b/inflate.c
@@ -1350,8 +1350,8 @@ int32_t Z_EXPORT PREFIX(inflateCopy)(PREFIX3(stream) *dest, PREFIX3(stream) *sou
     copy->next = copy->codes + (state->next - state->codes);
 
     /* window */
+    copy->window = NULL;
     if (state->window != NULL) {
-        copy->window = NULL;
         if (PREFIX(inflate_ensure_window)(copy)) {
             ZFREE_STATE(source, copy);
             return Z_MEM_ERROR;


### PR DESCRIPTION
Commit 61e181c8ae93dbf56040336179c9954078bd1399 no longer unconditionally nulled out `copy->window = NULL;` resulting in our application failing to decode most data. 