### PR TITLE
IBM zSystems DFLTCC: Inline DLFTCC states into zlib states

### DIFF
--- a/arch/s390/README.md
+++ b/arch/s390/README.md
@@ -61,11 +61,10 @@ integrated with the rest of zlib-ng using hook macros.
 ## Hook macros
 
 DFLTCC takes as arguments a parameter block, an input buffer, an output
-buffer and a window. `ZALLOC_DEFLATE_STATE()`, `ZALLOC_INFLATE_STATE()`,
-`ZFREE_STATE()`, `ZCOPY_DEFLATE_STATE()`, `ZCOPY_INFLATE_STATE()`,
-`ZALLOC_WINDOW()`, `ZCOPY_WINDOW()` and `TRY_FREE_WINDOW()` macros encapsulate
-allocation  details for the parameter block (which is allocated alongside
-zlib-ng state) and the window (which must be page-aligned and large enough).
+buffer, and a window. Parameter blocks are stored alongside zlib states;
+buffers are forwarded from the caller; and window (which must be page-aligned)
+is managed using `ZALLOC_WINDOW()`, `ZCOPY_WINDOW()` and `TRY_FREE_WINDOW()`
+macros.
 
 Software and hardware window formats do not match, therefore,
 `deflateSetDictionary()`, `deflateGetDictionary()`, `inflateSetDictionary()`

--- a/arch/s390/dfltcc_common.h
+++ b/arch/s390/dfltcc_common.h
@@ -3,11 +3,89 @@
 
 #include "zutil.h"
 
+/*
+   Parameter Block for Query Available Functions.
+ */
+struct dfltcc_qaf_param {
+    char fns[16];
+    char reserved1[8];
+    char fmts[2];
+    char reserved2[6];
+} ALIGNED_(8);
+
+/*
+   Parameter Block for Generate Dynamic-Huffman Table, Compress and Expand.
+ */
+struct dfltcc_param_v0 {
+    uint16_t pbvn;                     /* Parameter-Block-Version Number */
+    uint8_t mvn;                       /* Model-Version Number */
+    uint8_t ribm;                      /* Reserved for IBM use */
+    uint32_t reserved32 : 31;
+    uint32_t cf : 1;                   /* Continuation Flag */
+    uint8_t reserved64[8];
+    uint32_t nt : 1;                   /* New Task */
+    uint32_t reserved129 : 1;
+    uint32_t cvt : 1;                  /* Check Value Type */
+    uint32_t reserved131 : 1;
+    uint32_t htt : 1;                  /* Huffman-Table Type */
+    uint32_t bcf : 1;                  /* Block-Continuation Flag */
+    uint32_t bcc : 1;                  /* Block Closing Control */
+    uint32_t bhf : 1;                  /* Block Header Final */
+    uint32_t reserved136 : 1;
+    uint32_t reserved137 : 1;
+    uint32_t dhtgc : 1;                /* DHT Generation Control */
+    uint32_t reserved139 : 5;
+    uint32_t reserved144 : 5;
+    uint32_t sbb : 3;                  /* Sub-Byte Boundary */
+    uint8_t oesc;                      /* Operation-Ending-Supplemental Code */
+    uint32_t reserved160 : 12;
+    uint32_t ifs : 4;                  /* Incomplete-Function Status */
+    uint16_t ifl;                      /* Incomplete-Function Length */
+    uint8_t reserved192[8];
+    uint8_t reserved256[8];
+    uint8_t reserved320[4];
+    uint16_t hl;                       /* History Length */
+    uint32_t reserved368 : 1;
+    uint16_t ho : 15;                  /* History Offset */
+    uint32_t cv;                       /* Check Value */
+    uint32_t eobs : 15;                /* End-of-block Symbol */
+    uint32_t reserved431: 1;
+    uint8_t eobl : 4;                  /* End-of-block Length */
+    uint32_t reserved436 : 12;
+    uint32_t reserved448 : 4;
+    uint16_t cdhtl : 12;               /* Compressed-Dynamic-Huffman Table
+                                          Length */
+    uint8_t reserved464[6];
+    uint8_t cdht[288];                 /* Compressed-Dynamic-Huffman Table */
+    uint8_t reserved[24];
+    uint8_t ribm2[8];                  /* Reserved for IBM use */
+    uint8_t csb[1152];                 /* Continuation-State Buffer */
+} ALIGNED_(8);
+
+/*
+   Extension of inflate_state and deflate_state.
+ */
+struct dfltcc_state {
+    struct dfltcc_param_v0 param;      /* Parameter block. */
+    struct dfltcc_qaf_param af;        /* Available functions. */
+    char msg[64];                      /* Buffer for strm->msg */
+};
+
+typedef struct {
+    struct dfltcc_state common;
+    uint16_t level_mask;               /* Levels on which to use DFLTCC */
+    uint32_t block_size;               /* New block each X bytes */
+    size_t block_threshold;            /* New block after total_in > X */
+    uint32_t dht_threshold;            /* New block only if avail_in >= X */
+} arch_deflate_state;
+
+typedef struct {
+    struct dfltcc_state common;
+} arch_inflate_state;
+
 void Z_INTERNAL *PREFIX(dfltcc_alloc_window)(PREFIX3(streamp) strm, uInt items, uInt size);
 void Z_INTERNAL PREFIX(dfltcc_copy_window)(void *dest, const void *src, size_t n);
 void Z_INTERNAL PREFIX(dfltcc_free_window)(PREFIX3(streamp) strm, void *w);
