### PR TITLE
Simplify inflate window checks

### DIFF
--- a/arch/s390/dfltcc_inflate.c
+++ b/arch/s390/dfltcc_inflate.c
@@ -77,10 +77,9 @@ dfltcc_inflate_action Z_INTERNAL PREFIX(dfltcc_inflate)(PREFIX3(streamp) strm, i
     if (strm->avail_in == 0 && !param->cf)
         return DFLTCC_INFLATE_BREAK;
 
-    if (PREFIX(inflate_ensure_window)(state)) {
-        state->mode = MEM;
-        return DFLTCC_INFLATE_CONTINUE;
-    }
+    /* if window not in use yet, initialize */
+    if (state->wsize == 0)
+        state->wsize = 1U << state->wbits;
 
     /* Translate stream to parameter block */
     param->cvt = ((state->wrap & 4) && state->flags) ? CVT_CRC32 : CVT_ADLER32;
@@ -170,10 +169,9 @@ int Z_INTERNAL PREFIX(dfltcc_inflate_set_dictionary)(PREFIX3(streamp) strm,
     struct inflate_state *state = (struct inflate_state *)strm->state;
     struct dfltcc_param_v0 *param = &state->arch.common.param;
 
-    if (PREFIX(inflate_ensure_window)(state)) {
-        state->mode = MEM;
-        return Z_MEM_ERROR;
-    }
+    /* if window not in use yet, initialize */
+    if (state->wsize == 0)
+        state->wsize = 1U << state->wbits;
 
     append_history(param, state->window, dictionary, dict_length);
     state->havedict = 1;

--- a/inflate.h
+++ b/inflate.h
@@ -57,14 +57,13 @@ typedef enum {
     LENGTH,     /* i: waiting for 32-bit length (gzip) */
     DONE,       /* finished check, done -- remain here until reset */
     BAD,        /* got a data error -- remain here until reset */
-    MEM,        /* got an inflate() memory error -- remain here until reset */
     SYNC        /* looking for synchronization bytes to restart inflate() */
 } inflate_mode;
 
 /*
     State transitions between above modes -
 
-    (most modes can go to BAD or MEM on error -- not shown for clarity)
+    (most modes can go to BAD on error -- not shown for clarity)
 
     Process header:
         HEAD -> (gzip) or (zlib) or (raw)
@@ -151,7 +150,6 @@ struct ALIGNED_(64) inflate_state {
 #endif
 };
 
-int Z_INTERNAL PREFIX(inflate_ensure_window)(struct inflate_state *state);
 void Z_INTERNAL PREFIX(fixedtables)(struct inflate_state *state);
 Z_INTERNAL inflate_allocs* alloc_inflate(PREFIX3(stream) *strm);
 Z_INTERNAL void free_inflate(PREFIX3(stream) *strm);


### PR DESCRIPTION
Based on PR #1713, needs rebase when that has gone in. Didn't want to add it to that PR this late, although it really belongs there.

Since there is no need to worry about alloc calls failing after init has been done, we can
simplify the initialization and error checking of windows.

Optimization wasn't the purpose here, but in my preliminary tests, this improved inflate speed on big files by ~0.4-0.67%, so that is looking pretty good too.

PS: `inflateReset2` is called during init and whenever the windows needs a reset and its size set to 0.