### PR TITLE
Add support for sending "assume" hints to compilers

### DIFF
--- a/arch/arm/slide_hash_armv6.c
+++ b/arch/arm/slide_hash_armv6.c
@@ -40,7 +40,7 @@ static inline void slide_hash_chain(Pos *table, uint32_t entries, uint16_t wsize
 }
 
 Z_INTERNAL void slide_hash_armv6(deflate_state *s) {
-    Assert(s->w_size <= UINT16_MAX, "w_size should fit in uint16_t");
+    AssertHint(s->w_size <= UINT16_MAX, "w_size should fit in uint16_t");
     uint16_t wsize = (uint16_t)s->w_size;
 
     slide_hash_chain(s->head, HASH_SIZE, wsize);

--- a/arch/arm/slide_hash_neon.c
+++ b/arch/arm/slide_hash_neon.c
@@ -39,7 +39,7 @@ static inline void slide_hash_chain(Pos *table, uint32_t entries, uint16_t wsize
 }
 
 Z_INTERNAL void slide_hash_neon(deflate_state *s) {
-    Assert(s->w_size <= UINT16_MAX, "w_size should fit in uint16_t");
+    AssertHint(s->w_size <= UINT16_MAX, "w_size should fit in uint16_t");
     uint16_t wsize = (uint16_t)s->w_size;
 
     slide_hash_chain(s->head, HASH_SIZE, wsize);

--- a/arch/generic/crc32_braid_c.c
+++ b/arch/generic/crc32_braid_c.c
@@ -193,7 +193,7 @@ Z_INTERNAL uint32_t crc32_braid(uint32_t crc, const uint8_t *buf, size_t len) {
 #endif
 #endif
         words += BRAID_N;
-        Assert(comb <= UINT32_MAX, "comb should fit in uint32_t");
+        AssertHint(comb <= UINT32_MAX, "comb should fit in uint32_t");
         crc = (uint32_t)Z_WORD_FROM_LE(comb);
 
         /* Update the pointer to the remaining bytes to process. */

--- a/arch/power/slide_ppc_tpl.h
+++ b/arch/power/slide_ppc_tpl.h
@@ -24,7 +24,7 @@ static inline void slide_hash_chain(Pos *table, uint32_t entries, uint16_t wsize
 }
 
 void Z_INTERNAL SLIDE_PPC(deflate_state *s) {
-    Assert(s->w_size <= UINT16_MAX, "w_size should fit in uint16_t");
+    AssertHint(s->w_size <= UINT16_MAX, "w_size should fit in uint16_t");
     uint16_t wsize = (uint16_t)s->w_size;
 
     slide_hash_chain(s->head, HASH_SIZE, wsize);

--- a/arch/riscv/chunkset_rvv.c
+++ b/arch/riscv/chunkset_rvv.c
@@ -87,7 +87,7 @@ static inline void storechunk(uint8_t *out, chunk_t *chunk) {
  *         loadchunk and storechunk to ensure the result is correct.
  */
 static inline uint8_t* CHUNKCOPY(uint8_t *out, uint8_t const *from, unsigned len) {
-    Assert(len > 0, "chunkcopy should never have a length 0");
+    AssertHint(len > 0, "chunkcopy should never have a length 0");
     ptrdiff_t dist = out - from;
     if (dist < 0 || dist >= len) {
         memcpy(out, from, len);

--- a/arch/riscv/slide_hash_rvv.c
+++ b/arch/riscv/slide_hash_rvv.c
@@ -23,7 +23,7 @@ static inline void slide_hash_chain(Pos *table, uint32_t entries, uint16_t wsize
 }
 
 Z_INTERNAL void slide_hash_rvv(deflate_state *s) {
-    Assert(s->w_size <= UINT16_MAX, "w_size should fit in uint16_t");
+    AssertHint(s->w_size <= UINT16_MAX, "w_size should fit in uint16_t");
     uint16_t wsize = (uint16_t)s->w_size;
 
     slide_hash_chain(s->head, HASH_SIZE, wsize);

--- a/arch/s390/dfltcc_deflate.c
+++ b/arch/s390/dfltcc_deflate.c
@@ -220,8 +220,8 @@ again:
     /* DFLTCC-CMPR will write to next_out, so make sure that buffers with
      * higher precedence are empty.
      */
-    Assert(state->pending == 0, "There must be no pending bytes");
-    Assert(state->bi_valid < 8, "There must be less than 8 pending bits");
+    AssertHint(state->pending == 0, "There must be no pending bytes");
+    AssertHint(state->bi_valid < 8, "There must be less than 8 pending bits");
     param->sbb = (unsigned int)state->bi_valid;
     if (param->sbb > 0)
         *strm->next_out = (unsigned char)state->bi_buf;

--- a/arch/x86/slide_hash_avx2.c
+++ b/arch/x86/slide_hash_avx2.c
@@ -37,7 +37,7 @@ static inline void slide_hash_chain(Pos *table, uint32_t entries, const __m256i 
 }
 
 Z_INTERNAL void slide_hash_avx2(deflate_state *s) {
-    Assert(s->w_size <= UINT16_MAX, "w_size should fit in uint16_t");
+    AssertHint(s->w_size <= UINT16_MAX, "w_size should fit in uint16_t");
     uint16_t wsize = (uint16_t)s->w_size;
     const __m256i ymm_wsize = _mm256_set1_epi16((short)wsize);
 

--- a/arch/x86/slide_hash_sse2.c
+++ b/arch/x86/slide_hash_sse2.c
@@ -55,7 +55,7 @@ next_chain:
 }
 
 Z_INTERNAL void slide_hash_sse2(deflate_state *s) {
-    Assert(s->w_size <= UINT16_MAX, "w_size should fit in uint16_t");
+    AssertHint(s->w_size <= UINT16_MAX, "w_size should fit in uint16_t");
     uint16_t wsize = (uint16_t)s->w_size;
     const __m128i xmm_wsize = _mm_set1_epi16((short)wsize);
 

--- a/chunkset_tpl.h
+++ b/chunkset_tpl.h
@@ -22,7 +22,7 @@ static inline size_t CHUNKSIZE(void) {
    reliable. */
 #ifndef HAVE_CHUNKCOPY
 static inline uint8_t* CHUNKCOPY(uint8_t *out, uint8_t const *from, unsigned len) {
-    Assert(len > 0, "chunkcopy should never have a length 0");
+    AssertHint(len > 0, "chunkcopy should never have a length 0");
     chunk_t chunk;
     int32_t align = ((len - 1) % sizeof(chunk_t)) + 1;
     loadchunk(from, &chunk);
@@ -110,7 +110,7 @@ static inline uint8_t* HALFCHUNKCOPY(uint8_t *out, uint8_t const *from, unsigned
 static inline uint8_t* CHUNKMEMSET(uint8_t *out, uint8_t *from, unsigned len) {
     /* Debug performance related issues when len < sizeof(uint64_t):
        Assert(len >= sizeof(uint64_t), "chunkmemset should be called on larger chunks"); */
-    Assert(from != out, "chunkmemset cannot have a distance 0");
+    AssertHint(from != out, "chunkmemset cannot have a distance 0");
 
     chunk_t chunk_load;
     uint32_t chunk_mod = 0;

--- a/deflate.c
+++ b/deflate.c
@@ -1044,7 +1044,7 @@ int32_t Z_EXPORT PREFIX(deflate)(PREFIX3(stream) *strm, int32_t flush) {
     if (s->wrap > 0)
         s->wrap = -s->wrap; /* write the trailer only once! */
     if (s->pending == 0) {
-        Assert(s->bi_valid == 0, "bi_buf not flushed");
+        AssertHint(s->bi_valid == 0, "bi_buf not flushed");
         return Z_STREAM_END;
     }
     return Z_OK;
@@ -1171,7 +1171,7 @@ void Z_INTERNAL PREFIX(fill_window)(deflate_state *s) {
     unsigned int wsize = s->w_size;
     int level = s->level;
 
-    Assert(s->lookahead < MIN_LOOKAHEAD, "already enough lookahead");
+    AssertHint(s->lookahead < MIN_LOOKAHEAD, "already enough lookahead");
 
     if (level >= 9)
         insert_string_func = insert_string_roll;
@@ -1213,7 +1213,7 @@ void Z_INTERNAL PREFIX(fill_window)(deflate_state *s) {
          * Otherwise, window_size == 2*WSIZE so more >= 2.
          * If there was sliding, more >= WSIZE. So in all cases, more >= 2.
          */
-        Assert(more >= 2, "more < 2");
+        AssertHint(more >= 2, "more < 2");
 
         n = read_buf(strm, window + s->strstart + s->lookahead, more);
         s->lookahead += n;

--- a/deflate_fast.c
+++ b/deflate_fast.c
@@ -65,8 +65,8 @@ Z_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
         }
 
         if (match_len >= WANT_MIN_MATCH) {
-            Assert(s->strstart <= UINT16_MAX, "strstart should fit in uint16_t");
-            Assert(s->match_start <= UINT16_MAX, "match_start should fit in uint16_t");
+            AssertHint(s->strstart <= UINT16_MAX, "strstart should fit in uint16_t");
+            AssertHint(s->match_start <= UINT16_MAX, "match_start should fit in uint16_t");
             check_match(s, s->strstart, s->match_start, match_len);
 
             bflush = zng_tr_tally_dist(s, s->strstart - s->match_start, match_len - STD_MIN_MATCH);

--- a/deflate_p.h
+++ b/deflate_p.h
@@ -79,8 +79,8 @@ static inline int zng_tr_tally_dist(deflate_state* s, uint32_t dist, uint32_t le
     /* dist: distance of matched string */
     /* len: match length-STD_MIN_MATCH */
 #ifdef LIT_MEM
-    Assert(dist <= UINT16_MAX, "dist should fit in uint16_t");
-    Assert(len <= UINT8_MAX, "len should fit in uint8_t");
+    AssertHint(dist <= UINT16_MAX, "dist should fit in uint16_t");
+    AssertHint(len <= UINT8_MAX, "len should fit in uint8_t");
     s->d_buf[s->sym_next] = (uint16_t)dist;
     s->l_buf[s->sym_next++] = (uint8_t)len;
 #else

--- a/deflate_p.h
+++ b/deflate_p.h
@@ -90,7 +90,7 @@ static inline int zng_tr_tally_dist(deflate_state* s, uint32_t dist, uint32_t le
 #endif
     s->matches++;
     dist--;
-    Assert(dist < MAX_DIST(s) && (uint16_t)d_code(dist) < (uint16_t)D_CODES,
+    AssertHint(dist < MAX_DIST(s) && (uint16_t)d_code(dist) < (uint16_t)D_CODES,
         "zng_tr_tally: bad match");
 
     s->dyn_ltree[zng_length_code[len] + LITERALS + 1].Freq++;

--- a/deflate_p.h
+++ b/deflate_p.h
@@ -72,7 +72,6 @@ static inline int zng_tr_tally_lit(deflate_state *s, unsigned char c) {
 #endif
     s->dyn_ltree[c].Freq++;
     Tracevv((stderr, "%c", c));
-    Assert(c <= (STD_MAX_MATCH-STD_MIN_MATCH), "zng_tr_tally: bad literal");
     return (s->sym_next == s->sym_end);
 }
 

--- a/deflate_quick.c
+++ b/deflate_quick.c
@@ -105,8 +105,8 @@ Z_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
                         if (UNLIKELY(match_len > s->lookahead))
                             match_len = s->lookahead;
 
-                        Assert(match_len <= STD_MAX_MATCH, "match too long");
-                        Assert(s->strstart <= UINT16_MAX, "strstart should fit in uint16_t");
+                        AssertHint(match_len <= STD_MAX_MATCH, "match too long");
+                        AssertHint(s->strstart <= UINT16_MAX, "strstart should fit in uint16_t");
                         check_match(s, s->strstart, hash_head, match_len);
 
                         zng_tr_emit_dist(s, static_ltree, static_dtree, match_len - STD_MIN_MATCH, (uint32_t)dist);

--- a/deflate_rle.c
+++ b/deflate_rle.c
@@ -52,7 +52,7 @@ Z_INTERNAL block_state deflate_rle(deflate_state *s, int flush) {
 
         /* Emit match if have run of STD_MIN_MATCH or longer, else emit literal */
         if (match_len >= STD_MIN_MATCH) {
-            Assert(s->strstart <= UINT16_MAX, "strstart should fit in uint16_t");
+            AssertHint(s->strstart <= UINT16_MAX, "strstart should fit in uint16_t");
             check_match(s, s->strstart, s->strstart - 1, match_len);
 
             bflush = zng_tr_tally_dist(s, 1, match_len - STD_MIN_MATCH);

--- a/deflate_slow.c
+++ b/deflate_slow.c
@@ -85,7 +85,7 @@ Z_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
             unsigned int max_insert = s->strstart + s->lookahead - STD_MIN_MATCH;
             /* Do not insert strings in hash table beyond this. */
 
-            Assert((s->strstart-1) <= UINT16_MAX, "strstart-1 should fit in uint16_t");
+            AssertHint((s->strstart-1) <= UINT16_MAX, "strstart-1 should fit in uint16_t");
             check_match(s, s->strstart - 1, s->prev_match, s->prev_length);
 
             bflush = zng_tr_tally_dist(s, s->strstart -1 - s->prev_match, s->prev_length - STD_MIN_MATCH);

--- a/fallback_builtins.h
+++ b/fallback_builtins.h
@@ -18,7 +18,7 @@
  * is explicitly undefined per GCC/Clang docs. */
 
 Z_FORCEINLINE static uint32_t zng_ctz32(uint32_t value) {
-    Assert(value != 0, "Invalid input value: 0");
+    AssertHint(value != 0, "Invalid input value: 0");
 #if __has_builtin(__builtin_ctz)
     return (uint32_t)__builtin_ctz(value);
 #elif defined(_MSC_VER) && !defined(__clang__)
@@ -42,7 +42,7 @@ Z_FORCEINLINE static uint32_t zng_ctz32(uint32_t value) {
 }
 
 Z_FORCEINLINE static uint32_t zng_ctz64(uint64_t value) {
-    Assert(value != 0, "Invalid input value: 0");
+    AssertHint(value != 0, "Invalid input value: 0");
 #if __has_builtin(__builtin_ctzll)
     return (uint32_t)__builtin_ctzll(value);
 #elif defined(_MSC_VER) && !defined(__clang__) && defined(ARCH_64BIT)

--- a/inffast_tpl.h
+++ b/inffast_tpl.h
@@ -305,7 +305,7 @@ void Z_INTERNAL INFLATE_FAST(PREFIX3(stream) *strm, uint32_t start) {
     strm->avail_out = (unsigned)(out < end ? (INFLATE_FAST_MIN_LEFT - 1) + (end - out)
                                            : (INFLATE_FAST_MIN_LEFT - 1) - (out - end));
 
-    Assert(bits <= 32, "Remaining bits greater than 32");
+    AssertHint(bits <= 32, "Remaining bits greater than 32");
     state->hold = (uint32_t)hold;
     state->bits = bits;
     return;

--- a/inffast_tpl.h
+++ b/inffast_tpl.h
@@ -115,8 +115,15 @@ void Z_INTERNAL INFLATE_FAST(PREFIX3(stream) *strm, uint32_t start) {
     unsigned extra_safe;        /* copy chunks safely in all cases */
     uint64_t old;               /* look-behind buffer for extra bits */
 
-    /* copy state to local variables */
     state = (struct inflate_state *)strm->state;
+
+    Assume(state->mode == LEN);
+    Assume(state->bits < 8);
+    Assume(strm->avail_in >= INFLATE_FAST_MIN_HAVE);
+    Assume(strm->avail_out >= INFLATE_FAST_MIN_LEFT);
+    Assume(start >= strm->avail_out);
+
+    /* copy state to local variables */
     in = strm->next_in;
     last = in + (strm->avail_in - (INFLATE_FAST_MIN_HAVE - 1));
     out = strm->next_out;

--- a/match_tpl.h
+++ b/match_tpl.h
@@ -117,7 +117,7 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, uint32_t cur_match) {
 #else
     early_exit = s->level < EARLY_EXIT_TRIGGER_LEVEL;
 #endif
-    Assert((unsigned long)strstart <= s->window_size - MIN_LOOKAHEAD, "need lookahead");
+    AssertHint((unsigned long)strstart <= s->window_size - MIN_LOOKAHEAD, "need lookahead");
     for (;;) {
         if (cur_match >= strstart)
             break;

--- a/trees.c
+++ b/trees.c
@@ -493,7 +493,7 @@ static void send_tree(deflate_state *s, ct_data *tree, int max_code) {
                 send_code(s, curlen, s->bl_tree, bi_buf, bi_valid);
                 count--;
             }
-            Assert(count >= 3 && count <= 6, " 3_6?");
+            AssertHint(count >= 3 && count <= 6, " 3_6?");
             send_code(s, REP_3_6, s->bl_tree, bi_buf, bi_valid);
             send_bits(s, count-3, 2, bi_buf, bi_valid);
 
@@ -561,8 +561,8 @@ static int build_bl_tree(deflate_state *s) {
 static void send_all_trees(deflate_state *s, int lcodes, int dcodes, int blcodes) {
     int rank;                    /* index in bl_order */
 
-    Assert(lcodes >= 257 && dcodes >= 1 && blcodes >= 4, "not enough codes");
-    Assert(lcodes <= L_CODES && dcodes <= D_CODES && blcodes <= BL_CODES, "too many codes");
+    AssertHint(lcodes >= 257 && dcodes >= 1 && blcodes >= 4, "not enough codes");
+    AssertHint(lcodes <= L_CODES && dcodes <= D_CODES && blcodes <= BL_CODES, "too many codes");
 
     // Temp local variables
     uint32_t bi_valid = s->bi_valid;

--- a/trees.c
+++ b/trees.c
@@ -81,6 +81,7 @@ static int  detect_data_type (deflate_state *s);
  * Initialize the tree data structures for a new zlib stream.
  */
 void Z_INTERNAL zng_tr_init(deflate_state *s) {
+    Assume(s != NULL);
     s->l_desc.dyn_tree = s->dyn_ltree;
     s->l_desc.stat_desc = &static_l_desc;
 
@@ -105,6 +106,7 @@ void Z_INTERNAL zng_tr_init(deflate_state *s) {
  * Initialize a new block.
  */
 static void init_block(deflate_state *s) {
+    Assume(s != NULL);
     int n; /* iterates over tree elements */
 
     /* Initialize the trees. */
@@ -151,6 +153,7 @@ static void init_block(deflate_state *s) {
 static inline void pqdownheap(unsigned char *depth, int *heap, const int heap_len, ct_data *tree, int k) {
     /* tree: the tree to restore */
     /* k: node to move down */
+    Assume(depth != NULL && heap != NULL && tree != NULL);
     int j = k << 1;  /* left son of k */
     const int v = heap[k];
 
@@ -280,6 +283,7 @@ static void build_tree(deflate_state *s, tree_desc *desc) {
  */
 static void gen_bitlen(deflate_state *s, tree_desc *desc) {
     /* desc: the tree descriptor */
+    Assume(s != NULL && desc != NULL);
     ct_data *tree           = desc->dyn_tree;
     int max_code            = desc->max_code;
     const ct_data *stree    = desc->stat_desc->static_tree;
@@ -414,6 +418,7 @@ Z_INTERNAL void gen_codes(ct_data *tree, int max_code, uint16_t *bl_count) {
 static void scan_tree(deflate_state *s, ct_data *tree, int max_code) {
     /* tree: the tree to be scanned */
     /* max_code: and its largest code of non zero frequency */
+    Assume(s != NULL && tree != NULL);
     int n;                     /* iterates over all tree elements */
     int prevlen = -1;          /* last emitted length */
     int curlen;                /* length of current code */
@@ -462,6 +467,8 @@ static void scan_tree(deflate_state *s, ct_data *tree, int max_code) {
 static void send_tree(deflate_state *s, ct_data *tree, int max_code) {
     /* tree: the tree to be scanned */
     /* max_code and its largest code of non zero frequency */
+    Assume(s != NULL && tree != NULL);
+    Assume(s->bi_valid <= BIT_BUF_SIZE);
     int n;                     /* iterates over all tree elements */
     int prevlen = -1;          /* last emitted length */
     int curlen;                /* length of current code */
@@ -526,6 +533,7 @@ static void send_tree(deflate_state *s, ct_data *tree, int max_code) {
  * bl_order of the last bit length code to send.
  */
 static int build_bl_tree(deflate_state *s) {
+    Assume(s != NULL);
     int max_blindex;  /* index of last bit length code of non zero freq */
 
     /* Determine the bit length frequencies for literal and distance trees */
@@ -559,6 +567,8 @@ static int build_bl_tree(deflate_state *s) {
  * IN assertion: lcodes >= 257, dcodes >= 1, blcodes >= 4.
  */
 static void send_all_trees(deflate_state *s, int lcodes, int dcodes, int blcodes) {
+    Assume(s != NULL);
+    Assume(s->bi_valid <= BIT_BUF_SIZE);
     int rank;                    /* index in bl_order */
 
     AssertHint(lcodes >= 257 && dcodes >= 1 && blcodes >= 4, "not enough codes");
@@ -596,6 +606,8 @@ void Z_INTERNAL zng_tr_stored_block(deflate_state *s, char *buf, uint32_t stored
     /* buf: input block */
     /* stored_len: length of input block */
     /* last: one if this is the last block for a file */
+    Assume(s != NULL);
+
     zng_tr_emit_tree(s, STORED_BLOCK, last); /* send block type */
     zng_tr_emit_align(s);                    /* align on byte boundary */
     cmpr_bits_align(s);
@@ -616,6 +628,7 @@ void Z_INTERNAL zng_tr_stored_block(deflate_state *s, char *buf, uint32_t stored
  * This takes 10 bits, of which 7 may remain in the bit buffer.
  */
 void Z_INTERNAL zng_tr_align(deflate_state *s) {
+    Assume(s != NULL);
     zng_tr_emit_tree(s, STATIC_TREES, 0);
     zng_tr_emit_end_block(s, static_ltree, 0);
     zng_tr_flush_bits(s);
@@ -629,6 +642,8 @@ void Z_INTERNAL zng_tr_flush_block(deflate_state *s, char *buf, uint32_t stored_
     /* buf: input block, or NULL if too old */
     /* stored_len: length of input block */
     /* last: one if this is the last block for a file */
+    Assume(s != NULL);
+
     unsigned int opt_lenb, static_lenb; /* opt_len and static_len in bytes */
     int max_blindex = 0;  /* index of last bit length code of non zero freq */
 
@@ -669,7 +684,7 @@ void Z_INTERNAL zng_tr_flush_block(deflate_state *s, char *buf, uint32_t stored_
             opt_lenb = static_lenb;
 
     } else {
-        Assert(buf != NULL, "lost buf");
+        AssertHint(buf != NULL, "lost buf");
         opt_lenb = static_lenb = stored_len + 5; /* force a stored block */
     }
 
@@ -711,6 +726,8 @@ void Z_INTERNAL zng_tr_flush_block(deflate_state *s, char *buf, uint32_t stored_
 static void compress_block(deflate_state *s, const ct_data *ltree, const ct_data *dtree) {
     /* ltree: literal tree */
     /* dtree: distance tree */
+    Assume(s != NULL && ltree != NULL && dtree != NULL);
+
     unsigned dist;      /* distance of matched string */
     int lc;             /* match length or unmatched char (if dist == 0) */
     unsigned sx = 0;    /* running index in symbol buffers */
@@ -766,6 +783,7 @@ static void compress_block(deflate_state *s, const ct_data *ltree, const ct_data
  * IN assertion: the fields Freq of dyn_ltree are set.
  */
 static int detect_data_type(deflate_state *s) {
+    Assume(s != NULL);
     /* block_mask is the bit mask of block-listed bytes
      * set bits 0..6, 14..25, and 28..31
      * 0xf3ffc07f = binary 11110011111111111100000001111111
@@ -795,6 +813,8 @@ static int detect_data_type(deflate_state *s) {
  * Flush the bit buffer, keeping at most 7 bits in it.
  */
 void Z_INTERNAL zng_tr_flush_bits(deflate_state *s) {
+    Assume(s != NULL);
+    Assume(s->bi_valid <= BIT_BUF_SIZE);
     if (s->bi_valid >= 48) {
         put_uint32(s, (uint32_t)s->bi_buf);
         put_short(s, (uint16_t)(s->bi_buf >> 32));

--- a/trees_emit.h
+++ b/trees_emit.h
@@ -132,7 +132,7 @@ static uint32_t zng_emit_dist(deflate_state *s, const ct_data *ltree, const ct_d
     /* Send the length code, len is the match length - STD_MIN_MATCH */
     code = zng_length_code[lc];
     c = code+LITERALS+1;
-    Assert(c < L_CODES, "bad l_code");
+    AssertHint(c < L_CODES, "bad l_code");
     send_code_trace(s, c);
 
     match_bits = ltree[c].Code;
@@ -146,7 +146,7 @@ static uint32_t zng_emit_dist(deflate_state *s, const ct_data *ltree, const ct_d
 
     dist--; /* dist is now the match distance - 1 */
     code = d_code(dist);
-    Assert(code < D_CODES, "bad d_code");
+    AssertHint(code < D_CODES, "bad d_code");
     send_code_trace(s, code);
 
     /* Send the distance code */

--- a/trees_emit.h
+++ b/trees_emit.h
@@ -44,6 +44,7 @@ extern Z_INTERNAL const int base_dist[D_CODES];
  *       otherwise the shifts will overflow.
  */
 #define send_bits(s, t_val, t_len, bi_buf, bi_valid) {\
+    Assume(bi_valid <= BIT_BUF_SIZE);\
     uint64_t val = (uint64_t)t_val;\
     uint32_t len = (uint32_t)t_len;\
     uint32_t total_bits = bi_valid + len;\
@@ -79,6 +80,7 @@ extern Z_INTERNAL const int base_dist[D_CODES];
  * Flush the bit buffer and align the output on a byte boundary
  */
 static inline void bi_windup(deflate_state *s) {
+    Assume(s->bi_valid <= BIT_BUF_SIZE);
     if (s->bi_valid > 56) {
         put_uint64(s, s->bi_buf);
     } else {
@@ -104,6 +106,7 @@ static inline void bi_windup(deflate_state *s) {
  * Emit literal code
  */
 static inline uint32_t zng_emit_lit(deflate_state *s, const ct_data *ltree, unsigned c) {
+    Assume(s->bi_valid <= BIT_BUF_SIZE);
     uint32_t bi_valid = s->bi_valid;
     uint64_t bi_buf = s->bi_buf;
 
@@ -122,6 +125,7 @@ static inline uint32_t zng_emit_lit(deflate_state *s, const ct_data *ltree, unsi
  */
 static uint32_t zng_emit_dist(deflate_state *s, const ct_data *ltree, const ct_data *dtree,
     uint32_t lc, uint32_t dist) {
+    Assume(s->bi_valid <= BIT_BUF_SIZE);
     uint32_t c, extra;
     uint8_t code;
     uint64_t match_bits;
@@ -171,6 +175,7 @@ static uint32_t zng_emit_dist(deflate_state *s, const ct_data *ltree, const ct_d
  * Emit end block
  */
 static inline void zng_emit_end_block(deflate_state *s, const ct_data *ltree, const int last) {
+    Assume(s->bi_valid <= BIT_BUF_SIZE);
     uint32_t bi_valid = s->bi_valid;
     uint64_t bi_buf = s->bi_buf;
     send_code(s, END_BLOCK, ltree, bi_buf, bi_valid);
@@ -200,6 +205,7 @@ static inline void zng_tr_emit_dist(deflate_state *s, const ct_data *ltree, cons
  * Emit start of block
  */
 static inline void zng_tr_emit_tree(deflate_state *s, int type, const int last) {
+    Assume(s->bi_valid <= BIT_BUF_SIZE);
     uint32_t bi_valid = s->bi_valid;
     uint64_t bi_buf = s->bi_buf;
     uint32_t header_bits = (type << 1) + last;

--- a/zbuild.h
+++ b/zbuild.h
@@ -331,7 +331,7 @@
 #  define Assume(cond)          Assert(cond, "Value assumption failed")
 #else
 #  define Assert(cond, msg)
-#  define AssertHint(cind, msg) z_assume(cond)
+#  define AssertHint(cond, msg) z_assume(cond)
 #  define Assume(cond)          z_assume(cond)
 #endif
 

--- a/zbuild.h
+++ b/zbuild.h
@@ -284,19 +284,55 @@
 #ifdef ZLIB_DEBUG
    extern int Z_INTERNAL z_verbose;
    extern void Z_INTERNAL z_error(const char *m);
-#  define Assert(cond, msg) {int _cond = (cond); if (!(_cond)) z_error(msg);}
 #  define Trace(x) {if (z_verbose >= 0) fprintf x;}
 #  define Tracev(x) {if (z_verbose > 0) fprintf x;}
 #  define Tracevv(x) {if (z_verbose > 1) fprintf x;}
 #  define Tracec(c, x) {if (z_verbose > 0 && (c)) fprintf x;}
 #  define Tracecv(c, x) {if (z_verbose > 1 && (c)) fprintf x;}
 #else
-#  define Assert(cond, msg)
 #  define Trace(x)
 #  define Tracev(x)
 #  define Tracevv(x)
 #  define Tracec(c, x)
 #  define Tracecv(c, x)
+#endif
+
+/* Prepare compiler-specific assume intrinsics */
+#if defined(__clang__) && __has_builtin(__builtin_assume)
+  #define z_assume(...) __builtin_assume(__VA_ARGS__)
+#elif defined(__GNUC__) && __GNUC__ >= 13
+  #define z_assume(...) __attribute__((assume(__VA_ARGS__)))
+#elif defined(_MSC_VER) && _MSC_VER >= 1700
+  #define z_assume(...) __assume(__VA_ARGS__)
+#else
+  #define z_assume(...)
+#endif
+/*
+   Assume     - Run check in Debug builds, send hint to compiler in Release builds.
+   Assert     - Run check in Debug builds
+   AssertHint - Run check in Debug builds, send hint to compiler in Release builds.
+   Both Assert types require a second parameter msg containing an error message.
+
+   The Assume(cond) and AssertHint(cond,msg) macros provides hints to compiler and
+   static analyzers about what value range is valid for a variable, helping them
+   better understand and optimize for real use.
+   To ensure this does not hide bugs, compilation in debug mode will replace hinting
+   with assert checks of the hint, and will throw an error on failed checks.
+
+   Example:
+    void process_buffer(char* buf, size_t len) {
+      Assume(len <= 1024);  // Hint to compiler about maximum size
+      ...
+    }
+*/
+#ifdef ZLIB_DEBUG
+#  define Assert(cond, msg)     {int _cond = (cond); if (!(_cond)) z_error(msg);}
+#  define AssertHint(cond, msg) Assert(cond,msg)
+#  define Assume(cond)          Assert(cond, "Value assumption failed")
+#else
+#  define Assert(cond, msg)
+#  define AssertHint(cind, msg) z_assume(cond)
+#  define Assume(cond)          z_assume(cond)
 #endif
 
 /* OPTIMAL_CMP values determine the comparison width:


### PR DESCRIPTION
- Add support for giving compilers (and static analyzers) hints about value ranges of variables, allowing them to better optimize the code.
- It is very important that Assume hints are always true, therefore make debug builds check the values and throw errors if the assumption is not true.
- Make Assert() do Assume() in release builds.
- Add hints about value ranges coming into inffast
- Remove always-true Assert in zng_tr_tally_lit()

Just letting existing Asserts() calls go to Assume() reduces compiled code size by 104 bytes on x86-64.
Performance seems to be unchanged with these hints (within 0.01%).

The intentions behind adding this:
- Improve static analyzer hinting, letting them avoid false-positives.
- Possibly letting the compilers better optimize code and for example not try to optimize for big lengths where we already know that we will only have short lengths (for example 258bytes is the max length of matches, so there is no need to optimize for the 64kB lengths that the datatype would allow).
- Make adding asserts/assume to new code more attractive.
- This would then also make code more self-documenting and make it easier for anyone to understand the limitations of a function.