### PR TITLE
Disable CRC32-VX Extention for some Clang versions

### DIFF
--- a/arch/s390/s390_functions.h
+++ b/arch/s390/s390_functions.h
@@ -7,8 +7,15 @@
 
 #ifdef S390_CRC32_VX
 uint32_t crc32_s390_vx(uint32_t crc, const uint8_t *buf, size_t len);
+
+#ifdef __clang__
+#  if ((__clang_major__ == 18) || (__clang_major__ == 19 && (__clang_minor__ < 1 || (__clang_minor__ == 1 && __clang_patchlevel__ < 2))))
+# error CRC32-VX optimizations are broken due to compiler bug in Clang versions: 18.0.0 <= clang_version < 19.1.2. \
+        Either disable the zlib-ng CRC32-VX optimization, or switch to another compiler/compiler version.
+#  endif
 #endif
 
+#endif
 
 #ifdef DISABLE_RUNTIME_CPU_DETECTION
 #  if defined(S390_CRC32_VX) && defined(__zarch__) && __ARCH__ >= 11 && defined(__VX__)


### PR DESCRIPTION
We have to disable the CRC32-VX implementation for some Clang versions (18 <= version < 19.1.2) that generate bad code for the IBM S390 VGFMA intrinsics.

This fixes #1845

Question: should we print a warning during configure, if the intrinsics are not used. Or is it OK to just silently disable them?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Added compiler version compatibility checks for CRC32-VX functionality on S390 architecture.
	- Improved runtime CPU detection and CRC32 function selection for specific compiler versions. 
	- Provided user guidance for incompatible Clang versions regarding CRC32-VX extension usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->