### PR TITLE
added in-tree build artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@
 /switchlevels
 /zlib.pc
 /zlib-ng.pc
+/zconf-ng.h.included
+/zlib_name_mangling-ng.h
+/zlib-ng.h
 
 .DS_Store
 *_fuzzer
@@ -61,6 +64,7 @@ zconf-ng.h.cmakein
 ztest*
 /test/CTestTestfile.cmake
 /test/cmake_install.cmake
+/.cache
 
 configure.log
 a.out
@@ -72,6 +76,10 @@ a.out
 /arch/x86/Makefile
 .kdev4
 *.kdev4
+Makefile.tmp
+/makecrct
+/maketrees
+gzread.c
 
 /Debug
 /example.dir


### PR DESCRIPTION
when build with traditional `configure && make` in-tree, some build artifacts will pop up that are not excluded by `.gitignore`. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the `.gitignore` file to exclude additional files and directories, enhancing version control management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->