### PR TITLE
Remove no longer needed endianness check for compare256_bench

### DIFF
--- a/test/benchmarks/benchmark_compare256.cc
+++ b/test/benchmarks/benchmark_compare256.cc
@@ -66,7 +66,7 @@ BENCHMARK_COMPARE256(c, compare256_c, 1);
 BENCHMARK_COMPARE256(native, native_compare256, 1);
 #else
 
-#if BYTE_ORDER == LITTLE_ENDIAN && OPTIMAL_CMP >= 32
+#if OPTIMAL_CMP >= 32
 BENCHMARK_COMPARE256(unaligned_16, compare256_unaligned_16, 1);
 #  if defined(HAVE_BUILTIN_CTZ)
 BENCHMARK_COMPARE256(unaligned_32, compare256_unaligned_32, 1);

--- a/test/benchmarks/benchmark_compare256_rle.cc
+++ b/test/benchmarks/benchmark_compare256_rle.cc
@@ -61,7 +61,7 @@ public:
 
 BENCHMARK_COMPARE256_RLE(c, compare256_rle_c, 1);
 
-#if BYTE_ORDER == LITTLE_ENDIAN && OPTIMAL_CMP >= 32
+#if OPTIMAL_CMP >= 32
 BENCHMARK_COMPARE256_RLE(unaligned_16, compare256_rle_unaligned_16, 1);
 #  if defined(HAVE_BUILTIN_CTZ)
 BENCHMARK_COMPARE256_RLE(unaligned_32, compare256_rle_unaligned_32, 1);


### PR DESCRIPTION
Results confirm what we already suspected on PPC and saw through other benchmarks but, for those curious:

```
2024-12-23T10:03:55-05:00
Running ./benchmark_zlib
Run on (4 X 2500 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 64 KiB (x4)
  L2 Unified 1024 KiB (x4)
Load Average: 1.42, 1.77, 1.40
--------------------------------------------------------------------------
Benchmark                                Time             CPU   Iterations
--------------------------------------------------------------------------
compare256/c/1                        5.61 ns         5.61 ns    124784800
compare256/c/8                        10.4 ns         10.4 ns     67194475
compare256/c/64                       56.6 ns         56.5 ns     12367680
compare256/c/256                       198 ns          197 ns      3523389
compare256/unaligned_16/1             6.42 ns         6.41 ns    109155434
compare256/unaligned_16/8             8.02 ns         8.02 ns     87239016
compare256/unaligned_16/64            39.6 ns         39.6 ns     17648766
compare256/unaligned_16/256            120 ns          120 ns      5838021
compare256/unaligned_32/1             6.55 ns         6.54 ns    106940290
compare256/unaligned_32/8             8.02 ns         8.01 ns     87340516
compare256/unaligned_32/64            46.3 ns         46.3 ns     15116536
compare256/unaligned_32/256            124 ns          124 ns      5626073
compare256/unaligned_64/1             6.01 ns         6.01 ns    116474220
compare256/unaligned_64/8             6.01 ns         6.01 ns    116461260
compare256/unaligned_64/64            30.8 ns         30.8 ns     22687202
compare256/unaligned_64/256           63.8 ns         63.7 ns     10987990
compare256/power9/1             ERROR OCCURRED: 'CPU does not support power9'
compare256/power9/8             ERROR OCCURRED: 'CPU does not support power9'
compare256/power9/64            ERROR OCCURRED: 'CPU does not support power9'
compare256/power9/256           ERROR OCCURRED: 'CPU does not support power9'
compare256_rle/c/1                    1.62 ns         1.62 ns    429280312
compare256_rle/c/8                    8.02 ns         8.01 ns     87324199
compare256_rle/c/64                   60.0 ns         60.0 ns     11694096
compare256_rle/c/256                   214 ns          214 ns      3272686
compare256_rle/unaligned_16/1         2.84 ns         2.83 ns    245778536
compare256_rle/unaligned_16/8         5.15 ns         5.15 ns    136237830
compare256_rle/unaligned_16/64        47.3 ns         47.3 ns     14804168
compare256_rle/unaligned_16/256        148 ns          147 ns      4747072
compare256_rle/unaligned_32/1         2.81 ns         2.80 ns    249578910
compare256_rle/unaligned_32/8         3.76 ns         3.76 ns    186413248
compare256_rle/unaligned_32/64        28.9 ns         28.9 ns     24259600
compare256_rle/unaligned_32/256       95.2 ns         95.2 ns      7359497
compare256_rle/unaligned_64/1        0.000 ns        0.000 ns   1000000000
compare256_rle/unaligned_64/8        0.000 ns        0.000 ns   1000000000
compare256_rle/unaligned_64/64       0.000 ns        0.000 ns   1000000000
compare256_rle/unaligned_64/256       15.1 ns         15.1 ns     46150792
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded conditions for benchmarking unaligned comparisons, allowing broader inclusion based on optimal comparison settings.
  
- **Bug Fixes**
	- Simplified conditional compilation for benchmarking functions, enhancing compatibility across different architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->