### PR TITLE
Cancel previously running CI jobs for PR or branch.

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -1,5 +1,8 @@
 name: Static Analysis
 on: [push, pull_request]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   static-analysis:
     name: GCC

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -3,6 +3,9 @@ on: [push, pull_request]
 env:
   TERM: xterm-256color
   GTEST_COLOR: 1
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   cmake:
     name: ${{ matrix.name }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,4 @@
 name: "CodeQL"
-
 on:
   push:
     branches: [ "develop" ]
@@ -7,7 +6,9 @@ on:
     branches: [ "develop" ]
   schedule:
     - cron: "27 17 * * 0"
-
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -1,5 +1,8 @@
 name: Configure
 on: [push, pull_request]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   configure:
     name: ${{ matrix.name }}

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -9,7 +9,9 @@ on:
       - '2.*'
     tags:
       - '*'
-
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   fuzzing:
     name: Fuzzing

--- a/.github/workflows/libpng.yml
+++ b/.github/workflows/libpng.yml
@@ -1,5 +1,8 @@
 name: Libpng
 on: [push, pull_request]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   libpng:
     name: Ubuntu Clang

--- a/.github/workflows/link.yml
+++ b/.github/workflows/link.yml
@@ -1,5 +1,8 @@
 name: Link
 on: [push, pull_request]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   zlib:
     name: Link zlib

--- a/.github/workflows/nmake.yml
+++ b/.github/workflows/nmake.yml
@@ -1,5 +1,8 @@
 name: NMake
 on: [push, pull_request]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   nmake:
     name: ${{ matrix.name }}

--- a/.github/workflows/pigz.yml
+++ b/.github/workflows/pigz.yml
@@ -1,5 +1,8 @@
 name: Pigz
 on: [push, pull_request]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   pigz:
     name: ${{ matrix.name }}

--- a/.github/workflows/pkgcheck.yml
+++ b/.github/workflows/pkgcheck.yml
@@ -1,5 +1,8 @@
 name: Package Check
 on: [push, pull_request]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   pkgcheck:
     name: ${{ matrix.name }}


### PR DESCRIPTION
I have used this for other projects (work) with a lot of success. It prevents having to go through and cancel CI actions a lot. Plus, we run a TON of CI instances so it prevents a lot of CI usage when pushing many changes in a row.

For more info see https://stackoverflow.com/questions/70928424/limit-github-action-workflow-concurrency-on-push-and-pull-request