### PR TITLE
Remove tab-in-indent rule from lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,5 +13,5 @@ jobs:
 
     - name: Whitespace errors
       run: |
-        git config core.whitespace tab-in-indent,blank-at-eol
+        git config core.whitespace blank-at-eol
         git diff --color --check ${{ github.event.pull_request.base.sha }}


### PR DESCRIPTION
Makefiles require using tabs as indents. So we need to remove this rule. The `blank-at-eol` rule is what we care about the most.