### PR TITLE
Fixed false positive HAVE_ARMV6_INTRIN value on old ARM platforms

### DIFF
--- a/cmake/detect-intrinsics.cmake
+++ b/cmake/detect-intrinsics.cmake
@@ -66,7 +66,7 @@ macro(check_armv6_compiler_flag)
             return __uqsub16(a, b);
         #endif
         }
-        int main(void) { return 0; }"
+        int main(void) { return f(1,2); }"
         HAVE_ARMV6_INTRIN
     )
     set(CMAKE_REQUIRED_FLAGS)

--- a/configure
+++ b/configure
@@ -1243,7 +1243,7 @@ EOF
 unsigned int f(unsigned int a, unsigned int b) {
     return __uqsub16(a, b);
 }
-int main(void) { return 0; }
+int main(void) { return f(1, 2); }
 EOF
     if try ${CC} ${CFLAGS} ${armv6flag} $test.c; then
         echo "Checking for ARMv6 intrinsics ... Yes." | tee -a configure.log


### PR DESCRIPTION
The check returns 1, even if `__uqsub16` is not provided by compiler. The issue was reproduced with jetson TK1 (armv7 neon), GCC 5.4.0 and `-DWITH_RUNTIME_CPU_DETECTION=ON`