### PR TITLE
Minor cleanups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1021,7 +1021,7 @@ set(ZLIB_SRCS
     adler32.c
     compress.c
     cpu_features.c
-    crc32_braid.c
+    crc32.c
     crc32_braid_comb.c
     deflate.c
     deflate_fast.c

--- a/Makefile.in
+++ b/Makefile.in
@@ -85,7 +85,7 @@ OBJZ = \
 	adler32.o \
 	compress.o \
 	cpu_features.o \
-	crc32_braid.o \
+	crc32.o \
 	crc32_braid_comb.o \
 	deflate.o \
 	deflate_fast.o \
@@ -125,7 +125,7 @@ PIC_OBJZ = \
 	adler32.lo \
 	compress.lo \
 	cpu_features.lo \
-	crc32_braid.lo \
+	crc32.lo \
 	crc32_braid_comb.lo \
 	deflate.lo \
 	deflate_fast.lo \

--- a/Makefile.in
+++ b/Makefile.in
@@ -366,6 +366,7 @@ uninstall: uninstall-static uninstall-shared
 mostlyclean: clean
 clean:
 	@if [ -f $(ARCHDIR)/Makefile ]; then $(MAKE) -C $(ARCHDIR) clean; fi
+	@if [ -f arch/generic/Makefile ]; then $(MAKE) -C arch/generic clean; fi
 	@if [ -f test/Makefile ]; then $(MAKE) -C test clean; fi
 	rm -f *.o *.lo *~ \
 	   example$(EXE) minigzip$(EXE) minigzipsh$(EXE) \

--- a/crc32.c
+++ b/crc32.c
@@ -1,4 +1,4 @@
-/* crc32_braid.c -- compute the CRC-32 of a data stream
+/* crc32.c -- compute the CRC-32 of a data stream
  * Copyright (C) 1995-2022 Mark Adler
  * For conditions of distribution and use, see copyright notice in zlib.h
  *

--- a/tools/makecrct.c
+++ b/tools/makecrct.c
@@ -21,9 +21,6 @@
 
 static uint32_t crc_table[256];
 static z_word_t crc_big_table[256];
-
-static uint32_t crc_braid_table[W][256];
-static z_word_t crc_braid_big_table[W][256];
 static uint32_t x2n_table[32];
 
 #include "crc32_braid_comb_p.h"
@@ -80,9 +77,6 @@ static void make_crc_table(void) {
     x2n_table[0] = p;
     for (n = 1; n < 32; n++)
         x2n_table[n] = p = multmodp(p, p);
-
-    /* initialize the braiding tables -- needs x2n_table[] */
-    braid(crc_braid_table, crc_braid_big_table, N, W);
 }
 
 /*

--- a/win32/Makefile.a64
+++ b/win32/Makefile.a64
@@ -51,7 +51,7 @@ OBJS = \
 	compare256_c.obj \
 	compress.obj \
 	cpu_features.obj \
-	crc32_braid.obj \
+	crc32.obj \
 	crc32_braid_c.obj \
 	crc32_braid_comb.obj \
 	crc32_fold_c.obj \
@@ -193,7 +193,7 @@ gzwrite.obj: $(SRCDIR)/gzwrite.c $(SRCDIR)/zbuild.h $(SRCDIR)/gzguts.h $(SRCDIR)
 compress.obj: $(SRCDIR)/compress.c $(SRCDIR)/zbuild.h $(SRCDIR)/zlib$(SUFFIX).h
 uncompr.obj: $(SRCDIR)/uncompr.c $(SRCDIR)/zbuild.h $(SRCDIR)/zlib$(SUFFIX).h
 cpu_features.obj: $(SRCDIR)/cpu_features.c $(SRCDIR)/zbuild.h $(SRCDIR)/zutil.h
-crc32_braid.obj: $(SRCDIR)/crc32_braid.c $(SRCDIR)/zbuild.h $(SRCDIR)/functable.h $(SRCDIR)/crc32_braid_tbl.h
+crc32.obj: $(SRCDIR)/crc32.c $(SRCDIR)/zbuild.h $(SRCDIR)/functable.h $(SRCDIR)/crc32_braid_tbl.h
 crc32_braid_c.obj: $(SRCDIR)/arch/generic/crc32_braid_c.c $(SRCDIR)/zbuild.h $(SRCDIR)/crc32_braid_p.h $(SRCDIR)/crc32_braid_tbl.h
 crc32_braid_comb.obj: $(SRCDIR)/crc32_braid_comb.c $(SRCDIR)/zutil.h $(SRCDIR)/crc32_braid_p.h $(SRCDIR)/crc32_braid_tbl.h $(SRCDIR)/crc32_braid_comb_p.h
 crc32_fold_c.obj: $(SRCDIR)/arch/generic/crc32_fold_c.c $(SRCDIR)/zbuild.h $(SRCDIR)/functable.h $(SRCDIR)/arch/generic/crc32_fold_c.h

--- a/win32/Makefile.arm
+++ b/win32/Makefile.arm
@@ -56,7 +56,7 @@ OBJS = \
 	compare256_c.obj \
 	compress.obj \
 	cpu_features.obj \
-	crc32_braid.obj \
+	crc32.obj \
 	crc32_braid_c.obj \
 	crc32_braid_comb.obj \
 	crc32_fold_c.obj \
@@ -214,7 +214,7 @@ uncompr.obj: $(SRCDIR)/uncompr.c $(SRCDIR)/zbuild.h $(SRCDIR)/zlib$(SUFFIX).h
 chunkset_c.obj: $(SRCDIR)/arch/generic/chunkset_c.c $(SRCDIR)/zbuild.h $(SRCDIR)/chunkset_tpl.h $(SRCDIR)/inffast_tpl.h
 compare256_c.obj: $(SRCDIR)/arch/generic/compare256_c.c $(SRCDIR)/zbuild.h $(SRCDIR)/zutil_p.h $(SRCDIR)/deflate.h $(SRCDIR)/fallback_builtins.h
 cpu_features.obj: $(SRCDIR)/cpu_features.c $(SRCDIR)/zbuild.h $(SRCDIR)/zutil.h
-crc32_braid.obj: $(SRCDIR)/crc32_braid.c $(SRCDIR)/zbuild.h $(SRCDIR)/functable.h $(SRCDIR)/crc32_braid_tbl.h
+crc32.obj: $(SRCDIR)/crc32.c $(SRCDIR)/zbuild.h $(SRCDIR)/functable.h $(SRCDIR)/crc32_braid_tbl.h
 crc32_braid_c.obj: $(SRCDIR)/arch/generic/crc32_braid_c.c $(SRCDIR)/zbuild.h $(SRCDIR)/crc32_braid_p.h $(SRCDIR)/crc32_braid_tbl.h
 crc32_braid_comb.obj: $(SRCDIR)/crc32_braid_comb.c $(SRCDIR)/zutil.h $(SRCDIR)/crc32_braid_p.h $(SRCDIR)/crc32_braid_tbl.h $(SRCDIR)/crc32_braid_comb_p.h
 crc32_fold_c.obj: $(SRCDIR)/arch/generic/crc32_fold_c.c $(SRCDIR)/zbuild.h $(SRCDIR)/functable.h $(SRCDIR)/arch/generic/crc32_fold_c.h

--- a/win32/Makefile.msc
+++ b/win32/Makefile.msc
@@ -63,7 +63,7 @@ OBJS = \
 	compare256_sse2.obj \
 	compress.obj \
 	cpu_features.obj \
-	crc32_braid.obj \
+	crc32.obj \
 	crc32_braid_c.obj \
 	crc32_braid_comb.obj \
 	crc32_fold_c.obj \
@@ -214,7 +214,7 @@ compare256_c.obj: $(SRCDIR)/arch/generic/compare256_c.c $(SRCDIR)/zbuild.h $(SRC
 compare256_avx2.obj: $(SRCDIR)/arch/x86/compare256_avx2.c $(SRCDIR)/zbuild.h $(SRCDIR)/zutil_p.h $(SRCDIR)/deflate.h $(SRCDIR)/fallback_builtins.h
 compare256_sse2.obj: $(SRCDIR)/arch/x86/compare256_sse2.c $(SRCDIR)/zbuild.h $(SRCDIR)/zutil_p.h $(SRCDIR)/deflate.h $(SRCDIR)/fallback_builtins.h
 cpu_features.obj: $(SRCDIR)/cpu_features.c $(SRCDIR)/zbuild.h $(SRCDIR)/zutil.h
-crc32_braid.obj: $(SRCDIR)/crc32_braid.c $(SRCDIR)/zbuild.h $(SRCDIR)/functable.h $(SRCDIR)/crc32_braid_tbl.h
+crc32.obj: $(SRCDIR)/crc32.c $(SRCDIR)/zbuild.h $(SRCDIR)/functable.h $(SRCDIR)/crc32_braid_tbl.h
 crc32_braid_c.obj: $(SRCDIR)/arch/generic/crc32_braid_c.c $(SRCDIR)/zbuild.h $(SRCDIR)/crc32_braid_p.h $(SRCDIR)/crc32_braid_tbl.h
 crc32_braid_comb.obj: $(SRCDIR)/crc32_braid_comb.c $(SRCDIR)/zutil.h $(SRCDIR)/crc32_braid_p.h $(SRCDIR)/crc32_braid_tbl.h $(SRCDIR)/crc32_braid_comb_p.h
 crc32_fold_c.obj: $(SRCDIR)/arch/generic/crc32_fold_c.c $(SRCDIR)/zbuild.h $(SRCDIR)/functable.h $(SRCDIR)/arch/generic/crc32_fold_c.h


### PR DESCRIPTION
- Rename crc32_braid.c to crc32.c, since this file now does not contain anything related to crc32_braid.
- Add the missing clean rule for arch/generic to Makefile.in
- Remove unused code in makecrct.c