### PR TITLE
[configure] Try stripping "--version-script" from LDSHAREDFLAGS if testing shared library support fails

### DIFF
--- a/configure
+++ b/configure
@@ -600,9 +600,13 @@ int hello() {return getchar();}
 EOF
 if test $shared -eq 1; then
   printf "Checking for shared library support... " | tee -a configure.log
+  # Workaround for lld not liking --version-script
+  LDDSHAREDFLAGS="$(echo $LDSHAREDFLAGS | sed 's/,--version-script,[^ ]\+//')"
   # we must test in two steps (cc then ld), required at least on SunOS 4.x
   if try $CC -c $SFLAGS $test.c &&
      try $LDSHARED $LDSHAREDFLAGS $LDFLAGS -o $test$shared_ext $test.o $LDSHAREDLIBC; then
+    echo "Building shared library $SHAREDTARGET with $CC." | tee -a configure.log
+  elif try $LDSHARED $LDDSHAREDFLAGS $LDFLAGS -o $test$shared_ext $test.o $LDSHAREDLIBC; then
     echo "Building shared library $SHAREDTARGET with $CC." | tee -a configure.log
   elif test -z "$old_cc" -a -z "$old_cflags"; then
     echo "No shared library support." | tee -a configure.log


### PR DESCRIPTION
See #1748.