### PR TITLE
Fix macOS Github Actions

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -712,7 +712,9 @@ jobs:
       if: matrix.codecov
       shell: bash
       run: |
-        python3 -u -m pip install --user gcovr==5.0
+        python3 -u -m venv ${{ matrix.build-dir || '.' }}/venv
+        source ${{ matrix.build-dir || '.' }}/venv/${{ runner.os == 'Windows' && 'Scripts' || 'bin' }}/activate
+        python3 -u -m pip install gcovr==5.0
         python3 -m gcovr ${{ matrix.build-dir || '' }} -j 3 --verbose \
           --exclude-unreachable-branches \
           --gcov-executable "${{ matrix.gcov-exec || 'gcov' }}" \

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -546,20 +546,39 @@ jobs:
             codecov: win64_gcc_compat_no_opt
 
           - name: macOS Clang ASAN
-            os: macos-latest
+            os: macos-13
             compiler: clang
             cxx-compiler: clang++
             cmake-args: -DWITH_SANITIZER=Address
             codecov: macos_clang
 
-          - name: macOS GCC UBSAN
+          - name: macOS Clang ASAN (ARM64)
             os: macos-latest
+            compiler: clang
+            cxx-compiler: clang++
+            cmake-args: -DWITH_SANITIZER=Address
+            codecov: macos_clang_arm64
+
+          - name: macOS GCC UBSAN
+            os: macos-13
             compiler: gcc-10
             cxx-compiler: g++-10
+            # Xcode 15 uses a new linker that is not compatible with GCC. Switch to the old linker.
+            # Homebrew gcc@11 and later have a built-in workaround for it.
+            ldflags: -ld_classic
             cmake-args: -DWITH_SANITIZER=Undefined
             packages: gcc@10
             gcov-exec: gcov-10
             codecov: macos_gcc
+
+          - name: macOS GCC UBSAN (ARM64)
+            os: macos-latest
+            compiler: gcc-11
+            cxx-compiler: g++-11
+            cmake-args: -DWITH_SANITIZER=Undefined
+            packages: gcc@11
+            gcov-exec: gcov-11
+            codecov: macos_gcc_arm64
 
           - name: macOS Clang Native Instructions (ARM64)
             os: macos-14

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -195,19 +195,43 @@ jobs:
             emu-run: node
 
           - name: macOS GCC Symbol Prefix
-            os: macOS-latest
+            os: macos-13
             compiler: gcc-11
             configure-args: --sprefix=zTest_
+            packages: gcc@11
+
+          - name: macOS GCC Symbol Prefix (ARM64)
+            os: macos-latest
+            compiler: gcc-11
+            cflags: -std=gnu11
+            configure-args: --sprefix=zTest_
+            packages: gcc@11
 
           - name: macOS GCC Symbol Prefix & Compat
-            os: macOS-latest
+            os: macos-13
             compiler: gcc-11
             configure-args: --zlib-compat --sprefix=zTest_
+            packages: gcc@11
+
+          - name: macOS GCC Symbol Prefix & Compat (ARM64)
+            os: macos-latest
+            compiler: gcc-11
+            cflags: -std=gnu11
+            configure-args: --zlib-compat --sprefix=zTest_
+            packages: gcc@11
 
           - name: macOS GCC
-            os: macOS-latest
+            os: macos-13
             compiler: gcc-11
             configure-args: --warn
+            packages: gcc@11
+
+          - name: macOS GCC (ARM64)
+            os: macos-latest
+            compiler: gcc-11
+            cflags: -std=gnu11
+            configure-args: --warn
+            packages: gcc@11
 
     steps:
     - name: Checkout repository
@@ -228,6 +252,12 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y ${{ matrix.packages }}
+
+    - name: Install packages (macOS)
+      if: runner.os == 'macOS'
+      run: brew install ninja ${{ matrix.packages }}
+      env:
+        HOMEBREW_NO_INSTALL_CLEANUP: 1
 
     - name: Install Emscripten
       if: contains(matrix.name, 'WASM32')

--- a/configure
+++ b/configure
@@ -300,7 +300,9 @@ show $cc -c $test.c
 if test "$gcc" -eq 1 && ($cc $CFLAGS -c $test.c) >> configure.log 2>&1; then
   echo "$cc" | tee -a configure.log
   CC="$cc"
-  CFLAGS="${CFLAGS} -std=c11"
+  if test "${CFLAGS#*"-std="}" = "$CFLAGS" ; then
+    CFLAGS="${CFLAGS} -std=c11"
+  fi
 
   # Re-check ARCH if the compiler is a cross-compiler.
   if $CC -print-multiarch 1> /dev/null 2>&1 && test -n "$($CC -print-multiarch)" 1> /dev/null 2>&1; then


### PR DESCRIPTION
Fixes #1719 

1) New macOS pipelines, based on
``macos-13`` - x86 tests
``macos-latest`` - ARM64 tests

2) Fix ``configure`` script (replaced unconditional add ``-std=c11``).

3) Switch to ``python`` ``venv``.