### PR TITLE
Enable unaligned memory access on big endian PowerPC

### DIFF
--- a/cmake/detect-arch.c
+++ b/cmake/detect-arch.c
@@ -32,7 +32,7 @@
     #endif
 
 // PowerPC
-#elif defined(__powerpc__) || defined(_ppc__) || defined(__PPC__)
+#elif defined(__powerpc__) || defined(__ppc__) || defined(__PPC__)
     #if defined(__64BIT__) || defined(__powerpc64__) || defined(__ppc64__)
         #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
             #error archfound powerpc64le

--- a/compare256_rle.h
+++ b/compare256_rle.h
@@ -42,7 +42,7 @@ static inline uint32_t compare256_rle_c(const uint8_t *src0, const uint8_t *src1
     return 256;
 }
 
-#ifdef UNALIGNED_OK
+#if defined(UNALIGNED_OK) && BYTE_ORDER == LITTLE_ENDIAN
 /* 16-bit unaligned integer comparison */
 static inline uint32_t compare256_rle_unaligned_16(const uint8_t *src0, const uint8_t *src1) {
     uint32_t len = 0;

--- a/deflate_rle.c
+++ b/deflate_rle.c
@@ -10,7 +10,7 @@
 #include "deflate_p.h"
 #include "functable.h"
 
-#ifdef UNALIGNED_OK
+#if defined(UNALIGNED_OK) && BYTE_ORDER == LITTLE_ENDIAN
 #  if defined(UNALIGNED64_OK) && defined(HAVE_BUILTIN_CTZLL)
 #    define compare256_rle compare256_rle_unaligned_64
 #  elif defined(HAVE_BUILTIN_CTZ)

--- a/test/benchmarks/benchmark_compare256_rle.cc
+++ b/test/benchmarks/benchmark_compare256_rle.cc
@@ -62,7 +62,7 @@ public:
 
 BENCHMARK_COMPARE256_RLE(c, compare256_rle_c, 1);
 
-#ifdef UNALIGNED_OK
+#if defined(UNALIGNED_OK) && BYTE_ORDER == LITTLE_ENDIAN
 BENCHMARK_COMPARE256_RLE(unaligned_16, compare256_rle_unaligned_16, 1);
 #ifdef HAVE_BUILTIN_CTZ
 BENCHMARK_COMPARE256_RLE(unaligned_32, compare256_rle_unaligned_32, 1);

--- a/test/test_compare256_rle.cc
+++ b/test/test_compare256_rle.cc
@@ -52,7 +52,7 @@ static inline void compare256_rle_match_check(compare256_rle_func compare256_rle
 
 TEST_COMPARE256_RLE(c, compare256_rle_c, 1)
 
-#ifdef UNALIGNED_OK
+#if defined(UNALIGNED_OK) && BYTE_ORDER == LITTLE_ENDIAN
 TEST_COMPARE256_RLE(unaligned_16, compare256_rle_unaligned_16, 1)
 #ifdef HAVE_BUILTIN_CTZ
 TEST_COMPARE256_RLE(unaligned_32, compare256_rle_unaligned_32, 1)

--- a/zbuild.h
+++ b/zbuild.h
@@ -239,10 +239,10 @@
 #      define UNALIGNED_OK
 #    endif
 #  elif defined(__powerpc64__) || defined(__ppc64__)
-#    if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-#      define UNALIGNED_OK
-#      define UNALIGNED64_OK
-#    endif
+#    define UNALIGNED_OK
+#    define UNALIGNED64_OK
+#  elif defined(__powerpc__) || defined(__ppc__) || defined(__PPC__)
+#    define UNALIGNED_OK
 #  endif
 #endif
 


### PR DESCRIPTION
See also PR #1469. This will need testing on actual hardware, but it should work fine.