### PR TITLE
Clean up insert_match() in deflate_medium

### DIFF
--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -45,10 +45,12 @@ static void insert_match(deflate_state *s, struct match match) {
     if (UNLIKELY(s->lookahead <= (unsigned int)(match.match_length + WANT_MIN_MATCH)))
         return;
 
+    /* string at strstart already in table */
+    match.strstart++;
+    match.match_length--;
+
     /* matches that are not long enough we need to emit as literals */
-    if (LIKELY(match.match_length < WANT_MIN_MATCH)) {
-        match.strstart++;
-        match.match_length--;
+    if (LIKELY(match.match_length < WANT_MIN_MATCH - 1)) {
         if (UNLIKELY(match.match_length > 0)) {
             if (match.strstart >= match.orgstart) {
                 if (match.strstart + match.match_length - 1 >= match.orgstart) {
@@ -63,33 +65,18 @@ static void insert_match(deflate_state *s, struct match match) {
         return;
     }
 
-    /* Insert new strings in the hash table. */
-    if (s->lookahead >= WANT_MIN_MATCH) {
-        match.match_length--; /* string at strstart already in table */
-        match.strstart++;
-
-        if (LIKELY(match.strstart >= match.orgstart)) {
-            if (LIKELY(match.strstart + match.match_length - 1 >= match.orgstart)) {
-                insert_string(s, match.strstart, match.match_length);
-            } else {
-                insert_string(s, match.strstart, match.orgstart - match.strstart + 1);
-            }
-        } else if (match.orgstart < match.strstart + match.match_length) {
-            insert_string(s, match.orgstart, match.strstart + match.match_length - match.orgstart);
+    /* Insert into hash table. */
+    if (LIKELY(match.strstart >= match.orgstart)) {
+        if (LIKELY(match.strstart + match.match_length - 1 >= match.orgstart)) {
+            insert_string(s, match.strstart, match.match_length);
+        } else {
+            insert_string(s, match.strstart, match.orgstart - match.strstart + 1);
         }
-        match.strstart += match.match_length;
-        match.match_length = 0;
-    } else {
-        match.strstart += match.match_length;
-        match.match_length = 0;
-
-        if (match.strstart >= (STD_MIN_MATCH - 2))
-            quick_insert_string(s, match.strstart + 2 - STD_MIN_MATCH);
-
-        /* If lookahead < WANT_MIN_MATCH, ins_h is garbage, but it does not
-         * matter since it will be recomputed at next deflate call.
-         */
+    } else if (match.orgstart < match.strstart + match.match_length) {
+        insert_string(s, match.orgstart, match.strstart + match.match_length - match.orgstart);
     }
+    match.strstart += match.match_length;
+    match.match_length = 0;
 }
 
 static void fizzle_matches(deflate_state *s, struct match *current, struct match *next) {

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -63,10 +63,8 @@ static void insert_match(deflate_state *s, struct match match) {
         return;
     }
 
-    /* Insert new strings in the hash table only if the match length
-     * is not too large. This saves time but degrades compression.
-     */
-    if (match.match_length <= 16 * s->max_insert_length && s->lookahead >= WANT_MIN_MATCH) {
+    /* Insert new strings in the hash table. */
+    if (s->lookahead >= WANT_MIN_MATCH) {
         match.match_length--; /* string at strstart already in table */
         match.strstart++;
 


### PR DESCRIPTION
Based on #1681

insert_string() is no longer slow, so there is no need to avoid it any more.
The first commit removes the check for long matches, this also makes some of the code unreachable and warrants a further cleanup commit that removes unused code and restructures things a little bit.

The end result is that deflate_medium is the same speed or very slightly faster and also compresses slightly better on average (depends on the specific test data).

For reviewing, I recommend not showing whitespace changes.