### PR TITLE
Remove obsolete TARGET_OS_MAC check

### DIFF
--- a/zutil.h
+++ b/zutil.h
@@ -103,7 +103,7 @@ extern z_const char * const PREFIX(z_errmsg)[10]; /* indexed by 2-zlib_error */
 #  define OS_CODE  6
 #endif
 
-#if defined(MACOS) || defined(TARGET_OS_MAC)
+#if defined(MACOS)
 #  define OS_CODE  7
 #endif
 


### PR DESCRIPTION
Issue: #1702
zlib: https://github.com/madler/zlib/commit/4bd9a71f3539b5ce47f0c67ab5e01f3196dc8ef9
LLVM: https://github.com/llvm/llvm-project/pull/74676
