### PR TITLE
Add FAR macro to zlib-compat headers to improve compatibility.

### DIFF
--- a/zconf.h.in
+++ b/zconf.h.in
@@ -116,6 +116,9 @@
 #ifndef ZEXPORTVA
 #  define ZEXPORTVA Z_EXPORTVA
 #endif
+#ifndef FAR
+#  define FAR
+#endif
 
 /* Legacy zlib typedefs for backwards compatibility. Don't assume stdint.h is defined. */
 typedef unsigned char Byte;


### PR DESCRIPTION
Distros that are starting to use zlib-ng in compat mode are finding compile failures due to the missing FAR macro.
This adds that back as an empty define.