### PR TITLE
.gitattributes: Enforce LF line-endings on all non-binary files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,11 +1,7 @@
-* text=auto
-*.abi text eol=lf
-*.c text
-*.h text
-*.sh text eol=lf
+# By default, enforce LF line-endings on all files that are not considered binary files!
+* text=auto eol=lf
+
 crc32_braid_tbl.h hooks-max-size=1000000
-Makefile text
-configure text eol=lf
 
 # Don't export git/github-related files in tar/zip archives
 /.github export-ignore  


### PR DESCRIPTION
Although Git is able to automatically modify line-endings during checkin and checkout, this brings a lot of trouble, especially when trying to use a repository from different platforms (as Windows and Linux). This is due to the fact that Git consults different local gitconfig settings and uses problematic defaults if not set.

Therefore, Git should enfoce one type of line-ending (LF) and not consult the local config, which is what the change from this commit does.