### PR TITLE
Reorder variables in inflate functions to reduce padding holes

### DIFF
--- a/inffast_tpl.h
+++ b/inffast_tpl.h
@@ -59,10 +59,10 @@ void Z_INTERNAL INFLATE_FAST(PREFIX3(stream) *strm, uint32_t start) {
     unsigned char *beg;         /* inflate()'s initial strm->next_out */
     unsigned char *end;         /* while out < end, enough space available */
     unsigned char *safe;        /* can use chunkcopy provided out < safe */
+    unsigned char *window;      /* allocated sliding window, if wsize != 0 */
     unsigned wsize;             /* window size or zero if not using window */
     unsigned whave;             /* valid bytes in the window */
     unsigned wnext;             /* window write index */
-    unsigned char *window;      /* allocated sliding window, if wsize != 0 */
 
     /* hold is a local copy of strm->hold. By default, hold satisfies the same
        invariants that strm->hold does, namely that (hold >> bits) == 0. This
@@ -101,18 +101,18 @@ void Z_INTERNAL INFLATE_FAST(PREFIX3(stream) *strm, uint32_t start) {
        with (1<<bits)-1 to drop those excess bits so that, on function exit, we
        keep the invariant that (state->hold >> state->bits) == 0.
     */
-    uint64_t hold;              /* local strm->hold */
     unsigned bits;              /* local strm->bits */
-    code const *lcode;          /* local strm->lencode */
-    code const *dcode;          /* local strm->distcode */
+    uint64_t hold;              /* local strm->hold */
     unsigned lmask;             /* mask for first level of length codes */
     unsigned dmask;             /* mask for first level of distance codes */
+    code const *lcode;          /* local strm->lencode */
+    code const *dcode;          /* local strm->distcode */
     const code *here;           /* retrieved table entry */
     unsigned op;                /* code bits, operation, extra bits, or */
                                 /*  window position, window bytes to copy */
     unsigned len;               /* match length, unused bytes */
-    unsigned dist;              /* match distance */
     unsigned char *from;        /* where to copy match from */
+    unsigned dist;              /* match distance */
     unsigned extra_safe;        /* copy chunks safely in all cases */
 
     /* copy state to local variables */

--- a/inflate.c
+++ b/inflate.c
@@ -217,8 +217,8 @@ Z_INTERNAL void free_inflate(PREFIX3(stream) *strm) {
  * This function is hidden in ZLIB_COMPAT builds.
  */
 int32_t ZNG_CONDEXPORT PREFIX(inflateInit2)(PREFIX3(stream) *strm, int32_t windowBits) {
-    int32_t ret;
     struct inflate_state *state;
+    int32_t ret;
 
     /* Initialize functable */
     FUNCTABLE_INIT;
@@ -477,12 +477,12 @@ int32_t Z_EXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int32_t flush) {
     struct inflate_state *state;
     const unsigned char *next;  /* next input */
     unsigned char *put;         /* next output */
+    unsigned char *from;        /* where to copy match bytes from */
     unsigned have, left;        /* available input and output */
     uint32_t hold;              /* bit buffer */
     unsigned bits;              /* bits in bit buffer */
     uint32_t in, out;           /* save starting available input and output */
     unsigned copy;              /* number of stored or match bytes to copy */
-    unsigned char *from;        /* where to copy match bytes from */
     code here;                  /* current decoding table entry */
     code last;                  /* parent table entry */
     unsigned len;               /* length to copy for repeats, bits to drop */
@@ -1306,11 +1306,11 @@ static uint32_t syncsearch(uint32_t *have, const uint8_t *buf, uint32_t len) {
 }
 
 int32_t Z_EXPORT PREFIX(inflateSync)(PREFIX3(stream) *strm) {
+    struct inflate_state *state;
+    size_t in, out;             /* temporary to save total_in and total_out */
     unsigned len;               /* number of bytes to look at or looked at */
     int flags;                  /* temporary to save header status */
-    size_t in, out;             /* temporary to save total_in and total_out */
     unsigned char buf[4];       /* to restore bit buffer to byte string */
-    struct inflate_state *state;
 
     /* check parameters */
     if (inflateStateCheck(strm))


### PR DESCRIPTION
Reorder variables in inflate functions to reduce padding holes due to variable alignment requirements.

This is more a case of doing things the recommended way rather than an optimization.

This is a very very minor change, and while it is probable to have a positive impact on performance, it is so small that I can not reliably benchmark it as it is well within the run-to-run variability.
That said, it seems to trend towards being faster by around 0.02%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->