### PR TITLE
Fix Haiku default directories.

### DIFF
--- a/cmake/detect-install-dirs.cmake
+++ b/cmake/detect-install-dirs.cmake
@@ -16,6 +16,9 @@ if (DEFINED LIB_INSTALL_DIR)
     set(CMAKE_INSTALL_LIBDIR "${LIB_INSTALL_DIR}")
 elseif (DEFINED INSTALL_LIB_DIR)
     set(CMAKE_INSTALL_LIBDIR "${INSTALL_LIB_DIR}")
+elseif (CMAKE_INSTALL_PREFIX STREQUAL "/boot/system")
+    # Haiku development libraries
+    set(CMAKE_INSTALL_LIBDIR "develop/lib")
 endif()
 
 # Determine installation directory for include files
@@ -24,6 +27,20 @@ if (DEFINED INC_INSTALL_DIR)
     set(CMAKE_INSTALL_INCLUDEDIR "${INC_INSTALL_DIR}")
 elseif (DEFINED INSTALL_INC_DIR)
     set(CMAKE_INSTALL_INCLUDEDIR "${INSTALL_INC_DIR}")
+elseif (CMAKE_INSTALL_PREFIX STREQUAL "/boot/system")
+    # Haiku system headers
+    set(CMAKE_INSTALL_INCLUDEDIR "develop/headers")
+endif()
+
+# Determine installation directory for man files
+if (DEFINED MAN_INSTALL_DIR)
+    set(MAN_INSTALL_DIR "${MAN_INSTALL_DIR}" CACHE PATH "Installation directory for manuals (Deprecated)" FORCE)
+    set(CMAKE_INSTALL_MANDIR "${MAN_INSTALL_DIR}")
+elseif (DEFINED INSTALL_MAN_DIR)
+    set(CMAKE_INSTALL_MANDIR "${INSTALL_MAN_DIR}")
+elseif (CMAKE_INSTALL_PREFIX STREQUAL "/boot/system")
+    # Haiku system manuals
+    set(CMAKE_INSTALL_MANDIR "documentation/man")
 endif()
 
 # Define GNU standard installation directories

--- a/configure
+++ b/configure
@@ -30,6 +30,9 @@ if [ -n "${CHOST}" ]; then
     ARCH="$(echo "${NORM_CHOST}" | sed -e 's/-.*//')"
 else
     ARCH="$(uname -m)"
+    if test -z "$uname"; then
+      uname=$( (uname -s || echo unknown) 2>/dev/null)
+    fi
 fi
 
 case "${ARCH}" in
@@ -77,13 +80,29 @@ RCOBJS=
 STRIP=
 ARCHS=
 PC_CFLAGS=
-prefix=${prefix-/usr/local}
+if test "${uname}" = "Haiku" || test "${uname}" = "haiku"; then
+  prefix=${prefix-/boot/system}
+else
+  prefix=${prefix-/usr/local}
+fi
 exec_prefix=${exec_prefix-'${prefix}'}
 bindir=${bindir-'${exec_prefix}/bin'}
-libdir=${libdir-'${exec_prefix}/lib'}
+if test "${exec_prefix}" = "/boot/system" || (test "${prefix}" = "/boot/system" && test "${exec_prefix}" = '${prefix}'); then
+  libdir=${libdir-'${exec_prefix}/develop/lib'}
+else
+  libdir=${libdir-'${exec_prefix}/lib'}
+fi
 sharedlibdir=${sharedlibdir-'${libdir}'}
-includedir=${includedir-'${prefix}/include'}
-mandir=${mandir-'${prefix}/share/man'}
+if test "${prefix}" = "/boot/system"; then
+  includedir=${includedir-'${prefix}/develop/headers'}
+else
+  includedir=${includedir-'${prefix}/include'}
+fi
+if test "${prefix}" = "/boot/system"; then
+  mandir=${mandir-'${prefix}/documentation/man'}
+else
+  mandir=${mandir-'${prefix}/share/man'}
+fi
 shared_ext='.so'
 shared=1
 gzfileops=1
@@ -159,7 +178,7 @@ case "$1" in
       echo 'usage:' | tee -a configure.log
       echo '  configure [--prefix=PREFIX]  [--eprefix=EXPREFIX]' | tee -a configure.log
       echo '    [--static] [--32] [--64] [--libdir=LIBDIR] [--sharedlibdir=LIBDIR]' | tee -a configure.log
-      echo '    [--includedir=INCLUDEDIR] [--archs="-arch i386 -arch x86_64"]' | tee -a configure.log
+      echo '    [--includedir=INCLUDEDIR] [--mandir=MANDIR] [--archs="-arch i386 -arch x86_64"]' | tee -a configure.log
       echo '    [--sprefix=SYMBOL_PREFIX]   Adds a prefix to all exported symbols' | tee -a configure.log
       echo '    [--warn]                    Enables extra compiler warnings' | tee -a configure.log
       echo '    [--debug]                   Enables extra debug prints during operation' | tee -a configure.log
@@ -185,6 +204,7 @@ case "$1" in
     -l*=* | --libdir=*) libdir=$(echo $1 | sed 's/.*=//'); shift ;;
     --sharedlibdir=*) sharedlibdir=$(echo $1 | sed 's/.*=//'); shift ;;
     -i*=* | --includedir=*) includedir=$(echo $1 | sed 's/.*=//');shift ;;
+    --mandir=*) mandir=${echo $1 | sed 's/.*=//'}; shift ;;
     -u*=* | --uname=*) uname=$(echo $1 | sed 's/.*=//');shift ;;
     -p* | --prefix) prefix="$2"; shift; shift ;;
     -e* | --eprefix) exec_prefix="$2"; shift; shift ;;
@@ -359,11 +379,8 @@ if test "$gcc" -eq 1 && ($cc $CFLAGS -c $test.c) >> configure.log 2>&1; then
     CFLAGS="${CFLAGS} -DNDEBUG"
     SFLAGS="${SFLAGS} -DNDEBUG"
   fi
-  if test -z "$uname"; then
-    uname=$( (uname -s || echo unknown) 2>/dev/null)
-  fi
   case "$uname" in
-  Linux* | linux* | GNU | GNU/* | solaris*)
+  Linux* | linux* | GNU | GNU/* | solaris* | Haiku)
         LDSHARED=${LDSHARED-"$cc"}
         LDSHAREDFLAGS="-shared -Wl,-soname,${LIBNAME}.so.${VER1}" ;;
   *BSD | *bsd* | DragonFly)


### PR DESCRIPTION
Haiku is open-source operating system forked from BeOS. It doesn't use same file layout as Linux or *BSD.

We have to move uname check earlier, so defaults can be selected depending on operating system.