### PR TITLE
Fix "RLE" compression with big endian architectures

### DIFF
--- a/compare256_rle.h
+++ b/compare256_rle.h
@@ -5,6 +5,7 @@
 
 #include "zbuild.h"
 #include "fallback_builtins.h"
+#include "zendian.h"
 
 typedef uint32_t (*compare256_rle_func)(const uint8_t* src0, const uint8_t* src1);
 
@@ -88,7 +89,11 @@ static inline uint32_t compare256_rle_unaligned_32(const uint8_t *src0, const ui
 
         diff = sv ^ mv;
         if (diff) {
+#if BYTE_ORDER == LITTLE_ENDIAN
             uint32_t match_byte = __builtin_ctz(diff) / 8;
+#else
+            uint32_t match_byte = __builtin_clz(diff) / 8;
+#endif
             return len + match_byte;
         }
 
@@ -118,7 +123,11 @@ static inline uint32_t compare256_rle_unaligned_64(const uint8_t *src0, const ui
 
         diff = sv ^ mv;
         if (diff) {
+#if BYTE_ORDER == LITTLE_ENDIAN
             uint64_t match_byte = __builtin_ctzll(diff) / 8;
+#else
+            uint64_t match_byte = __builtin_clzll(diff) / 8;
+#endif
             return len + (uint32_t)match_byte;
         }
 


### PR DESCRIPTION
This was missed in #1831. The RLE methods compare a string of bytes directly with itself to directly derive a simple run length encoding. They use similar but not identical methods to compare256. This needs a similar endianness check at compile time to know which compare bit count to use (leading or trailing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new header file for enhanced functionality in comparing 256-byte arrays.
	- Added multiple functions for optimized byte and integer comparisons, supporting different data alignments and sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->