### PR TITLE
Improved setting of OPTIMAL_CMP on ARM

### DIFF
--- a/zbuild.h
+++ b/zbuild.h
@@ -249,17 +249,21 @@
       defined(__i686__) || defined(_X86_) || defined(_M_IX86)
 #  define OPTIMAL_CMP 32
 #elif defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
-#  if (defined(__GNUC__) && defined(__ARM_FEATURE_UNALIGNED)) || !defined(__GNUC__)
+#  if defined(__ARM_FEATURE_UNALIGNED) || defined(_WIN32)
 #    define OPTIMAL_CMP 64
+#  else
+#    define OPTIMAL_CMP 8
 #  endif
-#elif defined(__arm__) || (_M_ARM >= 7)
-#  if (defined(__GNUC__) && defined(__ARM_FEATURE_UNALIGNED)) || !defined(__GNUC__)
+#elif defined(__arm__) || defined(_M_ARM)
+#  if defined(__ARM_FEATURE_UNALIGNED) || defined(_WIN32)
 #    define OPTIMAL_CMP 32
+#  else
+#    define OPTIMAL_CMP 8
 #  endif
 #elif defined(__powerpc64__) || defined(__ppc64__)
-#    define OPTIMAL_CMP 64 
+#  define OPTIMAL_CMP 64
 #elif defined(__powerpc__) || defined(__ppc__) || defined(__PPC__)
-#    define OPTIMAL_CMP 32
+#  define OPTIMAL_CMP 32
 #endif
 #if defined(NO_UNALIGNED)
 #  undef OPTIMAL_CMP


### PR DESCRIPTION
Following the suggestion in https://github.com/zlib-ng/zlib-ng/pull/1830#issuecomment-2558277452, this PR explicitly sets `OPTIMAL_CMP` to 8 on ARM when unaligned memory access is unavailable. I've also changed the feature checks to better cover non-GCC compilers.

On ARM32, `-mno-unaligned-access` can be used to force alignment-safe loads, while `-mstrict-align` can be used with AArch64. This should help when running benchmarks on platforms that normally have it enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the flexibility of architecture-specific optimizations for comparison sizes.
	- Improved the conditions for defining optimal comparison sizes on ARM architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->