-
-#define ZFREE_STATE ZFREE
 
 #define ZALLOC_WINDOW PREFIX(dfltcc_alloc_window)
 

--- a/arch/s390/dfltcc_deflate.h
+++ b/arch/s390/dfltcc_deflate.h
@@ -1,11 +1,10 @@
 #ifndef DFLTCC_DEFLATE_H
 #define DFLTCC_DEFLATE_H
 
+#include "deflate.h"
 #include "dfltcc_common.h"
 
-void Z_INTERNAL *PREFIX(dfltcc_alloc_deflate_state)(PREFIX3(streamp));
 void Z_INTERNAL PREFIX(dfltcc_reset_deflate_state)(PREFIX3(streamp));
-void Z_INTERNAL PREFIX(dfltcc_copy_deflate_state)(void *dst, const void *src);
 int Z_INTERNAL PREFIX(dfltcc_can_deflate)(PREFIX3(streamp) strm);
 int Z_INTERNAL PREFIX(dfltcc_deflate)(PREFIX3(streamp) strm, int flush, block_state *result);
 int Z_INTERNAL PREFIX(dfltcc_deflate_params)(PREFIX3(streamp) strm, int level, int strategy, int *flush);
@@ -14,9 +13,6 @@ int Z_INTERNAL PREFIX(dfltcc_can_set_reproducible)(PREFIX3(streamp) strm, int re
 int Z_INTERNAL PREFIX(dfltcc_deflate_set_dictionary)(PREFIX3(streamp) strm,
                                                 const unsigned char *dictionary, uInt dict_length);
 int Z_INTERNAL PREFIX(dfltcc_deflate_get_dictionary)(PREFIX3(streamp) strm, unsigned char *dictionary, uInt* dict_length);
-
-#define ZALLOC_DEFLATE_STATE PREFIX(dfltcc_alloc_deflate_state)
-#define ZCOPY_DEFLATE_STATE PREFIX(dfltcc_copy_deflate_state)
 
 #define DEFLATE_SET_DICTIONARY_HOOK(strm, dict, dict_len) \
     do { \

--- a/arch/s390/dfltcc_detail.h
+++ b/arch/s390/dfltcc_detail.h
@@ -24,17 +24,7 @@
 #define DFLTCC_RIBM 0
 #endif
 
-/*
-   Parameter Block for Query Available Functions.
- */
 #define static_assert(c, msg) __attribute__((unused)) static char static_assert_failed_ ## msg[c ? 1 : -1]
-
-struct dfltcc_qaf_param {
-    char fns[16];
-    char reserved1[8];
-    char fmts[2];
-    char reserved2[6];
-};
 
 #define DFLTCC_SIZEOF_QAF 32
 static_assert(sizeof(struct dfltcc_qaf_param) == DFLTCC_SIZEOF_QAF, qaf);
@@ -74,59 +64,10 @@ static inline int is_dfltcc_enabled(void) {
 
 #define DFLTCC_FMT0 0
 
-/*
-   Parameter Block for Generate Dynamic-Huffman Table, Compress and Expand.
- */
 #define CVT_CRC32 0
 #define CVT_ADLER32 1
 #define HTT_FIXED 0
 #define HTT_DYNAMIC 1
-
-struct dfltcc_param_v0 {
-    uint16_t pbvn;                     /* Parameter-Block-Version Number */
-    uint8_t mvn;                       /* Model-Version Number */
-    uint8_t ribm;                      /* Reserved for IBM use */
-    uint32_t reserved32 : 31;
-    uint32_t cf : 1;                   /* Continuation Flag */
-    uint8_t reserved64[8];
-    uint32_t nt : 1;                   /* New Task */
-    uint32_t reserved129 : 1;
-    uint32_t cvt : 1;                  /* Check Value Type */
-    uint32_t reserved131 : 1;
-    uint32_t htt : 1;                  /* Huffman-Table Type */
-    uint32_t bcf : 1;                  /* Block-Continuation Flag */
-    uint32_t bcc : 1;                  /* Block Closing Control */
-    uint32_t bhf : 1;                  /* Block Header Final */
-    uint32_t reserved136 : 1;
-    uint32_t reserved137 : 1;
-    uint32_t dhtgc : 1;                /* DHT Generation Control */
-    uint32_t reserved139 : 5;
-    uint32_t reserved144 : 5;
-    uint32_t sbb : 3;                  /* Sub-Byte Boundary */
-    uint8_t oesc;                      /* Operation-Ending-Supplemental Code */
-    uint32_t reserved160 : 12;
-    uint32_t ifs : 4;                  /* Incomplete-Function Status */
-    uint16_t ifl;                      /* Incomplete-Function Length */
-    uint8_t reserved192[8];
-    uint8_t reserved256[8];
-    uint8_t reserved320[4];
-    uint16_t hl;                       /* History Length */
-    uint32_t reserved368 : 1;
-    uint16_t ho : 15;                  /* History Offset */
-    uint32_t cv;                       /* Check Value */
-    uint32_t eobs : 15;                /* End-of-block Symbol */
-    uint32_t reserved431: 1;
-    uint8_t eobl : 4;                  /* End-of-block Length */
-    uint32_t reserved436 : 12;
-    uint32_t reserved448 : 4;
-    uint16_t cdhtl : 12;               /* Compressed-Dynamic-Huffman Table
-                                          Length */
-    uint8_t reserved464[6];
-    uint8_t cdht[288];                 /* Compressed-Dynamic-Huffman Table */
-    uint8_t reserved[24];
-    uint8_t ribm2[8];                  /* Reserved for IBM use */
-    uint8_t csb[1152];                 /* Continuation-State Buffer */
-};
 
 #define DFLTCC_SIZEOF_GDHT_V0 384
 #define DFLTCC_SIZEOF_CMPR_XPND_V0 1536
@@ -229,18 +170,7 @@ static inline dfltcc_cc dfltcc(int fn, void *param,
     return (cc >> 28) & 3;
 }
 
-/*
-   Extension of inflate_state and deflate_state. Must be doubleword-aligned.
-*/
-struct dfltcc_state {
-    struct dfltcc_param_v0 param;      /* Parameter block. */
-    struct dfltcc_qaf_param af;        /* Available functions. */
-    char msg[64];                      /* Buffer for strm->msg */
-};
-
 #define ALIGN_UP(p, size) (__typeof__(p))(((uintptr_t)(p) + ((size) - 1)) & ~((size) - 1))
-
-#define GET_DFLTCC_STATE(state) ((struct dfltcc_state *)((char *)(state) + ALIGN_UP(sizeof(*state), 8)))
 
 static inline void *dfltcc_alloc_state(PREFIX3(streamp) strm, uInt size, uInt extension_size) {
     return ZALLOC(strm, 1, ALIGN_UP(size, 8) + extension_size);

--- a/arch/s390/dfltcc_inflate.c
+++ b/arch/s390/dfltcc_inflate.c
@@ -20,24 +20,15 @@
 #include "dfltcc_inflate.h"
 #include "dfltcc_detail.h"
 
-struct inflate_state Z_INTERNAL *PREFIX(dfltcc_alloc_inflate_state)(PREFIX3(streamp) strm) {
-    return (struct inflate_state *)dfltcc_alloc_state(strm, sizeof(struct inflate_state), sizeof(struct dfltcc_state));
-}
-
 void Z_INTERNAL PREFIX(dfltcc_reset_inflate_state)(PREFIX3(streamp) strm) {
     struct inflate_state *state = (struct inflate_state *)strm->state;
-    struct dfltcc_state *dfltcc_state = GET_DFLTCC_STATE(state);
 
-    dfltcc_reset_state(dfltcc_state);
-}
-
-void Z_INTERNAL PREFIX(dfltcc_copy_inflate_state)(struct inflate_state *dst, const struct inflate_state *src) {
-    dfltcc_copy_state(dst, src, sizeof(struct inflate_state), sizeof(struct dfltcc_state));
+    dfltcc_reset_state(&state->arch.common);
 }
 
 int Z_INTERNAL PREFIX(dfltcc_can_inflate)(PREFIX3(streamp) strm) {
     struct inflate_state *state = (struct inflate_state *)strm->state;
-    struct dfltcc_state *dfltcc_state = GET_DFLTCC_STATE(state);
+    struct dfltcc_state *dfltcc_state = &state->arch.common;
 
     /* Unsupported hardware */
     return is_bit_set(dfltcc_state->af.fns, DFLTCC_XPND) && is_bit_set(dfltcc_state->af.fmts, DFLTCC_FMT0);
@@ -45,7 +36,7 @@ int Z_INTERNAL PREFIX(dfltcc_can_inflate)(PREFIX3(streamp) strm) {
 
 static inline dfltcc_cc dfltcc_xpnd(PREFIX3(streamp) strm) {
     struct inflate_state *state = (struct inflate_state *)strm->state;
-    struct dfltcc_param_v0 *param = &GET_DFLTCC_STATE(state)->param;
+    struct dfltcc_param_v0 *param = &state->arch.common.param;
     size_t avail_in = strm->avail_in;
     size_t avail_out = strm->avail_out;
     dfltcc_cc cc;
@@ -60,7 +51,7 @@ static inline dfltcc_cc dfltcc_xpnd(PREFIX3(streamp) strm) {
 
 dfltcc_inflate_action Z_INTERNAL PREFIX(dfltcc_inflate)(PREFIX3(streamp) strm, int flush, int *ret) {
     struct inflate_state *state = (struct inflate_state *)strm->state;
-    struct dfltcc_state *dfltcc_state = GET_DFLTCC_STATE(state);
+    struct dfltcc_state *dfltcc_state = &state->arch.common;
     struct dfltcc_param_v0 *param = &dfltcc_state->param;
     dfltcc_cc cc;
 
@@ -123,9 +114,8 @@ dfltcc_inflate_action Z_INTERNAL PREFIX(dfltcc_inflate)(PREFIX3(streamp) strm, i
 
 int Z_INTERNAL PREFIX(dfltcc_was_inflate_used)(PREFIX3(streamp) strm) {
     struct inflate_state *state = (struct inflate_state *)strm->state;
-    struct dfltcc_param_v0 *param = &GET_DFLTCC_STATE(state)->param;
 
-    return !param->nt;
+    return !state->arch.common.param.nt;
 }
 
 /*
@@ -153,7 +143,7 @@ static void rotate(unsigned char *start, unsigned char *pivot, unsigned char *en
 
 int Z_INTERNAL PREFIX(dfltcc_inflate_disable)(PREFIX3(streamp) strm) {
     struct inflate_state *state = (struct inflate_state *)strm->state;
-    struct dfltcc_state *dfltcc_state = GET_DFLTCC_STATE(state);
+    struct dfltcc_state *dfltcc_state = &state->arch.common;
     struct dfltcc_param_v0 *param = &dfltcc_state->param;
 
     if (!PREFIX(dfltcc_can_inflate)(strm))
@@ -178,8 +168,7 @@ int Z_INTERNAL PREFIX(dfltcc_inflate_disable)(PREFIX3(streamp) strm) {
 int Z_INTERNAL PREFIX(dfltcc_inflate_set_dictionary)(PREFIX3(streamp) strm,
                                                      const unsigned char *dictionary, uInt dict_length) {
     struct inflate_state *state = (struct inflate_state *)strm->state;
-    struct dfltcc_state *dfltcc_state = GET_DFLTCC_STATE(state);
-    struct dfltcc_param_v0 *param = &dfltcc_state->param;
+    struct dfltcc_param_v0 *param = &state->arch.common.param;
 
     if (PREFIX(inflate_ensure_window)(state)) {
         state->mode = MEM;
@@ -194,8 +183,7 @@ int Z_INTERNAL PREFIX(dfltcc_inflate_set_dictionary)(PREFIX3(streamp) strm,
 int Z_INTERNAL PREFIX(dfltcc_inflate_get_dictionary)(PREFIX3(streamp) strm,
                                                      unsigned char *dictionary, uInt *dict_length) {
     struct inflate_state *state = (struct inflate_state *)strm->state;
-    struct dfltcc_state *dfltcc_state = GET_DFLTCC_STATE(state);
-    struct dfltcc_param_v0 *param = &dfltcc_state->param;
+    struct dfltcc_param_v0 *param = &state->arch.common.param;
 
     if (dictionary && state->window)
         get_history(param, state->window, dictionary);

--- a/arch/s390/dfltcc_inflate.h
+++ b/arch/s390/dfltcc_inflate.h
@@ -3,9 +3,7 @@
 
 #include "dfltcc_common.h"
 
-struct inflate_state Z_INTERNAL *PREFIX(dfltcc_alloc_inflate_state)(PREFIX3(streamp) strm);
 void Z_INTERNAL PREFIX(dfltcc_reset_inflate_state)(PREFIX3(streamp) strm);
-void Z_INTERNAL PREFIX(dfltcc_copy_inflate_state)(struct inflate_state *dst, const struct inflate_state *src);
 int Z_INTERNAL PREFIX(dfltcc_can_inflate)(PREFIX3(streamp) strm);
 typedef enum {
     DFLTCC_INFLATE_CONTINUE,
@@ -19,9 +17,6 @@ int Z_INTERNAL PREFIX(dfltcc_inflate_set_dictionary)(PREFIX3(streamp) strm,
                                                      const unsigned char *dictionary, uInt dict_length);
 int Z_INTERNAL PREFIX(dfltcc_inflate_get_dictionary)(PREFIX3(streamp) strm,
                                                      unsigned char *dictionary, uInt* dict_length);
-
-#define ZALLOC_INFLATE_STATE PREFIX(dfltcc_alloc_inflate_state)
-#define ZCOPY_INFLATE_STATE PREFIX(dfltcc_copy_inflate_state)
 
 #define INFLATE_RESET_KEEP_HOOK PREFIX(dfltcc_reset_inflate_state)
 

--- a/deflate.h
+++ b/deflate.h
@@ -14,6 +14,11 @@
 #include "zendian.h"
 #include "crc32.h"
 
+#ifdef S390_DFLTCC_DEFLATE
+#  include "arch/s390/dfltcc_common.h"
+#  define HAVE_ARCH_DEFLATE_STATE
+#endif
+
 /* define NO_GZIP when compiling if you want to disable gzip header and
    trailer creation by deflate().  NO_GZIP would be used to avoid linking in
    the crc code when it is not needed.  For shared libraries, gzip encoding
@@ -296,6 +301,10 @@ struct ALIGNED_(16) internal_state {
 
     /* Reserved for future use and alignment purposes */
     char *reserved_p;
+
+#ifdef HAVE_ARCH_DEFLATE_STATE
+    arch_deflate_state arch;      /* architecture-specific extensions */
+#endif
 
     uint64_t bi_buf;
     /* Output buffer. bits are inserted starting at the bottom (least significant bits). */

--- a/infback.c
+++ b/infback.c
@@ -43,7 +43,7 @@ int32_t ZNG_CONDEXPORT PREFIX(inflateBackInit)(PREFIX3(stream) *strm, int32_t wi
     }
     if (strm->zfree == NULL)
         strm->zfree = PREFIX(zcfree);
-    state = ZALLOC_INFLATE_STATE(strm);
+    state = ZALLOC(strm, 1, sizeof(struct inflate_state));
     if (state == NULL)
         return Z_MEM_ERROR;
     Tracev((stderr, "inflate: allocated\n"));
@@ -504,7 +504,7 @@ int32_t Z_EXPORT PREFIX(inflateBack)(PREFIX3(stream) *strm, in_func in, void *in
 int32_t Z_EXPORT PREFIX(inflateBackEnd)(PREFIX3(stream) *strm) {
     if (strm == NULL || strm->state == NULL || strm->zfree == NULL)
         return Z_STREAM_ERROR;
-    ZFREE_STATE(strm, strm->state);
+    ZFREE(strm, strm->state);
     strm->state = NULL;
     Tracev((stderr, "inflate: end\n"));
     return Z_OK;

--- a/inflate.h
+++ b/inflate.h
@@ -13,6 +13,11 @@
 
 #include "crc32.h"
 
+#ifdef S390_DFLTCC_INFLATE
+#  include "arch/s390/dfltcc_common.h"
+#  define HAVE_ARCH_INFLATE_STATE
+#endif
+
 /* define NO_GZIP when compiling if you want to disable gzip header and trailer decoding by inflate().
    NO_GZIP would be used to avoid linking in the crc code when it is not needed.
    For shared libraries, gzip decoding should be left enabled. */
@@ -131,6 +136,9 @@ struct inflate_state {
     int back;                   /* bits back of last unprocessed length/lit */
     unsigned was;               /* initial length of match */
     uint32_t chunksize;         /* size of memory copying chunk */
+#ifdef HAVE_ARCH_INFLATE_STATE
+    arch_inflate_state arch;    /* architecture-specific extensions */
+#endif
 };
 
 int Z_INTERNAL PREFIX(inflate_ensure_window)(struct inflate_state *state);

--- a/inflate_p.h
+++ b/inflate_p.h
@@ -11,10 +11,6 @@
 #ifdef S390_DFLTCC_INFLATE
 #  include "arch/s390/dfltcc_inflate.h"
 #else
-/* Memory management for the inflate state. Useful for allocating arch-specific extension blocks. */
-#  define ZALLOC_INFLATE_STATE(strm) ((struct inflate_state *)ZALLOC(strm, 1, sizeof(struct inflate_state)))
-#  define ZFREE_STATE(strm, addr) ZFREE(strm, addr)
-#  define ZCOPY_INFLATE_STATE(dst, src) memcpy(dst, src, sizeof(struct inflate_state))
 /* Memory management for the window. Useful for allocation the aligned window. */
 #  define ZALLOC_WINDOW(strm, items, size) ZALLOC(strm, items, size)
 #  define ZCOPY_WINDOW(dest, src, n) memcpy(dest, src, n)


### PR DESCRIPTION
Currently DFLTCC states are allocated using hook macros, complicating memory management. Inline them into zlib states and remove the hooks.