### PR TITLE
Fix kernel ASLR breaking LLVM ASAN/MSAN builds

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -568,6 +568,12 @@ jobs:
             cmake-args: -DWITH_NATIVE_INSTRUCTIONS=ON
 
     steps:
+    - name: Kernel ASLR
+      if: runner.os == 'Linux' && !contains(matrix.os, 'z15')
+      # Works around Kernel address randomization breaking LLVM ASAN/MSAN builds
+      # Ref: https://github.com/actions/runner-images/issues/9491
+      run: sudo sysctl vm.mmap_rnd_bits=28
+
     - name: Checkout repository
       uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Ubuntu image 20240310 contained a more secure kernel build with increased kernel address randomization settings.
This is unfortunately incompatible with the provided LLVM build, and makes MSAN/ASAN crash with segfaults.

Image update fixing this is ETA March 22.

Ref: https://github.com/actions/runner-images/issues/9491#issuecomment-1989718917