### PR TITLE
Prefer HAVE_ALIGNED_ALLOC when available in zng_alloc

### DIFF
--- a/test/test_compare256.cc
+++ b/test/test_compare256.cc
@@ -9,7 +9,7 @@
 
 extern "C" {
 #  include "zbuild.h"
-#  include "zutil_p.h"
+#  include "zutil.h"
 #  include "test_cpu_features.h"
 }
 
@@ -26,11 +26,11 @@ static inline void compare256_match_check(compare256_func compare256) {
     uint8_t *str1;
     uint8_t *str2;
 
-    str1 = (uint8_t *)zng_alloc(MAX_COMPARE_SIZE);
+    str1 = (uint8_t *)PREFIX3(alloc_aligned)(NULL, NULL, 1, MAX_COMPARE_SIZE, 64);
     ASSERT_TRUE(str1 != NULL);
     memset(str1, 'a', MAX_COMPARE_SIZE);
 
-    str2 = (uint8_t *)zng_alloc(MAX_COMPARE_SIZE);
+    str2 = (uint8_t *)PREFIX3(alloc_aligned)(NULL, NULL, 1, MAX_COMPARE_SIZE, 64);
     ASSERT_TRUE(str2 != NULL);
     memset(str2, 'a', MAX_COMPARE_SIZE);
 
@@ -45,8 +45,8 @@ static inline void compare256_match_check(compare256_func compare256) {
             str2[i] = 'a';
     }
 
-    zng_free(str1);
-    zng_free(str2);
+    PREFIX3(free_aligned)(NULL, NULL, str1);
+    PREFIX3(free_aligned)(NULL, NULL, str2);
 }
 
 #define TEST_COMPARE256(name, func, support_flag) \

--- a/test/test_compare256_rle.cc
+++ b/test/test_compare256_rle.cc
@@ -9,7 +9,7 @@
 
 extern "C" {
 #  include "zbuild.h"
-#  include "zutil_p.h"
+#  include "zutil.h"
 #  include "compare256_rle.h"
 }
 
@@ -23,7 +23,7 @@ static inline void compare256_rle_match_check(compare256_rle_func compare256_rle
     uint8_t str1[] = {'a', 'a', 0};
     uint8_t *str2;
 
-    str2 = (uint8_t *)zng_alloc(MAX_COMPARE_SIZE);
+    str2 = (uint8_t *)PREFIX3(alloc_aligned)(NULL, NULL, 1, MAX_COMPARE_SIZE, 64);
     ASSERT_TRUE(str2 != NULL);
     memset(str2, 'a', MAX_COMPARE_SIZE);
 
@@ -38,7 +38,7 @@ static inline void compare256_rle_match_check(compare256_rle_func compare256_rle
             str2[i] = 'a';
     }
 
-    zng_free(str2);
+    PREFIX3(free_aligned)(NULL, NULL, str2);
 }
 
 #define TEST_COMPARE256_RLE(name, func, support_flag) \

--- a/test/test_crc32.cc
+++ b/test/test_crc32.cc
@@ -11,7 +11,6 @@
 
 extern "C" {
 #  include "zbuild.h"
-#  include "zutil_p.h"
 #  include "test_cpu_features.h"
 }
 

--- a/zutil.c
+++ b/zutil.c
@@ -118,7 +118,7 @@ void Z_INTERNAL *PREFIX3(alloc_aligned)(zng_calloc_func zalloc, void *opaque, un
     void *ptr;
 
     /* If no custom calloc function used then call zlib-ng's aligned calloc */
-    if (zalloc == PREFIX(zcalloc))
+    if (zalloc == NULL || zalloc == PREFIX(zcalloc))
         return PREFIX(zcalloc)(opaque, items, size);
 
     /* Allocate enough memory for proper alignment and to store the original memory pointer */
@@ -143,7 +143,7 @@ void Z_INTERNAL *PREFIX3(alloc_aligned)(zng_calloc_func zalloc, void *opaque, un
 
 void Z_INTERNAL PREFIX3(free_aligned)(zng_cfree_func zfree, void *opaque, void *ptr) {
     /* If no custom cfree function used then call zlib-ng's aligned cfree */
-    if (zfree == PREFIX(zcfree)) {
+    if (zfree == NULL || zfree == PREFIX(zcfree)) {
         PREFIX(zcfree)(opaque, ptr);
         return;
     }

--- a/zutil_p.h
+++ b/zutil_p.h
@@ -16,15 +16,17 @@
 
 /* Function to allocate 16 or 64-byte aligned memory */
 static inline void *zng_alloc(size_t size) {
-#ifdef HAVE_POSIX_MEMALIGN
+#ifdef HAVE_ALIGNED_ALLOC
+    return (void *)aligned_alloc(64, size);  /* Defined in C11 */
+#elif defined(HAVE_POSIX_MEMALIGN)
     void *ptr;
     return posix_memalign(&ptr, 64, size) ? NULL : ptr;
 #elif defined(_WIN32)
     return (void *)_aligned_malloc(size, 64);
 #elif defined(__APPLE__)
-    return (void *)malloc(size);     /* MacOS always aligns to 16 bytes */
-#elif defined(HAVE_ALIGNED_ALLOC)
-    return (void *)aligned_alloc(64, size);
+    /* Fallback for when posix_memalign and aligned_alloc are not available.
+     * On macOS, it always aligns to 16 bytes. */
+    return (void *)malloc(size);
 #else
     return (void *)memalign(64, size);
 #endif

--- a/zutil_p.h
+++ b/zutil_p.h
@@ -17,6 +17,8 @@
 /* Function to allocate 16 or 64-byte aligned memory */
 static inline void *zng_alloc(size_t size) {
 #ifdef HAVE_ALIGNED_ALLOC
+    /* Size must be a multiple of alignment */
+    size = (size + (64 - 1)) & ~(64 - 1);
     return (void *)aligned_alloc(64, size);  /* Defined in C11 */
 #elif defined(HAVE_POSIX_MEMALIGN)
     void *ptr;


### PR DESCRIPTION
Added some more helpful comments for people who come across this code. I think people would otherwise skip to `APPLE` and forget that different versions of macOS have other aligned memory functions.