### PR TITLE
Inline CHUNKCOPY and CHUNKUNROLL

### DIFF
--- a/arch/x86/chunkset_ssse3.c
+++ b/arch/x86/chunkset_ssse3.c
@@ -4,9 +4,6 @@
 
 #include "zbuild.h"
 
-/* This requires SSE2 support. While it's implicit with SSSE3, we can minimize
- * code size by sharing the chunkcopy functions, which will certainly compile
- * to identical machine code */
 #if defined(X86_SSSE3)
 #include <immintrin.h>
 #include "../generic/chunk_permute_table.h"
@@ -19,8 +16,6 @@ typedef __m128i chunk_t;
 #define HAVE_CHUNKMEMSET_4
 #define HAVE_CHUNKMEMSET_8
 #define HAVE_CHUNK_MAG
-#define HAVE_CHUNKCOPY
-#define HAVE_CHUNKUNROLL
 
 static const lut_rem_pair perm_idx_lut[13] = {
     {0, 1},      /* 3 */
@@ -83,14 +78,11 @@ static inline chunk_t GET_CHUNK_MAG(uint8_t *buf, uint32_t *chunk_rem, uint32_t 
     return ret_vec;
 }
 
-extern uint8_t* chunkcopy_sse2(uint8_t *out, uint8_t const *from, unsigned len);
-extern uint8_t* chunkunroll_sse2(uint8_t *out, unsigned *dist, unsigned *len);
-
 #define CHUNKSIZE        chunksize_ssse3
 #define CHUNKMEMSET      chunkmemset_ssse3
 #define CHUNKMEMSET_SAFE chunkmemset_safe_ssse3
-#define CHUNKCOPY        chunkcopy_sse2
-#define CHUNKUNROLL      chunkunroll_sse2
+#define CHUNKCOPY        chunkcopy_ssse3
+#define CHUNKUNROLL      chunkunroll_ssse3
 
 #include "chunkset_tpl.h"
 

--- a/chunkset_tpl.h
+++ b/chunkset_tpl.h
@@ -25,7 +25,7 @@ Z_INTERNAL uint32_t CHUNKSIZE(void) {
    without iteration, which will hopefully make the branch prediction more
    reliable. */
 #ifndef HAVE_CHUNKCOPY
-Z_INTERNAL uint8_t* CHUNKCOPY(uint8_t *out, uint8_t const *from, unsigned len) {
+static inline uint8_t* CHUNKCOPY(uint8_t *out, uint8_t const *from, unsigned len) {
     Assert(len > 0, "chunkcopy should never have a length 0");
     chunk_t chunk;
     int32_t align = ((len - 1) % sizeof(chunk_t)) + 1;
@@ -54,7 +54,7 @@ Z_INTERNAL uint8_t* CHUNKCOPY(uint8_t *out, uint8_t const *from, unsigned len) {
    least 258 bytes of output space available (258 being the maximum length
    output from a single token; see inflate_fast()'s assumptions below). */
 #ifndef HAVE_CHUNKUNROLL
-Z_INTERNAL uint8_t* CHUNKUNROLL(uint8_t *out, unsigned *dist, unsigned *len) {
+static inline uint8_t* CHUNKUNROLL(uint8_t *out, unsigned *dist, unsigned *len) {
     unsigned char const *from = out - *dist;
     chunk_t chunk;
     while (*dist < *len && *dist < sizeof(chunk_t)) {


### PR DESCRIPTION
This slightly decreases the shared library size on x86_64 when both SSE2 and SSSE3 are enabled.