### PR TITLE
Fix unaligned access in ACLE based crc32

### DIFF
--- a/arch/arm/crc32_acle.c
+++ b/arch/arm/crc32_acle.c
@@ -11,9 +11,9 @@
 
 Z_INTERNAL Z_TARGET_CRC uint32_t crc32_acle(uint32_t crc, const uint8_t *buf, size_t len) {
     Z_REGISTER uint32_t c;
-    Z_REGISTER const uint16_t *buf2;
-    Z_REGISTER const uint32_t *buf4;
-    Z_REGISTER const uint64_t *buf8;
+    Z_REGISTER uint16_t buf2;
+    Z_REGISTER uint32_t buf4;
+    Z_REGISTER uint64_t buf8;
 
     c = ~crc;
 
@@ -29,45 +29,43 @@ Z_INTERNAL Z_TARGET_CRC uint32_t crc32_acle(uint32_t crc, const uint8_t *buf, si
             len--;
         }
 
-        if ((len >= sizeof(uint16_t)) && ((ptrdiff_t)buf & sizeof(uint16_t))) {
-            buf2 = (const uint16_t *) buf;
-            c = __crc32h(c, *buf2++);
+        if ((len >= sizeof(uint16_t)) && ((ptrdiff_t)buf & (sizeof(uint32_t) - 1))) {
+            buf2 = *((uint16_t*)buf);
+            c = __crc32h(c, buf2);
+            buf += sizeof(uint16_t);
             len -= sizeof(uint16_t);
-            buf4 = (const uint32_t *) buf2;
-        } else {
-            buf4 = (const uint32_t *) buf;
         }
 
-        if ((len >= sizeof(uint32_t)) && ((ptrdiff_t)buf & sizeof(uint32_t))) {
-            c = __crc32w(c, *buf4++);
+        if ((len >= sizeof(uint32_t)) && ((ptrdiff_t)buf & (sizeof(uint64_t) - 1))) {
+            buf4 = *((uint32_t*)buf);
+            c = __crc32w(c, buf4);
             len -= sizeof(uint32_t);
+            buf += sizeof(uint32_t);
         }
 
-        buf8 = (const uint64_t *) buf4;
-    } else {
-        buf8 = (const uint64_t *) buf;
     }
 
     while (len >= sizeof(uint64_t)) {
-        c = __crc32d(c, *buf8++);
+        buf8 = *((uint64_t*)buf);
+        c = __crc32d(c, buf8);
         len -= sizeof(uint64_t);
+        buf += sizeof(uint64_t);
     }
 
     if (len >= sizeof(uint32_t)) {
-        buf4 = (const uint32_t *) buf8;
-        c = __crc32w(c, *buf4++);
+        buf4 = *((uint32_t*)buf);
+        c = __crc32w(c, buf4);
         len -= sizeof(uint32_t);
-        buf2 = (const uint16_t *) buf4;
-    } else {
-        buf2 = (const uint16_t *) buf8;
+        buf += sizeof(uint32_t);
     }
 
     if (len >= sizeof(uint16_t)) {
-        c = __crc32h(c, *buf2++);
+        buf2 = *((uint16_t*)buf);
+        c = __crc32h(c, buf2);
         len -= sizeof(uint16_t);
+        buf += sizeof(uint16_t);
     }
 
-    buf = (const unsigned char *) buf2;
     if (len) {
         c = __crc32b(c, *buf);
     }


### PR DESCRIPTION
This fixes a rightful complaint from the alignment sanitizer that we alias memory in an unaligned fashion. A nice added bonus is that this improves performance a tiny by on the larger buffers, perhaps due to loops that idiomatically decrement a count and increment a single buffer pointer rather than the maze of conditional pointer reassignments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
  - Improved buffer handling for CRC computation, ensuring accurate processing of data.
  - Enhanced testing for alignment issues in CRC32 calculations.

- **New Features**
  - Streamlined the CRC calculation process by utilizing local variables for buffer data, enhancing performance.
  - Introduced a new test class to verify CRC32 functionality with varying alignment offsets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->