### PR TITLE
Fix cmake 3.10 warning with latest version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,11 @@
-cmake_minimum_required(VERSION 3.5.1)
 if(CMAKE_VERSION VERSION_LESS 3.12)
+    cmake_minimum_required(VERSION 3.5.1)
     cmake_policy(VERSION ${CMAKE_VERSION})
 else()
-    cmake_policy(VERSION 3.5.1...3.29.0)
+    cmake_minimum_required(VERSION 3.12.0)
+    cmake_policy(VERSION 3.12.0...3.31.0)
 endif()
+
 message(STATUS "Using CMake version ${CMAKE_VERSION}")
 
 if(POLICY CMP0169)

--- a/test/add-subdirectory-project/CMakeLists.txt
+++ b/test/add-subdirectory-project/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.12)
 
 project(zlib-ng-add-subdirecory-test C)
 

--- a/test/fuzz/CMakeLists.txt
+++ b/test/fuzz/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.12)
 
 if(CMAKE_C_COMPILER_ID MATCHES "Clang")
     enable_language(CXX)

--- a/test/pigz/CMakeLists.txt
+++ b/test/pigz/CMakeLists.txt
@@ -18,7 +18,7 @@
 #   PTHREADS4W_ROOT     - Path to pthreads4w source directory on Windows.
 #                         If not specified then threading will be disabled.
 
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.12)
 
 include(CheckCCompilerFlag)
 include(FeatureSummary)


### PR DESCRIPTION
We are seeing warnings like these with cmake 3.31 in github actions:

```
CMake Deprecation Warning at D:/a/runtime/runtime/runtime/src/native/external/zlib-ng/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.
```

e.g. https://github.com/dotnet/runtime/actions/runs/11948322805/job/33305725079?pr=109537

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced support for various architectures including ARM, PPC, RISC-V, S390, and X86.
	- Improved error handling for unsupported configurations.
	- More detailed status messages during the configuration process.

- **Bug Fixes**
	- Updated validation checks for C standard options to ensure compatibility.

- **Documentation**
	- Revised installation section for clarity on file placements.

- **Chores**
	- Updated minimum required CMake version across multiple projects to 3.12 for improved compatibility and features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->