### PR TITLE
Misc inflate cleanup

### DIFF
--- a/infback.c
+++ b/infback.c
@@ -53,14 +53,18 @@ int32_t ZNG_CONDEXPORT PREFIX(inflateBackInit)(PREFIX3(stream) *strm, int32_t wi
     Tracev((stderr, "inflate: allocated\n"));
 
     strm->state = (struct internal_state *)state;
-    state->dmax = 32768U;
     state->wbits = (unsigned int)windowBits;
     state->wsize = 1U << windowBits;
     state->window = window;
     state->wnext = 0;
     state->whave = 0;
-    state->sane = 1;
     state->chunksize = FUNCTABLE_CALL(chunksize)();
+#ifdef INFLATE_STRICT
+    state->dmax = 32768U;
+#endif
+#ifdef INFLATE_ALLOW_INVALID_DISTANCE_TOOFAR_ARRR
+    state->sane = 1;
+#endif
     return Z_OK;
 }
 

--- a/infback.c
+++ b/infback.c
@@ -55,6 +55,7 @@ int32_t ZNG_CONDEXPORT PREFIX(inflateBackInit)(PREFIX3(stream) *strm, int32_t wi
     strm->state = (struct internal_state *)state;
     state->wbits = (unsigned int)windowBits;
     state->wsize = 1U << windowBits;
+    state->wbufsize = 1U << windowBits;
     state->window = window;
     state->wnext = 0;
     state->whave = 0;

--- a/inffast_tpl.h
+++ b/inffast_tpl.h
@@ -137,7 +137,7 @@ void Z_INTERNAL INFLATE_FAST(PREFIX3(stream) *strm, uint32_t start) {
     /* Detect if out and window point to the same memory allocation. In this instance it is
        necessary to use safe chunk copy functions to prevent overwriting the window. If the
        window is overwritten then future matches with far distances will fail to copy correctly. */
-    extra_safe = (wsize != 0 && out >= window && out + INFLATE_FAST_MIN_LEFT <= window + wsize);
+    extra_safe = (wsize != 0 && out >= window && out + INFLATE_FAST_MIN_LEFT <= window + state->wbufsize);
 
 #define REFILL() do { \
         hold |= load_64_bits(in, bits); \

--- a/inflate.c
+++ b/inflate.c
@@ -240,6 +240,7 @@ int32_t ZNG_CONDEXPORT PREFIX(inflateInit2)(PREFIX3(stream) *strm, int32_t windo
     state = alloc_bufs->state;
     state->window = alloc_bufs->window;
     state->alloc_bufs = alloc_bufs;
+    state->wbufsize = INFLATE_ADJUST_WINDOW_SIZE((1 << MAX_WBITS) + 64);
     Tracev((stderr, "inflate: allocated\n"));
 
     strm->state = (struct internal_state *)state;

--- a/inflate.h
+++ b/inflate.h
@@ -97,7 +97,7 @@ typedef struct inflate_allocs_s {
 /* State maintained between inflate() calls -- approximately 7K bytes, not
    including the allocated sliding window, which is up to 32K bytes. */
 struct ALIGNED_(64) inflate_state {
-    PREFIX3(stream) *strm;             /* pointer back to this zlib stream */
+    PREFIX3(stream) *strm;      /* pointer back to this zlib stream */
     inflate_mode mode;          /* current inflate mode */
     int last;                   /* true if processing last block */
     int wrap;                   /* bit 0 true for zlib, bit 1 true for gzip,
@@ -105,9 +105,12 @@ struct ALIGNED_(64) inflate_state {
     int havedict;               /* true if dictionary provided */
     int flags;                  /* gzip header method and flags, 0 if zlib, or
                                    -1 if raw or no header yet */
+    unsigned was;               /* initial length of match, for inflateMark */
     unsigned long check;        /* protected copy of check value */
     unsigned long total;        /* protected copy of output count */
     PREFIX(gz_headerp) head;    /* where to save gzip header information */
+    int back;                   /* bits back of last unprocessed length/lit */
+
         /* sliding window */
     unsigned wbits;             /* log base 2 of requested window size */
     uint32_t wsize;             /* window size or zero if not using window */
@@ -115,39 +118,37 @@ struct ALIGNED_(64) inflate_state {
     uint32_t whave;             /* valid bytes in the window */
     uint32_t wnext;             /* window write index */
     unsigned char *window;      /* allocated sliding window, if needed */
-#if defined(_M_IX86) || defined(_M_ARM)
-    uint32_t padding;
-#else
-    uint32_t padding[2];
-#endif
-
-    struct crc32_fold_s ALIGNED_(16) crc_fold;
+    uint32_t chunksize;         /* size of memory copying chunk */
 
         /* bit accumulator */
     uint32_t hold;              /* input bit accumulator */
     unsigned bits;              /* number of bits in "in" */
+        /* fixed and dynamic code tables */
+    unsigned lenbits;           /* index bits for lencode */
+    code const *lencode;        /* starting table for length/literal codes */
+    code const *distcode;       /* starting table for distance codes */
+    unsigned distbits;          /* index bits for distcode */
         /* for string and stored block copying */
     uint32_t length;            /* literal or length of data to copy */
     unsigned offset;            /* distance back to copy string from */
         /* for table and code decoding */
     unsigned extra;             /* extra bits needed */
-        /* fixed and dynamic code tables */
-    code const *lencode;        /* starting table for length/literal codes */
-    code const *distcode;       /* starting table for distance codes */
-    unsigned lenbits;           /* index bits for lencode */
-    unsigned distbits;          /* index bits for distcode */
         /* dynamic table building */
     unsigned ncode;             /* number of code length code lengths */
     unsigned nlen;              /* number of length code lengths */
     unsigned ndist;             /* number of distance code lengths */
     uint32_t have;              /* number of code lengths in lens[] */
     code *next;                 /* next available space in codes[] */
+
+#if defined(_M_IX86) || defined(_M_ARM)
+    uint32_t padding[2];
+#endif
+    struct crc32_fold_s ALIGNED_(16) crc_fold;
+
     uint16_t lens[320];         /* temporary storage for code lengths */
     uint16_t work[288];         /* work area for code table building */
     code codes[ENOUGH];         /* space for code tables */
-    int back;                   /* bits back of last unprocessed length/lit */
-    unsigned was;               /* initial length of match */
-    uint32_t chunksize;         /* size of memory copying chunk */
+
     inflate_allocs *alloc_bufs; /* struct for handling memory allocations */
 
 #ifdef INFLATE_STRICT

--- a/inflate.h
+++ b/inflate.h
@@ -105,7 +105,6 @@ struct ALIGNED_(64) inflate_state {
     int havedict;               /* true if dictionary provided */
     int flags;                  /* gzip header method and flags, 0 if zlib, or
                                    -1 if raw or no header yet */
-    unsigned dmax;              /* zlib header max distance (INFLATE_STRICT) */
     unsigned long check;        /* protected copy of check value */
     unsigned long total;        /* protected copy of output count */
     PREFIX(gz_headerp) head;    /* where to save gzip header information */
@@ -145,11 +144,17 @@ struct ALIGNED_(64) inflate_state {
     uint16_t lens[320];         /* temporary storage for code lengths */
     uint16_t work[288];         /* work area for code table building */
     code codes[ENOUGH];         /* space for code tables */
-    int sane;                   /* if false, allow invalid distance too far */
     int back;                   /* bits back of last unprocessed length/lit */
     unsigned was;               /* initial length of match */
     uint32_t chunksize;         /* size of memory copying chunk */
     inflate_allocs *alloc_bufs; /* struct for handling memory allocations */
+
+#ifdef INFLATE_STRICT
+    unsigned dmax;              /* zlib header max distance (INFLATE_STRICT) */
+#endif
+#ifdef INFLATE_ALLOW_INVALID_DISTANCE_TOOFAR_ARRR
+    int sane;                   /* if false, allow invalid distance too far */
+#endif
 #ifdef HAVE_ARCH_INFLATE_STATE
     arch_inflate_state arch;    /* architecture-specific extensions */
 #endif

--- a/inflate.h
+++ b/inflate.h
@@ -111,6 +111,7 @@ struct ALIGNED_(64) inflate_state {
         /* sliding window */
     unsigned wbits;             /* log base 2 of requested window size */
     uint32_t wsize;             /* window size or zero if not using window */
+    uint32_t wbufsize;          /* real size of the allocated window buffer, including padding */
     uint32_t whave;             /* valid bytes in the window */
     uint32_t wnext;             /* window write index */
     unsigned char *window;      /* allocated sliding window, if needed */


### PR DESCRIPTION
- Stop updating 'dmax' and 'sane' and remove the variables from 'inflate_state' unless the checks are compiled in.
- Add a variable 'wbufsize' to track the real size of the window buffer, including padding. This allows chunkset code to spill garbage writes into the padding area if it is available. It is not available for inflateBack unfortunately.
- Reorder the 'inflate_state' struct to improve cache-locality of the variables needed by inffast (reduced from 6 to 1 cacheline)
  Also fills in some unnecessary holes.
  
On x86-64, default settings, inflate_state also shrinks from 9216 to 9152 bytes and now ends cleanly on a cacheline boundary.
