### PR TITLE
IBM zSystems: Hardcode HWCAP_S390_VXRS

### DIFF
--- a/arch/s390/s390_features.c
+++ b/arch/s390/s390_features.c
@@ -6,7 +6,7 @@
 #endif
 
 #ifndef HWCAP_S390_VXRS
-#define HWCAP_S390_VXRS HWCAP_S390_VX
+#define HWCAP_S390_VXRS (1 << 11)
 #endif
 
 void Z_INTERNAL s390_check_features(struct s390_cpu_features *features) {

--- a/cmake/detect-intrinsics.cmake
+++ b/cmake/detect-intrinsics.cmake
@@ -433,7 +433,7 @@ macro(check_s390_intrinsics)
     check_c_source_compiles(
         "#include <sys/auxv.h>
         #ifndef HWCAP_S390_VXRS
-        #define HWCAP_S390_VXRS HWCAP_S390_VX
+        #define HWCAP_S390_VXRS (1 << 11)
         #endif
         int main() {
             return (getauxval(AT_HWCAP) & HWCAP_S390_VXRS);


### PR DESCRIPTION
Compiling zlib-ng with glibc 2.17 (minimum version still supported by crosstool-ng) fails due to the lack of HWCAP_S390_VX - it was introduced in glibc 2.23.

Strictly speaking, this is a problem with the feature detection logic in cmake. However, it's not worth disabling the s390x vectorized CRC32 if the hwcap constant is missing and the compiler intrinsics are available.

So fix by hardcoding the constant. It's a part of the kernel ABI, which does not change.