### PR TITLE
Add a fallback to ALIGNED_ macro for other compilers

### DIFF
--- a/zbuild.h
+++ b/zbuild.h
@@ -200,6 +200,9 @@
 #  define ALIGNED_(x) __attribute__ ((aligned(x)))
 #elif defined(_MSC_VER)
 #  define ALIGNED_(x) __declspec(align(x))
+#else
+/* TODO: Define ALIGNED_ for your compiler */
+#  define ALIGNED_(x)
 #endif
 
 #ifdef HAVE_BUILTIN_ASSUME_ALIGNED


### PR DESCRIPTION

Since the affectes compiler does not support SSE/AVX,
a bigger alignment is not needed. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a fallback definition for the `ALIGNED_` macro to enhance compatibility with various compilers.

- **Bug Fixes**
	- Improved macro flexibility for future compiler-specific implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->