### PR TITLE
Allow disabling runtime CPU features detection in tests and benchmarks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -679,8 +679,12 @@ if(WITH_OPTIM)
                 endif()
             endif()
         endif()
-        list(APPEND ZLIB_ARCH_HDRS ${ARCHDIR}/arm_features.h ${ARCHDIR}/arm_functions.h)
-        list(APPEND ZLIB_ARCH_SRCS ${ARCHDIR}/arm_features.c)
+        list(APPEND ZLIB_ARCH_HDRS ${ARCHDIR}/arm_functions.h)
+        if(WITH_RUNTIME_CPU_DETECTION)
+            list(APPEND ZLIB_ARCH_HDRS ${ARCHDIR}/arm_features.h)
+            list(APPEND ZLIB_ARCH_SRCS ${ARCHDIR}/arm_features.c)
+        endif()
+
         if(WITH_ACLE)
             check_acle_compiler_flag()
             if(HAVE_ACLE_FLAG)
@@ -751,8 +755,11 @@ if(WITH_OPTIM)
             add_definitions(-DPOWER_FEATURES)
         endif()
         if(HAVE_VMX OR HAVE_POWER8_INTRIN OR HAVE_POWER9_INTRIN)
-            list(APPEND ZLIB_ARCH_HDRS ${ARCHDIR}/power_features.h ${ARCHDIR}/power_functions.h)
-            list(APPEND ZLIB_ARCH_SRCS ${ARCHDIR}/power_features.c)
+            list(APPEND ZLIB_ARCH_HDRS ${ARCHDIR}/power_functions.h)
+            if(WITH_RUNTIME_CPU_DETECTION)
+                list(APPEND ZLIB_ARCH_HDRS ${ARCHDIR}/power_features.h)
+                list(APPEND ZLIB_ARCH_SRCS ${ARCHDIR}/power_features.c)
+            endif()
         endif()
         # VMX specific options and files
         if(WITH_ALTIVEC)
@@ -801,11 +808,17 @@ if(WITH_OPTIM)
             if(HAVE_RVV_INTRIN)
                 add_definitions(-DRISCV_FEATURES)
                 add_definitions(-DRISCV_RVV)
-                list(APPEND ZLIB_ARCH_HDRS ${ARCHDIR}/riscv_features.h ${ARCHDIR}/riscv_functions.h)
-                list(APPEND ZLIB_ARCH_SRCS ${ARCHDIR}/riscv_features.c)
+                list(APPEND ZLIB_ARCH_HDRS ${ARCHDIR}/riscv_functions.h)
+                if(WITH_RUNTIME_CPU_DETECTION)
+                    list(APPEND ZLIB_ARCH_HDRS ${ARCHDIR}/riscv_features.h)
+                    list(APPEND ZLIB_ARCH_SRCS ${ARCHDIR}/riscv_features.c)
+                endif()
                 # FIXME: we will not set compile flags for riscv_features.c when
                 # the kernels update hwcap or hwprobe for riscv
-                set(RVV_SRCS ${ARCHDIR}/riscv_features.c ${ARCHDIR}/adler32_rvv.c ${ARCHDIR}/chunkset_rvv.c ${ARCHDIR}/compare256_rvv.c ${ARCHDIR}/slide_hash_rvv.c)
+                set(RVV_SRCS ${ARCHDIR}/adler32_rvv.c ${ARCHDIR}/chunkset_rvv.c ${ARCHDIR}/compare256_rvv.c ${ARCHDIR}/slide_hash_rvv.c)
+                if(WITH_RUNTIME_CPU_DETECTION)
+                    list(APPEND RVV_SRCS ${ARCHDIR}/riscv_features.c)
+                endif()
                 list(APPEND ZLIB_ARCH_SRCS ${RVV_SRCS})
                 set_property(SOURCE ${RVV_SRCS} PROPERTY COMPILE_FLAGS "${RISCVFLAG} ${NOLTOFLAG}")
             else()
