### PR TITLE
Add small compress() benchmark

### DIFF
--- a/test/benchmarks/CMakeLists.txt
+++ b/test/benchmarks/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(benchmark_zlib
     benchmark_adler32_copy.cc
     benchmark_compare256.cc
     benchmark_compare256_rle.cc
+    benchmark_compress.cc
     benchmark_crc32.cc
     benchmark_main.cc
     benchmark_slidehash.cc

--- a/test/benchmarks/benchmark_compress.cc
+++ b/test/benchmarks/benchmark_compress.cc
@@ -1,0 +1,67 @@
+/* benchmark_compress.cc -- benchmark compress()
+ * Copyright (C) 2024 Hans Kristian Rosbach
+ * For conditions of distribution and use, see copyright notice in zlib.h
+ */
+
+#include <stdio.h>
+#include <assert.h>
+#include <benchmark/benchmark.h>
+
+extern "C" {
+#  include "zbuild.h"
+#  include "zutil_p.h"
+#  if defined(ZLIB_COMPAT)
+#    include "zlib.h"
+#  else
+#    include "zlib-ng.h"
+#  endif
+}
+
+#define MAX_SIZE (32 * 1024)
+
+class compress: public benchmark::Fixture {
+private:
+    size_t maxlen;
+    uint8_t *inbuff;
+    uint8_t *outbuff;
+
+public:
+    void SetUp(const ::benchmark::State& state) {
+        const char teststr[42] = "Hello hello World broken Test tast mello.";
+        maxlen = MAX_SIZE;
+
+        inbuff = (uint8_t *)zng_alloc(MAX_SIZE + 1);
+        assert(inbuff != NULL);
+
+        outbuff = (uint8_t *)zng_alloc(MAX_SIZE + 1);
+        assert(outbuff != NULL);
+
+        int pos = 0;
+        for (int32_t i = 0; i < MAX_SIZE - 42 ; i+=42){
+           pos += sprintf((char *)inbuff+pos, "%s", teststr);
+        }
+    }
+
+    void Bench(benchmark::State& state) {
+        int err;
+
+        for (auto _ : state) {
+            err = PREFIX(compress)(outbuff, &maxlen, inbuff, (size_t)state.range(0));
+        }
+
+        benchmark::DoNotOptimize(err);
+    }
+
+    void TearDown(const ::benchmark::State& state) {
+        zng_free(inbuff);
+        zng_free(outbuff);
+    }
+};
+
+#define BENCHMARK_COMPRESS(name) \
+    BENCHMARK_DEFINE_F(compress, name)(benchmark::State& state) { \
+        Bench(state); \
+    } \
+    BENCHMARK_REGISTER_F(compress, name)->Arg(1)->Arg(8)->Arg(16)->Arg(32)->Arg(64)->Arg(512)->Arg(4<<10)->Arg(32<<10);
+
+BENCHMARK_COMPRESS(compress);


### PR DESCRIPTION
This minimal benchmark lets us test how long time it takes to do compress a small file.

The 1-byte compression will show the minimal time to initialize, compress and end, something we could use to calculate the maximum count we can do per second.. Lets call it COPS (Compression Operations Per Second).
The bigger sizes will spend more time doing payload compression, useful for adding some context to how much of the time is spent just doing init and end.

This PR lets us compare before/after code changes to see whether it affects COPS.

I intended to make one for decompress() as well, but never got around to it. It would need to compress multiple buffers during SetUp, to be able to do decompression on multiple sizes. It doesn't really need many different sizes though, I suggest `[1, 4096, 32768]`. If anyone wants to make that, I'd appreciate it.