### PR TITLE
Explicitly set CMake policy 0169 to silence warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,10 @@ else()
 endif()
 message(STATUS "Using CMake version ${CMAKE_VERSION}")
 
+if(POLICY CMP0169)
+    cmake_policy(SET CMP0169 OLD) # CMake 3.30: call FetchContent_Populate() with just the name of a dependency
+endif()
+
 # If not specified on the command line, enable C11 as the default
 # Configuration items that affect the global compiler environment standards
 # should be issued before the "project" command.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.5.1)
-
 macro(configure_test_executable target)
     target_include_directories(${target} PRIVATE ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR})
     set_target_properties(${target} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})


### PR DESCRIPTION
The recommended `FetchContent_MakeAvailable()` is introduced in CMake 3.14 which is greater than `cmake_minimum_required()`.

CMake policy will effects subdirectories.

The `cmake_minimum_required(VERSION)` command implicitly calls `cmake_policy(VERSION)`.

Closes https://github.com/zlib-ng/zlib-ng/issues/1788