### PR TITLE
Proposal: Disable dynamic function dispatching for native or arch-specific builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,7 @@ option(WITH_REDUCED_MEM "Reduced memory usage for special cases (reduces perform
 option(WITH_NEW_STRATEGIES "Use new strategies" ON)
 option(WITH_NATIVE_INSTRUCTIONS
     "Instruct the compiler to use the full instruction set on this host (gcc/clang -march=native)" OFF)
+option(WITH_RUNTIME_CPU_DETECTION "Build with runtime detection of CPU architecture" ON)
 option(WITH_MAINTAINER_WARNINGS "Build with project maintainer warnings" OFF)
 option(WITH_CODE_COVERAGE "Enable code coverage reporting" OFF)
 option(WITH_INFLATE_STRICT "Build with strict inflate distance checking" OFF)
@@ -271,10 +272,19 @@ if(WITH_NATIVE_INSTRUCTIONS)
     if(NATIVEFLAG)
         # Apply flag to all source files and compilation checks
         add_compile_options(${NATIVEFLAG})
+        set(WITH_RUNTIME_CPU_DETECTION OFF)
     else()
         message(STATUS "Ignoring WITH_NATIVE_INSTRUCTIONS; not implemented yet on this configuration")
         set(WITH_NATIVE_INSTRUCTIONS OFF)
     endif()
+endif()
+
+# Compile without functable or CPU detection
+if(NOT WITH_RUNTIME_CPU_DETECTION)
+    if(MSVC AND BASEARCH_X86_FOUND)
+        message(STATUS "WARNING: Microsoft Visual Studio does not support compile time detection of CPU features for \"/arch\" before \"AVX\"")
+    endif()
+    add_definitions(-DDISABLE_RUNTIME_CPU_DETECTION)
 endif()
 
 # Force disable LTO if WITH_NATIVE_INSTRUCTIONS is not active
@@ -1285,6 +1295,7 @@ add_feature_info(WITH_OPTIM WITH_OPTIM "Build with optimisation")
 add_feature_info(WITH_NEW_STRATEGIES WITH_NEW_STRATEGIES "Use new strategies")
 add_feature_info(WITH_NATIVE_INSTRUCTIONS WITH_NATIVE_INSTRUCTIONS
     "Instruct the compiler to use the full instruction set on this host (gcc/clang -march=native)")
+add_feature_info(WITH_RUNTIME_CPU_DETECTION WITH_RUNTIME_CPU_DETECTION "Build with runtime CPU detection")
 add_feature_info(WITH_MAINTAINER_WARNINGS WITH_MAINTAINER_WARNINGS "Build with project maintainer warnings")
 add_feature_info(WITH_CODE_COVERAGE WITH_CODE_COVERAGE "Enable code coverage reporting")
 add_feature_info(WITH_INFLATE_STRICT WITH_INFLATE_STRICT "Build with strict inflate distance checking")

--- a/README.md
+++ b/README.md
@@ -95,20 +95,21 @@ make test
 Build Options
 -------------
 
-| CMake                    | configure                | Description                                                                           | Default |
-|:-------------------------|:-------------------------|:--------------------------------------------------------------------------------------|---------|
-| ZLIB_COMPAT              | --zlib-compat            | Compile with zlib compatible API                                                      | OFF     |
-| ZLIB_ENABLE_TESTS        |                          | Build test binaries                                                                   | ON      |
-| WITH_GZFILEOP            | --without-gzfileops      | Compile with support for gzFile related functions                                     | ON      |
-| WITH_OPTIM               | --without-optimizations  | Build with optimisations                                                              | ON      |
-| WITH_NEW_STRATEGIES      | --without-new-strategies | Use new strategies                                                                    | ON      |
-| WITH_NATIVE_INSTRUCTIONS |                          | Compiles with full instruction set supported on this host (gcc/clang -march=native)   | OFF     |
-| WITH_SANITIZER           |                          | Build with sanitizer (memory, address, undefined)                                     | OFF     |
-| WITH_GTEST               |                          | Build gtest_zlib                                                                      | ON      |
-| WITH_FUZZERS             |                          | Build test/fuzz                                                                       | OFF     |
-| WITH_BENCHMARKS          |                          | Build test/benchmarks                                                                 | OFF     |
-| WITH_MAINTAINER_WARNINGS |                          | Build with project maintainer warnings                                                | OFF     |
-| WITH_CODE_COVERAGE       |                          | Enable code coverage reporting                                                        | OFF     |
+| CMake                      | configure                | Description                                                                         | Default |
+|:---------------------------|:-------------------------|:------------------------------------------------------------------------------------|---------|
+| ZLIB_COMPAT                | --zlib-compat            | Compile with zlib compatible API                                                    | OFF     |
+| ZLIB_ENABLE_TESTS          |                          | Build test binaries                                                                 | ON      |
+| WITH_GZFILEOP              | --without-gzfileops      | Compile with support for gzFile related functions                                   | ON      |
+| WITH_OPTIM                 | --without-optimizations  | Build with optimisations                                                            | ON      |
+| WITH_NEW_STRATEGIES        | --without-new-strategies | Use new strategies                                                                  | ON      |
+| WITH_NATIVE_INSTRUCTIONS   |                          | Compiles with full instruction set supported on this host (gcc/clang -march=native) | OFF     |
+| WITH_RUNTIME_CPU_DETECTION |                          | Compiles with runtime CPU detection                                                 | ON      |
+| WITH_SANITIZER             |                          | Build with sanitizer (memory, address, undefined)                                   | OFF     |
+| WITH_GTEST                 |                          | Build gtest_zlib                                                                    | ON      |
+| WITH_FUZZERS               |                          | Build test/fuzz                                                                     | OFF     |
+| WITH_BENCHMARKS            |                          | Build test/benchmarks                                                               | OFF     |
+| WITH_MAINTAINER_WARNINGS   |                          | Build with project maintainer warnings                                              | OFF     |
+| WITH_CODE_COVERAGE         |                          | Enable code coverage reporting                                                      | OFF     |
 
 
 Install

--- a/adler32.c
+++ b/adler32.c
@@ -9,22 +9,22 @@
 
 #ifdef ZLIB_COMPAT
 unsigned long Z_EXPORT PREFIX(adler32_z)(unsigned long adler, const unsigned char *buf, size_t len) {
-    return (unsigned long)functable.adler32((uint32_t)adler, buf, len);
+    return (unsigned long)FUNCTABLE_CALL(adler32)((uint32_t)adler, buf, len);
 }
 #else
 uint32_t Z_EXPORT PREFIX(adler32_z)(uint32_t adler, const unsigned char *buf, size_t len) {
-    return functable.adler32(adler, buf, len);
+    return FUNCTABLE_CALL(adler32)(adler, buf, len);
 }
 #endif
 
 /* ========================================================================= */
 #ifdef ZLIB_COMPAT
 unsigned long Z_EXPORT PREFIX(adler32)(unsigned long adler, const unsigned char *buf, unsigned int len) {
-    return (unsigned long)functable.adler32((uint32_t)adler, buf, len);
+    return (unsigned long)FUNCTABLE_CALL(adler32)((uint32_t)adler, buf, len);
 }
 #else
 uint32_t Z_EXPORT PREFIX(adler32)(uint32_t adler, const unsigned char *buf, uint32_t len) {
-    return functable.adler32(adler, buf, len);
+    return FUNCTABLE_CALL(adler32)(adler, buf, len);
 }
 #endif
 

--- a/arch/arm/arm_features.h
+++ b/arch/arm/arm_features.h
@@ -53,4 +53,45 @@ uint32_t crc32_acle(uint32_t crc, const uint8_t *buf, size_t len);
 
 #endif
 
+
+#ifdef DISABLE_RUNTIME_CPU_DETECTION
+//// ARM - SIMD
+#  if (defined(ARM_SIMD) && defined(__ARM_FEATURE_SIMD32)) || defined(ARM_NOCHECK_SIMD)
+#    undef native_slide_hash
+#    define native_slide_hash slide_hash_armv6
+#  endif
+// ARM - NEON
+#  if (defined(ARM_NEON) && (defined(__ARM_NEON__) || defined(__ARM_NEON))) || ARM_NOCHECK_NEON
+#    undef native_adler32
+#    define native_adler32 adler32_neon
+#    undef native_chunkmemset_safe
+#    define native_chunkmemset_safe chunkmemset_safe_neon
+#    undef native_chunksize
+#    define native_chunksize chunksize_neon
+#    undef native_inflate_fast
+#    define native_inflate_fast inflate_fast_neon
+#    undef native_slide_hash
+#    define native_slide_hash slide_hash_neon
+#    ifdef HAVE_BUILTIN_CTZLL
+#      undef native_compare256
+#      define native_compare256 compare256_neon
+#      undef native_longest_match
+#      define native_longest_match longest_match_neon
+#      undef native_longest_match_slow
+#      define native_longest_match_slow longest_match_slow_neon
+#    endif
+#  endif
+// ARM - ACLE
+#  if defined(ARM_ACLE) && defined(__ARM_ACLE) && defined(__ARM_FEATURE_CRC32)
+#    undef native_crc32
+#    define native_crc32 crc32_acle
+#    undef native_insert_string
+#    define native_insert_string insert_string_acle
+#    undef native_quick_insert_string
+#    define native_quick_insert_string quick_insert_string_acle
+#    undef native_update_hash
+#    define native_update_hash update_hash_acle
+#  endif
+#endif
+
 #endif /* ARM_H_ */

--- a/arch/generic/adler32_fold_c.c
+++ b/arch/generic/adler32_fold_c.c
@@ -10,7 +10,7 @@
 #include <limits.h>
 
 Z_INTERNAL uint32_t adler32_fold_copy_c(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len) {
-    adler = functable.adler32(adler, src, len);
+    adler = FUNCTABLE_CALL(adler32)(adler, src, len);
     memcpy(dst, src, len);
     return adler;
 }

--- a/arch/generic/crc32_fold_c.c
+++ b/arch/generic/crc32_fold_c.c
@@ -14,7 +14,7 @@ Z_INTERNAL uint32_t crc32_fold_reset_c(crc32_fold *crc) {
 }
 
 Z_INTERNAL void crc32_fold_copy_c(crc32_fold *crc, uint8_t *dst, const uint8_t *src, size_t len) {
-    crc->value = functable.crc32(crc->value, src, len);
+    crc->value = FUNCTABLE_CALL(crc32)(crc->value, src, len);
     memcpy(dst, src, len);
 }
 
@@ -24,7 +24,7 @@ Z_INTERNAL void crc32_fold_c(crc32_fold *crc, const uint8_t *src, size_t len, ui
      * same arguments for the versions that _do_ do a folding CRC but we don't want a copy. The
      * init_crc is an unused argument in this context */
     Z_UNUSED(init_crc);
-    crc->value = functable.crc32(crc->value, src, len);
+    crc->value = FUNCTABLE_CALL(crc32)(crc->value, src, len);
 }
 
 Z_INTERNAL uint32_t crc32_fold_final_c(crc32_fold *crc) {

--- a/arch/generic/generic_features.h
+++ b/arch/generic/generic_features.h
@@ -59,4 +59,48 @@ uint32_t longest_match_slow_c(deflate_state *const s, Pos cur_match);
 
 #endif
 
+
+#if defined(UNALIGNED_OK) && BYTE_ORDER == LITTLE_ENDIAN
+#  if defined(UNALIGNED64_OK) && defined(HAVE_BUILTIN_CTZLL)
+#    define longest_match_generic longest_match_unaligned_64
+#    define longest_match_slow_generic longest_match_slow_unaligned_64
+#    define compare256_generic compare256_unaligned_64
+#  elif defined(HAVE_BUILTIN_CTZ)
+#    define longest_match_generic longest_match_unaligned_32
+#    define longest_match_slow_generic longest_match_slow_unaligned_32
+#    define compare256_generic compare256_unaligned_32
+#  else
+#    define longest_match_generic longest_match_unaligned_16
+#    define longest_match_slow_generic longest_match_slow_unaligned_16
+#    define compare256_generic compare256_unaligned_16
+#  endif
+#else
+#  define longest_match_generic longest_match_c
+#  define longest_match_slow_generic longest_match_slow_c
+#  define compare256_generic compare256_c
+#endif
+
+
+#ifdef DISABLE_RUNTIME_CPU_DETECTION
+// Generic code
+#  define native_adler32 adler32_c
+#  define native_adler32_fold_copy adler32_fold_copy_c
+#  define native_chunkmemset_safe chunkmemset_safe_c
+#  define native_chunksize chunksize_c
+#  define native_crc32 PREFIX(crc32_braid)
+#  define native_crc32_fold crc32_fold_c
+#  define native_crc32_fold_copy crc32_fold_copy_c
+#  define native_crc32_fold_final crc32_fold_final_c
+#  define native_crc32_fold_reset crc32_fold_reset_c
+#  define native_inflate_fast inflate_fast_c
+#  define native_insert_string insert_string_c
+#  define native_quick_insert_string quick_insert_string_c
+#  define native_slide_hash slide_hash_c
+#  define native_update_hash update_hash_c
+#  define native_longest_match longest_match_generic
+#  define native_longest_match_slow longest_match_slow_generic
+#  define native_compare256 compare256_generic
+#endif
+
+
 #endif

--- a/arch/power/power_features.h
+++ b/arch/power/power_features.h
@@ -47,4 +47,41 @@ uint32_t compare256_power9(const uint8_t *src0, const uint8_t *src1);
 
 #endif
 
+
+#ifdef DISABLE_RUNTIME_CPU_DETECTION
+// Power - VMX
+#  if defined(PPC_VMX) && defined(__ALTIVEC__)
+#    undef native_adler32
+#    define native_adler32 adler32_vmx
+#    undef native_slide_hash
+#    define native_slide_hash slide_hash_vmx
+#  endif
+// Power8 - VSX
+#  if defined(POWER8_VSX) && defined(_ARCH_PWR8) && defined(__VSX__)
+#    undef native_adler32
+#    define native_adler32 adler32_power8
+#    undef native_chunkmemset_safe
+#    define native_chunkmemset_safe chunkmemset_safe_power8
+#    undef native_chunksize
+#    define native_chunksize chunksize_power8
+#    undef native_inflate_fast
+#    define native_inflate_fast inflate_fast_power8
+#    undef native_slide_hash
+#    define native_slide_hash slide_hash_power8
+#  endif
+#  if defined(POWER8_VSX_CRC32) && defined(_ARCH_PWR8) && defined(__VSX__)
+#    undef native_crc32
+#    define native_crc32 crc32_power8
+#  endif
+// Power9
+#  if defined(POWER9) && defined(_ARCH_PWR9)
+#    undef native_compare256
+#    define native_compare256 compare256_power9
+#    undef native_longest_match
+#    define native_longest_match longest_match_power9
+#    undef native_longest_match_slow
+#    define native_longest_match_slow longest_match_slow_power9
+#  endif
+#endif
+
 #endif /* POWER_H_ */

--- a/arch/riscv/riscv_features.h
+++ b/arch/riscv/riscv_features.h
@@ -36,4 +36,28 @@ uint32_t compare256_rvv(const uint8_t *src0, const uint8_t *src1);
 
 #endif
 
+#ifdef DISABLE_RUNTIME_CPU_DETECTION
+// RISCV - RVV
+#  if defined(RISCV_RVV) && defined(__riscv_v) && defined(__linux__)
+#    undef native_adler32
+#    define native_adler32 adler32_rvv
+#    undef native_adler32_fold_copy
+#    define native_adler32_fold_copy adler32_fold_copy_rvv
+#    undef native_chunkmemset_safe
+#    define native_chunkmemset_safe chunkmemset_safe_rvv
+#    undef native_chunksize
+#    define native_chunksize chunksize_rvv
+#    undef native_compare256
+#    define native_compare256 compare256_rvv
+#    undef native_inflate_fast
+#    define native_inflate_fast inflate_fast_rvv
+#    undef native_longest_match
+#    define native_longest_match longest_match_rvv
+#    undef native_longest_match_slow
+#    define native_longest_match_slow longest_match_slow_rvv
+#    undef native_slide_hash
+#    define native_slide_hash slide_hash_rvv
+#  endif
+#endif
+
 #endif /* RISCV_H_ */

--- a/arch/s390/s390_features.h
+++ b/arch/s390/s390_features.h
@@ -15,4 +15,12 @@ uint32_t crc32_s390_vx(uint32_t crc, const uint8_t *buf, size_t len);
 
 #endif
 
+
+#ifdef DISABLE_RUNTIME_CPU_DETECTION
+#  if defined(S390_CRC32_VX) && defined(__zarch__) && __ARCH__ >= 11 && defined(__VX__)
+#    undef native_crc32
+#    define native_crc32 = crc32_s390_vx
+#  endif
+#endif
+
 #endif

--- a/arch/x86/x86_features.h
+++ b/arch/x86/x86_features.h
@@ -104,4 +104,112 @@ uint32_t crc32_vpclmulqdq(uint32_t crc32, const uint8_t *buf, size_t len);
 
 #endif
 
+
+#ifdef DISABLE_RUNTIME_CPU_DETECTION
+// X86 - SSE2
+#  if (defined(X86_SSE2) && defined(__SSE2__)) || defined(__x86_64__) || defined(_M_X64) || defined(X86_NOCHECK_SSE2)
+#    undef native_chunkmemset_safe
+#    define native_chunkmemset_safe chunkmemset_safe_sse2
+#    undef native_chunksize
+#    define native_chunksize chunksize_sse2
+#    undef native_inflate_fast
+#    define native_inflate_fast inflate_fast_sse2
+#    undef native_slide_hash
+#    define native_slide_hash slide_hash_sse2
+#    ifdef HAVE_BUILTIN_CTZ
+#      undef native_compare256
+#      define native_compare256 compare256_sse2
+#      undef native_longest_match
+#      define native_longest_match longest_match_sse2
+#      undef native_longest_match_slow
+#      define native_longest_match_slow longest_match_slow_sse2
+#    endif
+#endif
+// X86 - SSSE3
+#  if defined(X86_SSSE3) && defined(__SSSE3__)
+#    undef native_adler32
+#    define native_adler32 adler32_ssse3
+#    undef native_chunkmemset_safe
+#    define native_chunkmemset_safe chunkmemset_safe_ssse3
+#    undef native_inflate_fast
+#    define native_inflate_fast inflate_fast_ssse3
+#  endif
+// X86 - SSE4.2
+#  if defined(X86_SSE42) && defined(__SSE4_2__)
+#    undef native_adler32_fold_copy
+#    define native_adler32_fold_copy adler32_fold_copy_sse42
+#    undef native_insert_string
+#    define native_insert_string insert_string_sse42
+#    undef native_quick_insert_string
+#    define native_quick_insert_string quick_insert_string_sse42
+#    undef native_update_hash
+#    define native_update_hash update_hash_sse42
+#  endif
+
+// X86 - PCLMUL
+#if defined(X86_PCLMULQDQ_CRC) && defined(__PCLMUL__)
+#  undef native_crc32
+#  define native_crc32 crc32_pclmulqdq
+#  undef native_crc32_fold
+#  define native_crc32_fold crc32_fold_pclmulqdq
+#  undef native_crc32_fold_copy
+#  define native_crc32_fold_copy crc32_fold_pclmulqdq_copy
+#  undef native_crc32_fold_final
+#  define native_crc32_fold_final crc32_fold_pclmulqdq_final
+#  undef native_crc32_fold_reset
+#  define native_crc32_fold_reset crc32_fold_pclmulqdq_reset
+#endif
+// X86 - AVX
+#  if defined(X86_AVX2) && defined(__AVX2__)
+#    undef native_adler32
+#    define native_adler32 adler32_avx2
+#    undef native_adler32_fold_copy
+#    define native_adler32_fold_copy adler32_fold_copy_avx2
+#    undef native_chunkmemset_safe
+#    define native_chunkmemset_safe chunkmemset_safe_avx2
+#    undef native_chunksize
+#    define native_chunksize chunksize_avx2
+#    undef native_inflate_fast
+#    define native_inflate_fast inflate_fast_avx2
+#    undef native_slide_hash
+#    define native_slide_hash slide_hash_avx2
+#    ifdef HAVE_BUILTIN_CTZ
+#      undef native_compare256
+#      define native_compare256 compare256_avx2
+#      undef native_longest_match
+#      define native_longest_match longest_match_avx2
+#      undef native_longest_match_slow
+#      define native_longest_match_slow longest_match_slow_avx2
+#    endif
+#  endif
+
+// X86 - AVX512 (F,DQ,BW,Vl)
+#  if defined(X86_AVX512) && defined(__AVX512F__) && defined(__AVX512DQ__) && defined(__AVX512BW__) && defined(__AVX512VL__)
+#    undef native_adler32
+#    define native_adler32 adler32_avx512
+#    undef native_adler32_fold_copy
+#    define native_adler32_fold_copy adler32_fold_copy_avx512
+// X86 - AVX512 (VNNI)
+#    if defined(X86_AVX512VNNI) && defined(__AVX512VNNI__)
+#      undef native_adler32
+#      define native_adler32 adler32_avx512_vnni
+#      undef native_adler32_fold_copy
+#      define native_adler32_fold_copy adler32_fold_copy_avx512_vnni
+#    endif
+// X86 - VPCLMULQDQ
+#    if defined(__PCLMUL__) && defined(__AVX512F__) && defined(__VPCLMULQDQ__)
+#      undef native_crc32
+#      define native_crc32 crc32_vpclmulqdq
+#      undef native_crc32_fold
+#      define native_crc32_fold crc32_fold_vpclmulqdq
+#      undef native_crc32_fold_copy
+#      define native_crc32_fold_copy crc32_fold_vpclmulqdq_copy
+#      undef native_crc32_fold_final
+#      define native_crc32_fold_final crc32_fold_vpclmulqdq_final
+#      undef native_crc32_fold_reset
+#      define native_crc32_fold_reset crc32_fold_vpclmulqdq_reset
+#    endif
+#  endif
+#endif
+
 #endif /* CPU_H_ */

--- a/crc32.c
+++ b/crc32.c
@@ -21,13 +21,13 @@ const uint32_t * Z_EXPORT PREFIX(get_crc_table)(void) {
 unsigned long Z_EXPORT PREFIX(crc32_z)(unsigned long crc, const unsigned char *buf, size_t len) {
     if (buf == NULL) return 0;
 
-    return (unsigned long)functable.crc32((uint32_t)crc, buf, len);
+    return (unsigned long)FUNCTABLE_CALL(crc32)((uint32_t)crc, buf, len);
 }
 #else
 uint32_t Z_EXPORT PREFIX(crc32_z)(uint32_t crc, const unsigned char *buf, size_t len) {
     if (buf == NULL) return 0;
 
-    return functable.crc32(crc, buf, len);
+    return FUNCTABLE_CALL(crc32)(crc, buf, len);
 }
 #endif
 

--- a/deflate.c
+++ b/deflate.c
@@ -194,8 +194,10 @@ int32_t ZNG_CONDEXPORT PREFIX(deflateInit2)(PREFIX3(stream) *strm, int32_t level
     deflate_state *s;
     int wrap = 1;
 
+#ifndef DISABLE_RUNTIME_CPU_DETECTION
     /* Force initialization functable, because deflate captures function pointers from functable. */
     functable.force_init();
+#endif
 
     if (strm == NULL)
         return Z_STREAM_ERROR;

--- a/deflate.c
+++ b/deflate.c
@@ -370,7 +370,7 @@ int32_t Z_EXPORT PREFIX(deflateSetDictionary)(PREFIX3(stream) *strm, const uint8
 
     /* when using zlib wrappers, compute Adler-32 for provided dictionary */
     if (wrap == 1)
-        strm->adler = functable.adler32(strm->adler, dictionary, dictLength);
+        strm->adler = FUNCTABLE_CALL(adler32)(strm->adler, dictionary, dictLength);
     DEFLATE_SET_DICTIONARY_HOOK(strm, dictionary, dictLength);  /* hook for IBM Z DFLTCC */
     s->wrap = 0;                    /* avoid computing Adler-32 in read_buf */
 
@@ -457,7 +457,7 @@ int32_t Z_EXPORT PREFIX(deflateResetKeep)(PREFIX3(stream) *strm) {
 
 #ifdef GZIP
     if (s->wrap == 2) {
-        strm->adler = functable.crc32_fold_reset(&s->crc_fold);
+        strm->adler = FUNCTABLE_CALL(crc32_fold_reset)(&s->crc_fold);
     } else
 #endif
         strm->adler = ADLER32_INITIAL_VALUE;
@@ -555,7 +555,7 @@ int32_t Z_EXPORT PREFIX(deflateParams)(PREFIX3(stream) *strm, int32_t level, int
     if (s->level != level) {
         if (s->level == 0 && s->matches != 0) {
             if (s->matches == 1) {
-                functable.slide_hash(s);
+                FUNCTABLE_CALL(slide_hash)(s);
             } else {
                 CLEAR_HASH(s);
             }
@@ -794,7 +794,7 @@ int32_t Z_EXPORT PREFIX(deflate)(PREFIX3(stream) *strm, int32_t flush) {
 #ifdef GZIP
     if (s->status == GZIP_STATE) {
         /* gzip header */
-        functable.crc32_fold_reset(&s->crc_fold);
+        FUNCTABLE_CALL(crc32_fold_reset)(&s->crc_fold);
         put_byte(s, 31);
         put_byte(s, 139);
         put_byte(s, 8);
@@ -911,7 +911,7 @@ int32_t Z_EXPORT PREFIX(deflate)(PREFIX3(stream) *strm, int32_t flush) {
                 }
             }
             put_short(s, (uint16_t)strm->adler);
-            functable.crc32_fold_reset(&s->crc_fold);
+            FUNCTABLE_CALL(crc32_fold_reset)(&s->crc_fold);
         }
         s->status = BUSY_STATE;
 
@@ -982,7 +982,7 @@ int32_t Z_EXPORT PREFIX(deflate)(PREFIX3(stream) *strm, int32_t flush) {
     /* Write the trailer */
 #ifdef GZIP
     if (s->wrap == 2) {
-        strm->adler = functable.crc32_fold_final(&s->crc_fold);
+        strm->adler = FUNCTABLE_CALL(crc32_fold_final)(&s->crc_fold);
 
         put_uint32(s, strm->adler);
         put_uint32(s, (uint32_t)strm->total_in);
@@ -1095,10 +1095,10 @@ Z_INTERNAL unsigned PREFIX(read_buf)(PREFIX3(stream) *strm, unsigned char *buf, 
         memcpy(buf, strm->next_in, len);
 #ifdef GZIP
     } else if (strm->state->wrap == 2) {
-        functable.crc32_fold_copy(&strm->state->crc_fold, buf, strm->next_in, len);
+        FUNCTABLE_CALL(crc32_fold_copy)(&strm->state->crc_fold, buf, strm->next_in, len);
 #endif
     } else if (strm->state->wrap == 1) {
-        strm->adler = functable.adler32_fold_copy(strm->adler, buf, strm->next_in, len);
+        strm->adler = FUNCTABLE_CALL(adler32_fold_copy)(strm->adler, buf, strm->next_in, len);
     } else {
         memcpy(buf, strm->next_in, len);
     }
@@ -1125,9 +1125,9 @@ static void lm_set_level(deflate_state *s, int level) {
         s->insert_string = &insert_string_roll;
         s->quick_insert_string = &quick_insert_string_roll;
     } else {
-        s->update_hash = functable.update_hash;
-        s->insert_string = functable.insert_string;
-        s->quick_insert_string = functable.quick_insert_string;
+        s->update_hash = FUNCTABLE_FPTR(update_hash);
+        s->insert_string = FUNCTABLE_FPTR(insert_string);
+        s->quick_insert_string = FUNCTABLE_FPTR(quick_insert_string);
     }
 
     s->level = level;
@@ -1191,7 +1191,7 @@ void Z_INTERNAL PREFIX(fill_window)(deflate_state *s) {
             s->block_start -= (int)wsize;
             if (s->insert > s->strstart)
                 s->insert = s->strstart;
-            functable.slide_hash(s);
+            FUNCTABLE_CALL(slide_hash)(s);
             more += wsize;
         }
         if (s->strm->avail_in == 0)

--- a/deflate_fast.c
+++ b/deflate_fast.c
@@ -41,7 +41,7 @@ Z_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
          * dictionary, and set hash_head to the head of the hash chain:
          */
         if (s->lookahead >= WANT_MIN_MATCH) {
-            hash_head = functable.quick_insert_string(s, s->strstart);
+            hash_head = FUNCTABLE_CALL(quick_insert_string)(s, s->strstart);
             dist = (int64_t)s->strstart - hash_head;
 
             /* Find the longest match, discarding those <= prev_length.
@@ -52,7 +52,7 @@ Z_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
                  * of window index 0 (in particular we have to avoid a match
                  * of the string with itself at the start of the input file).
                  */
-                match_len = functable.longest_match(s, hash_head);
+                match_len = FUNCTABLE_CALL(longest_match)(s, hash_head);
                 /* longest_match() sets match_start */
             }
         }
@@ -71,11 +71,11 @@ Z_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
                 match_len--; /* string at strstart already in table */
                 s->strstart++;
 
-                functable.insert_string(s, s->strstart, match_len);
+                FUNCTABLE_CALL(insert_string)(s, s->strstart, match_len);
                 s->strstart += match_len;
             } else {
                 s->strstart += match_len;
-                functable.quick_insert_string(s, s->strstart + 2 - STD_MIN_MATCH);
+                FUNCTABLE_CALL(quick_insert_string)(s, s->strstart + 2 - STD_MIN_MATCH);
 
                 /* If lookahead < STD_MIN_MATCH, ins_h is garbage, but it does not
                  * matter since it will be recomputed at next deflate call.

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -52,9 +52,9 @@ static void insert_match(deflate_state *s, struct match match) {
         if (UNLIKELY(match.match_length > 0)) {
             if (match.strstart >= match.orgstart) {
                 if (match.strstart + match.match_length - 1 >= match.orgstart) {
-                    functable.insert_string(s, match.strstart, match.match_length);
+                    FUNCTABLE_CALL(insert_string)(s, match.strstart, match.match_length);
                 } else {
-                    functable.insert_string(s, match.strstart, match.orgstart - match.strstart + 1);
+                    FUNCTABLE_CALL(insert_string)(s, match.strstart, match.orgstart - match.strstart + 1);
                 }
                 match.strstart += match.match_length;
                 match.match_length = 0;
@@ -72,12 +72,12 @@ static void insert_match(deflate_state *s, struct match match) {
 
         if (LIKELY(match.strstart >= match.orgstart)) {
             if (LIKELY(match.strstart + match.match_length - 1 >= match.orgstart)) {
-                functable.insert_string(s, match.strstart, match.match_length);
+                FUNCTABLE_CALL(insert_string)(s, match.strstart, match.match_length);
             } else {
-                functable.insert_string(s, match.strstart, match.orgstart - match.strstart + 1);
+                FUNCTABLE_CALL(insert_string)(s, match.strstart, match.orgstart - match.strstart + 1);
             }
         } else if (match.orgstart < match.strstart + match.match_length) {
-            functable.insert_string(s, match.orgstart, match.strstart + match.match_length - match.orgstart);
+            FUNCTABLE_CALL(insert_string)(s, match.orgstart, match.strstart + match.match_length - match.orgstart);
         }
         match.strstart += match.match_length;
         match.match_length = 0;
@@ -86,7 +86,7 @@ static void insert_match(deflate_state *s, struct match match) {
         match.match_length = 0;
 
         if (match.strstart >= (STD_MIN_MATCH - 2))
-            functable.quick_insert_string(s, match.strstart + 2 - STD_MIN_MATCH);
+            FUNCTABLE_CALL(quick_insert_string)(s, match.strstart + 2 - STD_MIN_MATCH);
 
         /* If lookahead < WANT_MIN_MATCH, ins_h is garbage, but it does not
          * matter since it will be recomputed at next deflate call.
@@ -199,7 +199,7 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
         } else {
             hash_head = 0;
             if (s->lookahead >= WANT_MIN_MATCH) {
-                hash_head = functable.quick_insert_string(s, s->strstart);
+                hash_head = FUNCTABLE_CALL(quick_insert_string)(s, s->strstart);
             }
 
             current_match.strstart = (uint16_t)s->strstart;
@@ -215,7 +215,7 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
                  * of window index 0 (in particular we have to avoid a match
                  * of the string with itself at the start of the input file).
                  */
-                current_match.match_length = (uint16_t)functable.longest_match(s, hash_head);
+                current_match.match_length = (uint16_t)FUNCTABLE_CALL(longest_match)(s, hash_head);
                 current_match.match_start = (uint16_t)s->match_start;
                 if (UNLIKELY(current_match.match_length < WANT_MIN_MATCH))
                     current_match.match_length = 1;
@@ -235,7 +235,7 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
         /* now, look ahead one */
         if (LIKELY(!early_exit && s->lookahead > MIN_LOOKAHEAD && (uint32_t)(current_match.strstart + current_match.match_length) < (s->window_size - MIN_LOOKAHEAD))) {
             s->strstart = current_match.strstart + current_match.match_length;
-            hash_head = functable.quick_insert_string(s, s->strstart);
+            hash_head = FUNCTABLE_CALL(quick_insert_string)(s, s->strstart);
 
             next_match.strstart = (uint16_t)s->strstart;
             next_match.orgstart = next_match.strstart;
@@ -250,7 +250,7 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
                  * of window index 0 (in particular we have to avoid a match
                  * of the string with itself at the start of the input file).
                  */
-                next_match.match_length = (uint16_t)functable.longest_match(s, hash_head);
+                next_match.match_length = (uint16_t)FUNCTABLE_CALL(longest_match)(s, hash_head);
                 next_match.match_start = (uint16_t)s->match_start;
                 if (UNLIKELY(next_match.match_start >= next_match.strstart)) {
                     /* this can happen due to some restarts */

--- a/deflate_quick.c
+++ b/deflate_quick.c
@@ -86,7 +86,7 @@ Z_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
         }
 
         if (LIKELY(s->lookahead >= WANT_MIN_MATCH)) {
-            hash_head = functable.quick_insert_string(s, s->strstart);
+            hash_head = FUNCTABLE_CALL(quick_insert_string)(s, s->strstart);
             dist = (int64_t)s->strstart - hash_head;
 
             if (dist <= MAX_DIST(s) && dist > 0) {
@@ -94,7 +94,7 @@ Z_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
                 const uint8_t *match_start = s->window + hash_head;
 
                 if (zng_memcmp_2(str_start, match_start) == 0) {
-                    match_len = functable.compare256(str_start+2, match_start+2) + 2;
+                    match_len = FUNCTABLE_CALL(compare256)(str_start+2, match_start+2) + 2;
 
                     if (match_len >= WANT_MIN_MATCH) {
                         if (UNLIKELY(match_len > s->lookahead))

--- a/deflate_slow.c
+++ b/deflate_slow.c
@@ -22,9 +22,9 @@ Z_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
     match_func longest_match;
 
     if (s->max_chain_length <= 1024)
-        longest_match = functable.longest_match;
+        longest_match = FUNCTABLE_FPTR(longest_match);
     else
-        longest_match = functable.longest_match_slow;
+        longest_match = FUNCTABLE_FPTR(longest_match_slow);
 
     /* Process the input block. */
     for (;;) {

--- a/functable.c
+++ b/functable.c
@@ -2,6 +2,7 @@
  * Copyright (C) 2017 Hans Kristian Rosbach
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
+#ifndef DISABLE_RUNTIME_CPU_DETECTION
 
 #include "zbuild.h"
 #include "zendian.h"
@@ -62,26 +63,9 @@ static void init_functable(void) {
     ft.quick_insert_string = &quick_insert_string_c;
     ft.slide_hash = &slide_hash_c;
     ft.update_hash = &update_hash_c;
-
-#if defined(UNALIGNED_OK) && BYTE_ORDER == LITTLE_ENDIAN
-#  if defined(UNALIGNED64_OK) && defined(HAVE_BUILTIN_CTZLL)
-    ft.longest_match = &longest_match_unaligned_64;
-    ft.longest_match_slow = &longest_match_slow_unaligned_64;
-    ft.compare256 = &compare256_unaligned_64;
-#  elif defined(HAVE_BUILTIN_CTZ)
-    ft.longest_match = &longest_match_unaligned_32;
-    ft.longest_match_slow = &longest_match_slow_unaligned_32;
-    ft.compare256 = &compare256_unaligned_32;
-#  else
-    ft.longest_match = &longest_match_unaligned_16;
-    ft.longest_match_slow = &longest_match_slow_unaligned_16;
-    ft.compare256 = &compare256_unaligned_16;
-#  endif
-#else
-    ft.longest_match = &longest_match_c;
-    ft.longest_match_slow = &longest_match_slow_c;
-    ft.compare256 = &compare256_c;
-#endif
+    ft.longest_match = &longest_match_generic;
+    ft.longest_match_slow = &longest_match_slow_generic;
+    ft.compare256 = &compare256_generic;
 
 
     // Select arch-optimized functions
@@ -146,6 +130,7 @@ static void init_functable(void) {
 #  endif
     }
 #endif
+    // X86 - AVX512 (F,DQ,BW,Vl)
 #ifdef X86_AVX512
     if (cf.x86.has_avx512) {
         ft.adler32 = &adler32_avx512;
@@ -396,3 +381,5 @@ Z_INTERNAL struct functable_s functable = {
     slide_hash_stub,
     update_hash_stub
 };
+
+#endif

--- a/functable.h
+++ b/functable.h
@@ -35,4 +35,11 @@ struct functable_s {
 
 Z_INTERNAL extern struct functable_s functable;
 
+
+/* Explicitly indicate functions are conditionally dispatched.
+ */
+#define FUNCTABLE_CALL(name) functable.name
+#define FUNCTABLE_FPTR(name) functable.name
+
+
 #endif

--- a/functable.h
+++ b/functable.h
@@ -12,6 +12,23 @@
 #include "inftrees.h"
 #include "inflate.h"
 
+
+#ifdef DISABLE_RUNTIME_CPU_DETECTION
+
+#  include "zbuild.h"
+#  include "zendian.h"
+#  include "crc32_braid_p.h"
+#  include "cpu_features.h"
+
+/* When compiling with native instructions it is not necessary to use functable.
+ * Instead we use native_ macro indicating the best available variant of arch-specific
+ * functions for the current platform.
+ */
+#  define FUNCTABLE_CALL(name) native_ ## name
+#  define FUNCTABLE_FPTR(name) &native_ ## name
+
+#else
+
 struct functable_s {
     void     (* force_init)         (void);
     uint32_t (* adler32)            (uint32_t adler, const uint8_t *buf, size_t len);
@@ -35,11 +52,11 @@ struct functable_s {
 
 Z_INTERNAL extern struct functable_s functable;
 
-
 /* Explicitly indicate functions are conditionally dispatched.
  */
-#define FUNCTABLE_CALL(name) functable.name
-#define FUNCTABLE_FPTR(name) functable.name
+#  define FUNCTABLE_CALL(name) functable.name
+#  define FUNCTABLE_FPTR(name) functable.name
 
+#endif
 
 #endif

--- a/infback.c
+++ b/infback.c
@@ -55,7 +55,7 @@ int32_t ZNG_CONDEXPORT PREFIX(inflateBackInit)(PREFIX3(stream) *strm, int32_t wi
     state->wnext = 0;
     state->whave = 0;
     state->sane = 1;
-    state->chunksize = functable.chunksize();
+    state->chunksize = FUNCTABLE_CALL(chunksize)();
     return Z_OK;
 }
 
@@ -357,7 +357,7 @@ int32_t Z_EXPORT PREFIX(inflateBack)(PREFIX3(stream) *strm, in_func in, void *in
                 RESTORE();
                 if (state->whave < state->wsize)
                     state->whave = state->wsize - left;
-                functable.inflate_fast(strm, state->wsize);
+                FUNCTABLE_CALL(inflate_fast)(strm, state->wsize);
                 LOAD();
                 break;
             }

--- a/inflate.c
+++ b/inflate.c
@@ -139,8 +139,10 @@ int32_t ZNG_CONDEXPORT PREFIX(inflateInit2)(PREFIX3(stream) *strm, int32_t windo
     int32_t ret;
     struct inflate_state *state;
 
+#ifndef DISABLE_RUNTIME_CPU_DETECTION
     /* Initialize functable earlier. */
     functable.force_init();
+#endif
 
     if (strm == NULL)
         return Z_STREAM_ERROR;

--- a/inflate_p.h
+++ b/inflate_p.h
@@ -46,9 +46,9 @@
 /* check function to use adler32() for zlib or crc32() for gzip */
 #ifdef GUNZIP
 #  define UPDATE(check, buf, len) \
-    (state->flags ? PREFIX(crc32)(check, buf, len) : functable.adler32(check, buf, len))
+    (state->flags ? PREFIX(crc32)(check, buf, len) : FUNCTABLE_CALL(adler32)(check, buf, len))
 #else
-#  define UPDATE(check, buf, len) functable.adler32(check, buf, len)
+#  define UPDATE(check, buf, len) FUNCTABLE_CALL(adler32)(check, buf, len)
 #endif
 
 /* check macros for header crc */


### PR DESCRIPTION
My vision of PR #1626 (@nmoinvaz)

~~Based on my PR #1643~~


For X86, PPC, RISC-V, s390 the conditions are correct.
**For ARM, they require verification.**

Microsoft Visual Studio does not support compile time detection of CPU features for ``/arch`` before ``AVX``. Missing predefined macros (``__SSE*__``).