### PR TITLE
Disable CodeCov for RISC-V as the toolchain doesn't support generating code coverage.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -452,7 +452,6 @@ jobs:
             os: ubuntu-latest
             cmake-args: -GNinja -DCMAKE_TOOLCHAIN_FILE=./cmake/toolchain-riscv.cmake -DTOOLCHAIN_PATH=${PWD}/prebuilt-riscv-toolchain-qemu/riscv-clang -DQEMU_PATH=${PWD}/prebuilt-riscv-toolchain-qemu/riscv-qemu/bin/qemu-riscv64
             packages: build-essential cmake ninja-build
-            codecov: ubuntu_clang_toolchain_riscv
 
           - name: Ubuntu Emscripten WASM32
             os: ubuntu-latest


### PR DESCRIPTION
No point whatsoever to enable generating code coverage until the RISC-V toolchain actually supports it, we get empty coverage file, which will mess up coverage data.