### PR TITLE
Fix casting warning/error in test_compress_bound.cc

### DIFF
--- a/test/test_compress_bound.cc
+++ b/test/test_compress_bound.cc
@@ -34,7 +34,7 @@ public:
             uncompressed[j] = (uint8_t)j;
         }
 
-        for (z_size_t i = 0; i < MAX_LENGTH; i++) {
+        for (z_uintmax_t i = 0; i < MAX_LENGTH; i++) {
             z_uintmax_t dest_len = sizeof(dest);
 
             /* calculate actual output length */


### PR DESCRIPTION
Fixes the following error when building with msvc compiler
```
test_compress_bound.cc
D:\zlib-ng\test\test_compress_bound.cc(41,50): error C2220: the following warning is treated as an error
D:\zlib-ng\test\test_compress_bound.cc(41,50): warning C4267: 'argument': conversion from 'size_t' to 'unsigned long', possible loss of data
D:\zlib-ng\test\test_compress_bound.cc(43,68): warning C4267: 'argument': conversion from 'size_t' to 'unsigned long', possible loss of data
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the accuracy of compression length estimation by adjusting the loop variable type in the compression testing method. 

This change enhances the reliability of the compression output verification process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->