### PR TITLE
Enable warning C4242 and treat warnings as errors for Visual C++.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,9 +191,9 @@ elseif(MSVC)
     # (who'd use cmake from an IDE...) but checking for ICC before checking for MSVC should
     # avoid mistakes.
     # /Oi ?
-    set(WARNFLAGS /W3)
+    set(WARNFLAGS /W3 /w34242 /WX)
     set(WARNFLAGS_MAINTAINER /W4)
-    set(WARNFLAGS_DISABLE)
+    set(WARNFLAGS_DISABLE /wd4206 /wd4054)
     if(BASEARCH_ARM_FOUND)
         add_definitions(-D_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE)
         if(NOT "${ARCH}" MATCHES "aarch64")

--- a/arch/arm/chunkset_neon.c
+++ b/arch/arm/chunkset_neon.c
@@ -84,7 +84,9 @@ static inline chunk_t GET_CHUNK_MAG(uint8_t *buf, uint32_t *chunk_rem, uint32_t 
     a = vld1_u8(buf);
     b = vld1_u8(buf + 8);
     ret0 = vtbl1_u8(a, perm_vec0);
-    uint8x8x2_t ab = {{a, b}};
+    uint8x8x2_t ab;
+    ab.val[0] = a;
+    ab.val[1] = b;
     ret1 = vtbl2_u8(ab, perm_vec1);
     return vcombine_u8(ret0, ret1);
 #endif

--- a/arch/arm/neon_intrins.h
+++ b/arch/arm/neon_intrins.h
@@ -36,20 +36,20 @@
 #  ifndef ARM_NEON_HASLD4
 
 static inline uint16x8x4_t vld1q_u16_x4(uint16_t const *a) {
-    uint16x8x4_t ret = (uint16x8x4_t) {{
-                          vld1q_u16(a),
-                          vld1q_u16(a+8),
-                          vld1q_u16(a+16),
-                          vld1q_u16(a+24)}};
+    uint16x8x4_t ret;
+    ret.val[0] = vld1q_u16(a);
+    ret.val[1] = vld1q_u16(a+8);
+    ret.val[2] = vld1q_u16(a+16);
+    ret.val[3] = vld1q_u16(a+24);
     return ret;
 }
 
 static inline uint8x16x4_t vld1q_u8_x4(uint8_t const *a) {
-    uint8x16x4_t ret = (uint8x16x4_t) {{
-                          vld1q_u8(a),
-                          vld1q_u8(a+16),
-                          vld1q_u8(a+32),
-                          vld1q_u8(a+48)}};
+    uint8x16x4_t ret;
+    ret.val[0] = vld1q_u8(a);
+    ret.val[1] = vld1q_u8(a+16);
+    ret.val[2] = vld1q_u8(a+32);
+    ret.val[3] = vld1q_u8(a+48);
     return ret;
 }
 

--- a/arch/x86/adler32_avx512_p.h
+++ b/arch/x86/adler32_avx512_p.h
@@ -3,6 +3,17 @@
 
 #include <immintrin.h>
 #include <stdint.h>
+
+/* Written because Visual C++ toolchains before v142 have constant overflow in AVX512 intrinsic macros */
+#if defined(_MSC_VER) && !defined(_MM_K0_REG8)
+#  undef _mm512_extracti64x4_epi64
+#  define _mm512_extracti64x4_epi64(v1, e1) _mm512_maskz_extracti64x4_epi64(UINT8_MAX, v1, e1)
+#  undef _mm512_set1_epi16
+#  define _mm512_set1_epi16(e1) _mm512_maskz_set1_epi16(UINT32_MAX, e1)
+#  undef _mm512_maddubs_epi16
+#  define _mm512_maddubs_epi16(v1, v2) _mm512_maskz_maddubs_epi16(UINT32_MAX, v1, v2)
+#endif
+
 /* Written because *_add_epi32(a) sets off ubsan */
 static inline uint32_t _mm512_reduce_add_epu32(__m512i x) {
     __m256i a = _mm512_extracti64x4_epi64(x, 1);

--- a/arch/x86/x86_intrins.h
+++ b/arch/x86/x86_intrins.h
@@ -84,4 +84,9 @@ static inline __m512i _mm512_zextsi128_si512(__m128i a) {
 #endif // __AVX512F__
 #endif // defined(_MSC_VER) && _MSC_VER < 1914
 
+/* Visual C++ toolchains before v142 have constant overflow in AVX512 intrinsics */
+#if defined(_MSC_VER) && defined(__AVX512F__) && !defined(_MM_K0_REG8)
+#  undef _mm512_extracti32x4_epi32
+#  define _mm512_extracti32x4_epi32(v1, e1) _mm512_maskz_extracti32x4_epi32(UINT8_MAX, v1, e1)
+#endif
 #endif // include guard X86_INTRINS_H

--- a/deflate.h
+++ b/deflate.h
@@ -243,6 +243,10 @@ struct ALIGNED_(64) internal_state {
 
     int nice_match; /* Stop searching when current match exceeds this */
 
+#if defined(_M_IX86) || defined(_M_ARM)
+    int padding[2];
+#endif
+
     struct crc32_fold_s ALIGNED_(16) crc_fold;
 
                 /* used by trees.c: */
@@ -323,7 +327,10 @@ struct ALIGNED_(64) internal_state {
     /* Number of valid bits in bi_buf.  All bits above the last valid bit are always zero. */
 
     /* Reserved for future use and alignment purposes */
-    int32_t reserved[11];
+    int32_t reserved[19];
+#if defined(_M_IX86) || defined(_M_ARM)
+    int32_t padding2[4];
+#endif
 };
 
 typedef enum {

--- a/inflate.h
+++ b/inflate.h
@@ -115,6 +115,11 @@ struct ALIGNED_(64) inflate_state {
     uint32_t whave;             /* valid bytes in the window */
     uint32_t wnext;             /* window write index */
     unsigned char *window;      /* allocated sliding window, if needed */
+#if defined(_M_IX86) || defined(_M_ARM)
+    uint32_t padding;
+#else
+    uint32_t padding[2];
+#endif
 
     struct crc32_fold_s ALIGNED_(16) crc_fold;
 
@@ -147,6 +152,9 @@ struct ALIGNED_(64) inflate_state {
     inflate_allocs *alloc_bufs; /* struct for handling memory allocations */
 #ifdef HAVE_ARCH_INFLATE_STATE
     arch_inflate_state arch;    /* architecture-specific extensions */
+#endif
+#if defined(_M_IX86) || defined(_M_ARM)
+    int padding2[8];
 #endif
 };
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -201,6 +201,13 @@ if(WITH_GTEST)
         add_executable(gtest_zlib ${TEST_SRCS})
         configure_test_executable(gtest_zlib)
 
+        if(MSVC)
+            target_compile_options(gtest_zlib PRIVATE /wd4389)
+            if(BASEARCH_ARM_FOUND)
+                target_compile_options(gtest_zlib PRIVATE /EHsc)
+            endif()
+        endif()
+
         if(WITH_SANITIZER STREQUAL "Memory")
             target_link_directories(gtest_zlib PRIVATE $ENV{LLVM_BUILD_DIR}/lib)
             target_link_options(gtest_zlib PRIVATE

--- a/test/fuzz/fuzzer_minigzip.c
+++ b/test/fuzz/fuzzer_minigzip.c
@@ -302,7 +302,9 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t dataLen) {
         }
         if (len == 0)
             break;
-        assert(0 == memcmp(data + offset, buf, len));
+        int c = memcmp(data + offset, buf, len);
+        assert(0 == c);
+        Z_UNUSED(c); // in Release build, assert() is a no-op.
         offset += len;
     }
 

--- a/test/test_gzio.cc
+++ b/test/test_gzio.cc
@@ -30,6 +30,7 @@ TEST(gzip, readwrite) {
     gzFile file;
     int err;
 
+    Z_UNUSED(compr);
     /* Write gz file with test data */
     file = PREFIX(gzopen)(TESTFILE, "wb");
     ASSERT_TRUE(file != NULL);

--- a/zbuild.h
+++ b/zbuild.h
@@ -225,7 +225,7 @@
 #  include <stdio.h>
    extern int Z_INTERNAL z_verbose;
    extern void Z_INTERNAL z_error(const char *m);
-#  define Assert(cond, msg) {if (!(cond)) z_error(msg);}
+#  define Assert(cond, msg) {int _cond = (cond); if (!_cond) z_error(msg);}
 #  define Trace(x) {if (z_verbose >= 0) fprintf x;}
 #  define Tracev(x) {if (z_verbose > 0) fprintf x;}
 #  define Tracevv(x) {if (z_verbose > 1) fprintf x;}


### PR DESCRIPTION
Level 4 warning C4242 is `'identifier': conversion from 'type1' to 'type2', possible loss of data`, which is usually result of missing truncating cast or incorrect type used in cast or expression.

See discussion in #1762. Rationale for treating warnings as errors is that most developers use Linux or other Unix-compatible systems and only small fraction have Windows to test any changes.