### PR TITLE
Compute the "safe" distance properly

### DIFF
--- a/inffast_tpl.h
+++ b/inffast_tpl.h
@@ -260,7 +260,7 @@ void Z_INTERNAL INFLATE_FAST(PREFIX3(stream) *strm, uint32_t start) {
                     if (dist >= len || dist >= state->chunksize)
                         out = chunkcopy_safe(out, out - dist, len, safe);
                     else
-                        out = CHUNKMEMSET_SAFE(out, dist, len, (unsigned)((safe - out) + 1));
+                        out = CHUNKMEMSET_SAFE(out, dist, len, (unsigned)((safe - out)));
                 } else {
                     /* Whole reference is in range of current output.  No range checks are
                        necessary because we start with room for at least 258 bytes of output,


### PR DESCRIPTION
The safe pointer that is computed is an exclusive, not inclusive bounds. While we were probably rarely ever bit this, if ever, it still makes sense to apply the limit, properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted memory operation parameters for improved performance in the decompression process. 

- **Documentation**
	- Maintained existing comments and documentation for clarity on function purpose and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->