### PR TITLE
Fix a name conflict when compiled with zlib-compat

### DIFF
--- a/test/benchmarks/benchmark_compress.cc
+++ b/test/benchmarks/benchmark_compress.cc
@@ -19,7 +19,7 @@ extern "C" {
 
 #define MAX_SIZE (32 * 1024)
 
-class compress: public benchmark::Fixture {
+class compress_bench: public benchmark::Fixture {
 private:
     size_t maxlen;
     uint8_t *inbuff;
@@ -59,9 +59,9 @@ public:
 };
 
 #define BENCHMARK_COMPRESS(name) \
-    BENCHMARK_DEFINE_F(compress, name)(benchmark::State& state) { \
+    BENCHMARK_DEFINE_F(compress_bench, name)(benchmark::State& state) { \
         Bench(state); \
     } \
-    BENCHMARK_REGISTER_F(compress, name)->Arg(1)->Arg(8)->Arg(16)->Arg(32)->Arg(64)->Arg(512)->Arg(4<<10)->Arg(32<<10);
+    BENCHMARK_REGISTER_F(compress_bench, name)->Arg(1)->Arg(8)->Arg(16)->Arg(32)->Arg(64)->Arg(512)->Arg(4<<10)->Arg(32<<10);
 
-BENCHMARK_COMPRESS(compress);
+BENCHMARK_COMPRESS(compress_bench);


### PR DESCRIPTION
The benchmarks fail to compile properly when built with ZLIB_COMPAT. The name of the class cannot have the same name as the function.

Without this, the compiler thinks we're trying to invoke the class's constructor:

```
/home/adam/scratch/zlib-ng/test/benchmarks/benchmark_compress.cc: In member function ‘void compress::Bench(benchmark::State&)’:
/home/adam/scratch/zlib-ng/test/benchmarks/benchmark_compress.cc:49:84: error: invalid cast to abstract class type ‘compress’
   49 |             err = PREFIX(compress)(outbuff, &maxlen, inbuff, (size_t)state.range(0));
      |                                                                                    ^
/home/adam/scratch/zlib-ng/test/benchmarks/benchmark_compress.cc:22:7: note:   because the following virtual functions are pure within ‘compress’:
   22 | class compress: public benchmark::Fixture {
      |       ^~~~~~~~
In file included from /home/adam/scratch/zlib-ng/test/benchmarks/benchmark_compress.cc:8:
  /* benchmark_compress.cc -- benchmark compress()
/usr/include/benchmark/benchmark.h:1436:16: note:     ‘virtual void benchmark::Fixture::BenchmarkCase(benchmark::State&)’
 1436 |   virtual void BenchmarkCase(State&) = 0;
      |                ^~~~~~~~~~~~~
make[2]: *** [test/benchmarks/CMakeFiles/benchmark_zlib.dir/build.make:132: test/benchmarks/CMakeFiles/benchmark_zlib.dir/benchmark_compress.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:425: test/benchmarks/CMakeFiles/benchmark_zlib.dir/all] Error 2
make: *** [Makefile:166: all] Error 2
```