### PR TITLE
Force use of latest Windows SDK with 32-bit ARM support for release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,13 +38,13 @@ jobs:
           - name: Windows MSVC ARM
             os: windows-latest
             compiler: cl
-            cmake-args: -A ARM
+            cmake-args: -A ARM,version=10.0.22621.0
             deploy-name: win-arm
 
           - name: Windows MSVC ARM Compat
             os: windows-latest
             compiler: cl
-            cmake-args: -A ARM -DZLIB_COMPAT=ON
+            cmake-args: -A ARM,version=10.0.22621.0 -DZLIB_COMPAT=ON
             deploy-name: win-arm-compat
 
           - name: Windows MSVC ARM64


### PR DESCRIPTION
Fix errors:
https://github.com/zlib-ng/zlib-ng/actions/runs/12565324781/job/35029455193
https://github.com/zlib-ng/zlib-ng/actions/runs/12565324781/job/35029455984


First part of the fix: #1811

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow configuration for Windows MSVC ARM builds
	- Added specific ARM architecture version specification for build configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->