### PR TITLE
Allow more cases to fall through to CHUNKMEMSET/CHUNKCOPY

### DIFF
--- a/arch/arm/chunkset_neon.c
+++ b/arch/arm/chunkset_neon.c
@@ -13,6 +13,7 @@ typedef uint8x16_t chunk_t;
 #define HAVE_CHUNKMEMSET_4
 #define HAVE_CHUNKMEMSET_8
 #define HAVE_CHUNK_MAG
+#define MIN_CHUNKSIZE sizeof(chunk_t)
 
 static const lut_rem_pair perm_idx_lut[13] = {
     {0, 1},      /* 3 */

--- a/arch/generic/chunkset_c.c
+++ b/arch/generic/chunkset_c.c
@@ -10,6 +10,7 @@ typedef uint64_t chunk_t;
 
 #define HAVE_CHUNKMEMSET_4
 #define HAVE_CHUNKMEMSET_8
+#define MIN_CHUNKSIZE sizeof(chunk_t)
 
 static inline void chunkmemset_4(uint8_t *from, chunk_t *chunk) {
     uint8_t *dest = (uint8_t *)chunk;

--- a/arch/power/chunkset_power8.c
+++ b/arch/power/chunkset_power8.c
@@ -13,6 +13,7 @@ typedef vector unsigned char chunk_t;
 #define HAVE_CHUNKMEMSET_2
 #define HAVE_CHUNKMEMSET_4
 #define HAVE_CHUNKMEMSET_8
+#define MIN_CHUNKSIZE sizeof(chunk_t)
 
 static inline void chunkmemset_2(uint8_t *from, chunk_t *chunk) {
     uint16_t tmp;

--- a/arch/riscv/chunkset_rvv.c
+++ b/arch/riscv/chunkset_rvv.c
@@ -15,6 +15,7 @@
 #define HAVE_CHUNKMEMSET_2
 #define HAVE_CHUNKMEMSET_4
 #define HAVE_CHUNKMEMSET_8
+#define MIN_CHUNKSIZE CHUNK_SIZE
 
 #define CHUNK_MEMSET_RVV_IMPL(elen)                                     \
 do {                                                                    \

--- a/arch/x86/chunkset_avx2.c
+++ b/arch/x86/chunkset_avx2.c
@@ -16,6 +16,7 @@ typedef __m128i halfchunk_t;
 #define HAVE_CHUNKMEMSET_8
 #define HAVE_CHUNKMEMSET_16
 #define HAVE_CHUNKMEMSET_1
+#define MIN_CHUNKSIZE sizeof(halfchunk_t)
 #define HAVE_CHUNK_MAG
 #define HAVE_HALF_CHUNK
 

--- a/arch/x86/chunkset_sse2.c
+++ b/arch/x86/chunkset_sse2.c
@@ -12,6 +12,7 @@ typedef __m128i chunk_t;
 #define HAVE_CHUNKMEMSET_2
 #define HAVE_CHUNKMEMSET_4
 #define HAVE_CHUNKMEMSET_8
+#define MIN_CHUNKSIZE sizeof(chunk_t)
 
 static inline void chunkmemset_2(uint8_t *from, chunk_t *chunk) {
     int16_t tmp;

--- a/arch/x86/chunkset_ssse3.c
+++ b/arch/x86/chunkset_ssse3.c
@@ -14,6 +14,7 @@ typedef __m128i chunk_t;
 #define HAVE_CHUNKMEMSET_4
 #define HAVE_CHUNKMEMSET_8
 #define HAVE_CHUNK_MAG
+#define MIN_CHUNKSIZE sizeof(chunk_t)
 
 static const lut_rem_pair perm_idx_lut[13] = {
     {0, 1},      /* 3 */

--- a/chunkset_tpl.h
+++ b/chunkset_tpl.h
@@ -250,7 +250,7 @@ Z_INTERNAL uint8_t* CHUNKMEMSET_SAFE(uint8_t *out, uint8_t *from, unsigned len, 
 #endif
 
 #ifndef HAVE_MASKED_READWRITE
-    if (UNLIKELY(left < sizeof(chunk_t))) {
+    if (UNLIKELY(left < MIN_CHUNKSIZE)) {
         while (len > 0) {
             *out++ = *from++;
             --len;
@@ -276,7 +276,7 @@ static inline uint8_t *CHUNKCOPY_SAFE(uint8_t *out, uint8_t *from, uint64_t len,
 
 #ifndef HAVE_MASKED_READWRITE
     uint64_t from_dist = (uint64_t)llabs(safe - from);
-    if (UNLIKELY(from_dist < sizeof(chunk_t) || safelen < sizeof(chunk_t))) {
+    if (UNLIKELY(from_dist < MIN_CHUNKSIZE || safelen < MIN_CHUNKSIZE)) {
         while (len--) {
             *out++ = *from++;
         }


### PR DESCRIPTION
For AVX2 specifically, our chunkmemset call chain allows for safely dealing with half sized chunks. Because this doesn't alter the code size in any meaningful way, we may as well use macros to define the constant we use for comparison in the "safe" variety of functions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new macro `MIN_CHUNKSIZE` to standardize minimum chunk sizes across various architectures.
	- Updated memory operation functions to utilize the new `MIN_CHUNKSIZE` for improved safety and consistency.

- **Bug Fixes**
	- Enhanced error handling in memory operations to prevent exceeding buffer limits.

- **Documentation**
	- Minor adjustments to comments for clarity regarding memory operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->