### PR TITLE
Workaround error G6E97C40B with RVV

### DIFF
--- a/arch/riscv/riscv_features.c
+++ b/arch/riscv/riscv_features.c
@@ -25,7 +25,7 @@ int Z_INTERNAL is_kernel_version_greater_or_equal_to_6_5() {
         return 0;
     }
 
-    if (major > 6 || major == 6 && minor >= 5)
+    if (major > 6 || (major == 6 && minor >= 5))
         return 1;
     return 0;
 }


### PR DESCRIPTION
Warning as an error with GCC from Uubuntu 24.04:
```
/home/runner/work/dotnet_riscv/dotnet_riscv/runtime/src/native/external/zlib-ng/arch/riscv/riscv_features.c(25,33): error G6E97C40B: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses] [/home/runner/work/dotnet_riscv/dotnet_riscv/runtime/src/native/libs/build-native.proj]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Improved readability of kernel version comparison logic by adding parentheses to clarify the logical expression
	- No functional changes to the code's behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->