### PR TITLE
Enabled orphaned unit tests for compare256_rle family of functions.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -190,6 +190,7 @@ if(WITH_GTEST)
             list(APPEND TEST_SRCS
                 test_adler32.cc             # adler32_neon(), etc
                 test_compare256.cc          # compare256_neon(), etc
+                test_compare256_rle.cc      # compare256_rle(), etc
                 test_crc32.cc               # crc32_acle(), etc
                 test_inflate_sync.cc        # expects a certain compressed block layout
                 test_main.cc                # cpu_check_features()

--- a/test/test_compare256_rle.cc
+++ b/test/test_compare256_rle.cc
@@ -23,7 +23,7 @@ static inline void compare256_rle_match_check(compare256_rle_func compare256_rle
     uint8_t str1[] = {'a', 'a', 0};
     uint8_t *str2;
 
-    str2 = (uint8_t *)PREFIX3(alloc_aligned)(NULL, NULL, 1, MAX_COMPARE_SIZE, 64);
+    str2 = (uint8_t *)PREFIX(zcalloc)(NULL, 1, MAX_COMPARE_SIZE);
     ASSERT_TRUE(str2 != NULL);
     memset(str2, 'a', MAX_COMPARE_SIZE);
 
@@ -38,7 +38,7 @@ static inline void compare256_rle_match_check(compare256_rle_func compare256_rle
             str2[i] = 'a';
     }
 
-    PREFIX3(free_aligned)(NULL, NULL, str2);
+    PREFIX(zcfree)(NULL, str2);
 }
 
 #define TEST_COMPARE256_RLE(name, func, support_flag) \


### PR DESCRIPTION
Bug is introduced in PR #810.