### PR TITLE
Remove duplicated codecov parameter

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -46,7 +46,7 @@ jobs:
             compiler: gcc
             cxx-compiler: g++
             cmake-args: -DWITH_NATIVE_INSTRUCTIONS=ON -DNATIVE_ARCH_OVERRIDE="-mavx -mpclmul"
-            codecov: ubuntu_gcc_native_inst
+            codecov: ubuntu_gcc_native_inst_avx
 
           - name: Ubuntu GCC Symbol Prefix
             os: ubuntu-latest


### PR DESCRIPTION
Remove duplicated ``codecov`` parameter.
Bug appeared in PR #1662.