### PR TITLE
Fix Clang arm32 build

### DIFF
--- a/arch/arm/neon_intrins.h
+++ b/arch/arm/neon_intrins.h
@@ -25,7 +25,7 @@
     out.val[3] = vqsubq_u16(a.val[3], b); \
 } while (0)
 
-#  if defined(__clang__) && defined(__arm__) && !defined(__GNUC__)
+#  if defined(__clang__) && defined(__arm__) && defined(__ANDROID__) && !defined(__GNUC__)
 /* Clang for 32-bit Android and musl-libc have too strict alignment requirement (:256) for x4 NEON intrinsics */
 #    undef ARM_NEON_HASLD4
 #    undef vld1q_u16_x4

--- a/arch/arm/neon_intrins.h
+++ b/arch/arm/neon_intrins.h
@@ -26,7 +26,7 @@
 } while (0)
 
 #  if defined(__clang__) && defined(__arm__) && !defined(__GNUC__)
-/* Clang for 32-bit Android and Alpine Linux has too strict alignment requirement (:256) for x4 NEON intrinsics */
+/* Clang for 32-bit Android and musl-libc have too strict alignment requirement (:256) for x4 NEON intrinsics */
 #    undef ARM_NEON_HASLD4
 #    undef vld1q_u16_x4
 #    undef vld1q_u8_x4

--- a/arch/arm/neon_intrins.h
+++ b/arch/arm/neon_intrins.h
@@ -25,7 +25,7 @@
     out.val[3] = vqsubq_u16(a.val[3], b); \
 } while (0)
 
-#  if defined(__clang__) && defined(__arm__) && defined(__ANDROID__)
+#  if defined(__clang__) && defined(__arm__)
 /* Clang for 32-bit Android has too strict alignment requirement (:256) for x4 NEON intrinsics */
 #    undef ARM_NEON_HASLD4
 #    undef vld1q_u16_x4

--- a/arch/arm/neon_intrins.h
+++ b/arch/arm/neon_intrins.h
@@ -25,7 +25,7 @@
     out.val[3] = vqsubq_u16(a.val[3], b); \
 } while (0)
 
-#  if defined(__clang__) && defined(__arm__) && defined(__ANDROID__) && !defined(__GLIBC__)
+#  if defined(__clang__) && defined(__arm__) && (defined(__ANDROID__) || !defined(__GLIBC__))
 /* Clang for 32-bit Android and musl-libc have too strict alignment requirement (:256) for x4 NEON intrinsics */
 #    undef ARM_NEON_HASLD4
 #    undef vld1q_u16_x4

--- a/arch/arm/neon_intrins.h
+++ b/arch/arm/neon_intrins.h
@@ -25,8 +25,8 @@
     out.val[3] = vqsubq_u16(a.val[3], b); \
 } while (0)
 
-#  if defined(__clang__) && defined(__arm__)
-/* Clang for 32-bit Android has too strict alignment requirement (:256) for x4 NEON intrinsics */
+#  if defined(__clang__) && defined(__arm__) && !defined(__GNUC__)
+/* Clang for 32-bit Android and Alpine Linux has too strict alignment requirement (:256) for x4 NEON intrinsics */
 #    undef ARM_NEON_HASLD4
 #    undef vld1q_u16_x4
 #    undef vld1q_u8_x4

--- a/arch/arm/neon_intrins.h
+++ b/arch/arm/neon_intrins.h
@@ -25,7 +25,7 @@
     out.val[3] = vqsubq_u16(a.val[3], b); \
 } while (0)
 
-#  if defined(__clang__) && defined(__arm__) && defined(__ANDROID__) && !defined(__GNUC__)
+#  if defined(__clang__) && defined(__arm__) && defined(__ANDROID__) && !defined(__GLIBC__)
 /* Clang for 32-bit Android and musl-libc have too strict alignment requirement (:256) for x4 NEON intrinsics */
 #    undef ARM_NEON_HASLD4
 #    undef vld1q_u16_x4


### PR DESCRIPTION
```sh
/runtime/src/native/external/zlib-ng/arch/arm/neon_intrins.h:38:28: error: expected identifier or '('
   38 | static inline uint16x8x4_t vld1q_u16_x4(uint16_t const *a) {
      |                            ^
/usr/lib/llvm19/lib/clang/19/include/arm_neon.h:13458:28: note: expanded from macro 'vld1q_u16_x4'
 13458 | #define vld1q_u16_x4(__p0) __extension__ ({ \
       |                            ^
```

with this delta, the library code builds. Ideally, we should avoid naming collision with toolchain and system headers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted conditional compilation to enhance compatibility with ARM NEON intrinsics across various platforms.
  
- **Refactor**
	- Simplified preprocessor directives for broader applicability, improving code maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->