@@ -816,8 +829,11 @@ if(WITH_OPTIM)
         check_s390_intrinsics()
         if(HAVE_S390_INTRIN)
             add_definitions(-DS390_FEATURES)
-            list(APPEND ZLIB_ARCH_HDRS ${ARCHDIR}/s390_features.h ${ARCHDIR}/s390_functions.h)
-            list(APPEND ZLIB_ARCH_SRCS ${ARCHDIR}/s390_features.c)
+            list(APPEND ZLIB_ARCH_HDRS ${ARCHDIR}/s390_functions.h)
+            if(WITH_RUNTIME_CPU_DETECTION)
+                list(APPEND ZLIB_ARCH_HDRS ${ARCHDIR}/s390_features.h)
+                list(APPEND ZLIB_ARCH_SRCS ${ARCHDIR}/s390_features.c)
+            endif()
         endif()
         if(WITH_DFLTCC_DEFLATE OR WITH_DFLTCC_INFLATE)
             list(APPEND ZLIB_ARCH_SRCS ${ARCHDIR}/dfltcc_common.c)
@@ -843,15 +859,20 @@ if(WITH_OPTIM)
         endif()
     elseif(BASEARCH_X86_FOUND)
         add_definitions(-DX86_FEATURES)
-        list(APPEND ZLIB_ARCH_HDRS ${ARCHDIR}/x86_features.h ${ARCHDIR}/x86_functions.h)
-        list(APPEND ZLIB_ARCH_SRCS ${ARCHDIR}/x86_features.c)
+        list(APPEND ZLIB_ARCH_HDRS ${ARCHDIR}/x86_functions.h)
+        if(WITH_RUNTIME_CPU_DETECTION)
+            list(APPEND ZLIB_ARCH_HDRS ${ARCHDIR}/x86_features.h)
+            list(APPEND ZLIB_ARCH_SRCS ${ARCHDIR}/x86_features.c)
+        endif()
         if(MSVC)
             list(APPEND ZLIB_ARCH_HDRS fallback_builtins.h)
         endif()
         check_xsave_intrinsics()
         if(HAVE_XSAVE_INTRIN)
             add_feature_info(XSAVE 1 "Support XSAVE intrinsics using \"${XSAVEFLAG}\"")
