### PR TITLE
Fix lint trailing whitespace error.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,6 @@
 crc32_braid_tbl.h hooks-max-size=1000000
 
 # Don't export git/github-related files in tar/zip archives
-/.github export-ignore  
-.gitattributes export-ignore  
+/.github export-ignore
+.gitattributes export-ignore
 .gitignore export-ignore


### PR DESCRIPTION
Fix lint trailing whitespace error:

```
.gitattributes:7: trailing whitespace.
+/.github export-ignore
.gitattributes:8: trailing whitespace.
+.gitattributes export-ignore
```

CI:
https://github.com/zlib-ng/zlib-ng/actions/runs/9305815228/job/25613627702
