### PR TITLE
Use arch-specific deflate_quick functions instead of compare256.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1086,6 +1086,7 @@ set(ZLIB_PRIVATE_HDRS
     crc32_braid_tbl.h
     deflate.h
     deflate_p.h
+    deflate_quick_tpl.h
     functable.h
     inffast_tpl.h
     inffixed_tbl.h
@@ -1117,7 +1118,6 @@ set(ZLIB_SRCS
     deflate_fast.c
     deflate_huff.c
     deflate_medium.c
-    deflate_quick.c
     deflate_rle.c
     deflate_slow.c
     deflate_stored.c

--- a/arch/arm/compare256_neon.c
+++ b/arch/arm/compare256_neon.c
@@ -57,4 +57,9 @@ Z_INTERNAL uint32_t compare256_neon(const uint8_t *src0, const uint8_t *src1) {
 
 #include "match_tpl.h"
 
+#define DEFLATE_QUICK       deflate_quick_neon
+
+#include "deflate_quick_tpl.h"
+
+
 #endif

--- a/arch/generic/compare256_c.c
+++ b/arch/generic/compare256_c.c
@@ -29,3 +29,8 @@ Z_INTERNAL uint32_t compare256_c(const uint8_t *src0, const uint8_t *src1) {
 #define LONGEST_MATCH_SLOW
 #define LONGEST_MATCH       longest_match_slow_c
 #include "match_tpl.h"
+
+// Generic deflate_quick_c
+#define DEFLATE_QUICK       deflate_quick_c
+
+#include "deflate_quick_tpl.h"

--- a/arch/generic/generic_functions.h
+++ b/arch/generic/generic_functions.h
@@ -14,6 +14,7 @@ Z_INTERNAL uint32_t crc32_fold_final_c(crc32_fold *crc);
 
 Z_INTERNAL uint32_t adler32_fold_copy_c(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len);
 
+Z_INTERNAL block_state deflate_quick_c(deflate_state *s, int flush);
 
 typedef uint32_t (*adler32_func)(uint32_t adler, const uint8_t *buf, size_t len);
 typedef uint32_t (*compare256_func)(const uint8_t *src0, const uint8_t *src1);
@@ -47,6 +48,7 @@ uint32_t longest_match_slow_c(deflate_state *const s, Pos cur_match);
 #  define native_crc32_fold_copy crc32_fold_copy_c
 #  define native_crc32_fold_final crc32_fold_final_c
 #  define native_crc32_fold_reset crc32_fold_reset_c
+#  define native_deflate_quick deflate_quick_c
 #  define native_inflate_fast inflate_fast_c
 #  define native_slide_hash slide_hash_c
 #  define native_longest_match longest_match_c

--- a/arch/power/compare256_power9.c
+++ b/arch/power/compare256_power9.c
@@ -63,4 +63,8 @@ Z_INTERNAL uint32_t compare256_power9(const uint8_t *src0, const uint8_t *src1) 
 
 #include "match_tpl.h"
 
+#define DEFLATE_QUICK       deflate_quick_power9
+
+#include "deflate_quick_tpl.h"
+
 #endif

--- a/arch/riscv/compare256_rvv.c
+++ b/arch/riscv/compare256_rvv.c
@@ -46,4 +46,8 @@ Z_INTERNAL uint32_t compare256_rvv(const uint8_t *src0, const uint8_t *src1) {
 
 #include "match_tpl.h"
 
+#define DEFLATE_QUICK       deflate_quick_rvv
+
+#include "deflate_quick_tpl.h"
+
 #endif // RISCV_RVV

--- a/arch/x86/compare256_avx2.c
+++ b/arch/x86/compare256_avx2.c
@@ -61,4 +61,8 @@ Z_INTERNAL uint32_t compare256_avx2(const uint8_t *src0, const uint8_t *src1) {
 
 #include "match_tpl.h"
 
+#define DEFLATE_QUICK       deflate_quick_avx2
+
+#include "deflate_quick_tpl.h"
+
 #endif

--- a/arch/x86/compare256_sse2.c
+++ b/arch/x86/compare256_sse2.c
@@ -94,4 +94,8 @@ Z_INTERNAL uint32_t compare256_sse2(const uint8_t *src0, const uint8_t *src1) {
 
 #include "match_tpl.h"
 
+#define DEFLATE_QUICK       deflate_quick_sse2
+
+#include "deflate_quick_tpl.h"
+
 #endif

--- a/arch/x86/x86_functions.h
+++ b/arch/x86/x86_functions.h
@@ -12,6 +12,7 @@ uint8_t* chunkmemset_safe_sse2(uint8_t *out, uint8_t *from, unsigned len, unsign
 
 #  ifdef HAVE_BUILTIN_CTZ
     uint32_t compare256_sse2(const uint8_t *src0, const uint8_t *src1);
+    block_state deflate_quick_sse2(deflate_state *s, int flush);
     uint32_t longest_match_sse2(deflate_state *const s, Pos cur_match);
     uint32_t longest_match_slow_sse2(deflate_state *const s, Pos cur_match);
     void slide_hash_sse2(deflate_state *s);
@@ -37,6 +38,7 @@ uint8_t* chunkmemset_safe_avx2(uint8_t *out, uint8_t *from, unsigned len, unsign
 
 #  ifdef HAVE_BUILTIN_CTZ
     uint32_t compare256_avx2(const uint8_t *src0, const uint8_t *src1);
+    block_state deflate_quick_avx2(deflate_state *s, int flush);
     uint32_t longest_match_avx2(deflate_state *const s, Pos cur_match);
     uint32_t longest_match_slow_avx2(deflate_state *const s, Pos cur_match);
     void slide_hash_avx2(deflate_state *s);
@@ -78,6 +80,8 @@ uint32_t crc32_vpclmulqdq(uint32_t crc32, const uint8_t *buf, size_t len);
 #    define native_chunkmemset_safe chunkmemset_safe_sse2
 #    undef native_chunksize
 #    define native_chunksize chunksize_sse2
+#    undef native_deflate_quick
+#    define native_deflate_quick deflate_quick_sse2
 #    undef native_inflate_fast
 #    define native_inflate_fast inflate_fast_sse2
 #    undef native_slide_hash
@@ -129,6 +133,8 @@ uint32_t crc32_vpclmulqdq(uint32_t crc32, const uint8_t *buf, size_t len);
 #    define native_chunkmemset_safe chunkmemset_safe_avx2
 #    undef native_chunksize
 #    define native_chunksize chunksize_avx2
+#    undef native_deflate_quick
+#    define native_deflate_quick deflate_quick_avx2
 #    undef native_inflate_fast
 #    define native_inflate_fast inflate_fast_avx2
 #    undef native_slide_hash

--- a/deflate.c
+++ b/deflate.c
@@ -111,7 +111,7 @@ const char PREFIX(deflate_copyright)[] = " deflate 1.3.1 Copyright 1995-2024 Jea
 static int deflateStateCheck      (PREFIX3(stream) *strm);
 Z_INTERNAL block_state deflate_stored(deflate_state *s, int flush);
 Z_INTERNAL block_state deflate_fast  (deflate_state *s, int flush);
-Z_INTERNAL block_state deflate_quick (deflate_state *s, int flush);
+Z_INTERNAL block_state deflate_quick_stub(deflate_state *s, int flush);
 #ifndef NO_MEDIUM_STRATEGY
 Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush);
 #endif
@@ -147,7 +147,7 @@ static const config configuration_table[10] = {
 /* 1 */ {4,    4,  8,    4, deflate_fast}, /* max speed, no lazy matches */
 /* 2 */ {4,    5, 16,    8, deflate_fast},
 #else
-/* 1 */ {0,    0,  0,    0, deflate_quick},
+/* 1 */ {0,    0,  0,    0, deflate_quick_stub},
 /* 2 */ {4,    4,  8,    4, deflate_fast}, /* max speed, no lazy matches */
 #endif
 

--- a/deflate_quick_tpl.h
+++ b/deflate_quick_tpl.h
@@ -1,3 +1,5 @@
+#ifndef DEFLATE_QUICK_H
+#define DEFLATE_QUICK_H
 /*
  * The deflate_quick deflate strategy, designed to be used when cycles are
  * at a premium.
@@ -44,7 +46,7 @@ extern const ct_data static_dtree[D_CODES];
     } \
 }
 
-Z_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
+Z_INTERNAL block_state DEFLATE_QUICK(deflate_state *s, int flush) {
     Pos hash_head;
     int64_t dist;
     unsigned match_len, last;
@@ -94,7 +96,7 @@ Z_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
                 const uint8_t *match_start = s->window + hash_head;
 
                 if (zng_memcmp_2(str_start, match_start) == 0) {
-                    match_len = FUNCTABLE_CALL(compare256)(str_start+2, match_start+2) + 2;
+                    match_len = COMPARE256(str_start+2, match_start+2) + 2;
 
                     if (match_len >= WANT_MIN_MATCH) {
                         if (UNLIKELY(match_len > s->lookahead))
@@ -128,3 +130,5 @@ Z_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
     QUICK_END_BLOCK(s, 0);
     return block_done;
 }
+
+#endif

--- a/functable.c
+++ b/functable.c
@@ -59,11 +59,11 @@ static void init_functable(void) {
     ft.crc32_fold_copy = &crc32_fold_copy_c;
     ft.crc32_fold_final = &crc32_fold_final_c;
     ft.crc32_fold_reset = &crc32_fold_reset_c;
+    ft.deflate_quick = &deflate_quick_c;
     ft.inflate_fast = &inflate_fast_c;
     ft.slide_hash = &slide_hash_c;
     ft.longest_match = &longest_match_c;
     ft.longest_match_slow = &longest_match_slow_c;
-    ft.compare256 = &compare256_c;
 
     // Select arch-optimized functions
 
@@ -78,7 +78,7 @@ static void init_functable(void) {
         ft.inflate_fast = &inflate_fast_sse2;
         ft.slide_hash = &slide_hash_sse2;
 #  ifdef HAVE_BUILTIN_CTZ
-        ft.compare256 = &compare256_sse2;
+        ft.deflate_quick = &deflate_quick_sse2;
         ft.longest_match = &longest_match_sse2;
         ft.longest_match_slow = &longest_match_slow_sse2;
 #  endif
@@ -119,10 +119,10 @@ static void init_functable(void) {
         ft.adler32_fold_copy = &adler32_fold_copy_avx2;
         ft.chunkmemset_safe = &chunkmemset_safe_avx2;
         ft.chunksize = &chunksize_avx2;
+        ft.deflate_quick = &deflate_quick_avx2;
         ft.inflate_fast = &inflate_fast_avx2;
         ft.slide_hash = &slide_hash_avx2;
 #  ifdef HAVE_BUILTIN_CTZ
-        ft.compare256 = &compare256_avx2;
         ft.longest_match = &longest_match_avx2;
         ft.longest_match_slow = &longest_match_slow_avx2;
 #  endif
@@ -178,6 +178,7 @@ static void init_functable(void) {
         ft.slide_hash = &slide_hash_neon;
 #  ifdef HAVE_BUILTIN_CTZLL
         ft.compare256 = &compare256_neon;
+        ft.deflate_quick = &deflate_quick_neon;
         ft.longest_match = &longest_match_neon;
         ft.longest_match_slow = &longest_match_slow_neon;
 #  endif
@@ -215,7 +216,7 @@ static void init_functable(void) {
     // Power9
 #ifdef POWER9
     if (cf.power.has_arch_3_00) {
-        ft.compare256 = &compare256_power9;
+        ft.deflate_quick = &deflate_quick_power9;
         ft.longest_match = &longest_match_power9;
         ft.longest_match_slow = &longest_match_slow_power9;
     }
@@ -229,7 +230,7 @@ static void init_functable(void) {
         ft.adler32_fold_copy = &adler32_fold_copy_rvv;
         ft.chunkmemset_safe = &chunkmemset_safe_rvv;
         ft.chunksize = &chunksize_rvv;
-        ft.compare256 = &compare256_rvv;
+        ft.deflate_quick = &deflate_quick_rvv;
         ft.inflate_fast = &inflate_fast_rvv;
         ft.longest_match = &longest_match_rvv;
         ft.longest_match_slow = &longest_match_slow_rvv;
@@ -250,12 +251,12 @@ static void init_functable(void) {
     FUNCTABLE_ASSIGN(ft, adler32_fold_copy);
     FUNCTABLE_ASSIGN(ft, chunkmemset_safe);
     FUNCTABLE_ASSIGN(ft, chunksize);
-    FUNCTABLE_ASSIGN(ft, compare256);
     FUNCTABLE_ASSIGN(ft, crc32);
     FUNCTABLE_ASSIGN(ft, crc32_fold);
     FUNCTABLE_ASSIGN(ft, crc32_fold_copy);
     FUNCTABLE_ASSIGN(ft, crc32_fold_final);
     FUNCTABLE_ASSIGN(ft, crc32_fold_reset);
+    FUNCTABLE_ASSIGN(ft, deflate_quick);
     FUNCTABLE_ASSIGN(ft, inflate_fast);
     FUNCTABLE_ASSIGN(ft, longest_match);
     FUNCTABLE_ASSIGN(ft, longest_match_slow);
@@ -290,11 +291,6 @@ static uint32_t chunksize_stub(void) {
     return functable.chunksize();
 }
 
-static uint32_t compare256_stub(const uint8_t* src0, const uint8_t* src1) {
-    init_functable();
-    return functable.compare256(src0, src1);
-}
-
 static uint32_t crc32_stub(uint32_t crc, const uint8_t* buf, size_t len) {
     init_functable();
     return functable.crc32(crc, buf, len);
@@ -318,6 +314,11 @@ static uint32_t crc32_fold_final_stub(crc32_fold* crc) {
 static uint32_t crc32_fold_reset_stub(crc32_fold* crc) {
     init_functable();
     return functable.crc32_fold_reset(crc);
+}
+
+block_state deflate_quick_stub(deflate_state* s, int flush) {
+    init_functable();
+    return functable.deflate_quick(s, flush);
 }
 
 static void inflate_fast_stub(PREFIX3(stream) *strm, uint32_t start) {
@@ -347,12 +348,12 @@ Z_INTERNAL struct functable_s functable = {
     adler32_fold_copy_stub,
     chunkmemset_safe_stub,
     chunksize_stub,
-    compare256_stub,
     crc32_stub,
     crc32_fold_stub,
     crc32_fold_copy_stub,
     crc32_fold_final_stub,
     crc32_fold_reset_stub,
+    deflate_quick_stub,
     inflate_fast_stub,
     longest_match_stub,
     longest_match_slow_stub,

--- a/functable.h
+++ b/functable.h
@@ -24,21 +24,21 @@
 #else
 
 struct functable_s {
-    void     (* force_init)         (void);
-    uint32_t (* adler32)            (uint32_t adler, const uint8_t *buf, size_t len);
-    uint32_t (* adler32_fold_copy)  (uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len);
-    uint8_t* (* chunkmemset_safe)   (uint8_t *out, uint8_t *from, unsigned len, unsigned left);
-    uint32_t (* chunksize)          (void);
-    uint32_t (* compare256)         (const uint8_t *src0, const uint8_t *src1);
-    uint32_t (* crc32)              (uint32_t crc, const uint8_t *buf, size_t len);
-    void     (* crc32_fold)         (struct crc32_fold_s *crc, const uint8_t *src, size_t len, uint32_t init_crc);
-    void     (* crc32_fold_copy)    (struct crc32_fold_s *crc, uint8_t *dst, const uint8_t *src, size_t len);
-    uint32_t (* crc32_fold_final)   (struct crc32_fold_s *crc);
-    uint32_t (* crc32_fold_reset)   (struct crc32_fold_s *crc);
-    void     (* inflate_fast)       (PREFIX3(stream) *strm, uint32_t start);
-    uint32_t (* longest_match)      (deflate_state *const s, Pos cur_match);
-    uint32_t (* longest_match_slow) (deflate_state *const s, Pos cur_match);
-    void     (* slide_hash)         (deflate_state *s);
+    void        (* force_init)         (void);
+    uint32_t    (* adler32)            (uint32_t adler, const uint8_t *buf, size_t len);
+    uint32_t    (* adler32_fold_copy)  (uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len);
+    uint8_t*    (* chunkmemset_safe)   (uint8_t *out, uint8_t *from, unsigned len, unsigned left);
+    uint32_t    (* chunksize)          (void);
+    uint32_t    (* crc32)              (uint32_t crc, const uint8_t *buf, size_t len);
+    void        (* crc32_fold)         (struct crc32_fold_s *crc, const uint8_t *src, size_t len, uint32_t init_crc);
+    void        (* crc32_fold_copy)    (struct crc32_fold_s *crc, uint8_t *dst, const uint8_t *src, size_t len);
+    uint32_t    (* crc32_fold_final)   (struct crc32_fold_s *crc);
+    uint32_t    (* crc32_fold_reset)   (struct crc32_fold_s *crc);
+    block_state (* deflate_quick)      (deflate_state *s, int flush);
+    void        (* inflate_fast)       (PREFIX3(stream) *strm, uint32_t start);
+    uint32_t    (* longest_match)      (deflate_state *const s, Pos cur_match);
+    uint32_t    (* longest_match_slow) (deflate_state *const s, Pos cur_match);
+    void        (* slide_hash)         (deflate_state *s);
 };
 
 Z_INTERNAL extern struct functable_s functable;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added optimized quick deflation functionality across multiple architectures (SSE2, AVX2, ARM NEON, RISC-V)

- **Performance Improvements**
  - Introduced architecture-specific quick deflation methods for enhanced compression efficiency
  - Expanded support for different CPU instruction sets

- **Technical Updates**
  - Refactored deflation implementation with new template-based approach
  - Updated function tables and configuration to support new quick deflation methods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->