### PR TITLE
Fix `deflate_state` alignment with MS or clang-cl compilers

### DIFF
--- a/deflate.h
+++ b/deflate.h
@@ -117,7 +117,7 @@ typedef uint32_t (* update_hash_cb)        (deflate_state *const s, uint32_t h, 
 typedef void     (* insert_string_cb)      (deflate_state *const s, uint32_t str, uint32_t count);
 typedef Pos      (* quick_insert_string_cb)(deflate_state *const s, uint32_t str);
 
-struct internal_state {
+struct ALIGNED_(8) internal_state {
     PREFIX3(stream)      *strm;            /* pointer back to this zlib stream */
     unsigned char        *pending_buf;     /* output still pending */
     unsigned char        *pending_out;     /* next pending byte to output to the stream */
@@ -297,7 +297,7 @@ struct internal_state {
 
     /* Reserved for future use and alignment purposes */
     int32_t reserved[11];
-} ALIGNED_(8);
+};
 
 typedef enum {
     need_more,      /* block not completed, need more input or more output */

--- a/deflate.h
+++ b/deflate.h
@@ -117,7 +117,7 @@ typedef uint32_t (* update_hash_cb)        (deflate_state *const s, uint32_t h, 
 typedef void     (* insert_string_cb)      (deflate_state *const s, uint32_t str, uint32_t count);
 typedef Pos      (* quick_insert_string_cb)(deflate_state *const s, uint32_t str);
 
-struct ALIGNED_(8) internal_state {
+struct ALIGNED_(16) internal_state {
     PREFIX3(stream)      *strm;            /* pointer back to this zlib stream */
     unsigned char        *pending_buf;     /* output still pending */
     unsigned char        *pending_out;     /* next pending byte to output to the stream */


### PR DESCRIPTION
When building with clang-cl, compiler produces the following warning:

```
zlib-ng/deflate.h(287,3): warning : attribute 'align' is ignored, place it after "struct" to apply attribute to type declaration [-Wignored-attributes]
zlib-ng/zbuild.h(196,34): note: expanded from macro 'ALIGNED_'
```
Repositioning align attribute after "struct" fixes the warning and aligns `deflate_state` correctly.