### PR TITLE
Fix various loss of data warnings

### DIFF
--- a/arch/arm/slide_hash_armv6.c
+++ b/arch/arm/slide_hash_armv6.c
@@ -39,7 +39,8 @@ static inline void slide_hash_chain(Pos *table, uint32_t entries, uint16_t wsize
 }
 
 Z_INTERNAL void slide_hash_armv6(deflate_state *s) {
-    unsigned int wsize = s->w_size;
+    Assert(s->w_size <= UINT16_MAX, "w_size should fit in uint16_t");
+    uint16_t wsize = (uint16_t)s->w_size;
 
     slide_hash_chain(s->head, HASH_SIZE, wsize);
     slide_hash_chain(s->prev, wsize, wsize);

--- a/arch/arm/slide_hash_neon.c
+++ b/arch/arm/slide_hash_neon.c
@@ -38,7 +38,8 @@ static inline void slide_hash_chain(Pos *table, uint32_t entries, uint16_t wsize
 }
 
 Z_INTERNAL void slide_hash_neon(deflate_state *s) {
-    unsigned int wsize = s->w_size;
+    Assert(s->w_size <= UINT16_MAX, "w_size should fit in uint16_t");
+    uint16_t wsize = (uint16_t)s->w_size;
 
     slide_hash_chain(s->head, HASH_SIZE, wsize);
     slide_hash_chain(s->prev, wsize, wsize);

--- a/arch/generic/crc32_braid_c.c
+++ b/arch/generic/crc32_braid_c.c
@@ -192,6 +192,7 @@ Z_INTERNAL uint32_t PREFIX(crc32_braid)(uint32_t crc, const uint8_t *buf, size_t
 #endif
 #endif
         words += N;
+        Assert(comb <= UINT32_MAX, "comb should fit in uint32_t");
         c = (uint32_t)ZSWAPWORD(comb);
 
         /* Update the pointer to the remaining bytes to process. */

--- a/arch/power/slide_ppc_tpl.h
+++ b/arch/power/slide_ppc_tpl.h
@@ -24,7 +24,8 @@ static inline void slide_hash_chain(Pos *table, uint32_t entries, uint16_t wsize
 }
 
 void Z_INTERNAL SLIDE_PPC(deflate_state *s) {
-    uint16_t wsize = s->w_size;
+    Assert(s->w_size <= UINT16_MAX, "w_size should fit in uint16_t");
+    uint16_t wsize = (uint16_t)s->w_size;
 
     slide_hash_chain(s->head, HASH_SIZE, wsize);
     slide_hash_chain(s->prev, wsize, wsize);

--- a/arch/riscv/slide_hash_rvv.c
+++ b/arch/riscv/slide_hash_rvv.c
@@ -23,6 +23,7 @@ static inline void slide_hash_chain(Pos *table, uint32_t entries, uint16_t wsize
 }
 
 Z_INTERNAL void slide_hash_rvv(deflate_state *s) {
+    Assert(s->w_size <= UINT16_MAX, "w_size should fit in uint16_t");
     uint16_t wsize = (uint16_t)s->w_size;
 
     slide_hash_chain(s->head, HASH_SIZE, wsize);

--- a/arch/x86/slide_hash_avx2.c
+++ b/arch/x86/slide_hash_avx2.c
@@ -31,6 +31,7 @@ static inline void slide_hash_chain(Pos *table, uint32_t entries, const __m256i 
 }
 
 Z_INTERNAL void slide_hash_avx2(deflate_state *s) {
+    Assert(s->w_size <= UINT16_MAX, "w_size should fit in uint16_t");
     uint16_t wsize = (uint16_t)s->w_size;
     const __m256i ymm_wsize = _mm256_set1_epi16((short)wsize);
 

--- a/arch/x86/slide_hash_sse2.c
+++ b/arch/x86/slide_hash_sse2.c
@@ -52,6 +52,7 @@ next_chain:
 }
 
 Z_INTERNAL void slide_hash_sse2(deflate_state *s) {
+    Assert(s->w_size <= UINT16_MAX, "w_size should fit in uint16_t");
     uint16_t wsize = (uint16_t)s->w_size;
     const __m128i xmm_wsize = _mm_set1_epi16((short)wsize);
 

--- a/deflate.c
+++ b/deflate.c
@@ -204,7 +204,7 @@ Z_INTERNAL deflate_allocs* alloc_deflate(PREFIX3(stream) *strm, int windowBits, 
 
     /* Define sizes */
     int window_size = DEFLATE_ADJUST_WINDOW_SIZE((1 << windowBits) * 2);
-    int prev_size = (1 << windowBits) * sizeof(Pos);
+    int prev_size = (1 << windowBits) * (int)sizeof(Pos);
     int head_size = HASH_SIZE * sizeof(Pos);
     int pending_size = lit_bufsize * LIT_BUFS;
     int state_size = sizeof(deflate_state);

--- a/deflate_fast.c
+++ b/deflate_fast.c
@@ -58,7 +58,9 @@ Z_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
         }
 
         if (match_len >= WANT_MIN_MATCH) {
-            check_match(s, s->strstart, s->match_start, match_len);
+            Assert(s->strstart <= UINT16_MAX, "strstart should fit in uint16_t");
+            Assert(s->match_start <= UINT16_MAX, "match_start should fit in uint16_t");
+            check_match(s, (Pos)s->strstart, (Pos)s->match_start, match_len);
 
             bflush = zng_tr_tally_dist(s, s->strstart - s->match_start, match_len - STD_MIN_MATCH);
 

--- a/deflate_p.h
+++ b/deflate_p.h
@@ -78,8 +78,10 @@ static inline int zng_tr_tally_dist(deflate_state* s, uint32_t dist, uint32_t le
     /* dist: distance of matched string */
     /* len: match length-STD_MIN_MATCH */
 #ifdef LIT_MEM
-    s->d_buf[s->sym_next] = dist;
-    s->l_buf[s->sym_next++] = len;
+    Assert(dist <= UINT16_MAX, "dist should fit in uint16_t");
+    Assert(len <= UINT8_MAX, "len should fit in uint8_t");
+    s->d_buf[s->sym_next] = (uint16_t)dist;
+    s->l_buf[s->sym_next++] = (uint8_t)len;
 #else
     s->sym_buf[s->sym_next++] = (uint8_t)(dist);
     s->sym_buf[s->sym_next++] = (uint8_t)(dist >> 8);

--- a/deflate_quick.c
+++ b/deflate_quick.c
@@ -102,7 +102,8 @@ Z_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
                         if (UNLIKELY(match_len > STD_MAX_MATCH))
                             match_len = STD_MAX_MATCH;
 
-                        check_match(s, s->strstart, hash_head, match_len);
+                        Assert(s->strstart <= UINT16_MAX, "strstart should fit in uint16_t");
+                        check_match(s, (Pos)s->strstart, hash_head, match_len);
 
                         zng_tr_emit_dist(s, static_ltree, static_dtree, match_len - STD_MIN_MATCH, (uint32_t)dist);
                         s->lookahead -= match_len;

--- a/deflate_rle.c
+++ b/deflate_rle.c
@@ -58,7 +58,8 @@ Z_INTERNAL block_state deflate_rle(deflate_state *s, int flush) {
 
         /* Emit match if have run of STD_MIN_MATCH or longer, else emit literal */
         if (match_len >= STD_MIN_MATCH) {
-            check_match(s, s->strstart, s->strstart - 1, match_len);
+            Assert(s->strstart <= UINT16_MAX, "strstart should fit in uint16_t");
+            check_match(s, (Pos)s->strstart, (Pos)(s->strstart - 1), match_len);
 
             bflush = zng_tr_tally_dist(s, 1, match_len - STD_MIN_MATCH);
 

--- a/deflate_slow.c
+++ b/deflate_slow.c
@@ -78,7 +78,8 @@ Z_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
             unsigned int max_insert = s->strstart + s->lookahead - STD_MIN_MATCH;
             /* Do not insert strings in hash table beyond this. */
 
-            check_match(s, s->strstart-1, s->prev_match, s->prev_length);
+            Assert((s->strstart-1) <= UINT16_MAX, "strstart-1 should fit in uint16_t");
+            check_match(s, (Pos)(s->strstart - 1), s->prev_match, s->prev_length);
 
             bflush = zng_tr_tally_dist(s, s->strstart -1 - s->prev_match, s->prev_length - STD_MIN_MATCH);
 


### PR DESCRIPTION
Fixes https://github.com/zlib-ng/zlib-ng/issues/1760

Fixed in the dotnet/runtime repo copy of zlib-ng: https://github.com/dotnet/runtime/pull/105433

WD4242 and WD4244 are compiler warnings that should not be suppressed because the warn about possible loss of data.

- WD4242 shows up in `/arch/*/slide_hash*.c` files and comes from the arguments passed to the `slide_hash_chain` method.
- WD4244 happens in Windows when building in Debug configuration, in various `deflate*.c` files, and comes from the arguments passed to the `check_match` method.
- Also fixed a couple additional failures that showed up after upgrading to v2.2.1.

Fixed by:
- Adding asserts to verify the values are below the maximum allowed for their type.
- Casting them the proper type before passing them as arguments to their methods.