### PR TITLE
Fix build on aarch64 android.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,7 @@ set_property(CACHE WITH_SANITIZER PROPERTY STRINGS "Memory" "Address" "Undefined
 if(BASEARCH_ARM_FOUND)
     option(WITH_ACLE "Build with ACLE" ON)
     option(WITH_NEON "Build with NEON intrinsics" ON)
-    cmake_dependent_option(WITH_ARMV6 "Build with ARMv6 SIMD" ON "NOT ARCH STREQUAL \"aarch64\"" OFF)
+    cmake_dependent_option(WITH_ARMV6 "Build with ARMv6 SIMD" ON "NOT ARCH MATCHES \"aarch64\"" OFF)
 elseif(BASEARCH_PPC_FOUND)
     option(WITH_ALTIVEC "Build with AltiVec (VMX) optimisations for PowerPC" ON)
     option(WITH_POWER8 "Build with optimisations for POWER8" ON)


### PR DESCRIPTION
When building with CMake toolchain provided by NDK, the ARCH variable is not "aarch64", but "aarch64-none-linux-android26" (or similar). The strict string match check causes the WITH_ARMV6 option to be enabled in such a case. In result, arch/arm/slide_hash_armv6.c is compiled, which is not intended to be used on aarch64, and fails.

Relax the check and assume aarch64 if the ARCH variable contains aarch64.