### PR TITLE
Remove unused HAVE_CHUNKMEMSET_1 define

### DIFF
--- a/arch/x86/chunkset_avx2.c
+++ b/arch/x86/chunkset_avx2.c
@@ -15,7 +15,6 @@ typedef __m128i halfchunk_t;
 #define HAVE_CHUNKMEMSET_4
 #define HAVE_CHUNKMEMSET_8
 #define HAVE_CHUNKMEMSET_16
-#define HAVE_CHUNKMEMSET_1
 #define HAVE_CHUNK_MAG
 #define HAVE_HALF_CHUNK
 

--- a/arch/x86/chunkset_avx512.c
+++ b/arch/x86/chunkset_avx512.c
@@ -18,7 +18,6 @@ typedef __mmask16 halfmask_t;
 #define HAVE_CHUNKMEMSET_4
 #define HAVE_CHUNKMEMSET_8
 #define HAVE_CHUNKMEMSET_16
-#define HAVE_CHUNKMEMSET_1
 #define HAVE_CHUNK_MAG
 #define HAVE_HALF_CHUNK
 #define HAVE_MASKED_READWRITE


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Support for chunk memory setting has been streamlined by removing 1-byte chunk operations, enhancing the focus on larger chunk sizes (2, 4, 8, and 16 bytes).

- **Bug Fixes**
	- Removed deprecated functionality for 1-byte chunk memory setting to improve overall performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->