### PR TITLE
Remove unused function dfltcc_alloc_state

### DIFF
--- a/arch/s390/README.md
+++ b/arch/s390/README.md
@@ -116,8 +116,7 @@ converted to calls to functions, which are implemented in
 `arch/s390/dfltcc_*` files. The functions can be grouped in three broad
 categories:
 
-* Base DFLTCC support, e.g. wrapping the machine instruction -
-  `dfltcc()` and allocating aligned memory - `dfltcc_alloc_state()`.
+* Base DFLTCC support, e.g. wrapping the machine instruction - `dfltcc()`.
 * Translating between software and hardware data formats, e.g.
   `dfltcc_deflate_set_dictionary()`.
 * Translating between software and hardware state machines, e.g.

--- a/arch/s390/dfltcc_detail.h
+++ b/arch/s390/dfltcc_detail.h
@@ -218,10 +218,6 @@ static inline dfltcc_cc dfltcc(int fn, void *param,
 
 #define ALIGN_UP(p, size) (__typeof__(p))(((uintptr_t)(p) + ((size) - 1)) & ~((size) - 1))
 
-static inline void *dfltcc_alloc_state(PREFIX3(streamp) strm, uInt size, uInt extension_size) {
-    return ZALLOC(strm, 1, ALIGN_UP(size, 8) + extension_size);
-}
-
 static inline void dfltcc_reset_state(struct dfltcc_state *dfltcc_state) {
     /* Initialize available functions */
     if (is_dfltcc_enabled()) {


### PR DESCRIPTION
Remove unused function ``dfltcc_alloc_state`` (after #1718).