### PR TITLE
Don't export git/github-related files in tar/zip archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,8 @@
 crc32_braid_tbl.h hooks-max-size=1000000
 Makefile text
 configure text eol=lf
+
+# Don't export git/github-related files in tar/zip archives
+/.github export-ignore  
+.gitattributes export-ignore  
+.gitignore export-ignore


### PR DESCRIPTION
These files are useless outside of git and github, so don't distribute them to users downloading/exporting tar.gz, zip or other archives. Doing this is relatively common for well-known projects.