### PR TITLE
Fix include paths

### DIFF
--- a/arch/arm/chunkset_neon.c
+++ b/arch/arm/chunkset_neon.c
@@ -5,7 +5,7 @@
 #ifdef ARM_NEON
 #include "neon_intrins.h"
 #include "zbuild.h"
-#include "chunk_permute_table.h"
+#include "arch/generic/chunk_permute_table.h"
 
 typedef uint8x16_t chunk_t;
 

--- a/functable.h
+++ b/functable.h
@@ -7,8 +7,8 @@
 #define FUNCTABLE_H_
 
 #include "deflate.h"
-#include "crc32_fold_c.h"
-#include "adler32_fold_c.h"
+#include "arch/generic/crc32_fold_c.h"
+#include "arch/generic/adler32_fold_c.h"
 #include "inftrees.h"
 #include "inflate.h"
 


### PR DESCRIPTION
zlb-ng shouldn't require to have arch/generic in the include path