### PR TITLE
Set OPTIMAL_CMP for 32-bit PowerPC

### DIFF
--- a/cmake/detect-arch.c
+++ b/cmake/detect-arch.c
@@ -32,7 +32,7 @@
     #endif
 
 // PowerPC
-#elif defined(__powerpc__) || defined(_ppc__) || defined(__PPC__)
+#elif defined(__powerpc__) || defined(__ppc__) || defined(__PPC__)
     #if defined(__64BIT__) || defined(__powerpc64__) || defined(__ppc64__)
         #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
             #error archfound powerpc64le

--- a/zbuild.h
+++ b/zbuild.h
@@ -258,6 +258,8 @@
 #  endif
 #elif defined(__powerpc64__) || defined(__ppc64__)
 #    define OPTIMAL_CMP 64 
+#elif defined(__powerpc__) || defined(__ppc__) || defined(__PPC__)
+#    define OPTIMAL_CMP 32
 #endif
 #if defined(NO_UNALIGNED)
 #  undef OPTIMAL_CMP


### PR DESCRIPTION
This contains the remaining useful changes from PR #1690. It will need testing on actual hardware, and likely requires PR #1832 to work correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced support for PowerPC architecture with updated conditional compilation directives.
	- Defined optimal comparison size for PowerPC architectures.

- **Bug Fixes**
	- Corrected preprocessor directive for PowerPC architecture detection to ensure consistency. 

- **Style**
	- Minor adjustments in comments and formatting for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->