### PR TITLE
Fix native detection of ARM CRC instruction

### DIFF
--- a/arch/arm/arm_functions.h
+++ b/arch/arm/arm_functions.h
@@ -56,7 +56,7 @@ void slide_hash_armv6(deflate_state *s);
 #    endif
 #  endif
 // ARM - ACLE
-#  if defined(ARM_ACLE) && defined(__ARM_ACLE) && defined(__ARM_FEATURE_CRC32)
+#  if defined(ARM_ACLE) && (defined(__ARM_ACLE) || defined(__ARM_FEATURE_CRC32))
 #    undef native_crc32
 #    define native_crc32 crc32_acle
 #  endif


### PR DESCRIPTION
It's unclear if raspberry pi OS's shipped GCC doesn't properly detect ACLE or not (/proc/cpuinfo claims to support AES), but in any case, the preprocessor macro for that flag is not defined with -march=native on a raspberry pi 5. Unfortunately that means when built "WITH_NATIVE", we do not get a fast CRC function.  The CRC32 preprocessor macro _IS_ defined, and the auto detection when built without NATIVE support does properly get dispatched to. Since we only need the scalar CRC32 and not the polynomial stuff anyhow, let's make it be an || condition and not a && one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced flexibility in the compilation of the `native_crc32` feature, allowing for broader compatibility with ARM architectures. 

- **Bug Fixes**
	- Resolved issues with the conditional compilation directives to ensure proper definition under varied ARM feature sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->