### PR TITLE
.gitattributes: Do no longer mess with line-endings and leave as is

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,11 +1,12 @@
-* text=auto
-*.abi text eol=lf
-*.c text
-*.h text
-*.sh text eol=lf
+# Do NO line-ending conversion on any file (by default)!
+* -text
+# Note: If one wants a specific line-ending on a file, one has to make sure to commit it
+#       with the correct line-endings! If at some point all files are committed with
+#       correct line-endings one should use some other mechanism (e.g. clang-format or
+#       .editorconfig) to ensure that no different line-endings are introduced.
+
+
 crc32_braid_tbl.h hooks-max-size=1000000
-Makefile text
-configure text eol=lf
 
 # Don't export git/github-related files in tar/zip archives
 /.github export-ignore  


### PR DESCRIPTION
Although Git is able to automatically modify line-endings during checkin and checkout, this brings a lot of trouble, especially when trying to use a repository from different platforms (as Windows and Linux).  
**Therefore, Git should leave line-endings as is and should not automatically modify them during checkin and checkout.**

_It is the committer's responsibility to commit files with correct line-endings (preferably `LF`) and the reviewer's responsibility to ensure that no wrong line-endings are introduced through pull-requests._

Probably, some tool like `clang-format` or an `.editorconfig` file for text-editors and IDEs should enforce line-endings.