### PR TITLE
Address deprecated cmake version warning.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,6 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.5.1...3.29.0)
 if(CMAKE_VERSION VERSION_LESS 3.12)
     cmake_policy(VERSION ${CMAKE_VERSION})
-else()
-    cmake_policy(VERSION 3.5.1...3.29.0)
 endif()
 message(STATUS "Using CMake version ${CMAKE_VERSION}")
 

--- a/test/add-subdirectory-project/CMakeLists.txt
+++ b/test/add-subdirectory-project/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.5.1...3.29.0)
 
 project(zlib-ng-add-subdirecory-test C)
 

--- a/test/fuzz/CMakeLists.txt
+++ b/test/fuzz/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.5.1...3.29.0)
 
 if(CMAKE_C_COMPILER_ID MATCHES "Clang")
     enable_language(CXX)


### PR DESCRIPTION
Use cmake_minimum_required(VERSION <min>...<policy_max>) syntax to set the policy at the same time as the compatibile CMake version.

The CMake documentation for this call is here:
https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html

Of note is the following:
```
The optional <policy_max> version, if specified, must be at least the <min> version and affects policy settings as described in [Policy Settings](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#policy-settings). If the running version of CMake is older than 3.12, the extra ... dots will be seen as version component separators, resulting in the ...<max> part being ignored and preserving the pre-3.12 behavior of basing policies on <min>.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced configurability with new options for building features such as gzFile support, zlib compatibility, and CPU architecture detection.
	- Introduced a feature summary section for better visibility of enabled features during configuration.

- **Bug Fixes**
	- Updated minimum CMake version for broader compatibility with newer features.

- **Documentation**
	- Improved clarity on project configurations and options available for users during the build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->