### PR TITLE
Increase cmake workflow timeout

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -10,7 +10,7 @@ jobs:
   cmake:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 80
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The run time of the ``Ubuntu GCC ARM HF * ASAN`` pipelines is 50-59 minutes.
Canceled by timeout: https://github.com/zlib-ng/zlib-ng/actions/runs/12919014579/job/36028690879


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow configuration to extend job timeout from 60 to 80 minutes, providing more time for build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->