### PR TITLE
Force use of latest Windows SDK with 32-bit ARM support

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -502,7 +502,7 @@ jobs:
           - name: Windows MSVC ARM No Test
             os: windows-latest
             compiler: cl
-            cmake-args: -A ARM
+            cmake-args: -A ARM,version=10.0.22621.0
 
           - name: Windows MSVC ARM64 No Test
             os: windows-latest

--- a/.github/workflows/nmake.yml
+++ b/.github/workflows/nmake.yml
@@ -43,6 +43,7 @@ jobs:
             os: windows-2022
             makefile: win32/Makefile.arm
             arch: x86_arm
+            sdk: 10.0.22621.0
 
           - name: Windows NMake ARM64 No Test
             os: windows-2022
@@ -59,6 +60,7 @@ jobs:
       uses: ilammy/msvc-dev-cmd@v1.13.0
       with:
         arch: ${{ matrix.arch }}
+        sdk: ${{ matrix.sdk }}
 
     - name: Compile source code
       shell: cmd


### PR DESCRIPTION
Fix for CI error:

``
      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Microsoft\VC\v170\Microsoft.Cpp.WindowsSDK.targets(49,5): error MSB8037: The Windows SDK version 10.0.26100.0 for Desktop C++ ARM Apps was not found. Install the required version of Windows SDK or change the SDK version in the project property pages or by right-clicking the solution and selecting "Retarget solution".  [D:\a\zlib-ng\zlib-ng\CMakeFiles\3.31.0\VCTargetsPath.vcxproj]
``

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added version specification for ARM architecture in CMake builds.
	- Enhanced flexibility of the NMake workflow by allowing dynamic SDK version referencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->