-            set_property(SOURCE ${ARCHDIR}/x86_features.c PROPERTY COMPILE_FLAGS "${XSAVEFLAG}")
+            if(WITH_RUNTIME_CPU_DETECTION)
+                set_property(SOURCE ${ARCHDIR}/x86_features.c PROPERTY COMPILE_FLAGS "${XSAVEFLAG}")
+            endif()
             if(NOT (CMAKE_C_COMPILER_ID MATCHES "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_LESS 8.2))
                 add_definitions(-DX86_HAVE_XSAVE_INTRIN)
             endif()
@@ -1038,7 +1059,6 @@ set(ZLIB_PRIVATE_HDRS
     chunkset_tpl.h
     compare256_rle.h
     arch_functions.h
-    cpu_features.h
     crc32_braid_p.h
     crc32_braid_comb_p.h
     crc32_braid_tbl.h
@@ -1069,7 +1089,6 @@ set(ZLIB_SRCS
     arch/generic/slide_hash_c.c
     adler32.c
     compress.c
-    cpu_features.c
     crc32.c
     crc32_braid_comb.c
     deflate.c
@@ -1090,6 +1109,11 @@ set(ZLIB_SRCS
     uncompr.c
     zutil.c
 )
+
+if(WITH_RUNTIME_CPU_DETECTION)
+    list(APPEND ZLIB_PRIVATE_HDRS cpu_features.h)
+    list(APPEND ZLIB_SRCS cpu_features.c)
+endif()
 
 set(ZLIB_GZFILE_PRIVATE_HDRS
     gzguts.h

--- a/Makefile.in
+++ b/Makefile.in
@@ -83,7 +83,6 @@ OBJZ = \
 	arch/generic/slide_hash_c.o \
 	adler32.o \
 	compress.o \
-	cpu_features.o \
 	crc32.o \
 	crc32_braid_comb.o \
 	deflate.o \
@@ -103,6 +102,7 @@ OBJZ = \
 	trees.o \
 	uncompr.o \
 	zutil.o \
+	cpu_features.o \
 	$(ARCH_STATIC_OBJS)
 
 OBJG = \
@@ -123,7 +123,6 @@ PIC_OBJZ = \
 	arch/generic/slide_hash_c.lo \
 	adler32.lo \
 	compress.lo \
-	cpu_features.lo \
 	crc32.lo \
 	crc32_braid_comb.lo \
 	deflate.lo \
@@ -143,6 +142,7 @@ PIC_OBJZ = \
 	trees.lo \
 	uncompr.lo \
 	zutil.lo \
+	cpu_features.lo \
 	$(ARCH_SHARED_OBJS)
 
 PIC_OBJG = \

--- a/cpu_features.h
+++ b/cpu_features.h
@@ -6,6 +6,8 @@
 #ifndef CPU_FEATURES_H_
 #define CPU_FEATURES_H_
 
+#ifndef DISABLE_RUNTIME_CPU_DETECTION
+
 #if defined(X86_FEATURES)
 #  include "arch/x86/x86_features.h"
 #elif defined(ARM_FEATURES)
@@ -35,5 +37,7 @@ struct cpu_features {
 };
 
 void cpu_check_features(struct cpu_features *features);
+
+#endif
 
 #endif

--- a/test/benchmarks/benchmark_adler32.cc
+++ b/test/benchmarks/benchmark_adler32.cc
@@ -65,6 +65,10 @@ public:
 
 BENCHMARK_ADLER32(c, adler32_c, 1);
 
+#ifdef DISABLE_RUNTIME_CPU_DETECTION
+BENCHMARK_ADLER32(native, native_adler32, 1);
+#else
+
 #ifdef ARM_NEON
 BENCHMARK_ADLER32(neon, adler32_neon, test_cpu_features.arm.has_neon);
 #endif
@@ -91,4 +95,6 @@ BENCHMARK_ADLER32(avx512, adler32_avx512, test_cpu_features.x86.has_avx512);
 #endif
 #ifdef X86_AVX512VNNI
 BENCHMARK_ADLER32(avx512_vnni, adler32_avx512_vnni, test_cpu_features.x86.has_avx512vnni);
+#endif
+
 #endif

--- a/test/benchmarks/benchmark_adler32_copy.cc
+++ b/test/benchmarks/benchmark_adler32_copy.cc
@@ -86,6 +86,10 @@ public:
 
 BENCHMARK_ADLER32_BASELINE_COPY(c, adler32_c, 1);
 
+#ifdef DISABLE_RUNTIME_CPU_DETECTION
+BENCHMARK_ADLER32_BASELINE_COPY(native, native_adler32, 1);
+#else
+
 #ifdef ARM_NEON
 /* If we inline this copy for neon, the function would go here */
 //BENCHMARK_ADLER32_COPY(neon, adler32_neon, test_cpu_features.arm.has_neon);
@@ -121,4 +125,6 @@ BENCHMARK_ADLER32_COPY(avx512, adler32_fold_copy_avx512, test_cpu_features.x86.h
 #ifdef X86_AVX512VNNI
 BENCHMARK_ADLER32_BASELINE_COPY(avx512_vnni_baseline, adler32_avx512_vnni, test_cpu_features.x86.has_avx512vnni);
 BENCHMARK_ADLER32_COPY(avx512_vnni, adler32_fold_copy_avx512_vnni, test_cpu_features.x86.has_avx512vnni);
+#endif
+
 #endif

--- a/test/benchmarks/benchmark_compare256.cc
+++ b/test/benchmarks/benchmark_compare256.cc
@@ -62,6 +62,10 @@ public:
 
 BENCHMARK_COMPARE256(c, compare256_c, 1);
 
+#ifdef DISABLE_RUNTIME_CPU_DETECTION
+BENCHMARK_COMPARE256(native, native_compare256, 1);
+#else
+
 #if defined(UNALIGNED_OK) && BYTE_ORDER == LITTLE_ENDIAN
 BENCHMARK_COMPARE256(unaligned_16, compare256_unaligned_16, 1);
 #ifdef HAVE_BUILTIN_CTZ
@@ -85,4 +89,6 @@ BENCHMARK_COMPARE256(power9, compare256_power9, test_cpu_features.power.has_arch
 #endif
 #ifdef RISCV_RVV
 BENCHMARK_COMPARE256(rvv, compare256_rvv, test_cpu_features.riscv.has_rvv);
+#endif
+
 #endif

--- a/test/benchmarks/benchmark_crc32.cc
+++ b/test/benchmarks/benchmark_crc32.cc
@@ -58,6 +58,10 @@ public:
 
 BENCHMARK_CRC32(braid, PREFIX(crc32_braid), 1);
 
+#ifdef DISABLE_RUNTIME_CPU_DETECTION
+BENCHMARK_CRC32(native, native_crc32, 1);
+#else
+
 #ifdef ARM_ACLE
 BENCHMARK_CRC32(acle, crc32_acle, test_cpu_features.arm.has_crc32);
 #endif
@@ -74,4 +78,6 @@ BENCHMARK_CRC32(pclmulqdq, crc32_pclmulqdq, test_cpu_features.x86.has_pclmulqdq)
 #ifdef X86_VPCLMULQDQ_CRC
 /* CRC32 fold does a memory copy while hashing */
 BENCHMARK_CRC32(vpclmulqdq, crc32_vpclmulqdq, (test_cpu_features.x86.has_pclmulqdq && test_cpu_features.x86.has_avx512 && test_cpu_features.x86.has_vpclmulqdq));
+#endif
+
 #endif

--- a/test/benchmarks/benchmark_main.cc
+++ b/test/benchmarks/benchmark_main.cc
@@ -12,13 +12,17 @@ extern "C" {
 #  include "zbuild.h"
 #  include "../test_cpu_features.h"
 
+#  ifndef DISABLE_RUNTIME_CPU_DETECTION
     struct cpu_features test_cpu_features;
+#  endif
 }
 #endif
 
 int main(int argc, char** argv) {
 #ifndef BUILD_ALT
+#  ifndef DISABLE_RUNTIME_CPU_DETECTION
     cpu_check_features(&test_cpu_features);
+#  endif
 #endif
 
     ::benchmark::Initialize(&argc, argv);

--- a/test/benchmarks/benchmark_slidehash.cc
+++ b/test/benchmarks/benchmark_slidehash.cc
@@ -69,6 +69,10 @@ public:
 
 BENCHMARK_SLIDEHASH(c, slide_hash_c, 1);
 
+#ifdef DISABLE_RUNTIME_CPU_DETECTION
+BENCHMARK_SLIDEHASH(native, native_slide_hash, 1);
+#else
+
 #ifdef ARM_SIMD
 BENCHMARK_SLIDEHASH(armv6, slide_hash_armv6, test_cpu_features.arm.has_simd);
 #endif
@@ -89,4 +93,6 @@ BENCHMARK_SLIDEHASH(sse2, slide_hash_sse2, test_cpu_features.x86.has_sse2);
 #endif
 #ifdef X86_AVX2
 BENCHMARK_SLIDEHASH(avx2, slide_hash_avx2, test_cpu_features.x86.has_avx2);
+#endif
+
 #endif

--- a/test/test_adler32.cc
+++ b/test/test_adler32.cc
@@ -365,6 +365,10 @@ INSTANTIATE_TEST_SUITE_P(adler32, adler32_variant, testing::ValuesIn(tests));
 
 TEST_ADLER32(c, adler32_c, 1)
 
+#ifdef DISABLE_RUNTIME_CPU_DETECTION
+TEST_ADLER32(native, native_adler32, 1)
+#else
+
 #ifdef ARM_NEON
 TEST_ADLER32(neon, adler32_neon, test_cpu_features.arm.has_neon)
 #elif defined(POWER8_VSX)
@@ -386,4 +390,6 @@ TEST_ADLER32(avx512, adler32_avx512, test_cpu_features.x86.has_avx512)
 #endif
 #ifdef X86_AVX512VNNI
 TEST_ADLER32(avx512_vnni, adler32_avx512_vnni, test_cpu_features.x86.has_avx512vnni)
+#endif
+
 #endif

--- a/test/test_compare256.cc
+++ b/test/test_compare256.cc
@@ -61,6 +61,10 @@ static inline void compare256_match_check(compare256_func compare256) {
 
 TEST_COMPARE256(c, compare256_c, 1)
 
+#ifdef DISABLE_RUNTIME_CPU_DETECTION
+TEST_COMPARE256(native, native_compare256, 1)
+#else
+
 #if defined(UNALIGNED_OK) && BYTE_ORDER == LITTLE_ENDIAN
 TEST_COMPARE256(unaligned_16, compare256_unaligned_16, 1)
 #ifdef HAVE_BUILTIN_CTZ
@@ -84,4 +88,6 @@ TEST_COMPARE256(power9, compare256_power9, test_cpu_features.power.has_arch_3_00
 #endif
 #ifdef RISCV_RVV
 TEST_COMPARE256(rvv, compare256_rvv, test_cpu_features.riscv.has_rvv)
+#endif
+
 #endif

--- a/test/test_cpu_features.h
+++ b/test/test_cpu_features.h
@@ -1,8 +1,12 @@
 #ifndef TEST_CPU_FEATURES_H
 #define TEST_CPU_FEATURES_H
 
-#include "cpu_features.h"
+#ifndef DISABLE_RUNTIME_CPU_DETECTION
+
+#  include "cpu_features.h"
 
 extern struct cpu_features test_cpu_features;
+
+#endif
 
 #endif

--- a/test/test_crc32.cc
+++ b/test/test_crc32.cc
@@ -208,6 +208,10 @@ INSTANTIATE_TEST_SUITE_P(crc32, crc32_variant, testing::ValuesIn(tests));
 
 TEST_CRC32(braid, PREFIX(crc32_braid), 1)
 
+#ifdef DISABLE_RUNTIME_CPU_DETECTION
+TEST_CRC32(native, native_crc32, 1)
+#else
+
 #ifdef ARM_ACLE
 TEST_CRC32(acle, crc32_acle, test_cpu_features.arm.has_crc32)
 #endif
@@ -222,4 +226,6 @@ TEST_CRC32(pclmulqdq, crc32_pclmulqdq, test_cpu_features.x86.has_pclmulqdq)
 #endif
 #ifdef X86_VPCLMULQDQ_CRC
 TEST_CRC32(vpclmulqdq, crc32_vpclmulqdq, (test_cpu_features.x86.has_pclmulqdq && test_cpu_features.x86.has_avx512 && test_cpu_features.x86.has_vpclmulqdq))
+#endif
+
 #endif

--- a/test/test_main.cc
+++ b/test/test_main.cc
@@ -7,13 +7,16 @@
 extern "C" {
 #  include "zbuild.h"
 #  include "test_cpu_features.h"
-
+#  ifndef DISABLE_RUNTIME_CPU_DETECTION
     struct cpu_features test_cpu_features;
+#  endif
 }
 
 GTEST_API_ int main(int argc, char **argv) {
   printf("Running main() from %s\n", __FILE__);
+#ifndef DISABLE_RUNTIME_CPU_DETECTION
   cpu_check_features(&test_cpu_features);
+#endif
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
The ``cpu_check_features`` and arch-specific ``*_check_features`` functions are no longer used and not included in the build if runtime checks are disabled.