### PR TITLE
configure: Fix linker flags for Haiku.

### DIFF
--- a/configure
+++ b/configure
@@ -363,7 +363,7 @@ if test "$gcc" -eq 1 && ($cc $CFLAGS -c $test.c) >> configure.log 2>&1; then
     uname=$( (uname -s || echo unknown) 2>/dev/null)
   fi
   case "$uname" in
-  Linux* | linux* | GNU | GNU/* | solaris*)
+  Linux* | linux* | GNU | GNU/* | solaris* | Haiku)
         LDSHARED=${LDSHARED-"$cc"}
         LDSHAREDFLAGS="-shared -Wl,-soname,${LIBNAME}.so.${VER1}" ;;
   *BSD | *bsd* | DragonFly)


### PR DESCRIPTION
Separated from #1798 

This makes output of configure build match CMake build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded compatibility to include the Haiku operating system in the configuration script. 

This enhancement allows users on Haiku to utilize the application seamlessly alongside other supported operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->