### PR TITLE
Disable MSVC warning 4819

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,7 +193,7 @@ elseif(MSVC)
     # /Oi ?
     set(WARNFLAGS /W3 /w34242 /WX)
     set(WARNFLAGS_MAINTAINER /W4)
-    set(WARNFLAGS_DISABLE /wd4206 /wd4054)
+    set(WARNFLAGS_DISABLE /wd4206 /wd4054 /wd4819)
     if(BASEARCH_ARM_FOUND)
         add_definitions(-D_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE)
         if(NOT "${ARCH}" MATCHES "aarch64")


### PR DESCRIPTION
Currently, zlib-ng doesn't compile on my machine due to warning C4819: The file contains a character that cannot be represented in the current code page (936). Save the file in Unicode format to prevent data loss.

The non-ascii characters live in zbuild.h.
```
 * gcc says: "warning: implicit declaration of function ‘...’"
 * g++ says: "error: new declaration ‘...’ ambiguates built-in declaration ‘...’"
```

Because zlib-ng treats warning as error, the project doesn't compile. If this warning is disabled, zlib-ng compiles well.