### PR TITLE
Bump max CMake policy version to 3.29.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5.1)
 if(CMAKE_VERSION VERSION_LESS 3.12)
     cmake_policy(VERSION ${CMAKE_VERSION})
 else()
-    cmake_policy(VERSION 3.5.1...3.13.2)
+    cmake_policy(VERSION 3.5.1...3.29.0)
 endif()
 message(STATUS "Using CMake version ${CMAKE_VERSION}")
 


### PR DESCRIPTION
Addresses:

  3.29.0/share/cmake/Modules/CMakeDependentOption.cmake:89 (message):
    Policy CMP0127 is not set: cmake_dependent_option() supports full Condition
    Syntax.  Run "cmake --help-policy CMP0127" for policy details.  Use the
    cmake_policy command to set the policy and suppress this warning.
  Call Stack (most recent call first):
    CMakeLists.txt:107 (cmake_dependent_option)
This warning is for project developers.  Use -Wno-dev to suppress it.
