### PR TITLE
Improve chunkset_avx2 performance

### DIFF
--- a/arch/arm/chunkset_neon.c
+++ b/arch/arm/chunkset_neon.c
@@ -9,8 +9,6 @@
 
 typedef uint8x16_t chunk_t;
 
-#define CHUNK_SIZE 16
-
 #define HAVE_CHUNKMEMSET_2
 #define HAVE_CHUNKMEMSET_4
 #define HAVE_CHUNKMEMSET_8

--- a/arch/x86/chunkset_avx2.c
+++ b/arch/x86/chunkset_avx2.c
@@ -14,6 +14,7 @@ typedef __m256i chunk_t;
 #define HAVE_CHUNKMEMSET_2
 #define HAVE_CHUNKMEMSET_4
 #define HAVE_CHUNKMEMSET_8
+#define HAVE_CHUNKMEMSET_16
 #define HAVE_CHUNK_MAG
 
 /* Populate don't cares so that this is a direct lookup (with some indirection into the permute table), because dist can
@@ -68,6 +69,10 @@ static inline void chunkmemset_8(uint8_t *from, chunk_t *chunk) {
     *chunk = _mm256_set1_epi64x(tmp);
 }
 
+static inline void chunkmemset_16(uint8_t *from, chunk_t *chunk) {
+    *chunk = _mm256_broadcastsi128_si256(_mm_loadu_si128((__m128i*)from));
+}
+
 static inline void loadchunk(uint8_t const *s, chunk_t *chunk) {
     *chunk = _mm256_loadu_si256((__m256i *)s);
 }
@@ -99,10 +104,7 @@ static inline chunk_t GET_CHUNK_MAG(uint8_t *buf, uint32_t *chunk_rem, uint32_t 
         perm_vec = _mm256_add_epi8(perm_vec, permute_xform);
         ret_vec = _mm256_inserti128_si256(_mm256_castsi128_si256(ret_vec0), ret_vec0, 1);
         ret_vec = _mm256_shuffle_epi8(ret_vec, perm_vec);
-    } else if (dist == 16) {
-        __m128i ret_vec0 = _mm_loadu_si128((__m128i*)buf);
-        return _mm256_inserti128_si256(_mm256_castsi128_si256(ret_vec0), ret_vec0, 1);
-    } else {
+    }  else {
         __m128i ret_vec0 = _mm_loadu_si128((__m128i*)buf);
         __m128i ret_vec1 = _mm_loadu_si128((__m128i*)(buf + 16));
         /* Take advantage of the fact that only the latter half of the 256 bit vector will actually differ */

--- a/arch/x86/chunkset_sse2.c
+++ b/arch/x86/chunkset_sse2.c
@@ -9,8 +9,6 @@
 
 typedef __m128i chunk_t;
 
-#define CHUNK_SIZE 16
-
 #define HAVE_CHUNKMEMSET_2
 #define HAVE_CHUNKMEMSET_4
 #define HAVE_CHUNKMEMSET_8

--- a/arch/x86/chunkset_ssse3.c
+++ b/arch/x86/chunkset_ssse3.c
@@ -10,8 +10,6 @@
 
 typedef __m128i chunk_t;
 
-#define CHUNK_SIZE 16
-
 #define HAVE_CHUNKMEMSET_2
 #define HAVE_CHUNKMEMSET_4
 #define HAVE_CHUNKMEMSET_8

--- a/chunkset_tpl.h
+++ b/chunkset_tpl.h
@@ -130,11 +130,16 @@ Z_INTERNAL uint8_t* CHUNKMEMSET(uint8_t *out, unsigned dist, unsigned len) {
 #ifdef HAVE_CHUNKMEMSET_8
     if (dist == 8) {
         chunkmemset_8(from, &chunk_load);
-    } else if (dist == sizeof(chunk_t)) {
-        loadchunk(from, &chunk_load);
     } else
 #endif
-    {
+#ifdef HAVE_CHUNKMEMSET_16
+    if (dist == 16) {
+        chunkmemset_16(from, &chunk_load);
+    } else
+#endif
+    if (dist == sizeof(chunk_t)) {
+        loadchunk(from, &chunk_load);
+    } else {
         chunk_load = GET_CHUNK_MAG(from, &chunk_mod, dist);
     }
 


### PR DESCRIPTION
Make chunkset_avx2 half chunk aware
    
This gives us appreciable gains on a number of fronts.  The first being
we're inlining a pretty hot function that was getting dispatched to
regularly. Another is that we're able to do a safe lagged copy of a
distance that is smaller, so CHUNKCOPY gets its teeth back here for
smaller sizes, without having to do another dispatch to a function.
    
We're also now doing two overlapping writes at once and letting the CPU
do its store forwarding. This was an enhancement @dougallj had suggested
a while back.
   
Additionally, the "half chunk mag" here is fundamentally less
complicated because it doesn't require sythensizing cross lane permutes
with a blend operation, so we can optimistically do that first if the
len is small enough that a full 32 byte chunk doesn't make any sense.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new inline functions for handling smaller data chunks using AVX2 instructions.
	- Added support for `halfchunk_t` type to optimize operations on 128-bit chunks.
	- Implemented a new function `HALFCHUNKCOPY` for efficient data copying of half-sized chunks.

- **Bug Fixes**
	- Adjusted memory operation handling in the `inflate_fast` function for improved safety.

- **Refactor**
	- Removed the `CHUNK_SIZE` macro across multiple files to streamline chunk size references.
	- Updated `CHUNKMEMSET` function to a static inline function for better linkage control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->