### PR TITLE
Silence possible loss of data warning in crc32_braid ZSWAPWORD call

### DIFF
--- a/arch/generic/crc32_braid_c.c
+++ b/arch/generic/crc32_braid_c.c
@@ -192,7 +192,7 @@ Z_INTERNAL uint32_t PREFIX(crc32_braid)(uint32_t crc, const uint8_t *buf, size_t
 #endif
 #endif
         words += N;
-        c = ZSWAPWORD(comb);
+        c = (uint32_t)ZSWAPWORD(comb);
 
         /* Update the pointer to the remaining bytes to process. */
         buf = (const unsigned char *)words;


### PR DESCRIPTION
MSVC
```
Warning	C4244
'=': conversion from 'z_word_t' to 'uint32_t', possible loss of data zlib
crc32_braid_c.c	195
```