### PR TITLE
[abicheck] Regenerate ABI files for zlib

### DIFF
--- a/test/abi/zlib-04f42ceca40f73e2978b50e93806c2a18c1281fc-aarch64-unknown-linux-gnu.abi
+++ b/test/abi/zlib-04f42ceca40f73e2978b50e93806c2a18c1281fc-aarch64-unknown-linux-gnu.abi
@@ -1,4 +1,4 @@
-<abi-corpus version='2.0' path='btmp1/libz.so.1.2.13' architecture='elf-arm-aarch64' soname='libz.so.1'>
+<abi-corpus version='2.2' path='btmp1/libz.so.1.2.13' architecture='elf-arm-aarch64' soname='libz.so.1'>
   <elf-needed>
     <dependency name='libc.so.6'/>
     <dependency name='ld-linux-aarch64.so.1'/>
@@ -95,54 +95,54 @@
   </elf-function-symbols>
   <abi-instr address-size='64' path='src.d/adler32.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
     <type-decl name='long int' size-in-bits='64' id='type-id-1'/>
+    <typedef-decl name='Byte' type-id='type-id-2' filepath='./zconf.h' line='397' column='1' id='type-id-3'/>
+    <typedef-decl name='Bytef' type-id='type-id-3' filepath='./zconf.h' line='406' column='1' id='type-id-4'/>
+    <typedef-decl name='__off64_t' type-id='type-id-1' filepath='/usr/aarch64-linux-gnu/include/bits/types.h' line='153' column='1' id='type-id-5'/>
+    <typedef-decl name='__off_t' type-id='type-id-1' filepath='/usr/aarch64-linux-gnu/include/bits/types.h' line='152' column='1' id='type-id-6'/>
+    <typedef-decl name='off64_t' type-id='type-id-5' filepath='/usr/aarch64-linux-gnu/include/sys/types.h' line='92' column='1' id='type-id-7'/>
+    <typedef-decl name='off_t' type-id='type-id-6' filepath='/usr/aarch64-linux-gnu/include/sys/types.h' line='85' column='1' id='type-id-8'/>
+    <typedef-decl name='size_t' type-id='type-id-9' filepath='/usr/lib/gcc-cross/aarch64-linux-gnu/13/include/stddef.h' line='214' column='1' id='type-id-10'/>
+    <typedef-decl name='uInt' type-id='type-id-11' filepath='./zconf.h' line='399' column='1' id='type-id-12'/>
+    <typedef-decl name='uLong' type-id='type-id-9' filepath='./zconf.h' line='400' column='1' id='type-id-13'/>
+    <typedef-decl name='z_size_t' type-id='type-id-10' filepath='./zconf.h' line='251' column='1' id='type-id-14'/>
     <type-decl name='unsigned char' size-in-bits='8' id='type-id-2'/>
-    <type-decl name='unsigned int' size-in-bits='32' id='type-id-3'/>
-    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-4'/>
-    <typedef-decl name='z_size_t' type-id='type-id-5' filepath='./zconf.h' line='251' column='1' id='type-id-6'/>
-    <typedef-decl name='Byte' type-id='type-id-2' filepath='./zconf.h' line='397' column='1' id='type-id-7'/>
-    <typedef-decl name='uInt' type-id='type-id-3' filepath='./zconf.h' line='399' column='1' id='type-id-8'/>
-    <typedef-decl name='uLong' type-id='type-id-4' filepath='./zconf.h' line='400' column='1' id='type-id-9'/>
-    <typedef-decl name='Bytef' type-id='type-id-7' filepath='./zconf.h' line='406' column='1' id='type-id-10'/>
-    <typedef-decl name='__off_t' type-id='type-id-1' filepath='/usr/aarch64-linux-gnu/include/bits/types.h' line='152' column='1' id='type-id-11'/>
-    <typedef-decl name='__off64_t' type-id='type-id-1' filepath='/usr/aarch64-linux-gnu/include/bits/types.h' line='153' column='1' id='type-id-12'/>
-    <typedef-decl name='off_t' type-id='type-id-11' filepath='/usr/aarch64-linux-gnu/include/sys/types.h' line='85' column='1' id='type-id-13'/>
-    <typedef-decl name='off64_t' type-id='type-id-12' filepath='/usr/aarch64-linux-gnu/include/sys/types.h' line='92' column='1' id='type-id-14'/>
-    <typedef-decl name='size_t' type-id='type-id-4' filepath='/usr/lib/gcc-cross/aarch64-linux-gnu/11/include/stddef.h' line='209' column='1' id='type-id-5'/>
-    <qualified-type-def type-id='type-id-10' const='yes' id='type-id-15'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-11'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-9'/>
+    <qualified-type-def type-id='type-id-4' const='yes' id='type-id-15'/>
     <pointer-type-def type-id='type-id-15' size-in-bits='64' id='type-id-16'/>
     <function-decl name='adler32_z' mangled-name='adler32_z' filepath='src.d/adler32.c' line='63' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='adler32_z@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-9' name='adler' filepath='src.d/adler32.c' line='64' column='1'/>
+      <parameter type-id='type-id-13' name='adler' filepath='src.d/adler32.c' line='64' column='1'/>
       <parameter type-id='type-id-16' name='buf' filepath='src.d/adler32.c' line='65' column='1'/>
-      <parameter type-id='type-id-6' name='len' filepath='src.d/adler32.c' line='66' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-14' name='len' filepath='src.d/adler32.c' line='66' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='adler32' mangled-name='adler32' filepath='src.d/adler32.c' line='134' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='adler32'>
-      <parameter type-id='type-id-9' name='adler' filepath='src.d/adler32.c' line='135' column='1'/>
+      <parameter type-id='type-id-13' name='adler' filepath='src.d/adler32.c' line='135' column='1'/>
       <parameter type-id='type-id-16' name='buf' filepath='src.d/adler32.c' line='136' column='1'/>
-      <parameter type-id='type-id-8' name='len' filepath='src.d/adler32.c' line='137' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-12' name='len' filepath='src.d/adler32.c' line='137' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='adler32_combine' mangled-name='adler32_combine' filepath='src.d/adler32.c' line='172' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='adler32_combine@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-9' name='adler1' filepath='src.d/adler32.c' line='173' column='1'/>
-      <parameter type-id='type-id-9' name='adler2' filepath='src.d/adler32.c' line='174' column='1'/>
-      <parameter type-id='type-id-13' name='len2' filepath='src.d/adler32.c' line='175' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-13' name='adler1' filepath='src.d/adler32.c' line='173' column='1'/>
+      <parameter type-id='type-id-13' name='adler2' filepath='src.d/adler32.c' line='174' column='1'/>
+      <parameter type-id='type-id-8' name='len2' filepath='src.d/adler32.c' line='175' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='adler32_combine64' mangled-name='adler32_combine64' filepath='src.d/adler32.c' line='180' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='adler32_combine64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-9' name='adler1' filepath='src.d/adler32.c' line='181' column='1'/>
-      <parameter type-id='type-id-9' name='adler2' filepath='src.d/adler32.c' line='182' column='1'/>
-      <parameter type-id='type-id-14' name='len2' filepath='src.d/adler32.c' line='183' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-13' name='adler1' filepath='src.d/adler32.c' line='181' column='1'/>
+      <parameter type-id='type-id-13' name='adler2' filepath='src.d/adler32.c' line='182' column='1'/>
+      <parameter type-id='type-id-7' name='len2' filepath='src.d/adler32.c' line='183' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/compress.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <typedef-decl name='uLongf' type-id='type-id-9' filepath='./zconf.h' line='411' column='1' id='type-id-17'/>
+    <typedef-decl name='uLongf' type-id='type-id-13' filepath='./zconf.h' line='411' column='1' id='type-id-17'/>
     <pointer-type-def type-id='type-id-17' size-in-bits='64' id='type-id-18'/>
     <function-decl name='compress2' mangled-name='compress2' filepath='src.d/compress.c' line='22' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='compress2'>
       <parameter type-id='type-id-19' name='dest' filepath='src.d/compress.c' line='23' column='1'/>
       <parameter type-id='type-id-18' name='destLen' filepath='src.d/compress.c' line='24' column='1'/>
       <parameter type-id='type-id-16' name='source' filepath='src.d/compress.c' line='25' column='1'/>
-      <parameter type-id='type-id-9' name='sourceLen' filepath='src.d/compress.c' line='26' column='1'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/compress.c' line='26' column='1'/>
       <parameter type-id='type-id-20' name='level' filepath='src.d/compress.c' line='27' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
@@ -150,362 +150,107 @@
       <parameter type-id='type-id-19' name='dest' filepath='src.d/compress.c' line='69' column='1'/>
       <parameter type-id='type-id-18' name='destLen' filepath='src.d/compress.c' line='70' column='1'/>
       <parameter type-id='type-id-16' name='source' filepath='src.d/compress.c' line='71' column='1'/>
-      <parameter type-id='type-id-9' name='sourceLen' filepath='src.d/compress.c' line='72' column='1'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/compress.c' line='72' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='compressBound' mangled-name='compressBound' filepath='src.d/compress.c' line='81' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='compressBound@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-9' name='sourceLen' filepath='src.d/compress.c' line='82' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/compress.c' line='82' column='1'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+    <function-decl name='deflate' filepath='src.d/zlib.h' line='250' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='deflateEnd' filepath='src.d/zlib.h' line='363' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-21'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='deflateInit_' filepath='src.d/zlib.h' line='1781' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/crc32.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <typedef-decl name='z_crc_t' type-id='type-id-3' filepath='./zconf.h' line='435' column='1' id='type-id-21'/>
-    <qualified-type-def type-id='type-id-2' const='yes' id='type-id-22'/>
-    <pointer-type-def type-id='type-id-22' size-in-bits='64' id='type-id-23'/>
-    <qualified-type-def type-id='type-id-21' const='yes' id='type-id-24'/>
+    <typedef-decl name='z_crc_t' type-id='type-id-11' filepath='./zconf.h' line='435' column='1' id='type-id-23'/>
+    <qualified-type-def type-id='type-id-2' const='yes' id='type-id-24'/>
     <pointer-type-def type-id='type-id-24' size-in-bits='64' id='type-id-25'/>
+    <qualified-type-def type-id='type-id-23' const='yes' id='type-id-26'/>
+    <pointer-type-def type-id='type-id-26' size-in-bits='64' id='type-id-27'/>
     <function-decl name='get_crc_table' mangled-name='get_crc_table' filepath='src.d/crc32.c' line='595' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='get_crc_table'>
-      <return type-id='type-id-25'/>
+      <return type-id='type-id-27'/>
     </function-decl>
     <function-decl name='crc32_z' mangled-name='crc32_z' filepath='src.d/crc32.c' line='748' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_z@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-4' name='crc' filepath='src.d/crc32.c' line='749' column='1'/>
-      <parameter type-id='type-id-23' name='buf' filepath='src.d/crc32.c' line='750' column='1'/>
-      <parameter type-id='type-id-6' name='len' filepath='src.d/crc32.c' line='751' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-9' name='crc' filepath='src.d/crc32.c' line='749' column='1'/>
+      <parameter type-id='type-id-25' name='buf' filepath='src.d/crc32.c' line='750' column='1'/>
+      <parameter type-id='type-id-14' name='len' filepath='src.d/crc32.c' line='751' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32' mangled-name='crc32' filepath='src.d/crc32.c' line='1072' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32'>
-      <parameter type-id='type-id-4' name='crc' filepath='src.d/crc32.c' line='1073' column='1'/>
-      <parameter type-id='type-id-23' name='buf' filepath='src.d/crc32.c' line='1074' column='1'/>
-      <parameter type-id='type-id-8' name='len' filepath='src.d/crc32.c' line='1075' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-9' name='crc' filepath='src.d/crc32.c' line='1073' column='1'/>
+      <parameter type-id='type-id-25' name='buf' filepath='src.d/crc32.c' line='1074' column='1'/>
+      <parameter type-id='type-id-12' name='len' filepath='src.d/crc32.c' line='1075' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine64' mangled-name='crc32_combine64' filepath='src.d/crc32.c' line='1081' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_combine64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-9' name='crc1' filepath='src.d/crc32.c' line='1082' column='1'/>
-      <parameter type-id='type-id-9' name='crc2' filepath='src.d/crc32.c' line='1083' column='1'/>
-      <parameter type-id='type-id-14' name='len2' filepath='src.d/crc32.c' line='1084' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-13' name='crc1' filepath='src.d/crc32.c' line='1082' column='1'/>
+      <parameter type-id='type-id-13' name='crc2' filepath='src.d/crc32.c' line='1083' column='1'/>
+      <parameter type-id='type-id-7' name='len2' filepath='src.d/crc32.c' line='1084' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine' mangled-name='crc32_combine' filepath='src.d/crc32.c' line='1093' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_combine@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-9' name='crc1' filepath='src.d/crc32.c' line='1094' column='1'/>
-      <parameter type-id='type-id-9' name='crc2' filepath='src.d/crc32.c' line='1095' column='1'/>
-      <parameter type-id='type-id-13' name='len2' filepath='src.d/crc32.c' line='1096' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-13' name='crc1' filepath='src.d/crc32.c' line='1094' column='1'/>
+      <parameter type-id='type-id-13' name='crc2' filepath='src.d/crc32.c' line='1095' column='1'/>
+      <parameter type-id='type-id-8' name='len2' filepath='src.d/crc32.c' line='1096' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine_gen64' mangled-name='crc32_combine_gen64' filepath='src.d/crc32.c' line='1102' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_combine_gen64@@ZLIB_1.2.12'>
-      <parameter type-id='type-id-14' name='len2' filepath='src.d/crc32.c' line='1103' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-7' name='len2' filepath='src.d/crc32.c' line='1103' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine_gen' mangled-name='crc32_combine_gen' filepath='src.d/crc32.c' line='1112' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_combine_gen@@ZLIB_1.2.12'>
-      <parameter type-id='type-id-13' name='len2' filepath='src.d/crc32.c' line='1113' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-8' name='len2' filepath='src.d/crc32.c' line='1113' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine_op' mangled-name='crc32_combine_op' filepath='src.d/crc32.c' line='1119' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_combine_op@@ZLIB_1.2.12'>
-      <parameter type-id='type-id-9' name='crc1' filepath='src.d/crc32.c' line='1120' column='1'/>
-      <parameter type-id='type-id-9' name='crc2' filepath='src.d/crc32.c' line='1121' column='1'/>
-      <parameter type-id='type-id-9' name='op' filepath='src.d/crc32.c' line='1122' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-13' name='crc1' filepath='src.d/crc32.c' line='1120' column='1'/>
+      <parameter type-id='type-id-13' name='crc2' filepath='src.d/crc32.c' line='1121' column='1'/>
+      <parameter type-id='type-id-13' name='op' filepath='src.d/crc32.c' line='1122' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/deflate.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <type-decl name='char' size-in-bits='8' id='type-id-26'/>
-    <class-decl name='static_tree_desc_s' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-27'/>
-    <array-type-def dimensions='1' type-id='type-id-28' size-in-bits='1248' id='type-id-29'>
-      <subrange length='39' type-id='type-id-4' id='type-id-30'/>
+    <type-decl name='char' size-in-bits='8' id='type-id-28'/>
+    <array-type-def dimensions='1' type-id='type-id-29' size-in-bits='1248' id='type-id-30'>
+      <subrange length='39' lower-bound='0' upper-bound='38' type-id='type-id-9' id='type-id-31'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-28' size-in-bits='18336' id='type-id-31'>
-      <subrange length='573' type-id='type-id-4' id='type-id-32'/>
+    <array-type-def dimensions='1' type-id='type-id-29' size-in-bits='18336' id='type-id-32'>
+      <subrange length='573' lower-bound='0' upper-bound='572' type-id='type-id-9' id='type-id-33'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-28' size-in-bits='1952' id='type-id-33'>
-      <subrange length='61' type-id='type-id-4' id='type-id-34'/>
+    <array-type-def dimensions='1' type-id='type-id-29' size-in-bits='1952' id='type-id-34'>
+      <subrange length='61' lower-bound='0' upper-bound='60' type-id='type-id-9' id='type-id-35'/>
     </array-type-def>
     <type-decl name='int' size-in-bits='32' id='type-id-20'/>
-    <array-type-def dimensions='1' type-id='type-id-20' size-in-bits='18336' id='type-id-35'>
-      <subrange length='573' type-id='type-id-4' id='type-id-32'/>
+    <array-type-def dimensions='1' type-id='type-id-20' size-in-bits='18336' id='type-id-36'>
+      <subrange length='573' lower-bound='0' upper-bound='572' type-id='type-id-9' id='type-id-33'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-36' size-in-bits='4584' id='type-id-37'>
-      <subrange length='573' type-id='type-id-4' id='type-id-32'/>
-    </array-type-def>
-    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-38'/>
-    <array-type-def dimensions='1' type-id='type-id-39' size-in-bits='256' id='type-id-40'>
-      <subrange length='16' type-id='type-id-4' id='type-id-41'/>
-    </array-type-def>
-    <type-decl name='void' id='type-id-42'/>
-    <typedef-decl name='charf' type-id='type-id-26' filepath='./zconf.h' line='408' column='1' id='type-id-43'/>
-    <typedef-decl name='voidpf' type-id='type-id-44' filepath='./zconf.h' line='415' column='1' id='type-id-45'/>
-    <class-decl name='ct_data_s' size-in-bits='32' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='68' column='1' id='type-id-28'>
+    <class-decl name='ct_data_s' size-in-bits='32' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='68' column='1' id='type-id-29'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='fc' type-id='type-id-46' visibility='default' filepath='src.d/deflate.h' line='72' column='1'/>
+        <var-decl name='fc' type-id='type-id-37' visibility='default' filepath='src.d/deflate.h' line='72' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='16'>
-        <var-decl name='dl' type-id='type-id-47' visibility='default' filepath='src.d/deflate.h' line='76' column='1'/>
+        <var-decl name='dl' type-id='type-id-38' visibility='default' filepath='src.d/deflate.h' line='76' column='1'/>
       </data-member>
     </class-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='69' column='1' id='type-id-46'>
-      <data-member access='public'>
-        <var-decl name='freq' type-id='type-id-39' visibility='default' filepath='src.d/deflate.h' line='70' column='1'/>
-      </data-member>
-      <data-member access='public'>
-        <var-decl name='code' type-id='type-id-39' visibility='default' filepath='src.d/deflate.h' line='71' column='1'/>
-      </data-member>
-    </union-decl>
-    <union-decl name='__anonymous_union__1' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='73' column='1' id='type-id-47'>
-      <data-member access='public'>
-        <var-decl name='dad' type-id='type-id-39' visibility='default' filepath='src.d/deflate.h' line='74' column='1'/>
-      </data-member>
-      <data-member access='public'>
-        <var-decl name='len' type-id='type-id-39' visibility='default' filepath='src.d/deflate.h' line='75' column='1'/>
-      </data-member>
-    </union-decl>
-    <typedef-decl name='ct_data' type-id='type-id-28' filepath='src.d/deflate.h' line='77' column='1' id='type-id-48'/>
-    <typedef-decl name='static_tree_desc' type-id='type-id-27' filepath='src.d/deflate.h' line='84' column='1' id='type-id-49'/>
-    <class-decl name='tree_desc_s' size-in-bits='192' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='86' column='1' id='type-id-50'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='dyn_tree' type-id='type-id-51' visibility='default' filepath='src.d/deflate.h' line='87' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='max_code' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='88' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='stat_desc' type-id='type-id-52' visibility='default' filepath='src.d/deflate.h' line='89' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='Pos' type-id='type-id-39' filepath='src.d/deflate.h' line='92' column='1' id='type-id-53'/>
-    <typedef-decl name='Posf' type-id='type-id-53' filepath='src.d/deflate.h' line='93' column='1' id='type-id-54'/>
-    <typedef-decl name='IPos' type-id='type-id-3' filepath='src.d/deflate.h' line='94' column='1' id='type-id-55'/>
-    <class-decl name='internal_state' size-in-bits='47616' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='100' column='1' id='type-id-56'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='strm' type-id='type-id-57' visibility='default' filepath='src.d/deflate.h' line='101' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='status' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='102' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='pending_buf' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='103' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='pending_buf_size' type-id='type-id-58' visibility='default' filepath='src.d/deflate.h' line='104' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='pending_out' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='105' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='pending' type-id='type-id-58' visibility='default' filepath='src.d/deflate.h' line='106' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='wrap' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='107' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='gzhead' type-id='type-id-59' visibility='default' filepath='src.d/deflate.h' line='108' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='gzindex' type-id='type-id-58' visibility='default' filepath='src.d/deflate.h' line='109' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='method' type-id='type-id-7' visibility='default' filepath='src.d/deflate.h' line='110' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='608'>
-        <var-decl name='last_flush' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='111' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='w_size' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='115' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='672'>
-        <var-decl name='w_bits' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='116' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='w_mask' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='117' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='window' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='119' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='window_size' type-id='type-id-58' visibility='default' filepath='src.d/deflate.h' line='129' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='prev' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='134' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='head' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='140' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='ins_h' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='142' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1056'>
-        <var-decl name='hash_size' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='143' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1088'>
-        <var-decl name='hash_bits' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='144' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1120'>
-        <var-decl name='hash_mask' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='145' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1152'>
-        <var-decl name='hash_shift' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='147' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='block_start' type-id='type-id-1' visibility='default' filepath='src.d/deflate.h' line='154' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='match_length' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='159' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1312'>
-        <var-decl name='prev_match' type-id='type-id-55' visibility='default' filepath='src.d/deflate.h' line='160' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1344'>
-        <var-decl name='match_available' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='161' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1376'>
-        <var-decl name='strstart' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='162' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1408'>
-        <var-decl name='match_start' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='163' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1440'>
-        <var-decl name='lookahead' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='164' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1472'>
-        <var-decl name='prev_length' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='166' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1504'>
-        <var-decl name='max_chain_length' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='171' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1536'>
-        <var-decl name='max_lazy_match' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='177' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1568'>
-        <var-decl name='level' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='188' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1600'>
-        <var-decl name='strategy' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='189' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1632'>
-        <var-decl name='good_match' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='191' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1664'>
-        <var-decl name='nice_match' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='194' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1696'>
-        <var-decl name='dyn_ltree' type-id='type-id-31' visibility='default' filepath='src.d/deflate.h' line='198' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='20032'>
-        <var-decl name='dyn_dtree' type-id='type-id-33' visibility='default' filepath='src.d/deflate.h' line='199' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='21984'>
-        <var-decl name='bl_tree' type-id='type-id-29' visibility='default' filepath='src.d/deflate.h' line='200' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='23232'>
-        <var-decl name='l_desc' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='202' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='23424'>
-        <var-decl name='d_desc' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='203' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='23616'>
-        <var-decl name='bl_desc' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='204' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='23808'>
-        <var-decl name='bl_count' type-id='type-id-40' visibility='default' filepath='src.d/deflate.h' line='206' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='24064'>
-        <var-decl name='heap' type-id='type-id-35' visibility='default' filepath='src.d/deflate.h' line='209' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='42400'>
-        <var-decl name='heap_len' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='210' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='42432'>
-        <var-decl name='heap_max' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='211' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='42464'>
-        <var-decl name='depth' type-id='type-id-37' visibility='default' filepath='src.d/deflate.h' line='216' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47104'>
-        <var-decl name='sym_buf' type-id='type-id-61' visibility='default' filepath='src.d/deflate.h' line='220' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47168'>
-        <var-decl name='lit_bufsize' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='222' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47200'>
-        <var-decl name='sym_next' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='242' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47232'>
-        <var-decl name='sym_end' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='243' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47296'>
-        <var-decl name='opt_len' type-id='type-id-58' visibility='default' filepath='src.d/deflate.h' line='245' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47360'>
-        <var-decl name='static_len' type-id='type-id-58' visibility='default' filepath='src.d/deflate.h' line='246' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47424'>
-        <var-decl name='matches' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='247' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47456'>
-        <var-decl name='insert' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='248' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47488'>
-        <var-decl name='bi_buf' type-id='type-id-39' visibility='default' filepath='src.d/deflate.h' line='255' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47520'>
-        <var-decl name='bi_valid' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='259' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47552'>
-        <var-decl name='high_water' type-id='type-id-58' visibility='default' filepath='src.d/deflate.h' line='264' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='deflate_state' type-id='type-id-56' filepath='src.d/deflate.h' line='271' column='1' id='type-id-62'/>
-    <typedef-decl name='alloc_func' type-id='type-id-63' filepath='src.d/zlib.h' line='81' column='1' id='type-id-64'/>
-    <typedef-decl name='free_func' type-id='type-id-65' filepath='src.d/zlib.h' line='82' column='1' id='type-id-66'/>
-    <class-decl name='z_stream_s' size-in-bits='896' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='86' column='1' id='type-id-67'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='next_in' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='87' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='avail_in' type-id='type-id-8' visibility='default' filepath='src.d/zlib.h' line='88' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='total_in' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='89' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='next_out' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='91' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='avail_out' type-id='type-id-8' visibility='default' filepath='src.d/zlib.h' line='92' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='total_out' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='93' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='msg' type-id='type-id-68' visibility='default' filepath='src.d/zlib.h' line='95' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='state' type-id='type-id-69' visibility='default' filepath='src.d/zlib.h' line='96' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='zalloc' type-id='type-id-64' visibility='default' filepath='src.d/zlib.h' line='98' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='zfree' type-id='type-id-66' visibility='default' filepath='src.d/zlib.h' line='99' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='opaque' type-id='type-id-45' visibility='default' filepath='src.d/zlib.h' line='100' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='data_type' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='102' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='adler' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='104' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='reserved' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='105' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='z_stream' type-id='type-id-67' filepath='src.d/zlib.h' line='106' column='1' id='type-id-70'/>
-    <typedef-decl name='z_streamp' type-id='type-id-71' filepath='src.d/zlib.h' line='108' column='1' id='type-id-57'/>
-    <class-decl name='gz_header_s' size-in-bits='640' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='114' column='1' id='type-id-72'>
+    <class-decl name='gz_header_s' size-in-bits='640' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='114' column='1' id='type-id-39'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='text' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='115' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='time' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='116' column='1'/>
+        <var-decl name='time' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='116' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
         <var-decl name='xflags' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='117' column='1'/>
@@ -517,22 +262,22 @@
         <var-decl name='extra' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='119' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='extra_len' type-id='type-id-8' visibility='default' filepath='src.d/zlib.h' line='120' column='1'/>
+        <var-decl name='extra_len' type-id='type-id-12' visibility='default' filepath='src.d/zlib.h' line='120' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='extra_max' type-id='type-id-8' visibility='default' filepath='src.d/zlib.h' line='121' column='1'/>
+        <var-decl name='extra_max' type-id='type-id-12' visibility='default' filepath='src.d/zlib.h' line='121' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
         <var-decl name='name' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='122' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='name_max' type-id='type-id-8' visibility='default' filepath='src.d/zlib.h' line='123' column='1'/>
+        <var-decl name='name_max' type-id='type-id-12' visibility='default' filepath='src.d/zlib.h' line='123' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
         <var-decl name='comment' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='124' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='comm_max' type-id='type-id-8' visibility='default' filepath='src.d/zlib.h' line='125' column='1'/>
+        <var-decl name='comm_max' type-id='type-id-12' visibility='default' filepath='src.d/zlib.h' line='125' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='544'>
         <var-decl name='hcrc' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='126' column='1'/>
@@ -541,108 +286,368 @@
         <var-decl name='done' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='127' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='gz_header' type-id='type-id-72' filepath='src.d/zlib.h' line='129' column='1' id='type-id-73'/>
-    <typedef-decl name='gz_headerp' type-id='type-id-74' filepath='src.d/zlib.h' line='131' column='1' id='type-id-59'/>
-    <typedef-decl name='uch' type-id='type-id-2' filepath='src.d/zutil.h' line='39' column='1' id='type-id-36'/>
-    <typedef-decl name='uchf' type-id='type-id-36' filepath='src.d/zutil.h' line='40' column='1' id='type-id-75'/>
-    <typedef-decl name='ush' type-id='type-id-38' filepath='src.d/zutil.h' line='41' column='1' id='type-id-39'/>
-    <typedef-decl name='ulg' type-id='type-id-4' filepath='src.d/zutil.h' line='43' column='1' id='type-id-58'/>
-    <pointer-type-def type-id='type-id-10' size-in-bits='64' id='type-id-19'/>
-    <pointer-type-def type-id='type-id-54' size-in-bits='64' id='type-id-60'/>
-    <pointer-type-def type-id='type-id-26' size-in-bits='64' id='type-id-68'/>
-    <pointer-type-def type-id='type-id-43' size-in-bits='64' id='type-id-76'/>
-    <qualified-type-def type-id='type-id-26' const='yes' id='type-id-77'/>
-    <pointer-type-def type-id='type-id-77' size-in-bits='64' id='type-id-78'/>
-    <qualified-type-def type-id='type-id-49' const='yes' id='type-id-79'/>
-    <pointer-type-def type-id='type-id-79' size-in-bits='64' id='type-id-52'/>
-    <pointer-type-def type-id='type-id-48' size-in-bits='64' id='type-id-51'/>
-    <pointer-type-def type-id='type-id-62' size-in-bits='64' id='type-id-80'/>
-    <pointer-type-def type-id='type-id-73' size-in-bits='64' id='type-id-74'/>
-    <pointer-type-def type-id='type-id-20' size-in-bits='64' id='type-id-81'/>
-    <pointer-type-def type-id='type-id-56' size-in-bits='64' id='type-id-69'/>
-    <pointer-type-def type-id='type-id-82' size-in-bits='64' id='type-id-63'/>
-    <pointer-type-def type-id='type-id-8' size-in-bits='64' id='type-id-83'/>
-    <pointer-type-def type-id='type-id-75' size-in-bits='64' id='type-id-61'/>
-    <pointer-type-def type-id='type-id-3' size-in-bits='64' id='type-id-84'/>
-    <pointer-type-def type-id='type-id-85' size-in-bits='64' id='type-id-65'/>
-    <pointer-type-def type-id='type-id-42' size-in-bits='64' id='type-id-44'/>
+    <class-decl name='internal_state' size-in-bits='47616' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='100' column='1' id='type-id-40'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='strm' type-id='type-id-21' visibility='default' filepath='src.d/deflate.h' line='101' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='status' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='102' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='pending_buf' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='103' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='pending_buf_size' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='104' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='pending_out' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='105' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='pending' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='106' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='wrap' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='107' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='gzhead' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='108' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='gzindex' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='109' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='method' type-id='type-id-3' visibility='default' filepath='src.d/deflate.h' line='110' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='608'>
+        <var-decl name='last_flush' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='111' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='w_size' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='115' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='672'>
+        <var-decl name='w_bits' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='116' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='w_mask' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='117' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='window' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='119' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='window_size' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='129' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='prev' type-id='type-id-43' visibility='default' filepath='src.d/deflate.h' line='134' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='head' type-id='type-id-43' visibility='default' filepath='src.d/deflate.h' line='140' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='ins_h' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='142' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1056'>
+        <var-decl name='hash_size' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='143' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1088'>
+        <var-decl name='hash_bits' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='144' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1120'>
+        <var-decl name='hash_mask' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='145' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1152'>
+        <var-decl name='hash_shift' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='147' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1216'>
+        <var-decl name='block_start' type-id='type-id-1' visibility='default' filepath='src.d/deflate.h' line='154' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='match_length' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='159' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1312'>
+        <var-decl name='prev_match' type-id='type-id-44' visibility='default' filepath='src.d/deflate.h' line='160' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1344'>
+        <var-decl name='match_available' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='161' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1376'>
+        <var-decl name='strstart' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='162' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1408'>
+        <var-decl name='match_start' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='163' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1440'>
+        <var-decl name='lookahead' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='164' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1472'>
+        <var-decl name='prev_length' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='166' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1504'>
+        <var-decl name='max_chain_length' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='171' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1536'>
+        <var-decl name='max_lazy_match' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='177' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1568'>
+        <var-decl name='level' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='188' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1600'>
+        <var-decl name='strategy' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='189' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1632'>
+        <var-decl name='good_match' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='191' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1664'>
+        <var-decl name='nice_match' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='194' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1696'>
+        <var-decl name='dyn_ltree' type-id='type-id-32' visibility='default' filepath='src.d/deflate.h' line='198' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='20032'>
+        <var-decl name='dyn_dtree' type-id='type-id-34' visibility='default' filepath='src.d/deflate.h' line='199' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='21984'>
+        <var-decl name='bl_tree' type-id='type-id-30' visibility='default' filepath='src.d/deflate.h' line='200' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='23232'>
+        <var-decl name='l_desc' type-id='type-id-45' visibility='default' filepath='src.d/deflate.h' line='202' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='23424'>
+        <var-decl name='d_desc' type-id='type-id-45' visibility='default' filepath='src.d/deflate.h' line='203' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='23616'>
+        <var-decl name='bl_desc' type-id='type-id-45' visibility='default' filepath='src.d/deflate.h' line='204' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='23808'>
+        <var-decl name='bl_count' type-id='type-id-46' visibility='default' filepath='src.d/deflate.h' line='206' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='24064'>
+        <var-decl name='heap' type-id='type-id-36' visibility='default' filepath='src.d/deflate.h' line='209' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='42400'>
+        <var-decl name='heap_len' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='210' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='42432'>
+        <var-decl name='heap_max' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='211' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='42464'>
+        <var-decl name='depth' type-id='type-id-47' visibility='default' filepath='src.d/deflate.h' line='216' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47104'>
+        <var-decl name='sym_buf' type-id='type-id-48' visibility='default' filepath='src.d/deflate.h' line='220' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47168'>
+        <var-decl name='lit_bufsize' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='222' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47200'>
+        <var-decl name='sym_next' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='242' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47232'>
+        <var-decl name='sym_end' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='243' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47296'>
+        <var-decl name='opt_len' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='245' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47360'>
+        <var-decl name='static_len' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='246' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47424'>
+        <var-decl name='matches' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='247' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47456'>
+        <var-decl name='insert' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='248' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47488'>
+        <var-decl name='bi_buf' type-id='type-id-49' visibility='default' filepath='src.d/deflate.h' line='255' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47520'>
+        <var-decl name='bi_valid' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='259' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47552'>
+        <var-decl name='high_water' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='264' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='tree_desc_s' size-in-bits='192' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='86' column='1' id='type-id-45'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dyn_tree' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='87' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='max_code' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='88' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='stat_desc' type-id='type-id-51' visibility='default' filepath='src.d/deflate.h' line='89' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='z_stream_s' size-in-bits='896' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='86' column='1' id='type-id-52'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next_in' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='87' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='avail_in' type-id='type-id-12' visibility='default' filepath='src.d/zlib.h' line='88' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='total_in' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='89' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='next_out' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='91' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='avail_out' type-id='type-id-12' visibility='default' filepath='src.d/zlib.h' line='92' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='total_out' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='93' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='msg' type-id='type-id-53' visibility='default' filepath='src.d/zlib.h' line='95' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='state' type-id='type-id-54' visibility='default' filepath='src.d/zlib.h' line='96' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='zalloc' type-id='type-id-55' visibility='default' filepath='src.d/zlib.h' line='98' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='zfree' type-id='type-id-56' visibility='default' filepath='src.d/zlib.h' line='99' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='opaque' type-id='type-id-57' visibility='default' filepath='src.d/zlib.h' line='100' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='data_type' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='102' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='adler' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='104' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='reserved' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='105' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='IPos' type-id='type-id-11' filepath='src.d/deflate.h' line='94' column='1' id='type-id-44'/>
+    <typedef-decl name='Pos' type-id='type-id-49' filepath='src.d/deflate.h' line='92' column='1' id='type-id-58'/>
+    <typedef-decl name='Posf' type-id='type-id-58' filepath='src.d/deflate.h' line='93' column='1' id='type-id-59'/>
+    <typedef-decl name='alloc_func' type-id='type-id-60' filepath='src.d/zlib.h' line='81' column='1' id='type-id-55'/>
+    <typedef-decl name='charf' type-id='type-id-28' filepath='./zconf.h' line='408' column='1' id='type-id-61'/>
+    <typedef-decl name='ct_data' type-id='type-id-29' filepath='src.d/deflate.h' line='77' column='1' id='type-id-62'/>
+    <typedef-decl name='deflate_state' type-id='type-id-40' filepath='src.d/deflate.h' line='271' column='1' id='type-id-63'/>
+    <typedef-decl name='free_func' type-id='type-id-64' filepath='src.d/zlib.h' line='82' column='1' id='type-id-56'/>
+    <typedef-decl name='gz_header' type-id='type-id-39' filepath='src.d/zlib.h' line='129' column='1' id='type-id-65'/>
+    <typedef-decl name='gz_headerp' type-id='type-id-66' filepath='src.d/zlib.h' line='131' column='1' id='type-id-42'/>
+    <typedef-decl name='uch' type-id='type-id-2' filepath='src.d/zutil.h' line='39' column='1' id='type-id-67'/>
+    <typedef-decl name='uchf' type-id='type-id-67' filepath='src.d/zutil.h' line='40' column='1' id='type-id-68'/>
+    <typedef-decl name='ulg' type-id='type-id-9' filepath='src.d/zutil.h' line='43' column='1' id='type-id-41'/>
+    <typedef-decl name='ush' type-id='type-id-69' filepath='src.d/zutil.h' line='41' column='1' id='type-id-49'/>
+    <typedef-decl name='z_stream' type-id='type-id-52' filepath='src.d/zlib.h' line='106' column='1' id='type-id-70'/>
+    <typedef-decl name='z_streamp' type-id='type-id-71' filepath='src.d/zlib.h' line='108' column='1' id='type-id-21'/>
+    <array-type-def dimensions='1' type-id='type-id-67' size-in-bits='4584' id='type-id-47'>
+      <subrange length='573' lower-bound='0' upper-bound='572' type-id='type-id-9' id='type-id-33'/>
+    </array-type-def>
+    <union-decl name='__anonymous_union__1' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='73' column='1' id='type-id-38'>
+      <data-member access='public'>
+        <var-decl name='dad' type-id='type-id-49' visibility='default' filepath='src.d/deflate.h' line='74' column='1'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='len' type-id='type-id-49' visibility='default' filepath='src.d/deflate.h' line='75' column='1'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='__anonymous_union__' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='69' column='1' id='type-id-37'>
+      <data-member access='public'>
+        <var-decl name='freq' type-id='type-id-49' visibility='default' filepath='src.d/deflate.h' line='70' column='1'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='code' type-id='type-id-49' visibility='default' filepath='src.d/deflate.h' line='71' column='1'/>
+      </data-member>
+    </union-decl>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-69'/>
+    <array-type-def dimensions='1' type-id='type-id-49' size-in-bits='256' id='type-id-46'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-9' id='type-id-72'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-4' size-in-bits='64' id='type-id-19'/>
+    <pointer-type-def type-id='type-id-59' size-in-bits='64' id='type-id-43'/>
+    <pointer-type-def type-id='type-id-28' size-in-bits='64' id='type-id-53'/>
+    <pointer-type-def type-id='type-id-61' size-in-bits='64' id='type-id-73'/>
+    <qualified-type-def type-id='type-id-28' const='yes' id='type-id-74'/>
+    <pointer-type-def type-id='type-id-74' size-in-bits='64' id='type-id-22'/>
+    <pointer-type-def type-id='type-id-62' size-in-bits='64' id='type-id-50'/>
+    <pointer-type-def type-id='type-id-63' size-in-bits='64' id='type-id-75'/>
+    <pointer-type-def type-id='type-id-65' size-in-bits='64' id='type-id-66'/>
+    <pointer-type-def type-id='type-id-20' size-in-bits='64' id='type-id-76'/>
+    <pointer-type-def type-id='type-id-40' size-in-bits='64' id='type-id-54'/>
+    <pointer-type-def type-id='type-id-77' size-in-bits='64' id='type-id-60'/>
+    <pointer-type-def type-id='type-id-12' size-in-bits='64' id='type-id-78'/>
+    <pointer-type-def type-id='type-id-68' size-in-bits='64' id='type-id-48'/>
+    <pointer-type-def type-id='type-id-11' size-in-bits='64' id='type-id-79'/>
+    <pointer-type-def type-id='type-id-80' size-in-bits='64' id='type-id-64'/>
     <pointer-type-def type-id='type-id-70' size-in-bits='64' id='type-id-71'/>
-    <class-decl name='static_tree_desc_s' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-27'/>
+    <qualified-type-def type-id='type-id-81' const='yes' id='type-id-82'/>
+    <pointer-type-def type-id='type-id-82' size-in-bits='64' id='type-id-51'/>
+    <class-decl name='static_tree_desc_s' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-83'/>
+    <typedef-decl name='voidpf' type-id='type-id-84' filepath='./zconf.h' line='415' column='1' id='type-id-57'/>
     <function-decl name='memcpy' filepath='/usr/aarch64-linux-gnu/include/string.h' line='43' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-44'/>
-      <parameter type-id='type-id-44'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-84'/>
+      <parameter type-id='type-id-84'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-84'/>
     </function-decl>
     <function-decl name='memset' filepath='/usr/aarch64-linux-gnu/include/string.h' line='61' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-84'/>
       <parameter type-id='type-id-20'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-44'/>
-    </function-decl>
-    <function-decl name='deflateInit_' mangled-name='deflateInit_' filepath='src.d/deflate.c' line='225' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateInit_'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='226' column='1'/>
-      <parameter type-id='type-id-20' name='level' filepath='src.d/deflate.c' line='227' column='1'/>
-      <parameter type-id='type-id-78' name='version' filepath='src.d/deflate.c' line='228' column='1'/>
-      <parameter type-id='type-id-20' name='stream_size' filepath='src.d/deflate.c' line='229' column='1'/>
-      <return type-id='type-id-20'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-84'/>
     </function-decl>
     <function-decl name='deflateInit2_' mangled-name='deflateInit2_' filepath='src.d/deflate.c' line='237' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateInit2_'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='239' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='239' column='1'/>
       <parameter type-id='type-id-20' name='level' filepath='src.d/deflate.c' line='240' column='1'/>
       <parameter type-id='type-id-20' name='method' filepath='src.d/deflate.c' line='241' column='1'/>
       <parameter type-id='type-id-20' name='windowBits' filepath='src.d/deflate.c' line='242' column='1'/>
       <parameter type-id='type-id-20' name='memLevel' filepath='src.d/deflate.c' line='243' column='1'/>
       <parameter type-id='type-id-20' name='strategy' filepath='src.d/deflate.c' line='244' column='1'/>
-      <parameter type-id='type-id-78' name='version' filepath='src.d/deflate.c' line='245' column='1'/>
+      <parameter type-id='type-id-22' name='version' filepath='src.d/deflate.c' line='245' column='1'/>
       <parameter type-id='type-id-20' name='stream_size' filepath='src.d/deflate.c' line='246' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateSetDictionary' mangled-name='deflateSetDictionary' filepath='src.d/deflate.c' line='412' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateSetDictionary'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='413' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='413' column='1'/>
       <parameter type-id='type-id-16' name='dictionary' filepath='src.d/deflate.c' line='414' column='1'/>
-      <parameter type-id='type-id-8' name='dictLength' filepath='src.d/deflate.c' line='415' column='1'/>
+      <parameter type-id='type-id-12' name='dictLength' filepath='src.d/deflate.c' line='415' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateGetDictionary' mangled-name='deflateGetDictionary' filepath='src.d/deflate.c' line='481' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateGetDictionary@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='482' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='482' column='1'/>
       <parameter type-id='type-id-19' name='dictionary' filepath='src.d/deflate.c' line='483' column='1'/>
-      <parameter type-id='type-id-83' name='dictLength' filepath='src.d/deflate.c' line='484' column='1'/>
+      <parameter type-id='type-id-78' name='dictLength' filepath='src.d/deflate.c' line='484' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateResetKeep' mangled-name='deflateResetKeep' filepath='src.d/deflate.c' line='503' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateResetKeep@@ZLIB_1.2.5.2'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='504' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='504' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateReset' mangled-name='deflateReset' filepath='src.d/deflate.c' line='541' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateReset'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='542' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='542' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateSetHeader' mangled-name='deflateSetHeader' filepath='src.d/deflate.c' line='553' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateSetHeader@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='554' column='1'/>
-      <parameter type-id='type-id-59' name='head' filepath='src.d/deflate.c' line='555' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='554' column='1'/>
+      <parameter type-id='type-id-42' name='head' filepath='src.d/deflate.c' line='555' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflatePending' mangled-name='deflatePending' filepath='src.d/deflate.c' line='564' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflatePending@@ZLIB_1.2.5.1'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='567' column='1'/>
-      <parameter type-id='type-id-84' name='pending' filepath='src.d/deflate.c' line='565' column='1'/>
-      <parameter type-id='type-id-81' name='bits' filepath='src.d/deflate.c' line='566' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='567' column='1'/>
+      <parameter type-id='type-id-79' name='pending' filepath='src.d/deflate.c' line='565' column='1'/>
+      <parameter type-id='type-id-76' name='bits' filepath='src.d/deflate.c' line='566' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflatePrime' mangled-name='deflatePrime' filepath='src.d/deflate.c' line='578' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflatePrime@@ZLIB_1.2.0.8'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='579' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='579' column='1'/>
       <parameter type-id='type-id-20' name='bits' filepath='src.d/deflate.c' line='580' column='1'/>
       <parameter type-id='type-id-20' name='value' filepath='src.d/deflate.c' line='581' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateParams' mangled-name='deflateParams' filepath='src.d/deflate.c' line='605' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateParams'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='606' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='606' column='1'/>
       <parameter type-id='type-id-20' name='level' filepath='src.d/deflate.c' line='607' column='1'/>
       <parameter type-id='type-id-20' name='strategy' filepath='src.d/deflate.c' line='608' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateTune' mangled-name='deflateTune' filepath='src.d/deflate.c' line='654' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateTune@@ZLIB_1.2.2.3'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='655' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='655' column='1'/>
       <parameter type-id='type-id-20' name='good_length' filepath='src.d/deflate.c' line='656' column='1'/>
       <parameter type-id='type-id-20' name='max_lazy' filepath='src.d/deflate.c' line='657' column='1'/>
       <parameter type-id='type-id-20' name='nice_length' filepath='src.d/deflate.c' line='658' column='1'/>
@@ -650,198 +655,203 @@
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateBound' mangled-name='deflateBound' filepath='src.d/deflate.c' line='696' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateBound@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='697' column='1'/>
-      <parameter type-id='type-id-9' name='sourceLen' filepath='src.d/deflate.c' line='698' column='1'/>
-      <return type-id='type-id-9'/>
-    </function-decl>
-    <function-decl name='deflate' mangled-name='deflate' filepath='src.d/deflate.c' line='815' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflate'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='816' column='1'/>
-      <parameter type-id='type-id-20' name='flush' filepath='src.d/deflate.c' line='817' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
-    <function-decl name='deflateEnd' mangled-name='deflateEnd' filepath='src.d/deflate.c' line='1130' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateEnd'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='1131' column='1'/>
-      <return type-id='type-id-20'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='697' column='1'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/deflate.c' line='698' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='deflateCopy' mangled-name='deflateCopy' filepath='src.d/deflate.c' line='1156' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateCopy'>
-      <parameter type-id='type-id-57' name='dest' filepath='src.d/deflate.c' line='1157' column='1'/>
-      <parameter type-id='type-id-57' name='source' filepath='src.d/deflate.c' line='1158' column='1'/>
+      <parameter type-id='type-id-21' name='dest' filepath='src.d/deflate.c' line='1157' column='1'/>
+      <parameter type-id='type-id-21' name='source' filepath='src.d/deflate.c' line='1158' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
+    <typedef-decl name='static_tree_desc' type-id='type-id-83' filepath='src.d/deflate.h' line='84' column='1' id='type-id-81'/>
     <function-decl name='_tr_init' filepath='src.d/deflate.h' line='294' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-80'/>
-      <return type-id='type-id-42'/>
+      <parameter type-id='type-id-75'/>
+      <return type-id='type-id-85'/>
     </function-decl>
     <function-decl name='_tr_flush_block' filepath='src.d/deflate.h' line='296' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-80'/>
-      <parameter type-id='type-id-76'/>
-      <parameter type-id='type-id-58'/>
+      <parameter type-id='type-id-75'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-41'/>
       <parameter type-id='type-id-20'/>
-      <return type-id='type-id-42'/>
+      <return type-id='type-id-85'/>
     </function-decl>
     <function-decl name='_tr_flush_bits' filepath='src.d/deflate.h' line='298' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-80'/>
-      <return type-id='type-id-42'/>
+      <parameter type-id='type-id-75'/>
+      <return type-id='type-id-85'/>
     </function-decl>
     <function-decl name='_tr_align' filepath='src.d/deflate.h' line='299' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-80'/>
-      <return type-id='type-id-42'/>
+      <parameter type-id='type-id-75'/>
+      <return type-id='type-id-85'/>
     </function-decl>
     <function-decl name='_tr_stored_block' filepath='src.d/deflate.h' line='300' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-80'/>
-      <parameter type-id='type-id-76'/>
-      <parameter type-id='type-id-58'/>
+      <parameter type-id='type-id-75'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-41'/>
       <parameter type-id='type-id-20'/>
-      <return type-id='type-id-42'/>
+      <return type-id='type-id-85'/>
+    </function-decl>
+    <function-decl name='crc32' filepath='src.d/zlib.h' line='1727' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-13'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-12'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='zcalloc' filepath='src.d/zutil.h' line='261' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-45'/>
-      <parameter type-id='type-id-3'/>
-      <parameter type-id='type-id-3'/>
-      <return type-id='type-id-45'/>
+      <parameter type-id='type-id-57'/>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-11'/>
+      <return type-id='type-id-57'/>
     </function-decl>
     <function-decl name='zcfree' filepath='src.d/zutil.h' line='263' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-45'/>
-      <parameter type-id='type-id-45'/>
-      <return type-id='type-id-42'/>
+      <parameter type-id='type-id-57'/>
+      <parameter type-id='type-id-57'/>
+      <return type-id='type-id-85'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-82'>
-      <parameter type-id='type-id-45'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-45'/>
+    <type-decl name='void' id='type-id-85'/>
+    <pointer-type-def type-id='type-id-85' id='type-id-84'/>
+    <function-type size-in-bits='64' id='type-id-80'>
+      <parameter type-id='type-id-57'/>
+      <parameter type-id='type-id-57'/>
+      <return type-id='type-id-85'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-85'>
-      <parameter type-id='type-id-45'/>
-      <parameter type-id='type-id-45'/>
-      <return type-id='type-id-42'/>
+    <function-type size-in-bits='64' id='type-id-77'>
+      <parameter type-id='type-id-57'/>
+      <parameter type-id='type-id-12'/>
+      <parameter type-id='type-id-12'/>
+      <return type-id='type-id-57'/>
     </function-type>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/gzclose.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <typedef-decl name='gzFile' type-id='type-id-86' filepath='src.d/zlib.h' line='1302' column='1' id='type-id-87'/>
-    <class-decl name='gzFile_s' size-in-bits='192' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='1834' column='1' id='type-id-88'>
+    <class-decl name='gzFile_s' size-in-bits='192' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='1834' column='1' id='type-id-86'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='have' type-id='type-id-3' visibility='default' filepath='src.d/zlib.h' line='1835' column='1'/>
+        <var-decl name='have' type-id='type-id-11' visibility='default' filepath='src.d/zlib.h' line='1835' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='next' type-id='type-id-89' visibility='default' filepath='src.d/zlib.h' line='1836' column='1'/>
+        <var-decl name='next' type-id='type-id-87' visibility='default' filepath='src.d/zlib.h' line='1836' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='pos' type-id='type-id-14' visibility='default' filepath='src.d/zlib.h' line='1837' column='1'/>
+        <var-decl name='pos' type-id='type-id-7' visibility='default' filepath='src.d/zlib.h' line='1837' column='1'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-88' size-in-bits='64' id='type-id-86'/>
+    <typedef-decl name='gzFile' type-id='type-id-88' filepath='src.d/zlib.h' line='1302' column='1' id='type-id-89'/>
+    <pointer-type-def type-id='type-id-86' size-in-bits='64' id='type-id-88'/>
     <function-decl name='gzclose' mangled-name='gzclose' filepath='src.d/gzclose.c' line='11' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzclose'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzclose.c' line='12' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzclose.c' line='12' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='gzclose_r' mangled-name='gzclose_r' filepath='src.d/zlib.h' line='1644' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzclose_r@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-87'/>
+    <function-decl name='gzclose_r' filepath='src.d/zlib.h' line='1644' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-89'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='gzclose_w' mangled-name='gzclose_w' filepath='src.d/zlib.h' line='1645' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzclose_w@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-87'/>
+    <function-decl name='gzclose_w' filepath='src.d/zlib.h' line='1645' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-89'/>
       <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/gzlib.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <type-decl name='variadic parameter type' id='type-id-90'/>
-    <function-decl name='open' filepath='/usr/aarch64-linux-gnu/include/fcntl.h' line='181' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-78'/>
+    <function-decl name='open' filepath='/usr/aarch64-linux-gnu/include/fcntl.h' line='209' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-22'/>
       <parameter type-id='type-id-20'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='snprintf' filepath='/usr/aarch64-linux-gnu/include/stdio.h' line='378' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-68'/>
-      <parameter type-id='type-id-5'/>
-      <parameter type-id='type-id-78'/>
+    <function-decl name='snprintf' filepath='/usr/aarch64-linux-gnu/include/stdio.h' line='385' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-10'/>
+      <parameter type-id='type-id-22'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-20'/>
     </function-decl>
+    <function-decl name='malloc' filepath='/usr/aarch64-linux-gnu/include/stdlib.h' line='672' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='free' filepath='/usr/aarch64-linux-gnu/include/stdlib.h' line='687' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-84'/>
+      <return type-id='type-id-85'/>
+    </function-decl>
     <function-decl name='strlen' filepath='/usr/aarch64-linux-gnu/include/string.h' line='407' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-78'/>
-      <return type-id='type-id-5'/>
+      <parameter type-id='type-id-22'/>
+      <return type-id='type-id-10'/>
     </function-decl>
     <function-decl name='lseek64' filepath='/usr/aarch64-linux-gnu/include/unistd.h' line='350' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-20'/>
-      <parameter type-id='type-id-12'/>
+      <parameter type-id='type-id-5'/>
       <parameter type-id='type-id-20'/>
-      <return type-id='type-id-12'/>
+      <return type-id='type-id-5'/>
     </function-decl>
     <function-decl name='gzopen' mangled-name='gzopen' filepath='src.d/gzlib.c' line='272' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzopen'>
-      <parameter type-id='type-id-78' name='path' filepath='src.d/gzlib.c' line='273' column='1'/>
-      <parameter type-id='type-id-78' name='mode' filepath='src.d/gzlib.c' line='274' column='1'/>
-      <return type-id='type-id-87'/>
+      <parameter type-id='type-id-22' name='path' filepath='src.d/gzlib.c' line='273' column='1'/>
+      <parameter type-id='type-id-22' name='mode' filepath='src.d/gzlib.c' line='274' column='1'/>
+      <return type-id='type-id-89'/>
     </function-decl>
     <function-decl name='gzopen64' mangled-name='gzopen64' filepath='src.d/gzlib.c' line='280' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzopen64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-78' name='path' filepath='src.d/gzlib.c' line='281' column='1'/>
-      <parameter type-id='type-id-78' name='mode' filepath='src.d/gzlib.c' line='282' column='1'/>
-      <return type-id='type-id-87'/>
+      <parameter type-id='type-id-22' name='path' filepath='src.d/gzlib.c' line='281' column='1'/>
+      <parameter type-id='type-id-22' name='mode' filepath='src.d/gzlib.c' line='282' column='1'/>
+      <return type-id='type-id-89'/>
     </function-decl>
     <function-decl name='gzdopen' mangled-name='gzdopen' filepath='src.d/gzlib.c' line='288' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzdopen'>
       <parameter type-id='type-id-20' name='fd' filepath='src.d/gzlib.c' line='289' column='1'/>
-      <parameter type-id='type-id-78' name='mode' filepath='src.d/gzlib.c' line='290' column='1'/>
-      <return type-id='type-id-87'/>
+      <parameter type-id='type-id-22' name='mode' filepath='src.d/gzlib.c' line='290' column='1'/>
+      <return type-id='type-id-89'/>
     </function-decl>
     <function-decl name='gzbuffer' mangled-name='gzbuffer' filepath='src.d/gzlib.c' line='318' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzbuffer@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='319' column='1'/>
-      <parameter type-id='type-id-3' name='size' filepath='src.d/gzlib.c' line='320' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='319' column='1'/>
+      <parameter type-id='type-id-11' name='size' filepath='src.d/gzlib.c' line='320' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzrewind' mangled-name='gzrewind' filepath='src.d/gzlib.c' line='345' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzrewind'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='346' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='346' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzseek64' mangled-name='gzseek64' filepath='src.d/gzlib.c' line='368' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzseek64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='369' column='1'/>
-      <parameter type-id='type-id-14' name='offset' filepath='src.d/gzlib.c' line='370' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='369' column='1'/>
+      <parameter type-id='type-id-7' name='offset' filepath='src.d/gzlib.c' line='370' column='1'/>
       <parameter type-id='type-id-20' name='whence' filepath='src.d/gzlib.c' line='371' column='1'/>
-      <return type-id='type-id-14'/>
+      <return type-id='type-id-7'/>
     </function-decl>
     <function-decl name='gzseek' mangled-name='gzseek' filepath='src.d/gzlib.c' line='445' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzseek'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='446' column='1'/>
-      <parameter type-id='type-id-13' name='offset' filepath='src.d/gzlib.c' line='447' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='446' column='1'/>
+      <parameter type-id='type-id-8' name='offset' filepath='src.d/gzlib.c' line='447' column='1'/>
       <parameter type-id='type-id-20' name='whence' filepath='src.d/gzlib.c' line='448' column='1'/>
-      <return type-id='type-id-13'/>
+      <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='gztell64' mangled-name='gztell64' filepath='src.d/gzlib.c' line='457' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gztell64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='458' column='1'/>
-      <return type-id='type-id-14'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='458' column='1'/>
+      <return type-id='type-id-7'/>
     </function-decl>
     <function-decl name='gztell' mangled-name='gztell' filepath='src.d/gzlib.c' line='474' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gztell'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='475' column='1'/>
-      <return type-id='type-id-13'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='475' column='1'/>
+      <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='gzoffset64' mangled-name='gzoffset64' filepath='src.d/gzlib.c' line='484' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzoffset64@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='485' column='1'/>
-      <return type-id='type-id-14'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='485' column='1'/>
+      <return type-id='type-id-7'/>
     </function-decl>
     <function-decl name='gzoffset' mangled-name='gzoffset' filepath='src.d/gzlib.c' line='507' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzoffset@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='508' column='1'/>
-      <return type-id='type-id-13'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='508' column='1'/>
+      <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='gzeof' mangled-name='gzeof' filepath='src.d/gzlib.c' line='517' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzeof'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='518' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='518' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzerror' mangled-name='gzerror' filepath='src.d/gzlib.c' line='534' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzerror'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='535' column='1'/>
-      <parameter type-id='type-id-81' name='errnum' filepath='src.d/gzlib.c' line='536' column='1'/>
-      <return type-id='type-id-78'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='535' column='1'/>
+      <parameter type-id='type-id-76' name='errnum' filepath='src.d/gzlib.c' line='536' column='1'/>
+      <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='gzclearerr' mangled-name='gzclearerr' filepath='src.d/gzlib.c' line='555' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzclearerr@@ZLIB_1.2.0.2'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='556' column='1'/>
-      <return type-id='type-id-42'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='556' column='1'/>
+      <return type-id='type-id-85'/>
     </function-decl>
+    <type-decl name='variadic parameter type' id='type-id-90'/>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/gzread.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <typedef-decl name='voidp' type-id='type-id-44' filepath='./zconf.h' line='416' column='1' id='type-id-91'/>
-    <typedef-decl name='__ssize_t' type-id='type-id-1' filepath='/usr/aarch64-linux-gnu/include/bits/types.h' line='194' column='1' id='type-id-92'/>
-    <typedef-decl name='ssize_t' type-id='type-id-92' filepath='/usr/aarch64-linux-gnu/include/sys/types.h' line='108' column='1' id='type-id-93'/>
-    <class-decl name='gz_state' size-in-bits='1920' is-struct='yes' naming-typedef-id='type-id-94' visibility='default' filepath='src.d/gzguts.h' line='170' column='1' id='type-id-95'>
+    <class-decl name='gz_state' size-in-bits='1920' is-struct='yes' naming-typedef-id='type-id-91' visibility='default' filepath='src.d/gzguts.h' line='170' column='1' id='type-id-92'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='x' type-id='type-id-88' visibility='default' filepath='src.d/gzguts.h' line='172' column='1'/>
+        <var-decl name='x' type-id='type-id-86' visibility='default' filepath='src.d/gzguts.h' line='172' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
         <var-decl name='mode' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='177' column='1'/>
@@ -850,19 +860,19 @@
         <var-decl name='fd' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='178' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='path' type-id='type-id-68' visibility='default' filepath='src.d/gzguts.h' line='179' column='1'/>
+        <var-decl name='path' type-id='type-id-53' visibility='default' filepath='src.d/gzguts.h' line='179' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='size' type-id='type-id-3' visibility='default' filepath='src.d/gzguts.h' line='180' column='1'/>
+        <var-decl name='size' type-id='type-id-11' visibility='default' filepath='src.d/gzguts.h' line='180' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='want' type-id='type-id-3' visibility='default' filepath='src.d/gzguts.h' line='181' column='1'/>
+        <var-decl name='want' type-id='type-id-11' visibility='default' filepath='src.d/gzguts.h' line='181' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='in' type-id='type-id-89' visibility='default' filepath='src.d/gzguts.h' line='182' column='1'/>
+        <var-decl name='in' type-id='type-id-87' visibility='default' filepath='src.d/gzguts.h' line='182' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='out' type-id='type-id-89' visibility='default' filepath='src.d/gzguts.h' line='183' column='1'/>
+        <var-decl name='out' type-id='type-id-87' visibility='default' filepath='src.d/gzguts.h' line='183' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
         <var-decl name='direct' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='184' column='1'/>
@@ -871,7 +881,7 @@
         <var-decl name='how' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='186' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='start' type-id='type-id-14' visibility='default' filepath='src.d/gzguts.h' line='187' column='1'/>
+        <var-decl name='start' type-id='type-id-7' visibility='default' filepath='src.d/gzguts.h' line='187' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='640'>
         <var-decl name='eof' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='188' column='1'/>
@@ -889,7 +899,7 @@
         <var-decl name='reset' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='193' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='skip' type-id='type-id-14' visibility='default' filepath='src.d/gzguts.h' line='195' column='1'/>
+        <var-decl name='skip' type-id='type-id-7' visibility='default' filepath='src.d/gzguts.h' line='195' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='896'>
         <var-decl name='seek' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='196' column='1'/>
@@ -898,27 +908,30 @@
         <var-decl name='err' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='198' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='msg' type-id='type-id-68' visibility='default' filepath='src.d/gzguts.h' line='199' column='1'/>
+        <var-decl name='msg' type-id='type-id-53' visibility='default' filepath='src.d/gzguts.h' line='199' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1024'>
         <var-decl name='strm' type-id='type-id-70' visibility='default' filepath='src.d/gzguts.h' line='201' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='gz_state' type-id='type-id-95' filepath='src.d/gzguts.h' line='202' column='1' id='type-id-94'/>
-    <typedef-decl name='gz_statep' type-id='type-id-96' filepath='src.d/gzguts.h' line='203' column='1' id='type-id-97'/>
-    <pointer-type-def type-id='type-id-94' size-in-bits='64' id='type-id-96'/>
+    <typedef-decl name='__ssize_t' type-id='type-id-1' filepath='/usr/aarch64-linux-gnu/include/bits/types.h' line='194' column='1' id='type-id-93'/>
+    <typedef-decl name='gz_state' type-id='type-id-92' filepath='src.d/gzguts.h' line='202' column='1' id='type-id-91'/>
+    <typedef-decl name='gz_statep' type-id='type-id-94' filepath='src.d/gzguts.h' line='203' column='1' id='type-id-95'/>
+    <typedef-decl name='ssize_t' type-id='type-id-93' filepath='/usr/aarch64-linux-gnu/include/sys/types.h' line='108' column='1' id='type-id-96'/>
+    <pointer-type-def type-id='type-id-91' size-in-bits='64' id='type-id-94'/>
+    <typedef-decl name='voidp' type-id='type-id-84' filepath='./zconf.h' line='416' column='1' id='type-id-97'/>
     <function-decl name='__errno_location' filepath='/usr/aarch64-linux-gnu/include/errno.h' line='37' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-81'/>
+      <return type-id='type-id-76'/>
     </function-decl>
     <function-decl name='memchr' filepath='/usr/aarch64-linux-gnu/include/string.h' line='107' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-84'/>
       <parameter type-id='type-id-20'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-84'/>
     </function-decl>
     <function-decl name='strerror' filepath='/usr/aarch64-linux-gnu/include/string.h' line='419' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-20'/>
-      <return type-id='type-id-68'/>
+      <return type-id='type-id-53'/>
     </function-decl>
     <function-decl name='close' filepath='/usr/aarch64-linux-gnu/include/unistd.h' line='358' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-20'/>
@@ -926,63 +939,83 @@
     </function-decl>
     <function-decl name='read' filepath='/usr/aarch64-linux-gnu/include/unistd.h' line='371' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-20'/>
-      <parameter type-id='type-id-44'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-93'/>
+      <parameter type-id='type-id-84'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-96'/>
     </function-decl>
     <function-decl name='gz_error' filepath='src.d/gzguts.h' line='206' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-97'/>
+      <parameter type-id='type-id-95'/>
       <parameter type-id='type-id-20'/>
-      <parameter type-id='type-id-78'/>
-      <return type-id='type-id-42'/>
+      <parameter type-id='type-id-22'/>
+      <return type-id='type-id-85'/>
     </function-decl>
     <function-decl name='gzread' mangled-name='gzread' filepath='src.d/gzread.c' line='373' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzread'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzread.c' line='374' column='1'/>
-      <parameter type-id='type-id-91' name='buf' filepath='src.d/gzread.c' line='375' column='1'/>
-      <parameter type-id='type-id-3' name='len' filepath='src.d/gzread.c' line='376' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='374' column='1'/>
+      <parameter type-id='type-id-97' name='buf' filepath='src.d/gzread.c' line='375' column='1'/>
+      <parameter type-id='type-id-11' name='len' filepath='src.d/gzread.c' line='376' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzfread' mangled-name='gzfread' filepath='src.d/gzread.c' line='409' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzfread@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-91' name='buf' filepath='src.d/gzread.c' line='410' column='1'/>
-      <parameter type-id='type-id-6' name='size' filepath='src.d/gzread.c' line='411' column='1'/>
-      <parameter type-id='type-id-6' name='nitems' filepath='src.d/gzread.c' line='412' column='1'/>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzread.c' line='413' column='1'/>
-      <return type-id='type-id-6'/>
+      <parameter type-id='type-id-97' name='buf' filepath='src.d/gzread.c' line='410' column='1'/>
+      <parameter type-id='type-id-14' name='size' filepath='src.d/gzread.c' line='411' column='1'/>
+      <parameter type-id='type-id-14' name='nitems' filepath='src.d/gzread.c' line='412' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='413' column='1'/>
+      <return type-id='type-id-14'/>
     </function-decl>
     <function-decl name='gzgetc' mangled-name='gzgetc' filepath='src.d/gzread.c' line='445' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzgetc'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzread.c' line='446' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='446' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzgetc_' mangled-name='gzgetc_' filepath='src.d/gzread.c' line='472' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzgetc_@@ZLIB_1.2.5.2'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzread.c' line='473' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='473' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzungetc' mangled-name='gzungetc' filepath='src.d/gzread.c' line='479' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzungetc@@ZLIB_1.2.0.2'>
       <parameter type-id='type-id-20' name='c' filepath='src.d/gzread.c' line='480' column='1'/>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzread.c' line='481' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='481' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzgets' mangled-name='gzgets' filepath='src.d/gzread.c' line='539' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzgets'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzread.c' line='540' column='1'/>
-      <parameter type-id='type-id-68' name='buf' filepath='src.d/gzread.c' line='541' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='540' column='1'/>
+      <parameter type-id='type-id-53' name='buf' filepath='src.d/gzread.c' line='541' column='1'/>
       <parameter type-id='type-id-20' name='len' filepath='src.d/gzread.c' line='542' column='1'/>
-      <return type-id='type-id-68'/>
+      <return type-id='type-id-53'/>
     </function-decl>
     <function-decl name='gzdirect' mangled-name='gzdirect' filepath='src.d/gzread.c' line='603' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzdirect@@ZLIB_1.2.2.3'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzread.c' line='604' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='604' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflate' filepath='src.d/zlib.h' line='400' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateEnd' filepath='src.d/zlib.h' line='520' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-21'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateReset' filepath='src.d/zlib.h' line='959' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-21'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateInit2_' filepath='src.d/zlib.h' line='1789' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-20'/>
       <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/gzwrite.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
     <class-decl name='__va_list' size-in-bits='256' is-struct='yes' visibility='default' id='type-id-98'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__stack' type-id='type-id-44' visibility='default'/>
+        <var-decl name='__stack' type-id='type-id-84' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='__gr_top' type-id='type-id-44' visibility='default'/>
+        <var-decl name='__gr_top' type-id='type-id-84' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='__vr_top' type-id='type-id-44' visibility='default'/>
+        <var-decl name='__vr_top' type-id='type-id-84' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
         <var-decl name='__gr_offs' type-id='type-id-20' visibility='default'/>
@@ -991,78 +1024,83 @@
         <var-decl name='__vr_offs' type-id='type-id-20' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='voidpc' type-id='type-id-44' filepath='./zconf.h' line='414' column='1' id='type-id-99'/>
-    <typedef-decl name='__gnuc_va_list' type-id='type-id-98' filepath='/usr/lib/gcc-cross/aarch64-linux-gnu/11/include/stdarg.h' line='40' column='1' id='type-id-100'/>
-    <typedef-decl name='va_list' type-id='type-id-100' filepath='/usr/lib/gcc-cross/aarch64-linux-gnu/11/include/stdarg.h' line='99' column='1' id='type-id-101'/>
-    <function-decl name='vsnprintf' filepath='/usr/aarch64-linux-gnu/include/stdio.h' line='382' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-68'/>
-      <parameter type-id='type-id-5'/>
-      <parameter type-id='type-id-78'/>
-      <parameter type-id='type-id-100'/>
+    <typedef-decl name='__gnuc_va_list' type-id='type-id-98' filepath='/usr/lib/gcc-cross/aarch64-linux-gnu/13/include/stdarg.h' line='40' column='1' id='type-id-99'/>
+    <typedef-decl name='va_list' type-id='type-id-99' filepath='/usr/lib/gcc-cross/aarch64-linux-gnu/13/include/stdarg.h' line='103' column='1' id='type-id-100'/>
+    <typedef-decl name='voidpc' type-id='type-id-84' filepath='./zconf.h' line='414' column='1' id='type-id-101'/>
+    <function-decl name='vsnprintf' filepath='/usr/aarch64-linux-gnu/include/stdio.h' line='389' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-10'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-99'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='memmove' filepath='/usr/aarch64-linux-gnu/include/string.h' line='47' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-44'/>
-      <parameter type-id='type-id-44'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-84'/>
+      <parameter type-id='type-id-84'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-84'/>
     </function-decl>
     <function-decl name='write' filepath='/usr/aarch64-linux-gnu/include/unistd.h' line='378' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-20'/>
-      <parameter type-id='type-id-44'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-93'/>
+      <parameter type-id='type-id-84'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-96'/>
     </function-decl>
     <function-decl name='gzwrite' mangled-name='gzwrite' filepath='src.d/gzwrite.c' line='255' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzwrite'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='256' column='1'/>
-      <parameter type-id='type-id-99' name='buf' filepath='src.d/gzwrite.c' line='257' column='1'/>
-      <parameter type-id='type-id-3' name='len' filepath='src.d/gzwrite.c' line='258' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='256' column='1'/>
+      <parameter type-id='type-id-101' name='buf' filepath='src.d/gzwrite.c' line='257' column='1'/>
+      <parameter type-id='type-id-11' name='len' filepath='src.d/gzwrite.c' line='258' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzfwrite' mangled-name='gzfwrite' filepath='src.d/gzwrite.c' line='283' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzfwrite@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-99' name='buf' filepath='src.d/gzwrite.c' line='284' column='1'/>
-      <parameter type-id='type-id-6' name='size' filepath='src.d/gzwrite.c' line='285' column='1'/>
-      <parameter type-id='type-id-6' name='nitems' filepath='src.d/gzwrite.c' line='286' column='1'/>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='287' column='1'/>
-      <return type-id='type-id-6'/>
+      <parameter type-id='type-id-101' name='buf' filepath='src.d/gzwrite.c' line='284' column='1'/>
+      <parameter type-id='type-id-14' name='size' filepath='src.d/gzwrite.c' line='285' column='1'/>
+      <parameter type-id='type-id-14' name='nitems' filepath='src.d/gzwrite.c' line='286' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='287' column='1'/>
+      <return type-id='type-id-14'/>
     </function-decl>
     <function-decl name='gzputc' mangled-name='gzputc' filepath='src.d/gzwrite.c' line='313' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzputc'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='314' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='314' column='1'/>
       <parameter type-id='type-id-20' name='c' filepath='src.d/gzwrite.c' line='315' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzputs' mangled-name='gzputs' filepath='src.d/gzwrite.c' line='361' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzputs'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='362' column='1'/>
-      <parameter type-id='type-id-78' name='s' filepath='src.d/gzwrite.c' line='363' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='362' column='1'/>
+      <parameter type-id='type-id-22' name='s' filepath='src.d/gzwrite.c' line='363' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzvprintf' mangled-name='gzvprintf' filepath='src.d/gzwrite.c' line='391' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzvprintf@@ZLIB_1.2.7.1'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='391' column='1'/>
-      <parameter type-id='type-id-78' name='format' filepath='src.d/gzwrite.c' line='391' column='1'/>
-      <parameter type-id='type-id-101' name='va' filepath='src.d/gzwrite.c' line='391' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='391' column='1'/>
+      <parameter type-id='type-id-22' name='format' filepath='src.d/gzwrite.c' line='391' column='1'/>
+      <parameter type-id='type-id-100' name='va' filepath='src.d/gzwrite.c' line='391' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzprintf' mangled-name='gzprintf' filepath='src.d/gzwrite.c' line='463' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzprintf'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='463' column='1'/>
-      <parameter type-id='type-id-78' name='format' filepath='src.d/gzwrite.c' line='463' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='463' column='1'/>
+      <parameter type-id='type-id-22' name='format' filepath='src.d/gzwrite.c' line='463' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzflush' mangled-name='gzflush' filepath='src.d/gzwrite.c' line='565' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzflush'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='566' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='566' column='1'/>
       <parameter type-id='type-id-20' name='flush' filepath='src.d/gzwrite.c' line='567' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzsetparams' mangled-name='gzsetparams' filepath='src.d/gzwrite.c' line='597' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzsetparams'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='598' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='598' column='1'/>
       <parameter type-id='type-id-20' name='level' filepath='src.d/gzwrite.c' line='599' column='1'/>
       <parameter type-id='type-id-20' name='strategy' filepath='src.d/gzwrite.c' line='600' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/infback.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-102'/>
-    <class-decl name='code' size-in-bits='32' is-struct='yes' naming-typedef-id='type-id-103' visibility='default' filepath='src.d/inftrees.h' line='24' column='1' id='type-id-104'>
+    <enum-decl name='codetype' naming-typedef-id='type-id-102' filepath='src.d/inftrees.h' line='54' column='1' id='type-id-103'>
+      <underlying-type type-id='type-id-104'/>
+      <enumerator name='CODES' value='0'/>
+      <enumerator name='LENS' value='1'/>
+      <enumerator name='DISTS' value='2'/>
+    </enum-decl>
+    <class-decl name='code' size-in-bits='32' is-struct='yes' naming-typedef-id='type-id-105' visibility='default' filepath='src.d/inftrees.h' line='24' column='1' id='type-id-106'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='op' type-id='type-id-2' visibility='default' filepath='src.d/inftrees.h' line='25' column='1'/>
       </data-member>
@@ -1070,217 +1108,186 @@
         <var-decl name='bits' type-id='type-id-2' visibility='default' filepath='src.d/inftrees.h' line='26' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='16'>
-        <var-decl name='val' type-id='type-id-38' visibility='default' filepath='src.d/inftrees.h' line='27' column='1'/>
+        <var-decl name='val' type-id='type-id-69' visibility='default' filepath='src.d/inftrees.h' line='27' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='code' type-id='type-id-104' filepath='src.d/inftrees.h' line='28' column='1' id='type-id-103'/>
-    <enum-decl name='codetype' naming-typedef-id='type-id-105' filepath='src.d/inftrees.h' line='54' column='1' id='type-id-106'>
-      <underlying-type type-id='type-id-102'/>
-      <enumerator name='CODES' value='0'/>
-      <enumerator name='LENS' value='1'/>
-      <enumerator name='DISTS' value='2'/>
-    </enum-decl>
-    <typedef-decl name='codetype' type-id='type-id-106' filepath='src.d/inftrees.h' line='58' column='1' id='type-id-105'/>
+    <typedef-decl name='code' type-id='type-id-106' filepath='src.d/inftrees.h' line='28' column='1' id='type-id-105'/>
+    <typedef-decl name='codetype' type-id='type-id-103' filepath='src.d/inftrees.h' line='58' column='1' id='type-id-102'/>
     <typedef-decl name='in_func' type-id='type-id-107' filepath='src.d/zlib.h' line='1094' column='1' id='type-id-108'/>
     <typedef-decl name='out_func' type-id='type-id-109' filepath='src.d/zlib.h' line='1096' column='1' id='type-id-110'/>
-    <pointer-type-def type-id='type-id-103' size-in-bits='64' id='type-id-111'/>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-104'/>
+    <pointer-type-def type-id='type-id-105' size-in-bits='64' id='type-id-111'/>
     <pointer-type-def type-id='type-id-111' size-in-bits='64' id='type-id-112'/>
     <pointer-type-def type-id='type-id-113' size-in-bits='64' id='type-id-109'/>
-    <pointer-type-def type-id='type-id-2' size-in-bits='64' id='type-id-89'/>
-    <pointer-type-def type-id='type-id-89' size-in-bits='64' id='type-id-114'/>
+    <pointer-type-def type-id='type-id-2' size-in-bits='64' id='type-id-87'/>
+    <pointer-type-def type-id='type-id-87' size-in-bits='64' id='type-id-114'/>
     <pointer-type-def type-id='type-id-115' size-in-bits='64' id='type-id-107'/>
-    <pointer-type-def type-id='type-id-38' size-in-bits='64' id='type-id-116'/>
+    <pointer-type-def type-id='type-id-69' size-in-bits='64' id='type-id-116'/>
+    <typedef-decl name='voidpf' type-id='type-id-84' filepath='./zconf.h' line='415' column='1' id='type-id-117'/>
     <function-decl name='inflateBackInit_' mangled-name='inflateBackInit_' filepath='src.d/infback.c' line='28' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateBackInit_@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/infback.c' line='29' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/infback.c' line='29' column='1'/>
       <parameter type-id='type-id-20' name='windowBits' filepath='src.d/infback.c' line='30' column='1'/>
-      <parameter type-id='type-id-89' name='window' filepath='src.d/infback.c' line='31' column='1'/>
-      <parameter type-id='type-id-78' name='version' filepath='src.d/infback.c' line='32' column='1'/>
+      <parameter type-id='type-id-87' name='window' filepath='src.d/infback.c' line='31' column='1'/>
+      <parameter type-id='type-id-22' name='version' filepath='src.d/infback.c' line='32' column='1'/>
       <parameter type-id='type-id-20' name='stream_size' filepath='src.d/infback.c' line='33' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateBack' mangled-name='inflateBack' filepath='src.d/infback.c' line='251' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateBack@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/infback.c' line='252' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/infback.c' line='252' column='1'/>
       <parameter type-id='type-id-108' name='in' filepath='src.d/infback.c' line='253' column='1'/>
-      <parameter type-id='type-id-44' name='in_desc' filepath='src.d/infback.c' line='254' column='1'/>
+      <parameter type-id='type-id-84' name='in_desc' filepath='src.d/infback.c' line='254' column='1'/>
       <parameter type-id='type-id-110' name='out' filepath='src.d/infback.c' line='255' column='1'/>
-      <parameter type-id='type-id-44' name='out_desc' filepath='src.d/infback.c' line='256' column='1'/>
+      <parameter type-id='type-id-84' name='out_desc' filepath='src.d/infback.c' line='256' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateBackEnd' mangled-name='inflateBackEnd' filepath='src.d/infback.c' line='635' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateBackEnd@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/infback.c' line='636' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/infback.c' line='636' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflate_fast' filepath='src.d/inffast.h' line='11' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-57'/>
-      <parameter type-id='type-id-3'/>
-      <return type-id='type-id-42'/>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-11'/>
+      <return type-id='type-id-85'/>
     </function-decl>
     <function-decl name='inflate_table' filepath='src.d/inftrees.h' line='60' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-105'/>
+      <parameter type-id='type-id-102'/>
       <parameter type-id='type-id-116'/>
-      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-11'/>
       <parameter type-id='type-id-112'/>
-      <parameter type-id='type-id-84'/>
+      <parameter type-id='type-id-79'/>
       <parameter type-id='type-id-116'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-type size-in-bits='64' id='type-id-113'>
-      <parameter type-id='type-id-44'/>
-      <parameter type-id='type-id-89'/>
-      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-84'/>
+      <parameter type-id='type-id-87'/>
+      <parameter type-id='type-id-11'/>
       <return type-id='type-id-20'/>
     </function-type>
     <function-type size-in-bits='64' id='type-id-115'>
-      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-84'/>
       <parameter type-id='type-id-114'/>
-      <return type-id='type-id-3'/>
+      <return type-id='type-id-11'/>
     </function-type>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/inflate.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
+    <typedef-decl name='voidpf' type-id='type-id-84' filepath='./zconf.h' line='415' column='1' id='type-id-118'/>
     <function-decl name='inflateResetKeep' mangled-name='inflateResetKeep' filepath='src.d/inflate.c' line='119' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateResetKeep@@ZLIB_1.2.5.2'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='120' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
-    <function-decl name='inflateReset' mangled-name='inflateReset' filepath='src.d/inflate.c' line='145' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateReset'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='146' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='120' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateReset2' mangled-name='inflateReset2' filepath='src.d/inflate.c' line='158' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateReset2@@ZLIB_1.2.3.4'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='159' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='159' column='1'/>
       <parameter type-id='type-id-20' name='windowBits' filepath='src.d/inflate.c' line='160' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='inflateInit2_' mangled-name='inflateInit2_' filepath='src.d/inflate.c' line='198' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateInit2_'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='199' column='1'/>
-      <parameter type-id='type-id-20' name='windowBits' filepath='src.d/inflate.c' line='200' column='1'/>
-      <parameter type-id='type-id-78' name='version' filepath='src.d/inflate.c' line='201' column='1'/>
-      <parameter type-id='type-id-20' name='stream_size' filepath='src.d/inflate.c' line='202' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
     <function-decl name='inflateInit_' mangled-name='inflateInit_' filepath='src.d/inflate.c' line='242' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateInit_'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='243' column='1'/>
-      <parameter type-id='type-id-78' name='version' filepath='src.d/inflate.c' line='244' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='243' column='1'/>
+      <parameter type-id='type-id-22' name='version' filepath='src.d/inflate.c' line='244' column='1'/>
       <parameter type-id='type-id-20' name='stream_size' filepath='src.d/inflate.c' line='245' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflatePrime' mangled-name='inflatePrime' filepath='src.d/inflate.c' line='250' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflatePrime@@ZLIB_1.2.2.4'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='251' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='251' column='1'/>
       <parameter type-id='type-id-20' name='bits' filepath='src.d/inflate.c' line='252' column='1'/>
       <parameter type-id='type-id-20' name='value' filepath='src.d/inflate.c' line='253' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='inflate' mangled-name='inflate' filepath='src.d/inflate.c' line='625' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflate'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='626' column='1'/>
-      <parameter type-id='type-id-20' name='flush' filepath='src.d/inflate.c' line='627' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
-    <function-decl name='inflateEnd' mangled-name='inflateEnd' filepath='src.d/inflate.c' line='1304' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateEnd'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1305' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
     <function-decl name='inflateGetDictionary' mangled-name='inflateGetDictionary' filepath='src.d/inflate.c' line='1318' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateGetDictionary@@ZLIB_1.2.7.1'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1319' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1319' column='1'/>
       <parameter type-id='type-id-19' name='dictionary' filepath='src.d/inflate.c' line='1320' column='1'/>
-      <parameter type-id='type-id-83' name='dictLength' filepath='src.d/inflate.c' line='1321' column='1'/>
+      <parameter type-id='type-id-78' name='dictLength' filepath='src.d/inflate.c' line='1321' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateSetDictionary' mangled-name='inflateSetDictionary' filepath='src.d/inflate.c' line='1341' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateSetDictionary'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1342' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1342' column='1'/>
       <parameter type-id='type-id-16' name='dictionary' filepath='src.d/inflate.c' line='1343' column='1'/>
-      <parameter type-id='type-id-8' name='dictLength' filepath='src.d/inflate.c' line='1344' column='1'/>
+      <parameter type-id='type-id-12' name='dictLength' filepath='src.d/inflate.c' line='1344' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateGetHeader' mangled-name='inflateGetHeader' filepath='src.d/inflate.c' line='1376' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateGetHeader@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1377' column='1'/>
-      <parameter type-id='type-id-59' name='head' filepath='src.d/inflate.c' line='1378' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1377' column='1'/>
+      <parameter type-id='type-id-42' name='head' filepath='src.d/inflate.c' line='1378' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateSync' mangled-name='inflateSync' filepath='src.d/inflate.c' line='1427' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateSync'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1428' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1428' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateSyncPoint' mangled-name='inflateSyncPoint' filepath='src.d/inflate.c' line='1485' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateSyncPoint'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1486' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1486' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateCopy' mangled-name='inflateCopy' filepath='src.d/inflate.c' line='1495' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateCopy@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-57' name='dest' filepath='src.d/inflate.c' line='1496' column='1'/>
-      <parameter type-id='type-id-57' name='source' filepath='src.d/inflate.c' line='1497' column='1'/>
+      <parameter type-id='type-id-21' name='dest' filepath='src.d/inflate.c' line='1496' column='1'/>
+      <parameter type-id='type-id-21' name='source' filepath='src.d/inflate.c' line='1497' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateUndermine' mangled-name='inflateUndermine' filepath='src.d/inflate.c' line='1542' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateUndermine@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1543' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1543' column='1'/>
       <parameter type-id='type-id-20' name='subvert' filepath='src.d/inflate.c' line='1544' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateValidate' mangled-name='inflateValidate' filepath='src.d/inflate.c' line='1560' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateValidate@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1561' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1561' column='1'/>
       <parameter type-id='type-id-20' name='check' filepath='src.d/inflate.c' line='1562' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateMark' mangled-name='inflateMark' filepath='src.d/inflate.c' line='1575' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateMark@@ZLIB_1.2.3.4'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1576' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1576' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='inflateCodesUsed' mangled-name='inflateCodesUsed' filepath='src.d/inflate.c' line='1588' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateCodesUsed@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1589' column='1'/>
-      <return type-id='type-id-4'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1589' column='1'/>
+      <return type-id='type-id-9'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/trees.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <array-type-def dimensions='1' type-id='type-id-117' size-in-bits='2048' id='type-id-118'>
-      <subrange length='256' type-id='type-id-4' id='type-id-119'/>
+    <array-type-def dimensions='1' type-id='type-id-119' size-in-bits='2048' id='type-id-120'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-9' id='type-id-121'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-117' size-in-bits='4096' id='type-id-120'>
-      <subrange length='512' type-id='type-id-4' id='type-id-121'/>
+    <array-type-def dimensions='1' type-id='type-id-119' size-in-bits='4096' id='type-id-122'>
+      <subrange length='512' lower-bound='0' upper-bound='511' type-id='type-id-9' id='type-id-123'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-117' size-in-bits='infinite' id='type-id-122'>
-      <subrange length='infinite' id='type-id-123'/>
+    <array-type-def dimensions='1' type-id='type-id-119' size-in-bits='unknown' id='type-id-124'>
+      <subrange length='unknown' lower-bound='0' upper-bound='0' id='type-id-125'/>
     </array-type-def>
-    <qualified-type-def type-id='type-id-36' const='yes' id='type-id-117'/>
-    <var-decl name='_length_code' type-id='type-id-122' visibility='default' filepath='src.d/deflate.h' line='317' column='1'/>
+    <qualified-type-def type-id='type-id-67' const='yes' id='type-id-119'/>
+    <var-decl name='_length_code' type-id='type-id-120' visibility='default' filepath='src.d/deflate.h' line='317' column='1'/>
     <var-decl name='_dist_code' type-id='type-id-122' visibility='default' filepath='src.d/deflate.h' line='318' column='1'/>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/uncompr.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <pointer-type-def type-id='type-id-9' size-in-bits='64' id='type-id-124'/>
+    <pointer-type-def type-id='type-id-13' size-in-bits='64' id='type-id-126'/>
     <function-decl name='uncompress2' mangled-name='uncompress2' filepath='src.d/uncompr.c' line='27' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uncompress2@@ZLIB_1.2.9'>
       <parameter type-id='type-id-19' name='dest' filepath='src.d/uncompr.c' line='28' column='1'/>
       <parameter type-id='type-id-18' name='destLen' filepath='src.d/uncompr.c' line='29' column='1'/>
       <parameter type-id='type-id-16' name='source' filepath='src.d/uncompr.c' line='30' column='1'/>
-      <parameter type-id='type-id-124' name='sourceLen' filepath='src.d/uncompr.c' line='31' column='1'/>
+      <parameter type-id='type-id-126' name='sourceLen' filepath='src.d/uncompr.c' line='31' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='uncompress' mangled-name='uncompress' filepath='src.d/uncompr.c' line='86' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uncompress'>
       <parameter type-id='type-id-19' name='dest' filepath='src.d/uncompr.c' line='87' column='1'/>
       <parameter type-id='type-id-18' name='destLen' filepath='src.d/uncompr.c' line='88' column='1'/>
       <parameter type-id='type-id-16' name='source' filepath='src.d/uncompr.c' line='89' column='1'/>
-      <parameter type-id='type-id-9' name='sourceLen' filepath='src.d/uncompr.c' line='90' column='1'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/uncompr.c' line='90' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/zutil.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <array-type-def dimensions='1' type-id='type-id-125' size-in-bits='640' id='type-id-126'>
-      <subrange length='10' type-id='type-id-4' id='type-id-127'/>
+    <array-type-def dimensions='1' type-id='type-id-127' size-in-bits='640' id='type-id-128'>
+      <subrange length='10' lower-bound='0' upper-bound='9' type-id='type-id-9' id='type-id-129'/>
     </array-type-def>
-    <qualified-type-def type-id='type-id-68' const='yes' id='type-id-125'/>
-    <function-decl name='malloc' filepath='/usr/aarch64-linux-gnu/include/stdlib.h' line='540' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-44'/>
-    </function-decl>
-    <function-decl name='free' filepath='/usr/aarch64-linux-gnu/include/stdlib.h' line='555' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-44'/>
-      <return type-id='type-id-42'/>
-    </function-decl>
+    <qualified-type-def type-id='type-id-53' const='yes' id='type-id-127'/>
     <function-decl name='zlibVersion' mangled-name='zlibVersion' filepath='src.d/zutil.c' line='27' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zlibVersion'>
-      <return type-id='type-id-78'/>
+      <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='zlibCompileFlags' mangled-name='zlibCompileFlags' filepath='src.d/zutil.c' line='32' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zlibCompileFlags@@ZLIB_1.2.0.2'>
-      <return type-id='type-id-9'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='zError' mangled-name='zError' filepath='src.d/zutil.c' line='135' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zError'>
       <parameter type-id='type-id-20' name='err' filepath='src.d/zutil.c' line='136' column='1'/>
-      <return type-id='type-id-78'/>
+      <return type-id='type-id-22'/>
     </function-decl>
-    <var-decl name='z_errmsg' type-id='type-id-126' visibility='default' filepath='src.d/zutil.h' line='56' column='1'/>
+    <var-decl name='z_errmsg' type-id='type-id-128' visibility='default' filepath='src.d/zutil.h' line='56' column='1'/>
   </abi-instr>
 </abi-corpus>

--- a/test/abi/zlib-04f42ceca40f73e2978b50e93806c2a18c1281fc-arm-unknown-linux-gnueabi.abi
+++ b/test/abi/zlib-04f42ceca40f73e2978b50e93806c2a18c1281fc-arm-unknown-linux-gnueabi.abi
@@ -1,4 +1,4 @@
-<abi-corpus version='2.0' path='btmp1/libz.so.1.2.13' architecture='elf-arm' soname='libz.so.1'>
+<abi-corpus version='2.2' path='btmp1/libz.so.1.2.13' architecture='elf-arm' soname='libz.so.1'>
   <elf-needed>
     <dependency name='libc.so.6'/>
     <dependency name='ld-linux.so.3'/>
@@ -94,75 +94,89 @@
     <elf-symbol name='zlibVersion' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
   </elf-function-symbols>
   <abi-instr address-size='32' path='src.d/adler32.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <type-decl name='long int' size-in-bits='32' id='type-id-1'/>
-    <type-decl name='long long int' size-in-bits='64' id='type-id-2'/>
-    <type-decl name='unsigned char' size-in-bits='8' id='type-id-3'/>
-    <type-decl name='unsigned int' size-in-bits='32' id='type-id-4'/>
-    <type-decl name='unsigned long int' size-in-bits='32' id='type-id-5'/>
-    <typedef-decl name='z_size_t' type-id='type-id-6' filepath='./zconf.h' line='251' column='1' id='type-id-7'/>
-    <typedef-decl name='Byte' type-id='type-id-3' filepath='./zconf.h' line='397' column='1' id='type-id-8'/>
-    <typedef-decl name='uInt' type-id='type-id-4' filepath='./zconf.h' line='399' column='1' id='type-id-9'/>
-    <typedef-decl name='uLong' type-id='type-id-5' filepath='./zconf.h' line='400' column='1' id='type-id-10'/>
-    <typedef-decl name='Bytef' type-id='type-id-8' filepath='./zconf.h' line='406' column='1' id='type-id-11'/>
-    <typedef-decl name='__int64_t' type-id='type-id-2' filepath='/usr/arm-linux-gnueabi/include/bits/types.h' line='47' column='1' id='type-id-12'/>
-    <typedef-decl name='__off_t' type-id='type-id-1' filepath='/usr/arm-linux-gnueabi/include/bits/types.h' line='152' column='1' id='type-id-13'/>
-    <typedef-decl name='__off64_t' type-id='type-id-12' filepath='/usr/arm-linux-gnueabi/include/bits/types.h' line='153' column='1' id='type-id-14'/>
-    <typedef-decl name='off_t' type-id='type-id-13' filepath='/usr/arm-linux-gnueabi/include/sys/types.h' line='85' column='1' id='type-id-15'/>
-    <typedef-decl name='off64_t' type-id='type-id-14' filepath='/usr/arm-linux-gnueabi/include/sys/types.h' line='92' column='1' id='type-id-16'/>
-    <typedef-decl name='size_t' type-id='type-id-4' filepath='/usr/lib/gcc-cross/arm-linux-gnueabi/11/include/stddef.h' line='209' column='1' id='type-id-6'/>
-    <qualified-type-def type-id='type-id-11' const='yes' id='type-id-17'/>
-    <pointer-type-def type-id='type-id-17' size-in-bits='32' id='type-id-18'/>
+    <type-decl name='long long int' size-in-bits='64' id='type-id-1'/>
+    <typedef-decl name='Byte' type-id='type-id-2' filepath='./zconf.h' line='397' column='1' id='type-id-3'/>
+    <typedef-decl name='Bytef' type-id='type-id-3' filepath='./zconf.h' line='406' column='1' id='type-id-4'/>
+    <typedef-decl name='__int64_t' type-id='type-id-1' filepath='/usr/arm-linux-gnueabi/include/bits/types.h' line='47' column='1' id='type-id-5'/>
+    <typedef-decl name='__off64_t' type-id='type-id-5' filepath='/usr/arm-linux-gnueabi/include/bits/types.h' line='153' column='1' id='type-id-6'/>
+    <typedef-decl name='off64_t' type-id='type-id-6' filepath='/usr/arm-linux-gnueabi/include/sys/types.h' line='92' column='1' id='type-id-7'/>
+    <typedef-decl name='off_t' type-id='type-id-6' filepath='/usr/arm-linux-gnueabi/include/sys/types.h' line='87' column='1' id='type-id-8'/>
+    <typedef-decl name='size_t' type-id='type-id-9' filepath='/usr/lib/gcc-cross/arm-linux-gnueabi/13/include/stddef.h' line='214' column='1' id='type-id-10'/>
+    <typedef-decl name='uInt' type-id='type-id-9' filepath='./zconf.h' line='399' column='1' id='type-id-11'/>
+    <typedef-decl name='uLong' type-id='type-id-12' filepath='./zconf.h' line='400' column='1' id='type-id-13'/>
+    <typedef-decl name='z_size_t' type-id='type-id-10' filepath='./zconf.h' line='251' column='1' id='type-id-14'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-2'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-9'/>
+    <type-decl name='unsigned long int' size-in-bits='32' id='type-id-12'/>
+    <qualified-type-def type-id='type-id-4' const='yes' id='type-id-15'/>
+    <pointer-type-def type-id='type-id-15' size-in-bits='32' id='type-id-16'/>
     <function-decl name='adler32_z' mangled-name='adler32_z' filepath='src.d/adler32.c' line='63' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='adler32_z@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-10' name='adler' filepath='src.d/adler32.c' line='64' column='1'/>
-      <parameter type-id='type-id-18' name='buf' filepath='src.d/adler32.c' line='65' column='1'/>
-      <parameter type-id='type-id-7' name='len' filepath='src.d/adler32.c' line='66' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-13' name='adler' filepath='src.d/adler32.c' line='64' column='1'/>
+      <parameter type-id='type-id-16' name='buf' filepath='src.d/adler32.c' line='65' column='1'/>
+      <parameter type-id='type-id-14' name='len' filepath='src.d/adler32.c' line='66' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='adler32' mangled-name='adler32' filepath='src.d/adler32.c' line='134' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='adler32'>
-      <parameter type-id='type-id-10' name='adler' filepath='src.d/adler32.c' line='135' column='1'/>
-      <parameter type-id='type-id-18' name='buf' filepath='src.d/adler32.c' line='136' column='1'/>
-      <parameter type-id='type-id-9' name='len' filepath='src.d/adler32.c' line='137' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-13' name='adler' filepath='src.d/adler32.c' line='135' column='1'/>
+      <parameter type-id='type-id-16' name='buf' filepath='src.d/adler32.c' line='136' column='1'/>
+      <parameter type-id='type-id-11' name='len' filepath='src.d/adler32.c' line='137' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='adler32_combine' mangled-name='adler32_combine' filepath='src.d/adler32.c' line='172' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='adler32_combine@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-10' name='adler1' filepath='src.d/adler32.c' line='173' column='1'/>
-      <parameter type-id='type-id-10' name='adler2' filepath='src.d/adler32.c' line='174' column='1'/>
-      <parameter type-id='type-id-15' name='len2' filepath='src.d/adler32.c' line='175' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-13' name='adler1' filepath='src.d/adler32.c' line='173' column='1'/>
+      <parameter type-id='type-id-13' name='adler2' filepath='src.d/adler32.c' line='174' column='1'/>
+      <parameter type-id='type-id-8' name='len2' filepath='src.d/adler32.c' line='175' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='adler32_combine64' mangled-name='adler32_combine64' filepath='src.d/adler32.c' line='180' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='adler32_combine64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-10' name='adler1' filepath='src.d/adler32.c' line='181' column='1'/>
-      <parameter type-id='type-id-10' name='adler2' filepath='src.d/adler32.c' line='182' column='1'/>
-      <parameter type-id='type-id-16' name='len2' filepath='src.d/adler32.c' line='183' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-13' name='adler1' filepath='src.d/adler32.c' line='181' column='1'/>
+      <parameter type-id='type-id-13' name='adler2' filepath='src.d/adler32.c' line='182' column='1'/>
+      <parameter type-id='type-id-7' name='len2' filepath='src.d/adler32.c' line='183' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/compress.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <typedef-decl name='uLongf' type-id='type-id-10' filepath='./zconf.h' line='411' column='1' id='type-id-19'/>
-    <pointer-type-def type-id='type-id-19' size-in-bits='32' id='type-id-20'/>
+    <typedef-decl name='uLongf' type-id='type-id-13' filepath='./zconf.h' line='411' column='1' id='type-id-17'/>
+    <pointer-type-def type-id='type-id-17' size-in-bits='32' id='type-id-18'/>
     <function-decl name='compress2' mangled-name='compress2' filepath='src.d/compress.c' line='22' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='compress2'>
-      <parameter type-id='type-id-21' name='dest' filepath='src.d/compress.c' line='23' column='1'/>
-      <parameter type-id='type-id-20' name='destLen' filepath='src.d/compress.c' line='24' column='1'/>
-      <parameter type-id='type-id-18' name='source' filepath='src.d/compress.c' line='25' column='1'/>
-      <parameter type-id='type-id-10' name='sourceLen' filepath='src.d/compress.c' line='26' column='1'/>
-      <parameter type-id='type-id-22' name='level' filepath='src.d/compress.c' line='27' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-19' name='dest' filepath='src.d/compress.c' line='23' column='1'/>
+      <parameter type-id='type-id-18' name='destLen' filepath='src.d/compress.c' line='24' column='1'/>
+      <parameter type-id='type-id-16' name='source' filepath='src.d/compress.c' line='25' column='1'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/compress.c' line='26' column='1'/>
+      <parameter type-id='type-id-20' name='level' filepath='src.d/compress.c' line='27' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='compress' mangled-name='compress' filepath='src.d/compress.c' line='68' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='compress'>
-      <parameter type-id='type-id-21' name='dest' filepath='src.d/compress.c' line='69' column='1'/>
-      <parameter type-id='type-id-20' name='destLen' filepath='src.d/compress.c' line='70' column='1'/>
-      <parameter type-id='type-id-18' name='source' filepath='src.d/compress.c' line='71' column='1'/>
-      <parameter type-id='type-id-10' name='sourceLen' filepath='src.d/compress.c' line='72' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-19' name='dest' filepath='src.d/compress.c' line='69' column='1'/>
+      <parameter type-id='type-id-18' name='destLen' filepath='src.d/compress.c' line='70' column='1'/>
+      <parameter type-id='type-id-16' name='source' filepath='src.d/compress.c' line='71' column='1'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/compress.c' line='72' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='compressBound' mangled-name='compressBound' filepath='src.d/compress.c' line='81' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='compressBound@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-10' name='sourceLen' filepath='src.d/compress.c' line='82' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/compress.c' line='82' column='1'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+    <function-decl name='deflate' filepath='src.d/zlib.h' line='250' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='deflateEnd' filepath='src.d/zlib.h' line='363' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-21'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='deflateInit_' filepath='src.d/zlib.h' line='1781' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/crc32.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <typedef-decl name='z_crc_t' type-id='type-id-4' filepath='./zconf.h' line='435' column='1' id='type-id-23'/>
-    <qualified-type-def type-id='type-id-3' const='yes' id='type-id-24'/>
+    <typedef-decl name='z_crc_t' type-id='type-id-9' filepath='./zconf.h' line='435' column='1' id='type-id-23'/>
+    <qualified-type-def type-id='type-id-2' const='yes' id='type-id-24'/>
     <pointer-type-def type-id='type-id-24' size-in-bits='32' id='type-id-25'/>
     <qualified-type-def type-id='type-id-23' const='yes' id='type-id-26'/>
     <pointer-type-def type-id='type-id-26' size-in-bits='32' id='type-id-27'/>
@@ -170,1107 +184,1093 @@
       <return type-id='type-id-27'/>
     </function-decl>
     <function-decl name='crc32_z' mangled-name='crc32_z' filepath='src.d/crc32.c' line='748' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='crc32_z@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-5' name='crc' filepath='src.d/crc32.c' line='749' column='1'/>
+      <parameter type-id='type-id-12' name='crc' filepath='src.d/crc32.c' line='749' column='1'/>
       <parameter type-id='type-id-25' name='buf' filepath='src.d/crc32.c' line='750' column='1'/>
-      <parameter type-id='type-id-7' name='len' filepath='src.d/crc32.c' line='751' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-14' name='len' filepath='src.d/crc32.c' line='751' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32' mangled-name='crc32' filepath='src.d/crc32.c' line='1072' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='crc32'>
-      <parameter type-id='type-id-5' name='crc' filepath='src.d/crc32.c' line='1073' column='1'/>
+      <parameter type-id='type-id-12' name='crc' filepath='src.d/crc32.c' line='1073' column='1'/>
       <parameter type-id='type-id-25' name='buf' filepath='src.d/crc32.c' line='1074' column='1'/>
-      <parameter type-id='type-id-9' name='len' filepath='src.d/crc32.c' line='1075' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-11' name='len' filepath='src.d/crc32.c' line='1075' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine64' mangled-name='crc32_combine64' filepath='src.d/crc32.c' line='1081' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='crc32_combine64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-10' name='crc1' filepath='src.d/crc32.c' line='1082' column='1'/>
-      <parameter type-id='type-id-10' name='crc2' filepath='src.d/crc32.c' line='1083' column='1'/>
-      <parameter type-id='type-id-16' name='len2' filepath='src.d/crc32.c' line='1084' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-13' name='crc1' filepath='src.d/crc32.c' line='1082' column='1'/>
+      <parameter type-id='type-id-13' name='crc2' filepath='src.d/crc32.c' line='1083' column='1'/>
+      <parameter type-id='type-id-7' name='len2' filepath='src.d/crc32.c' line='1084' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine' mangled-name='crc32_combine' filepath='src.d/crc32.c' line='1093' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='crc32_combine@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-10' name='crc1' filepath='src.d/crc32.c' line='1094' column='1'/>
-      <parameter type-id='type-id-10' name='crc2' filepath='src.d/crc32.c' line='1095' column='1'/>
-      <parameter type-id='type-id-15' name='len2' filepath='src.d/crc32.c' line='1096' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-13' name='crc1' filepath='src.d/crc32.c' line='1094' column='1'/>
+      <parameter type-id='type-id-13' name='crc2' filepath='src.d/crc32.c' line='1095' column='1'/>
+      <parameter type-id='type-id-8' name='len2' filepath='src.d/crc32.c' line='1096' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine_gen64' mangled-name='crc32_combine_gen64' filepath='src.d/crc32.c' line='1102' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='crc32_combine_gen64@@ZLIB_1.2.12'>
-      <parameter type-id='type-id-16' name='len2' filepath='src.d/crc32.c' line='1103' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-7' name='len2' filepath='src.d/crc32.c' line='1103' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine_gen' mangled-name='crc32_combine_gen' filepath='src.d/crc32.c' line='1112' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='crc32_combine_gen@@ZLIB_1.2.12'>
-      <parameter type-id='type-id-15' name='len2' filepath='src.d/crc32.c' line='1113' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-8' name='len2' filepath='src.d/crc32.c' line='1113' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine_op' mangled-name='crc32_combine_op' filepath='src.d/crc32.c' line='1119' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='crc32_combine_op@@ZLIB_1.2.12'>
-      <parameter type-id='type-id-10' name='crc1' filepath='src.d/crc32.c' line='1120' column='1'/>
-      <parameter type-id='type-id-10' name='crc2' filepath='src.d/crc32.c' line='1121' column='1'/>
-      <parameter type-id='type-id-10' name='op' filepath='src.d/crc32.c' line='1122' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-13' name='crc1' filepath='src.d/crc32.c' line='1120' column='1'/>
+      <parameter type-id='type-id-13' name='crc2' filepath='src.d/crc32.c' line='1121' column='1'/>
+      <parameter type-id='type-id-13' name='op' filepath='src.d/crc32.c' line='1122' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/deflate.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
     <type-decl name='char' size-in-bits='8' id='type-id-28'/>
-    <class-decl name='static_tree_desc_s' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-29'/>
-    <array-type-def dimensions='1' type-id='type-id-30' size-in-bits='1248' id='type-id-31'>
-      <subrange length='39' type-id='type-id-4' id='type-id-32'/>
+    <array-type-def dimensions='1' type-id='type-id-29' size-in-bits='1248' id='type-id-30'>
+      <subrange length='39' lower-bound='0' upper-bound='38' type-id='type-id-9' id='type-id-31'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-30' size-in-bits='18336' id='type-id-33'>
-      <subrange length='573' type-id='type-id-4' id='type-id-34'/>
+    <array-type-def dimensions='1' type-id='type-id-29' size-in-bits='18336' id='type-id-32'>
+      <subrange length='573' lower-bound='0' upper-bound='572' type-id='type-id-9' id='type-id-33'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-30' size-in-bits='1952' id='type-id-35'>
-      <subrange length='61' type-id='type-id-4' id='type-id-36'/>
+    <array-type-def dimensions='1' type-id='type-id-29' size-in-bits='1952' id='type-id-34'>
+      <subrange length='61' lower-bound='0' upper-bound='60' type-id='type-id-9' id='type-id-35'/>
     </array-type-def>
-    <type-decl name='int' size-in-bits='32' id='type-id-22'/>
-    <array-type-def dimensions='1' type-id='type-id-22' size-in-bits='18336' id='type-id-37'>
-      <subrange length='573' type-id='type-id-4' id='type-id-34'/>
+    <type-decl name='int' size-in-bits='32' id='type-id-20'/>
+    <array-type-def dimensions='1' type-id='type-id-20' size-in-bits='18336' id='type-id-36'>
+      <subrange length='573' lower-bound='0' upper-bound='572' type-id='type-id-9' id='type-id-33'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-38' size-in-bits='4584' id='type-id-39'>
-      <subrange length='573' type-id='type-id-4' id='type-id-34'/>
-    </array-type-def>
-    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-40'/>
-    <array-type-def dimensions='1' type-id='type-id-41' size-in-bits='256' id='type-id-42'>
-      <subrange length='16' type-id='type-id-4' id='type-id-43'/>
-    </array-type-def>
-    <type-decl name='void' id='type-id-44'/>
-    <typedef-decl name='charf' type-id='type-id-28' filepath='./zconf.h' line='408' column='1' id='type-id-45'/>
-    <typedef-decl name='voidpf' type-id='type-id-46' filepath='./zconf.h' line='415' column='1' id='type-id-47'/>
-    <class-decl name='ct_data_s' size-in-bits='32' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='68' column='1' id='type-id-30'>
+    <type-decl name='long int' size-in-bits='32' id='type-id-37'/>
+    <class-decl name='ct_data_s' size-in-bits='32' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='68' column='1' id='type-id-29'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='fc' type-id='type-id-48' visibility='default' filepath='src.d/deflate.h' line='72' column='1'/>
+        <var-decl name='fc' type-id='type-id-38' visibility='default' filepath='src.d/deflate.h' line='72' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='16'>
-        <var-decl name='dl' type-id='type-id-49' visibility='default' filepath='src.d/deflate.h' line='76' column='1'/>
+        <var-decl name='dl' type-id='type-id-39' visibility='default' filepath='src.d/deflate.h' line='76' column='1'/>
       </data-member>
     </class-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='69' column='1' id='type-id-48'>
-      <data-member access='public'>
-        <var-decl name='freq' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='70' column='1'/>
-      </data-member>
-      <data-member access='public'>
-        <var-decl name='code' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='71' column='1'/>
-      </data-member>
-    </union-decl>
-    <union-decl name='__anonymous_union__1' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='73' column='1' id='type-id-49'>
-      <data-member access='public'>
-        <var-decl name='dad' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='74' column='1'/>
-      </data-member>
-      <data-member access='public'>
-        <var-decl name='len' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='75' column='1'/>
-      </data-member>
-    </union-decl>
-    <typedef-decl name='ct_data' type-id='type-id-30' filepath='src.d/deflate.h' line='77' column='1' id='type-id-50'/>
-    <typedef-decl name='static_tree_desc' type-id='type-id-29' filepath='src.d/deflate.h' line='84' column='1' id='type-id-51'/>
-    <class-decl name='tree_desc_s' size-in-bits='96' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='86' column='1' id='type-id-52'>
+    <class-decl name='gz_header_s' size-in-bits='416' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='114' column='1' id='type-id-40'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='dyn_tree' type-id='type-id-53' visibility='default' filepath='src.d/deflate.h' line='87' column='1'/>
+        <var-decl name='text' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='115' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='max_code' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='88' column='1'/>
+        <var-decl name='time' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='116' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='stat_desc' type-id='type-id-54' visibility='default' filepath='src.d/deflate.h' line='89' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='Pos' type-id='type-id-41' filepath='src.d/deflate.h' line='92' column='1' id='type-id-55'/>
-    <typedef-decl name='Posf' type-id='type-id-55' filepath='src.d/deflate.h' line='93' column='1' id='type-id-56'/>
-    <typedef-decl name='IPos' type-id='type-id-4' filepath='src.d/deflate.h' line='94' column='1' id='type-id-57'/>
-    <class-decl name='internal_state' size-in-bits='46624' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='100' column='1' id='type-id-58'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='strm' type-id='type-id-59' visibility='default' filepath='src.d/deflate.h' line='101' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='status' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='102' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='pending_buf' type-id='type-id-21' visibility='default' filepath='src.d/deflate.h' line='103' column='1'/>
+        <var-decl name='xflags' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='117' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='pending_buf_size' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='104' column='1'/>
+        <var-decl name='os' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='118' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='pending_out' type-id='type-id-21' visibility='default' filepath='src.d/deflate.h' line='105' column='1'/>
+        <var-decl name='extra' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='119' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='pending' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='106' column='1'/>
+        <var-decl name='extra_len' type-id='type-id-11' visibility='default' filepath='src.d/zlib.h' line='120' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='wrap' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='107' column='1'/>
+        <var-decl name='extra_max' type-id='type-id-11' visibility='default' filepath='src.d/zlib.h' line='121' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='gzhead' type-id='type-id-61' visibility='default' filepath='src.d/deflate.h' line='108' column='1'/>
+        <var-decl name='name' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='122' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='gzindex' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='109' column='1'/>
+        <var-decl name='name_max' type-id='type-id-11' visibility='default' filepath='src.d/zlib.h' line='123' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='method' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='110' column='1'/>
+        <var-decl name='comment' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='124' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='last_flush' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='111' column='1'/>
+        <var-decl name='comm_max' type-id='type-id-11' visibility='default' filepath='src.d/zlib.h' line='125' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='w_size' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='115' column='1'/>
+        <var-decl name='hcrc' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='126' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='w_bits' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='116' column='1'/>
+        <var-decl name='done' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='127' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='internal_state' size-in-bits='46624' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='100' column='1' id='type-id-41'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='strm' type-id='type-id-21' visibility='default' filepath='src.d/deflate.h' line='101' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='status' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='102' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='pending_buf' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='103' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='pending_buf_size' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='104' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='pending_out' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='105' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='pending' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='106' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='wrap' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='107' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='gzhead' type-id='type-id-43' visibility='default' filepath='src.d/deflate.h' line='108' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gzindex' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='109' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='method' type-id='type-id-3' visibility='default' filepath='src.d/deflate.h' line='110' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='last_flush' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='111' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='w_size' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='115' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='w_bits' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='116' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='416'>
-        <var-decl name='w_mask' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='117' column='1'/>
+        <var-decl name='w_mask' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='117' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='window' type-id='type-id-21' visibility='default' filepath='src.d/deflate.h' line='119' column='1'/>
+        <var-decl name='window' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='119' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='480'>
-        <var-decl name='window_size' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='129' column='1'/>
+        <var-decl name='window_size' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='129' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='prev' type-id='type-id-62' visibility='default' filepath='src.d/deflate.h' line='134' column='1'/>
+        <var-decl name='prev' type-id='type-id-44' visibility='default' filepath='src.d/deflate.h' line='134' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='544'>
-        <var-decl name='head' type-id='type-id-62' visibility='default' filepath='src.d/deflate.h' line='140' column='1'/>
+        <var-decl name='head' type-id='type-id-44' visibility='default' filepath='src.d/deflate.h' line='140' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='ins_h' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='142' column='1'/>
+        <var-decl name='ins_h' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='142' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='608'>
-        <var-decl name='hash_size' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='143' column='1'/>
+        <var-decl name='hash_size' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='143' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='hash_bits' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='144' column='1'/>
+        <var-decl name='hash_bits' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='144' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='672'>
-        <var-decl name='hash_mask' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='145' column='1'/>
+        <var-decl name='hash_mask' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='145' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='hash_shift' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='147' column='1'/>
+        <var-decl name='hash_shift' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='147' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='736'>
-        <var-decl name='block_start' type-id='type-id-1' visibility='default' filepath='src.d/deflate.h' line='154' column='1'/>
+        <var-decl name='block_start' type-id='type-id-37' visibility='default' filepath='src.d/deflate.h' line='154' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='match_length' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='159' column='1'/>
+        <var-decl name='match_length' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='159' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='800'>
-        <var-decl name='prev_match' type-id='type-id-57' visibility='default' filepath='src.d/deflate.h' line='160' column='1'/>
+        <var-decl name='prev_match' type-id='type-id-45' visibility='default' filepath='src.d/deflate.h' line='160' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='match_available' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='161' column='1'/>
+        <var-decl name='match_available' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='161' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='864'>
-        <var-decl name='strstart' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='162' column='1'/>
+        <var-decl name='strstart' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='162' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='match_start' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='163' column='1'/>
+        <var-decl name='match_start' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='163' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='928'>
-        <var-decl name='lookahead' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='164' column='1'/>
+        <var-decl name='lookahead' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='164' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='prev_length' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='166' column='1'/>
+        <var-decl name='prev_length' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='166' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='992'>
-        <var-decl name='max_chain_length' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='171' column='1'/>
+        <var-decl name='max_chain_length' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='171' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='max_lazy_match' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='177' column='1'/>
+        <var-decl name='max_lazy_match' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='177' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1056'>
-        <var-decl name='level' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='188' column='1'/>
+        <var-decl name='level' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='188' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1088'>
-        <var-decl name='strategy' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='189' column='1'/>
+        <var-decl name='strategy' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='189' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1120'>
-        <var-decl name='good_match' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='191' column='1'/>
+        <var-decl name='good_match' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='191' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1152'>
-        <var-decl name='nice_match' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='194' column='1'/>
+        <var-decl name='nice_match' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='194' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1184'>
-        <var-decl name='dyn_ltree' type-id='type-id-33' visibility='default' filepath='src.d/deflate.h' line='198' column='1'/>
+        <var-decl name='dyn_ltree' type-id='type-id-32' visibility='default' filepath='src.d/deflate.h' line='198' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='19520'>
-        <var-decl name='dyn_dtree' type-id='type-id-35' visibility='default' filepath='src.d/deflate.h' line='199' column='1'/>
+        <var-decl name='dyn_dtree' type-id='type-id-34' visibility='default' filepath='src.d/deflate.h' line='199' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='21472'>
-        <var-decl name='bl_tree' type-id='type-id-31' visibility='default' filepath='src.d/deflate.h' line='200' column='1'/>
+        <var-decl name='bl_tree' type-id='type-id-30' visibility='default' filepath='src.d/deflate.h' line='200' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='22720'>
-        <var-decl name='l_desc' type-id='type-id-52' visibility='default' filepath='src.d/deflate.h' line='202' column='1'/>
+        <var-decl name='l_desc' type-id='type-id-46' visibility='default' filepath='src.d/deflate.h' line='202' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='22816'>
-        <var-decl name='d_desc' type-id='type-id-52' visibility='default' filepath='src.d/deflate.h' line='203' column='1'/>
+        <var-decl name='d_desc' type-id='type-id-46' visibility='default' filepath='src.d/deflate.h' line='203' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='22912'>
-        <var-decl name='bl_desc' type-id='type-id-52' visibility='default' filepath='src.d/deflate.h' line='204' column='1'/>
+        <var-decl name='bl_desc' type-id='type-id-46' visibility='default' filepath='src.d/deflate.h' line='204' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='23008'>
-        <var-decl name='bl_count' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='206' column='1'/>
+        <var-decl name='bl_count' type-id='type-id-47' visibility='default' filepath='src.d/deflate.h' line='206' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='23264'>
-        <var-decl name='heap' type-id='type-id-37' visibility='default' filepath='src.d/deflate.h' line='209' column='1'/>
+        <var-decl name='heap' type-id='type-id-36' visibility='default' filepath='src.d/deflate.h' line='209' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='41600'>
-        <var-decl name='heap_len' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='210' column='1'/>
+        <var-decl name='heap_len' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='210' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='41632'>
-        <var-decl name='heap_max' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='211' column='1'/>
+        <var-decl name='heap_max' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='211' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='41664'>
-        <var-decl name='depth' type-id='type-id-39' visibility='default' filepath='src.d/deflate.h' line='216' column='1'/>
+        <var-decl name='depth' type-id='type-id-48' visibility='default' filepath='src.d/deflate.h' line='216' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46272'>
-        <var-decl name='sym_buf' type-id='type-id-63' visibility='default' filepath='src.d/deflate.h' line='220' column='1'/>
+        <var-decl name='sym_buf' type-id='type-id-49' visibility='default' filepath='src.d/deflate.h' line='220' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46304'>
-        <var-decl name='lit_bufsize' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='222' column='1'/>
+        <var-decl name='lit_bufsize' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='222' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46336'>
-        <var-decl name='sym_next' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='242' column='1'/>
+        <var-decl name='sym_next' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='242' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46368'>
-        <var-decl name='sym_end' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='243' column='1'/>
+        <var-decl name='sym_end' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='243' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46400'>
-        <var-decl name='opt_len' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='245' column='1'/>
+        <var-decl name='opt_len' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='245' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46432'>
-        <var-decl name='static_len' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='246' column='1'/>
+        <var-decl name='static_len' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='246' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46464'>
-        <var-decl name='matches' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='247' column='1'/>
+        <var-decl name='matches' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='247' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46496'>
-        <var-decl name='insert' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='248' column='1'/>
+        <var-decl name='insert' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='248' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46528'>
-        <var-decl name='bi_buf' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='255' column='1'/>
+        <var-decl name='bi_buf' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='255' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46560'>
-        <var-decl name='bi_valid' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='259' column='1'/>
+        <var-decl name='bi_valid' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='259' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46592'>
-        <var-decl name='high_water' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='264' column='1'/>
+        <var-decl name='high_water' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='264' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='deflate_state' type-id='type-id-58' filepath='src.d/deflate.h' line='271' column='1' id='type-id-64'/>
-    <typedef-decl name='alloc_func' type-id='type-id-65' filepath='src.d/zlib.h' line='81' column='1' id='type-id-66'/>
-    <typedef-decl name='free_func' type-id='type-id-67' filepath='src.d/zlib.h' line='82' column='1' id='type-id-68'/>
-    <class-decl name='z_stream_s' size-in-bits='448' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='86' column='1' id='type-id-69'>
+    <class-decl name='tree_desc_s' size-in-bits='96' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='86' column='1' id='type-id-46'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='next_in' type-id='type-id-21' visibility='default' filepath='src.d/zlib.h' line='87' column='1'/>
+        <var-decl name='dyn_tree' type-id='type-id-51' visibility='default' filepath='src.d/deflate.h' line='87' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='avail_in' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='88' column='1'/>
+        <var-decl name='max_code' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='88' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='total_in' type-id='type-id-10' visibility='default' filepath='src.d/zlib.h' line='89' column='1'/>
+        <var-decl name='stat_desc' type-id='type-id-52' visibility='default' filepath='src.d/deflate.h' line='89' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='z_stream_s' size-in-bits='448' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='86' column='1' id='type-id-53'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next_in' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='87' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='avail_in' type-id='type-id-11' visibility='default' filepath='src.d/zlib.h' line='88' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='total_in' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='89' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='next_out' type-id='type-id-21' visibility='default' filepath='src.d/zlib.h' line='91' column='1'/>
+        <var-decl name='next_out' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='91' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='avail_out' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='92' column='1'/>
+        <var-decl name='avail_out' type-id='type-id-11' visibility='default' filepath='src.d/zlib.h' line='92' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='total_out' type-id='type-id-10' visibility='default' filepath='src.d/zlib.h' line='93' column='1'/>
+        <var-decl name='total_out' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='93' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='msg' type-id='type-id-70' visibility='default' filepath='src.d/zlib.h' line='95' column='1'/>
+        <var-decl name='msg' type-id='type-id-54' visibility='default' filepath='src.d/zlib.h' line='95' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='state' type-id='type-id-71' visibility='default' filepath='src.d/zlib.h' line='96' column='1'/>
+        <var-decl name='state' type-id='type-id-55' visibility='default' filepath='src.d/zlib.h' line='96' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='zalloc' type-id='type-id-66' visibility='default' filepath='src.d/zlib.h' line='98' column='1'/>
+        <var-decl name='zalloc' type-id='type-id-56' visibility='default' filepath='src.d/zlib.h' line='98' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='zfree' type-id='type-id-68' visibility='default' filepath='src.d/zlib.h' line='99' column='1'/>
+        <var-decl name='zfree' type-id='type-id-57' visibility='default' filepath='src.d/zlib.h' line='99' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='opaque' type-id='type-id-47' visibility='default' filepath='src.d/zlib.h' line='100' column='1'/>
+        <var-decl name='opaque' type-id='type-id-58' visibility='default' filepath='src.d/zlib.h' line='100' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='data_type' type-id='type-id-22' visibility='default' filepath='src.d/zlib.h' line='102' column='1'/>
+        <var-decl name='data_type' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='102' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='adler' type-id='type-id-10' visibility='default' filepath='src.d/zlib.h' line='104' column='1'/>
+        <var-decl name='adler' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='104' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='416'>
-        <var-decl name='reserved' type-id='type-id-10' visibility='default' filepath='src.d/zlib.h' line='105' column='1'/>
+        <var-decl name='reserved' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='105' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='z_stream' type-id='type-id-69' filepath='src.d/zlib.h' line='106' column='1' id='type-id-72'/>
-    <typedef-decl name='z_streamp' type-id='type-id-73' filepath='src.d/zlib.h' line='108' column='1' id='type-id-59'/>
-    <class-decl name='gz_header_s' size-in-bits='416' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='114' column='1' id='type-id-74'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='text' type-id='type-id-22' visibility='default' filepath='src.d/zlib.h' line='115' column='1'/>
+    <typedef-decl name='IPos' type-id='type-id-9' filepath='src.d/deflate.h' line='94' column='1' id='type-id-45'/>
+    <typedef-decl name='Pos' type-id='type-id-50' filepath='src.d/deflate.h' line='92' column='1' id='type-id-59'/>
+    <typedef-decl name='Posf' type-id='type-id-59' filepath='src.d/deflate.h' line='93' column='1' id='type-id-60'/>
+    <typedef-decl name='alloc_func' type-id='type-id-61' filepath='src.d/zlib.h' line='81' column='1' id='type-id-56'/>
+    <typedef-decl name='charf' type-id='type-id-28' filepath='./zconf.h' line='408' column='1' id='type-id-62'/>
+    <typedef-decl name='ct_data' type-id='type-id-29' filepath='src.d/deflate.h' line='77' column='1' id='type-id-63'/>
+    <typedef-decl name='deflate_state' type-id='type-id-41' filepath='src.d/deflate.h' line='271' column='1' id='type-id-64'/>
+    <typedef-decl name='free_func' type-id='type-id-65' filepath='src.d/zlib.h' line='82' column='1' id='type-id-57'/>
+    <typedef-decl name='gz_header' type-id='type-id-40' filepath='src.d/zlib.h' line='129' column='1' id='type-id-66'/>
+    <typedef-decl name='gz_headerp' type-id='type-id-67' filepath='src.d/zlib.h' line='131' column='1' id='type-id-43'/>
+    <typedef-decl name='uch' type-id='type-id-2' filepath='src.d/zutil.h' line='39' column='1' id='type-id-68'/>
+    <typedef-decl name='uchf' type-id='type-id-68' filepath='src.d/zutil.h' line='40' column='1' id='type-id-69'/>
+    <typedef-decl name='ulg' type-id='type-id-12' filepath='src.d/zutil.h' line='43' column='1' id='type-id-42'/>
+    <typedef-decl name='ush' type-id='type-id-70' filepath='src.d/zutil.h' line='41' column='1' id='type-id-50'/>
+    <typedef-decl name='z_stream' type-id='type-id-53' filepath='src.d/zlib.h' line='106' column='1' id='type-id-71'/>
+    <typedef-decl name='z_streamp' type-id='type-id-72' filepath='src.d/zlib.h' line='108' column='1' id='type-id-21'/>
+    <array-type-def dimensions='1' type-id='type-id-68' size-in-bits='4584' id='type-id-48'>
+      <subrange length='573' lower-bound='0' upper-bound='572' type-id='type-id-9' id='type-id-33'/>
+    </array-type-def>
+    <union-decl name='__anonymous_union__1' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='73' column='1' id='type-id-39'>
+      <data-member access='public'>
+        <var-decl name='dad' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='74' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='time' type-id='type-id-10' visibility='default' filepath='src.d/zlib.h' line='116' column='1'/>
+      <data-member access='public'>
+        <var-decl name='len' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='75' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='xflags' type-id='type-id-22' visibility='default' filepath='src.d/zlib.h' line='117' column='1'/>
+    </union-decl>
+    <union-decl name='__anonymous_union__' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='69' column='1' id='type-id-38'>
+      <data-member access='public'>
+        <var-decl name='freq' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='70' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='os' type-id='type-id-22' visibility='default' filepath='src.d/zlib.h' line='118' column='1'/>
+      <data-member access='public'>
+        <var-decl name='code' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='71' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='extra' type-id='type-id-21' visibility='default' filepath='src.d/zlib.h' line='119' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='extra_len' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='120' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='extra_max' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='121' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='name' type-id='type-id-21' visibility='default' filepath='src.d/zlib.h' line='122' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='name_max' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='123' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='comment' type-id='type-id-21' visibility='default' filepath='src.d/zlib.h' line='124' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='comm_max' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='125' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='hcrc' type-id='type-id-22' visibility='default' filepath='src.d/zlib.h' line='126' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='done' type-id='type-id-22' visibility='default' filepath='src.d/zlib.h' line='127' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='gz_header' type-id='type-id-74' filepath='src.d/zlib.h' line='129' column='1' id='type-id-75'/>
-    <typedef-decl name='gz_headerp' type-id='type-id-76' filepath='src.d/zlib.h' line='131' column='1' id='type-id-61'/>
-    <typedef-decl name='uch' type-id='type-id-3' filepath='src.d/zutil.h' line='39' column='1' id='type-id-38'/>
-    <typedef-decl name='uchf' type-id='type-id-38' filepath='src.d/zutil.h' line='40' column='1' id='type-id-77'/>
-    <typedef-decl name='ush' type-id='type-id-40' filepath='src.d/zutil.h' line='41' column='1' id='type-id-41'/>
-    <typedef-decl name='ulg' type-id='type-id-5' filepath='src.d/zutil.h' line='43' column='1' id='type-id-60'/>
-    <pointer-type-def type-id='type-id-11' size-in-bits='32' id='type-id-21'/>
-    <pointer-type-def type-id='type-id-56' size-in-bits='32' id='type-id-62'/>
-    <pointer-type-def type-id='type-id-28' size-in-bits='32' id='type-id-70'/>
-    <pointer-type-def type-id='type-id-45' size-in-bits='32' id='type-id-78'/>
-    <qualified-type-def type-id='type-id-28' const='yes' id='type-id-79'/>
-    <pointer-type-def type-id='type-id-79' size-in-bits='32' id='type-id-80'/>
-    <qualified-type-def type-id='type-id-51' const='yes' id='type-id-81'/>
-    <pointer-type-def type-id='type-id-81' size-in-bits='32' id='type-id-54'/>
-    <pointer-type-def type-id='type-id-50' size-in-bits='32' id='type-id-53'/>
-    <pointer-type-def type-id='type-id-64' size-in-bits='32' id='type-id-82'/>
-    <pointer-type-def type-id='type-id-75' size-in-bits='32' id='type-id-76'/>
-    <pointer-type-def type-id='type-id-22' size-in-bits='32' id='type-id-83'/>
-    <pointer-type-def type-id='type-id-58' size-in-bits='32' id='type-id-71'/>
-    <pointer-type-def type-id='type-id-84' size-in-bits='32' id='type-id-65'/>
-    <pointer-type-def type-id='type-id-9' size-in-bits='32' id='type-id-85'/>
-    <pointer-type-def type-id='type-id-77' size-in-bits='32' id='type-id-63'/>
-    <pointer-type-def type-id='type-id-4' size-in-bits='32' id='type-id-86'/>
-    <pointer-type-def type-id='type-id-87' size-in-bits='32' id='type-id-67'/>
-    <pointer-type-def type-id='type-id-44' size-in-bits='32' id='type-id-46'/>
-    <pointer-type-def type-id='type-id-72' size-in-bits='32' id='type-id-73'/>
-    <class-decl name='static_tree_desc_s' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-29'/>
+    </union-decl>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-70'/>
+    <array-type-def dimensions='1' type-id='type-id-50' size-in-bits='256' id='type-id-47'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-9' id='type-id-73'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-4' size-in-bits='32' id='type-id-19'/>
+    <pointer-type-def type-id='type-id-60' size-in-bits='32' id='type-id-44'/>
+    <pointer-type-def type-id='type-id-28' size-in-bits='32' id='type-id-54'/>
+    <pointer-type-def type-id='type-id-62' size-in-bits='32' id='type-id-74'/>
+    <qualified-type-def type-id='type-id-28' const='yes' id='type-id-75'/>
+    <pointer-type-def type-id='type-id-75' size-in-bits='32' id='type-id-22'/>
+    <pointer-type-def type-id='type-id-63' size-in-bits='32' id='type-id-51'/>
+    <pointer-type-def type-id='type-id-64' size-in-bits='32' id='type-id-76'/>
+    <pointer-type-def type-id='type-id-66' size-in-bits='32' id='type-id-67'/>
+    <pointer-type-def type-id='type-id-20' size-in-bits='32' id='type-id-77'/>
+    <pointer-type-def type-id='type-id-41' size-in-bits='32' id='type-id-55'/>
+    <pointer-type-def type-id='type-id-78' size-in-bits='32' id='type-id-61'/>
+    <pointer-type-def type-id='type-id-11' size-in-bits='32' id='type-id-79'/>
+    <pointer-type-def type-id='type-id-69' size-in-bits='32' id='type-id-49'/>
+    <pointer-type-def type-id='type-id-9' size-in-bits='32' id='type-id-80'/>
+    <pointer-type-def type-id='type-id-81' size-in-bits='32' id='type-id-65'/>
+    <pointer-type-def type-id='type-id-71' size-in-bits='32' id='type-id-72'/>
+    <qualified-type-def type-id='type-id-82' const='yes' id='type-id-83'/>
+    <pointer-type-def type-id='type-id-83' size-in-bits='32' id='type-id-52'/>
+    <class-decl name='static_tree_desc_s' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-84'/>
+    <typedef-decl name='voidpf' type-id='type-id-85' filepath='./zconf.h' line='415' column='1' id='type-id-58'/>
     <function-decl name='memcpy' filepath='/usr/arm-linux-gnueabi/include/string.h' line='43' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-46'/>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-85'/>
     </function-decl>
     <function-decl name='memset' filepath='/usr/arm-linux-gnueabi/include/string.h' line='61' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-22'/>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-46'/>
-    </function-decl>
-    <function-decl name='deflateInit_' mangled-name='deflateInit_' filepath='src.d/deflate.c' line='225' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateInit_'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='226' column='1'/>
-      <parameter type-id='type-id-22' name='level' filepath='src.d/deflate.c' line='227' column='1'/>
-      <parameter type-id='type-id-80' name='version' filepath='src.d/deflate.c' line='228' column='1'/>
-      <parameter type-id='type-id-22' name='stream_size' filepath='src.d/deflate.c' line='229' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-85'/>
     </function-decl>
     <function-decl name='deflateInit2_' mangled-name='deflateInit2_' filepath='src.d/deflate.c' line='237' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateInit2_'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='239' column='1'/>
-      <parameter type-id='type-id-22' name='level' filepath='src.d/deflate.c' line='240' column='1'/>
-      <parameter type-id='type-id-22' name='method' filepath='src.d/deflate.c' line='241' column='1'/>
-      <parameter type-id='type-id-22' name='windowBits' filepath='src.d/deflate.c' line='242' column='1'/>
-      <parameter type-id='type-id-22' name='memLevel' filepath='src.d/deflate.c' line='243' column='1'/>
-      <parameter type-id='type-id-22' name='strategy' filepath='src.d/deflate.c' line='244' column='1'/>
-      <parameter type-id='type-id-80' name='version' filepath='src.d/deflate.c' line='245' column='1'/>
-      <parameter type-id='type-id-22' name='stream_size' filepath='src.d/deflate.c' line='246' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='239' column='1'/>
+      <parameter type-id='type-id-20' name='level' filepath='src.d/deflate.c' line='240' column='1'/>
+      <parameter type-id='type-id-20' name='method' filepath='src.d/deflate.c' line='241' column='1'/>
+      <parameter type-id='type-id-20' name='windowBits' filepath='src.d/deflate.c' line='242' column='1'/>
+      <parameter type-id='type-id-20' name='memLevel' filepath='src.d/deflate.c' line='243' column='1'/>
+      <parameter type-id='type-id-20' name='strategy' filepath='src.d/deflate.c' line='244' column='1'/>
+      <parameter type-id='type-id-22' name='version' filepath='src.d/deflate.c' line='245' column='1'/>
+      <parameter type-id='type-id-20' name='stream_size' filepath='src.d/deflate.c' line='246' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateSetDictionary' mangled-name='deflateSetDictionary' filepath='src.d/deflate.c' line='412' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateSetDictionary'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='413' column='1'/>
-      <parameter type-id='type-id-18' name='dictionary' filepath='src.d/deflate.c' line='414' column='1'/>
-      <parameter type-id='type-id-9' name='dictLength' filepath='src.d/deflate.c' line='415' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='413' column='1'/>
+      <parameter type-id='type-id-16' name='dictionary' filepath='src.d/deflate.c' line='414' column='1'/>
+      <parameter type-id='type-id-11' name='dictLength' filepath='src.d/deflate.c' line='415' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateGetDictionary' mangled-name='deflateGetDictionary' filepath='src.d/deflate.c' line='481' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateGetDictionary@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='482' column='1'/>
-      <parameter type-id='type-id-21' name='dictionary' filepath='src.d/deflate.c' line='483' column='1'/>
-      <parameter type-id='type-id-85' name='dictLength' filepath='src.d/deflate.c' line='484' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='482' column='1'/>
+      <parameter type-id='type-id-19' name='dictionary' filepath='src.d/deflate.c' line='483' column='1'/>
+      <parameter type-id='type-id-79' name='dictLength' filepath='src.d/deflate.c' line='484' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateResetKeep' mangled-name='deflateResetKeep' filepath='src.d/deflate.c' line='503' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateResetKeep@@ZLIB_1.2.5.2'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='504' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='504' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateReset' mangled-name='deflateReset' filepath='src.d/deflate.c' line='541' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateReset'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='542' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='542' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateSetHeader' mangled-name='deflateSetHeader' filepath='src.d/deflate.c' line='553' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateSetHeader@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='554' column='1'/>
-      <parameter type-id='type-id-61' name='head' filepath='src.d/deflate.c' line='555' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='554' column='1'/>
+      <parameter type-id='type-id-43' name='head' filepath='src.d/deflate.c' line='555' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflatePending' mangled-name='deflatePending' filepath='src.d/deflate.c' line='564' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflatePending@@ZLIB_1.2.5.1'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='567' column='1'/>
-      <parameter type-id='type-id-86' name='pending' filepath='src.d/deflate.c' line='565' column='1'/>
-      <parameter type-id='type-id-83' name='bits' filepath='src.d/deflate.c' line='566' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='567' column='1'/>
+      <parameter type-id='type-id-80' name='pending' filepath='src.d/deflate.c' line='565' column='1'/>
+      <parameter type-id='type-id-77' name='bits' filepath='src.d/deflate.c' line='566' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflatePrime' mangled-name='deflatePrime' filepath='src.d/deflate.c' line='578' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflatePrime@@ZLIB_1.2.0.8'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='579' column='1'/>
-      <parameter type-id='type-id-22' name='bits' filepath='src.d/deflate.c' line='580' column='1'/>
-      <parameter type-id='type-id-22' name='value' filepath='src.d/deflate.c' line='581' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='579' column='1'/>
+      <parameter type-id='type-id-20' name='bits' filepath='src.d/deflate.c' line='580' column='1'/>
+      <parameter type-id='type-id-20' name='value' filepath='src.d/deflate.c' line='581' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateParams' mangled-name='deflateParams' filepath='src.d/deflate.c' line='605' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateParams'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='606' column='1'/>
-      <parameter type-id='type-id-22' name='level' filepath='src.d/deflate.c' line='607' column='1'/>
-      <parameter type-id='type-id-22' name='strategy' filepath='src.d/deflate.c' line='608' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='606' column='1'/>
+      <parameter type-id='type-id-20' name='level' filepath='src.d/deflate.c' line='607' column='1'/>
+      <parameter type-id='type-id-20' name='strategy' filepath='src.d/deflate.c' line='608' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateTune' mangled-name='deflateTune' filepath='src.d/deflate.c' line='654' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateTune@@ZLIB_1.2.2.3'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='655' column='1'/>
-      <parameter type-id='type-id-22' name='good_length' filepath='src.d/deflate.c' line='656' column='1'/>
-      <parameter type-id='type-id-22' name='max_lazy' filepath='src.d/deflate.c' line='657' column='1'/>
-      <parameter type-id='type-id-22' name='nice_length' filepath='src.d/deflate.c' line='658' column='1'/>
-      <parameter type-id='type-id-22' name='max_chain' filepath='src.d/deflate.c' line='659' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='655' column='1'/>
+      <parameter type-id='type-id-20' name='good_length' filepath='src.d/deflate.c' line='656' column='1'/>
+      <parameter type-id='type-id-20' name='max_lazy' filepath='src.d/deflate.c' line='657' column='1'/>
+      <parameter type-id='type-id-20' name='nice_length' filepath='src.d/deflate.c' line='658' column='1'/>
+      <parameter type-id='type-id-20' name='max_chain' filepath='src.d/deflate.c' line='659' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateBound' mangled-name='deflateBound' filepath='src.d/deflate.c' line='696' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateBound@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='697' column='1'/>
-      <parameter type-id='type-id-10' name='sourceLen' filepath='src.d/deflate.c' line='698' column='1'/>
-      <return type-id='type-id-10'/>
-    </function-decl>
-    <function-decl name='deflate' mangled-name='deflate' filepath='src.d/deflate.c' line='815' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflate'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='816' column='1'/>
-      <parameter type-id='type-id-22' name='flush' filepath='src.d/deflate.c' line='817' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='deflateEnd' mangled-name='deflateEnd' filepath='src.d/deflate.c' line='1130' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateEnd'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='1131' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='697' column='1'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/deflate.c' line='698' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='deflateCopy' mangled-name='deflateCopy' filepath='src.d/deflate.c' line='1156' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateCopy'>
-      <parameter type-id='type-id-59' name='dest' filepath='src.d/deflate.c' line='1157' column='1'/>
-      <parameter type-id='type-id-59' name='source' filepath='src.d/deflate.c' line='1158' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='dest' filepath='src.d/deflate.c' line='1157' column='1'/>
+      <parameter type-id='type-id-21' name='source' filepath='src.d/deflate.c' line='1158' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
+    <typedef-decl name='static_tree_desc' type-id='type-id-84' filepath='src.d/deflate.h' line='84' column='1' id='type-id-82'/>
     <function-decl name='_tr_init' filepath='src.d/deflate.h' line='294' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-82'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-76'/>
+      <return type-id='type-id-86'/>
     </function-decl>
     <function-decl name='_tr_flush_block' filepath='src.d/deflate.h' line='296' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-82'/>
-      <parameter type-id='type-id-78'/>
-      <parameter type-id='type-id-60'/>
-      <parameter type-id='type-id-22'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-76'/>
+      <parameter type-id='type-id-74'/>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-86'/>
     </function-decl>
     <function-decl name='_tr_flush_bits' filepath='src.d/deflate.h' line='298' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-82'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-76'/>
+      <return type-id='type-id-86'/>
     </function-decl>
     <function-decl name='_tr_align' filepath='src.d/deflate.h' line='299' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-82'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-76'/>
+      <return type-id='type-id-86'/>
     </function-decl>
     <function-decl name='_tr_stored_block' filepath='src.d/deflate.h' line='300' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-82'/>
-      <parameter type-id='type-id-78'/>
-      <parameter type-id='type-id-60'/>
-      <parameter type-id='type-id-22'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-76'/>
+      <parameter type-id='type-id-74'/>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-86'/>
+    </function-decl>
+    <function-decl name='crc32' filepath='src.d/zlib.h' line='1727' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-13'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-11'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='zcalloc' filepath='src.d/zutil.h' line='261' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-47'/>
-      <parameter type-id='type-id-4'/>
-      <parameter type-id='type-id-4'/>
-      <return type-id='type-id-47'/>
+      <parameter type-id='type-id-58'/>
+      <parameter type-id='type-id-9'/>
+      <parameter type-id='type-id-9'/>
+      <return type-id='type-id-58'/>
     </function-decl>
     <function-decl name='zcfree' filepath='src.d/zutil.h' line='263' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-47'/>
-      <parameter type-id='type-id-47'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-58'/>
+      <parameter type-id='type-id-58'/>
+      <return type-id='type-id-86'/>
     </function-decl>
-    <function-type size-in-bits='32' id='type-id-84'>
-      <parameter type-id='type-id-47'/>
-      <parameter type-id='type-id-9'/>
-      <parameter type-id='type-id-9'/>
-      <return type-id='type-id-47'/>
+    <type-decl name='void' id='type-id-86'/>
+    <pointer-type-def type-id='type-id-86' id='type-id-85'/>
+    <function-type size-in-bits='32' id='type-id-81'>
+      <parameter type-id='type-id-58'/>
+      <parameter type-id='type-id-58'/>
+      <return type-id='type-id-86'/>
     </function-type>
-    <function-type size-in-bits='32' id='type-id-87'>
-      <parameter type-id='type-id-47'/>
-      <parameter type-id='type-id-47'/>
-      <return type-id='type-id-44'/>
+    <function-type size-in-bits='32' id='type-id-78'>
+      <parameter type-id='type-id-58'/>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-11'/>
+      <return type-id='type-id-58'/>
     </function-type>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/gzclose.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <typedef-decl name='gzFile' type-id='type-id-88' filepath='src.d/zlib.h' line='1302' column='1' id='type-id-89'/>
-    <class-decl name='gzFile_s' size-in-bits='128' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='1834' column='1' id='type-id-90'>
+    <class-decl name='gzFile_s' size-in-bits='128' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='1834' column='1' id='type-id-87'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='have' type-id='type-id-4' visibility='default' filepath='src.d/zlib.h' line='1835' column='1'/>
+        <var-decl name='have' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='1835' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='next' type-id='type-id-91' visibility='default' filepath='src.d/zlib.h' line='1836' column='1'/>
+        <var-decl name='next' type-id='type-id-88' visibility='default' filepath='src.d/zlib.h' line='1836' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='pos' type-id='type-id-16' visibility='default' filepath='src.d/zlib.h' line='1837' column='1'/>
+        <var-decl name='pos' type-id='type-id-7' visibility='default' filepath='src.d/zlib.h' line='1837' column='1'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-90' size-in-bits='32' id='type-id-88'/>
+    <typedef-decl name='gzFile' type-id='type-id-89' filepath='src.d/zlib.h' line='1302' column='1' id='type-id-90'/>
+    <pointer-type-def type-id='type-id-87' size-in-bits='32' id='type-id-89'/>
     <function-decl name='gzclose' mangled-name='gzclose' filepath='src.d/gzclose.c' line='11' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzclose'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzclose.c' line='12' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzclose.c' line='12' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='gzclose_r' mangled-name='gzclose_r' filepath='src.d/zlib.h' line='1644' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzclose_r@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-89'/>
-      <return type-id='type-id-22'/>
+    <function-decl name='gzclose_r' filepath='src.d/zlib.h' line='1644' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-90'/>
+      <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='gzclose_w' mangled-name='gzclose_w' filepath='src.d/zlib.h' line='1645' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzclose_w@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-89'/>
-      <return type-id='type-id-22'/>
+    <function-decl name='gzclose_w' filepath='src.d/zlib.h' line='1645' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-90'/>
+      <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/gzlib.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <type-decl name='variadic parameter type' id='type-id-92'/>
-    <function-decl name='open' filepath='/usr/arm-linux-gnueabi/include/fcntl.h' line='181' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-80'/>
+    <function-decl name='snprintf' filepath='/usr/arm-linux-gnueabi/include/stdio.h' line='385' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-54'/>
+      <parameter type-id='type-id-10'/>
       <parameter type-id='type-id-22'/>
       <parameter is-variadic='yes'/>
-      <return type-id='type-id-22'/>
+      <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='snprintf' filepath='/usr/arm-linux-gnueabi/include/stdio.h' line='378' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-70'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-80'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-22'/>
+    <function-decl name='malloc' filepath='/usr/arm-linux-gnueabi/include/stdlib.h' line='672' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-85'/>
+    </function-decl>
+    <function-decl name='free' filepath='/usr/arm-linux-gnueabi/include/stdlib.h' line='687' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-85'/>
+      <return type-id='type-id-86'/>
     </function-decl>
     <function-decl name='strlen' filepath='/usr/arm-linux-gnueabi/include/string.h' line='407' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-80'/>
-      <return type-id='type-id-6'/>
+      <parameter type-id='type-id-22'/>
+      <return type-id='type-id-10'/>
     </function-decl>
     <function-decl name='lseek64' filepath='/usr/arm-linux-gnueabi/include/unistd.h' line='350' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-22'/>
-      <parameter type-id='type-id-14'/>
-      <parameter type-id='type-id-22'/>
-      <return type-id='type-id-14'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='gzopen' mangled-name='gzopen' filepath='src.d/gzlib.c' line='272' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzopen'>
-      <parameter type-id='type-id-80' name='path' filepath='src.d/gzlib.c' line='273' column='1'/>
-      <parameter type-id='type-id-80' name='mode' filepath='src.d/gzlib.c' line='274' column='1'/>
-      <return type-id='type-id-89'/>
+      <parameter type-id='type-id-22' name='path' filepath='src.d/gzlib.c' line='273' column='1'/>
+      <parameter type-id='type-id-22' name='mode' filepath='src.d/gzlib.c' line='274' column='1'/>
+      <return type-id='type-id-90'/>
     </function-decl>
     <function-decl name='gzopen64' mangled-name='gzopen64' filepath='src.d/gzlib.c' line='280' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzopen64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-80' name='path' filepath='src.d/gzlib.c' line='281' column='1'/>
-      <parameter type-id='type-id-80' name='mode' filepath='src.d/gzlib.c' line='282' column='1'/>
-      <return type-id='type-id-89'/>
+      <parameter type-id='type-id-22' name='path' filepath='src.d/gzlib.c' line='281' column='1'/>
+      <parameter type-id='type-id-22' name='mode' filepath='src.d/gzlib.c' line='282' column='1'/>
+      <return type-id='type-id-90'/>
     </function-decl>
     <function-decl name='gzdopen' mangled-name='gzdopen' filepath='src.d/gzlib.c' line='288' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzdopen'>
-      <parameter type-id='type-id-22' name='fd' filepath='src.d/gzlib.c' line='289' column='1'/>
-      <parameter type-id='type-id-80' name='mode' filepath='src.d/gzlib.c' line='290' column='1'/>
-      <return type-id='type-id-89'/>
+      <parameter type-id='type-id-20' name='fd' filepath='src.d/gzlib.c' line='289' column='1'/>
+      <parameter type-id='type-id-22' name='mode' filepath='src.d/gzlib.c' line='290' column='1'/>
+      <return type-id='type-id-90'/>
     </function-decl>
     <function-decl name='gzbuffer' mangled-name='gzbuffer' filepath='src.d/gzlib.c' line='318' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzbuffer@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='319' column='1'/>
-      <parameter type-id='type-id-4' name='size' filepath='src.d/gzlib.c' line='320' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='319' column='1'/>
+      <parameter type-id='type-id-9' name='size' filepath='src.d/gzlib.c' line='320' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzrewind' mangled-name='gzrewind' filepath='src.d/gzlib.c' line='345' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzrewind'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='346' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='346' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzseek64' mangled-name='gzseek64' filepath='src.d/gzlib.c' line='368' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzseek64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='369' column='1'/>
-      <parameter type-id='type-id-16' name='offset' filepath='src.d/gzlib.c' line='370' column='1'/>
-      <parameter type-id='type-id-22' name='whence' filepath='src.d/gzlib.c' line='371' column='1'/>
-      <return type-id='type-id-16'/>
-    </function-decl>
-    <function-decl name='gzseek' mangled-name='gzseek' filepath='src.d/gzlib.c' line='445' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzseek'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='446' column='1'/>
-      <parameter type-id='type-id-15' name='offset' filepath='src.d/gzlib.c' line='447' column='1'/>
-      <parameter type-id='type-id-22' name='whence' filepath='src.d/gzlib.c' line='448' column='1'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='gztell64' mangled-name='gztell64' filepath='src.d/gzlib.c' line='457' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gztell64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='458' column='1'/>
-      <return type-id='type-id-16'/>
-    </function-decl>
-    <function-decl name='gztell' mangled-name='gztell' filepath='src.d/gzlib.c' line='474' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gztell'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='475' column='1'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='gzoffset64' mangled-name='gzoffset64' filepath='src.d/gzlib.c' line='484' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzoffset64@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='485' column='1'/>
-      <return type-id='type-id-16'/>
-    </function-decl>
-    <function-decl name='gzoffset' mangled-name='gzoffset' filepath='src.d/gzlib.c' line='507' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzoffset@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='508' column='1'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='gzeof' mangled-name='gzeof' filepath='src.d/gzlib.c' line='517' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzeof'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='518' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='gzerror' mangled-name='gzerror' filepath='src.d/gzlib.c' line='534' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzerror'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='535' column='1'/>
-      <parameter type-id='type-id-83' name='errnum' filepath='src.d/gzlib.c' line='536' column='1'/>
-      <return type-id='type-id-80'/>
-    </function-decl>
-    <function-decl name='gzclearerr' mangled-name='gzclearerr' filepath='src.d/gzlib.c' line='555' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzclearerr@@ZLIB_1.2.0.2'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='556' column='1'/>
-      <return type-id='type-id-44'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr address-size='32' path='src.d/gzread.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <typedef-decl name='voidp' type-id='type-id-46' filepath='./zconf.h' line='416' column='1' id='type-id-93'/>
-    <typedef-decl name='__ssize_t' type-id='type-id-22' filepath='/usr/arm-linux-gnueabi/include/bits/types.h' line='194' column='1' id='type-id-94'/>
-    <typedef-decl name='ssize_t' type-id='type-id-94' filepath='/usr/arm-linux-gnueabi/include/sys/types.h' line='108' column='1' id='type-id-95'/>
-    <class-decl name='gz_state' size-in-bits='1344' is-struct='yes' naming-typedef-id='type-id-96' visibility='default' filepath='src.d/gzguts.h' line='170' column='1' id='type-id-97'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='x' type-id='type-id-90' visibility='default' filepath='src.d/gzguts.h' line='172' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='mode' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='177' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='fd' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='178' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='path' type-id='type-id-70' visibility='default' filepath='src.d/gzguts.h' line='179' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='size' type-id='type-id-4' visibility='default' filepath='src.d/gzguts.h' line='180' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='want' type-id='type-id-4' visibility='default' filepath='src.d/gzguts.h' line='181' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='in' type-id='type-id-91' visibility='default' filepath='src.d/gzguts.h' line='182' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='out' type-id='type-id-91' visibility='default' filepath='src.d/gzguts.h' line='183' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='direct' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='184' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='how' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='186' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='start' type-id='type-id-16' visibility='default' filepath='src.d/gzguts.h' line='187' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='eof' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='188' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='544'>
-        <var-decl name='past' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='189' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='level' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='191' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='608'>
-        <var-decl name='strategy' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='192' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='reset' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='193' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='skip' type-id='type-id-16' visibility='default' filepath='src.d/gzguts.h' line='195' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='seek' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='196' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='800'>
-        <var-decl name='err' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='198' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='msg' type-id='type-id-70' visibility='default' filepath='src.d/gzguts.h' line='199' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='864'>
-        <var-decl name='strm' type-id='type-id-72' visibility='default' filepath='src.d/gzguts.h' line='201' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='gz_state' type-id='type-id-97' filepath='src.d/gzguts.h' line='202' column='1' id='type-id-96'/>
-    <typedef-decl name='gz_statep' type-id='type-id-98' filepath='src.d/gzguts.h' line='203' column='1' id='type-id-99'/>
-    <pointer-type-def type-id='type-id-96' size-in-bits='32' id='type-id-98'/>
-    <function-decl name='__errno_location' filepath='/usr/arm-linux-gnueabi/include/errno.h' line='37' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <return type-id='type-id-83'/>
-    </function-decl>
-    <function-decl name='memchr' filepath='/usr/arm-linux-gnueabi/include/string.h' line='107' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-22'/>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-46'/>
-    </function-decl>
-    <function-decl name='strerror' filepath='/usr/arm-linux-gnueabi/include/string.h' line='419' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-22'/>
-      <return type-id='type-id-70'/>
-    </function-decl>
-    <function-decl name='close' filepath='/usr/arm-linux-gnueabi/include/unistd.h' line='358' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-22'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='read' filepath='/usr/arm-linux-gnueabi/include/unistd.h' line='371' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-22'/>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-95'/>
-    </function-decl>
-    <function-decl name='gz_error' filepath='src.d/gzguts.h' line='206' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-99'/>
-      <parameter type-id='type-id-22'/>
-      <parameter type-id='type-id-80'/>
-      <return type-id='type-id-44'/>
-    </function-decl>
-    <function-decl name='gzread' mangled-name='gzread' filepath='src.d/gzread.c' line='373' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzread'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='374' column='1'/>
-      <parameter type-id='type-id-93' name='buf' filepath='src.d/gzread.c' line='375' column='1'/>
-      <parameter type-id='type-id-4' name='len' filepath='src.d/gzread.c' line='376' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='gzfread' mangled-name='gzfread' filepath='src.d/gzread.c' line='409' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzfread@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-93' name='buf' filepath='src.d/gzread.c' line='410' column='1'/>
-      <parameter type-id='type-id-7' name='size' filepath='src.d/gzread.c' line='411' column='1'/>
-      <parameter type-id='type-id-7' name='nitems' filepath='src.d/gzread.c' line='412' column='1'/>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='413' column='1'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='369' column='1'/>
+      <parameter type-id='type-id-7' name='offset' filepath='src.d/gzlib.c' line='370' column='1'/>
+      <parameter type-id='type-id-20' name='whence' filepath='src.d/gzlib.c' line='371' column='1'/>
       <return type-id='type-id-7'/>
     </function-decl>
-    <function-decl name='gzgetc' mangled-name='gzgetc' filepath='src.d/gzread.c' line='445' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzgetc'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='446' column='1'/>
+    <function-decl name='gzseek' mangled-name='gzseek' filepath='src.d/gzlib.c' line='445' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzseek'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='446' column='1'/>
+      <parameter type-id='type-id-8' name='offset' filepath='src.d/gzlib.c' line='447' column='1'/>
+      <parameter type-id='type-id-20' name='whence' filepath='src.d/gzlib.c' line='448' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='gztell64' mangled-name='gztell64' filepath='src.d/gzlib.c' line='457' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gztell64@@ZLIB_1.2.3.3'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='458' column='1'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='gztell' mangled-name='gztell' filepath='src.d/gzlib.c' line='474' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gztell'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='475' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='gzoffset64' mangled-name='gzoffset64' filepath='src.d/gzlib.c' line='484' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzoffset64@@ZLIB_1.2.3.5'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='485' column='1'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='gzoffset' mangled-name='gzoffset' filepath='src.d/gzlib.c' line='507' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzoffset@@ZLIB_1.2.3.5'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='508' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='gzeof' mangled-name='gzeof' filepath='src.d/gzlib.c' line='517' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzeof'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='518' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzerror' mangled-name='gzerror' filepath='src.d/gzlib.c' line='534' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzerror'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='535' column='1'/>
+      <parameter type-id='type-id-77' name='errnum' filepath='src.d/gzlib.c' line='536' column='1'/>
       <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='gzclearerr' mangled-name='gzclearerr' filepath='src.d/gzlib.c' line='555' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzclearerr@@ZLIB_1.2.0.2'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='556' column='1'/>
+      <return type-id='type-id-86'/>
+    </function-decl>
+    <type-decl name='variadic parameter type' id='type-id-91'/>
+  </abi-instr>
+  <abi-instr address-size='32' path='src.d/gzread.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
+    <class-decl name='gz_state' size-in-bits='1344' is-struct='yes' naming-typedef-id='type-id-92' visibility='default' filepath='src.d/gzguts.h' line='170' column='1' id='type-id-93'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='x' type-id='type-id-87' visibility='default' filepath='src.d/gzguts.h' line='172' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='mode' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='177' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='fd' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='178' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='path' type-id='type-id-54' visibility='default' filepath='src.d/gzguts.h' line='179' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='size' type-id='type-id-9' visibility='default' filepath='src.d/gzguts.h' line='180' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='want' type-id='type-id-9' visibility='default' filepath='src.d/gzguts.h' line='181' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='in' type-id='type-id-88' visibility='default' filepath='src.d/gzguts.h' line='182' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='out' type-id='type-id-88' visibility='default' filepath='src.d/gzguts.h' line='183' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='direct' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='184' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='how' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='186' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='start' type-id='type-id-7' visibility='default' filepath='src.d/gzguts.h' line='187' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='eof' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='188' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='544'>
+        <var-decl name='past' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='189' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='level' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='191' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='608'>
+        <var-decl name='strategy' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='192' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='reset' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='193' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='skip' type-id='type-id-7' visibility='default' filepath='src.d/gzguts.h' line='195' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='seek' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='196' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='800'>
+        <var-decl name='err' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='198' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='msg' type-id='type-id-54' visibility='default' filepath='src.d/gzguts.h' line='199' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='864'>
+        <var-decl name='strm' type-id='type-id-71' visibility='default' filepath='src.d/gzguts.h' line='201' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__ssize_t' type-id='type-id-20' filepath='/usr/arm-linux-gnueabi/include/bits/types.h' line='194' column='1' id='type-id-94'/>
+    <typedef-decl name='gz_state' type-id='type-id-93' filepath='src.d/gzguts.h' line='202' column='1' id='type-id-92'/>
+    <typedef-decl name='gz_statep' type-id='type-id-95' filepath='src.d/gzguts.h' line='203' column='1' id='type-id-96'/>
+    <typedef-decl name='ssize_t' type-id='type-id-94' filepath='/usr/arm-linux-gnueabi/include/sys/types.h' line='108' column='1' id='type-id-97'/>
+    <pointer-type-def type-id='type-id-92' size-in-bits='32' id='type-id-95'/>
+    <typedef-decl name='voidp' type-id='type-id-85' filepath='./zconf.h' line='416' column='1' id='type-id-98'/>
+    <function-decl name='__errno_location' filepath='/usr/arm-linux-gnueabi/include/errno.h' line='37' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <return type-id='type-id-77'/>
+    </function-decl>
+    <function-decl name='memchr' filepath='/usr/arm-linux-gnueabi/include/string.h' line='107' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-85'/>
+    </function-decl>
+    <function-decl name='strerror' filepath='/usr/arm-linux-gnueabi/include/string.h' line='419' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-54'/>
+    </function-decl>
+    <function-decl name='close' filepath='/usr/arm-linux-gnueabi/include/unistd.h' line='358' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='read' filepath='/usr/arm-linux-gnueabi/include/unistd.h' line='371' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-97'/>
+    </function-decl>
+    <function-decl name='gz_error' filepath='src.d/gzguts.h' line='206' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-96'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-22'/>
+      <return type-id='type-id-86'/>
+    </function-decl>
+    <function-decl name='gzread' mangled-name='gzread' filepath='src.d/gzread.c' line='373' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzread'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzread.c' line='374' column='1'/>
+      <parameter type-id='type-id-98' name='buf' filepath='src.d/gzread.c' line='375' column='1'/>
+      <parameter type-id='type-id-9' name='len' filepath='src.d/gzread.c' line='376' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzfread' mangled-name='gzfread' filepath='src.d/gzread.c' line='409' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzfread@@ZLIB_1.2.9'>
+      <parameter type-id='type-id-98' name='buf' filepath='src.d/gzread.c' line='410' column='1'/>
+      <parameter type-id='type-id-14' name='size' filepath='src.d/gzread.c' line='411' column='1'/>
+      <parameter type-id='type-id-14' name='nitems' filepath='src.d/gzread.c' line='412' column='1'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzread.c' line='413' column='1'/>
+      <return type-id='type-id-14'/>
+    </function-decl>
+    <function-decl name='gzgetc' mangled-name='gzgetc' filepath='src.d/gzread.c' line='445' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzgetc'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzread.c' line='446' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzgetc_' mangled-name='gzgetc_' filepath='src.d/gzread.c' line='472' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzgetc_@@ZLIB_1.2.5.2'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='473' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzread.c' line='473' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzungetc' mangled-name='gzungetc' filepath='src.d/gzread.c' line='479' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzungetc@@ZLIB_1.2.0.2'>
-      <parameter type-id='type-id-22' name='c' filepath='src.d/gzread.c' line='480' column='1'/>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='481' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-20' name='c' filepath='src.d/gzread.c' line='480' column='1'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzread.c' line='481' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzgets' mangled-name='gzgets' filepath='src.d/gzread.c' line='539' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzgets'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='540' column='1'/>
-      <parameter type-id='type-id-70' name='buf' filepath='src.d/gzread.c' line='541' column='1'/>
-      <parameter type-id='type-id-22' name='len' filepath='src.d/gzread.c' line='542' column='1'/>
-      <return type-id='type-id-70'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzread.c' line='540' column='1'/>
+      <parameter type-id='type-id-54' name='buf' filepath='src.d/gzread.c' line='541' column='1'/>
+      <parameter type-id='type-id-20' name='len' filepath='src.d/gzread.c' line='542' column='1'/>
+      <return type-id='type-id-54'/>
     </function-decl>
     <function-decl name='gzdirect' mangled-name='gzdirect' filepath='src.d/gzread.c' line='603' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzdirect@@ZLIB_1.2.2.3'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='604' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzread.c' line='604' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflate' filepath='src.d/zlib.h' line='400' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateEnd' filepath='src.d/zlib.h' line='520' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-21'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateReset' filepath='src.d/zlib.h' line='959' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-21'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateInit2_' filepath='src.d/zlib.h' line='1789' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/gzwrite.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <class-decl name='__va_list' size-in-bits='32' is-struct='yes' visibility='default' id='type-id-100'>
+    <class-decl name='__va_list' size-in-bits='32' is-struct='yes' visibility='default' id='type-id-99'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__ap' type-id='type-id-46' visibility='default'/>
+        <var-decl name='__ap' type-id='type-id-85' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='voidpc' type-id='type-id-46' filepath='./zconf.h' line='414' column='1' id='type-id-101'/>
-    <typedef-decl name='__gnuc_va_list' type-id='type-id-100' filepath='/usr/lib/gcc-cross/arm-linux-gnueabi/11/include/stdarg.h' line='40' column='1' id='type-id-102'/>
-    <typedef-decl name='va_list' type-id='type-id-102' filepath='/usr/lib/gcc-cross/arm-linux-gnueabi/11/include/stdarg.h' line='99' column='1' id='type-id-103'/>
-    <function-decl name='vsnprintf' filepath='/usr/arm-linux-gnueabi/include/stdio.h' line='382' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-70'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-80'/>
-      <parameter type-id='type-id-102'/>
-      <return type-id='type-id-22'/>
+    <typedef-decl name='__gnuc_va_list' type-id='type-id-99' filepath='/usr/lib/gcc-cross/arm-linux-gnueabi/13/include/stdarg.h' line='40' column='1' id='type-id-100'/>
+    <typedef-decl name='va_list' type-id='type-id-100' filepath='/usr/lib/gcc-cross/arm-linux-gnueabi/13/include/stdarg.h' line='103' column='1' id='type-id-101'/>
+    <typedef-decl name='voidpc' type-id='type-id-85' filepath='./zconf.h' line='414' column='1' id='type-id-102'/>
+    <function-decl name='vsnprintf' filepath='/usr/arm-linux-gnueabi/include/stdio.h' line='389' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-54'/>
+      <parameter type-id='type-id-10'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-100'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='memmove' filepath='/usr/arm-linux-gnueabi/include/string.h' line='47' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-46'/>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-85'/>
     </function-decl>
     <function-decl name='write' filepath='/usr/arm-linux-gnueabi/include/unistd.h' line='378' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-22'/>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-95'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-97'/>
     </function-decl>
     <function-decl name='gzwrite' mangled-name='gzwrite' filepath='src.d/gzwrite.c' line='255' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzwrite'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='256' column='1'/>
-      <parameter type-id='type-id-101' name='buf' filepath='src.d/gzwrite.c' line='257' column='1'/>
-      <parameter type-id='type-id-4' name='len' filepath='src.d/gzwrite.c' line='258' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzwrite.c' line='256' column='1'/>
+      <parameter type-id='type-id-102' name='buf' filepath='src.d/gzwrite.c' line='257' column='1'/>
+      <parameter type-id='type-id-9' name='len' filepath='src.d/gzwrite.c' line='258' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzfwrite' mangled-name='gzfwrite' filepath='src.d/gzwrite.c' line='283' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzfwrite@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-101' name='buf' filepath='src.d/gzwrite.c' line='284' column='1'/>
-      <parameter type-id='type-id-7' name='size' filepath='src.d/gzwrite.c' line='285' column='1'/>
-      <parameter type-id='type-id-7' name='nitems' filepath='src.d/gzwrite.c' line='286' column='1'/>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='287' column='1'/>
-      <return type-id='type-id-7'/>
+      <parameter type-id='type-id-102' name='buf' filepath='src.d/gzwrite.c' line='284' column='1'/>
+      <parameter type-id='type-id-14' name='size' filepath='src.d/gzwrite.c' line='285' column='1'/>
+      <parameter type-id='type-id-14' name='nitems' filepath='src.d/gzwrite.c' line='286' column='1'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzwrite.c' line='287' column='1'/>
+      <return type-id='type-id-14'/>
     </function-decl>
     <function-decl name='gzputc' mangled-name='gzputc' filepath='src.d/gzwrite.c' line='313' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzputc'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='314' column='1'/>
-      <parameter type-id='type-id-22' name='c' filepath='src.d/gzwrite.c' line='315' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzwrite.c' line='314' column='1'/>
+      <parameter type-id='type-id-20' name='c' filepath='src.d/gzwrite.c' line='315' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzputs' mangled-name='gzputs' filepath='src.d/gzwrite.c' line='361' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzputs'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='362' column='1'/>
-      <parameter type-id='type-id-80' name='s' filepath='src.d/gzwrite.c' line='363' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzwrite.c' line='362' column='1'/>
+      <parameter type-id='type-id-22' name='s' filepath='src.d/gzwrite.c' line='363' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzvprintf' mangled-name='gzvprintf' filepath='src.d/gzwrite.c' line='391' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzvprintf@@ZLIB_1.2.7.1'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='391' column='1'/>
-      <parameter type-id='type-id-80' name='format' filepath='src.d/gzwrite.c' line='391' column='1'/>
-      <parameter type-id='type-id-103' name='va' filepath='src.d/gzwrite.c' line='391' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzwrite.c' line='391' column='1'/>
+      <parameter type-id='type-id-22' name='format' filepath='src.d/gzwrite.c' line='391' column='1'/>
+      <parameter type-id='type-id-101' name='va' filepath='src.d/gzwrite.c' line='391' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzprintf' mangled-name='gzprintf' filepath='src.d/gzwrite.c' line='463' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzprintf'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='463' column='1'/>
-      <parameter type-id='type-id-80' name='format' filepath='src.d/gzwrite.c' line='463' column='1'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzwrite.c' line='463' column='1'/>
+      <parameter type-id='type-id-22' name='format' filepath='src.d/gzwrite.c' line='463' column='1'/>
       <parameter is-variadic='yes'/>
-      <return type-id='type-id-22'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzflush' mangled-name='gzflush' filepath='src.d/gzwrite.c' line='565' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzflush'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='566' column='1'/>
-      <parameter type-id='type-id-22' name='flush' filepath='src.d/gzwrite.c' line='567' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzwrite.c' line='566' column='1'/>
+      <parameter type-id='type-id-20' name='flush' filepath='src.d/gzwrite.c' line='567' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzsetparams' mangled-name='gzsetparams' filepath='src.d/gzwrite.c' line='597' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzsetparams'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='598' column='1'/>
-      <parameter type-id='type-id-22' name='level' filepath='src.d/gzwrite.c' line='599' column='1'/>
-      <parameter type-id='type-id-22' name='strategy' filepath='src.d/gzwrite.c' line='600' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzwrite.c' line='598' column='1'/>
+      <parameter type-id='type-id-20' name='level' filepath='src.d/gzwrite.c' line='599' column='1'/>
+      <parameter type-id='type-id-20' name='strategy' filepath='src.d/gzwrite.c' line='600' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/infback.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-104'/>
-    <class-decl name='code' size-in-bits='32' is-struct='yes' naming-typedef-id='type-id-105' visibility='default' filepath='src.d/inftrees.h' line='24' column='1' id='type-id-106'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-3' visibility='default' filepath='src.d/inftrees.h' line='25' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='8'>
-        <var-decl name='bits' type-id='type-id-3' visibility='default' filepath='src.d/inftrees.h' line='26' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='16'>
-        <var-decl name='val' type-id='type-id-40' visibility='default' filepath='src.d/inftrees.h' line='27' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='code' type-id='type-id-106' filepath='src.d/inftrees.h' line='28' column='1' id='type-id-105'/>
-    <enum-decl name='codetype' naming-typedef-id='type-id-107' filepath='src.d/inftrees.h' line='54' column='1' id='type-id-108'>
-      <underlying-type type-id='type-id-104'/>
+    <enum-decl name='codetype' naming-typedef-id='type-id-103' filepath='src.d/inftrees.h' line='54' column='1' id='type-id-104'>
+      <underlying-type type-id='type-id-105'/>
       <enumerator name='CODES' value='0'/>
       <enumerator name='LENS' value='1'/>
       <enumerator name='DISTS' value='2'/>
     </enum-decl>
-    <typedef-decl name='codetype' type-id='type-id-108' filepath='src.d/inftrees.h' line='58' column='1' id='type-id-107'/>
-    <typedef-decl name='in_func' type-id='type-id-109' filepath='src.d/zlib.h' line='1094' column='1' id='type-id-110'/>
-    <typedef-decl name='out_func' type-id='type-id-111' filepath='src.d/zlib.h' line='1096' column='1' id='type-id-112'/>
-    <pointer-type-def type-id='type-id-105' size-in-bits='32' id='type-id-113'/>
-    <pointer-type-def type-id='type-id-113' size-in-bits='32' id='type-id-114'/>
-    <pointer-type-def type-id='type-id-115' size-in-bits='32' id='type-id-111'/>
-    <pointer-type-def type-id='type-id-3' size-in-bits='32' id='type-id-91'/>
-    <pointer-type-def type-id='type-id-91' size-in-bits='32' id='type-id-116'/>
-    <pointer-type-def type-id='type-id-117' size-in-bits='32' id='type-id-109'/>
-    <pointer-type-def type-id='type-id-40' size-in-bits='32' id='type-id-118'/>
+    <class-decl name='code' size-in-bits='32' is-struct='yes' naming-typedef-id='type-id-106' visibility='default' filepath='src.d/inftrees.h' line='24' column='1' id='type-id-107'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-2' visibility='default' filepath='src.d/inftrees.h' line='25' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8'>
+        <var-decl name='bits' type-id='type-id-2' visibility='default' filepath='src.d/inftrees.h' line='26' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='val' type-id='type-id-70' visibility='default' filepath='src.d/inftrees.h' line='27' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='code' type-id='type-id-107' filepath='src.d/inftrees.h' line='28' column='1' id='type-id-106'/>
+    <typedef-decl name='codetype' type-id='type-id-104' filepath='src.d/inftrees.h' line='58' column='1' id='type-id-103'/>
+    <typedef-decl name='in_func' type-id='type-id-108' filepath='src.d/zlib.h' line='1094' column='1' id='type-id-109'/>
+    <typedef-decl name='out_func' type-id='type-id-110' filepath='src.d/zlib.h' line='1096' column='1' id='type-id-111'/>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-105'/>
+    <pointer-type-def type-id='type-id-106' size-in-bits='32' id='type-id-112'/>
+    <pointer-type-def type-id='type-id-112' size-in-bits='32' id='type-id-113'/>
+    <pointer-type-def type-id='type-id-114' size-in-bits='32' id='type-id-110'/>
+    <pointer-type-def type-id='type-id-2' size-in-bits='32' id='type-id-88'/>
+    <pointer-type-def type-id='type-id-88' size-in-bits='32' id='type-id-115'/>
+    <pointer-type-def type-id='type-id-116' size-in-bits='32' id='type-id-108'/>
+    <pointer-type-def type-id='type-id-70' size-in-bits='32' id='type-id-117'/>
+    <typedef-decl name='voidpf' type-id='type-id-85' filepath='./zconf.h' line='415' column='1' id='type-id-118'/>
     <function-decl name='inflateBackInit_' mangled-name='inflateBackInit_' filepath='src.d/infback.c' line='28' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateBackInit_@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/infback.c' line='29' column='1'/>
-      <parameter type-id='type-id-22' name='windowBits' filepath='src.d/infback.c' line='30' column='1'/>
-      <parameter type-id='type-id-91' name='window' filepath='src.d/infback.c' line='31' column='1'/>
-      <parameter type-id='type-id-80' name='version' filepath='src.d/infback.c' line='32' column='1'/>
-      <parameter type-id='type-id-22' name='stream_size' filepath='src.d/infback.c' line='33' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/infback.c' line='29' column='1'/>
+      <parameter type-id='type-id-20' name='windowBits' filepath='src.d/infback.c' line='30' column='1'/>
+      <parameter type-id='type-id-88' name='window' filepath='src.d/infback.c' line='31' column='1'/>
+      <parameter type-id='type-id-22' name='version' filepath='src.d/infback.c' line='32' column='1'/>
+      <parameter type-id='type-id-20' name='stream_size' filepath='src.d/infback.c' line='33' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateBack' mangled-name='inflateBack' filepath='src.d/infback.c' line='251' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateBack@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/infback.c' line='252' column='1'/>
-      <parameter type-id='type-id-110' name='in' filepath='src.d/infback.c' line='253' column='1'/>
-      <parameter type-id='type-id-46' name='in_desc' filepath='src.d/infback.c' line='254' column='1'/>
-      <parameter type-id='type-id-112' name='out' filepath='src.d/infback.c' line='255' column='1'/>
-      <parameter type-id='type-id-46' name='out_desc' filepath='src.d/infback.c' line='256' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/infback.c' line='252' column='1'/>
+      <parameter type-id='type-id-109' name='in' filepath='src.d/infback.c' line='253' column='1'/>
+      <parameter type-id='type-id-85' name='in_desc' filepath='src.d/infback.c' line='254' column='1'/>
+      <parameter type-id='type-id-111' name='out' filepath='src.d/infback.c' line='255' column='1'/>
+      <parameter type-id='type-id-85' name='out_desc' filepath='src.d/infback.c' line='256' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateBackEnd' mangled-name='inflateBackEnd' filepath='src.d/infback.c' line='635' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateBackEnd@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/infback.c' line='636' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/infback.c' line='636' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflate_fast' filepath='src.d/inffast.h' line='11' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-59'/>
-      <parameter type-id='type-id-4'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-9'/>
+      <return type-id='type-id-86'/>
     </function-decl>
     <function-decl name='inflate_table' filepath='src.d/inftrees.h' line='60' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-107'/>
-      <parameter type-id='type-id-118'/>
-      <parameter type-id='type-id-4'/>
-      <parameter type-id='type-id-114'/>
-      <parameter type-id='type-id-86'/>
-      <parameter type-id='type-id-118'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-103'/>
+      <parameter type-id='type-id-117'/>
+      <parameter type-id='type-id-9'/>
+      <parameter type-id='type-id-113'/>
+      <parameter type-id='type-id-80'/>
+      <parameter type-id='type-id-117'/>
+      <return type-id='type-id-20'/>
     </function-decl>
-    <function-type size-in-bits='32' id='type-id-115'>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-4'/>
-      <return type-id='type-id-22'/>
+    <function-type size-in-bits='32' id='type-id-114'>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-88'/>
+      <parameter type-id='type-id-9'/>
+      <return type-id='type-id-20'/>
     </function-type>
-    <function-type size-in-bits='32' id='type-id-117'>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-116'/>
-      <return type-id='type-id-4'/>
+    <function-type size-in-bits='32' id='type-id-116'>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-115'/>
+      <return type-id='type-id-9'/>
     </function-type>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/inflate.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
+    <typedef-decl name='voidpf' type-id='type-id-85' filepath='./zconf.h' line='415' column='1' id='type-id-119'/>
     <function-decl name='inflateResetKeep' mangled-name='inflateResetKeep' filepath='src.d/inflate.c' line='119' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateResetKeep@@ZLIB_1.2.5.2'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='120' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='inflateReset' mangled-name='inflateReset' filepath='src.d/inflate.c' line='145' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateReset'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='146' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='120' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateReset2' mangled-name='inflateReset2' filepath='src.d/inflate.c' line='158' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateReset2@@ZLIB_1.2.3.4'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='159' column='1'/>
-      <parameter type-id='type-id-22' name='windowBits' filepath='src.d/inflate.c' line='160' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='inflateInit2_' mangled-name='inflateInit2_' filepath='src.d/inflate.c' line='198' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateInit2_'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='199' column='1'/>
-      <parameter type-id='type-id-22' name='windowBits' filepath='src.d/inflate.c' line='200' column='1'/>
-      <parameter type-id='type-id-80' name='version' filepath='src.d/inflate.c' line='201' column='1'/>
-      <parameter type-id='type-id-22' name='stream_size' filepath='src.d/inflate.c' line='202' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='159' column='1'/>
+      <parameter type-id='type-id-20' name='windowBits' filepath='src.d/inflate.c' line='160' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateInit_' mangled-name='inflateInit_' filepath='src.d/inflate.c' line='242' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateInit_'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='243' column='1'/>
-      <parameter type-id='type-id-80' name='version' filepath='src.d/inflate.c' line='244' column='1'/>
-      <parameter type-id='type-id-22' name='stream_size' filepath='src.d/inflate.c' line='245' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='243' column='1'/>
+      <parameter type-id='type-id-22' name='version' filepath='src.d/inflate.c' line='244' column='1'/>
+      <parameter type-id='type-id-20' name='stream_size' filepath='src.d/inflate.c' line='245' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflatePrime' mangled-name='inflatePrime' filepath='src.d/inflate.c' line='250' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflatePrime@@ZLIB_1.2.2.4'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='251' column='1'/>
-      <parameter type-id='type-id-22' name='bits' filepath='src.d/inflate.c' line='252' column='1'/>
-      <parameter type-id='type-id-22' name='value' filepath='src.d/inflate.c' line='253' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='inflate' mangled-name='inflate' filepath='src.d/inflate.c' line='625' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflate'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='626' column='1'/>
-      <parameter type-id='type-id-22' name='flush' filepath='src.d/inflate.c' line='627' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='inflateEnd' mangled-name='inflateEnd' filepath='src.d/inflate.c' line='1304' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateEnd'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1305' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='251' column='1'/>
+      <parameter type-id='type-id-20' name='bits' filepath='src.d/inflate.c' line='252' column='1'/>
+      <parameter type-id='type-id-20' name='value' filepath='src.d/inflate.c' line='253' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateGetDictionary' mangled-name='inflateGetDictionary' filepath='src.d/inflate.c' line='1318' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateGetDictionary@@ZLIB_1.2.7.1'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1319' column='1'/>
-      <parameter type-id='type-id-21' name='dictionary' filepath='src.d/inflate.c' line='1320' column='1'/>
-      <parameter type-id='type-id-85' name='dictLength' filepath='src.d/inflate.c' line='1321' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1319' column='1'/>
+      <parameter type-id='type-id-19' name='dictionary' filepath='src.d/inflate.c' line='1320' column='1'/>
+      <parameter type-id='type-id-79' name='dictLength' filepath='src.d/inflate.c' line='1321' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateSetDictionary' mangled-name='inflateSetDictionary' filepath='src.d/inflate.c' line='1341' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateSetDictionary'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1342' column='1'/>
-      <parameter type-id='type-id-18' name='dictionary' filepath='src.d/inflate.c' line='1343' column='1'/>
-      <parameter type-id='type-id-9' name='dictLength' filepath='src.d/inflate.c' line='1344' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1342' column='1'/>
+      <parameter type-id='type-id-16' name='dictionary' filepath='src.d/inflate.c' line='1343' column='1'/>
+      <parameter type-id='type-id-11' name='dictLength' filepath='src.d/inflate.c' line='1344' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateGetHeader' mangled-name='inflateGetHeader' filepath='src.d/inflate.c' line='1376' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateGetHeader@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1377' column='1'/>
-      <parameter type-id='type-id-61' name='head' filepath='src.d/inflate.c' line='1378' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1377' column='1'/>
+      <parameter type-id='type-id-43' name='head' filepath='src.d/inflate.c' line='1378' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateSync' mangled-name='inflateSync' filepath='src.d/inflate.c' line='1427' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateSync'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1428' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1428' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateSyncPoint' mangled-name='inflateSyncPoint' filepath='src.d/inflate.c' line='1485' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateSyncPoint'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1486' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1486' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateCopy' mangled-name='inflateCopy' filepath='src.d/inflate.c' line='1495' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateCopy@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-59' name='dest' filepath='src.d/inflate.c' line='1496' column='1'/>
-      <parameter type-id='type-id-59' name='source' filepath='src.d/inflate.c' line='1497' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='dest' filepath='src.d/inflate.c' line='1496' column='1'/>
+      <parameter type-id='type-id-21' name='source' filepath='src.d/inflate.c' line='1497' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateUndermine' mangled-name='inflateUndermine' filepath='src.d/inflate.c' line='1542' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateUndermine@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1543' column='1'/>
-      <parameter type-id='type-id-22' name='subvert' filepath='src.d/inflate.c' line='1544' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1543' column='1'/>
+      <parameter type-id='type-id-20' name='subvert' filepath='src.d/inflate.c' line='1544' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateValidate' mangled-name='inflateValidate' filepath='src.d/inflate.c' line='1560' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateValidate@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1561' column='1'/>
-      <parameter type-id='type-id-22' name='check' filepath='src.d/inflate.c' line='1562' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1561' column='1'/>
+      <parameter type-id='type-id-20' name='check' filepath='src.d/inflate.c' line='1562' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateMark' mangled-name='inflateMark' filepath='src.d/inflate.c' line='1575' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateMark@@ZLIB_1.2.3.4'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1576' column='1'/>
-      <return type-id='type-id-1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1576' column='1'/>
+      <return type-id='type-id-37'/>
     </function-decl>
     <function-decl name='inflateCodesUsed' mangled-name='inflateCodesUsed' filepath='src.d/inflate.c' line='1588' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateCodesUsed@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1589' column='1'/>
-      <return type-id='type-id-5'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1589' column='1'/>
+      <return type-id='type-id-12'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/trees.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <array-type-def dimensions='1' type-id='type-id-119' size-in-bits='2048' id='type-id-120'>
-      <subrange length='256' type-id='type-id-4' id='type-id-121'/>
+    <array-type-def dimensions='1' type-id='type-id-120' size-in-bits='2048' id='type-id-121'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-9' id='type-id-122'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-119' size-in-bits='4096' id='type-id-122'>
-      <subrange length='512' type-id='type-id-4' id='type-id-123'/>
+    <array-type-def dimensions='1' type-id='type-id-120' size-in-bits='4096' id='type-id-123'>
+      <subrange length='512' lower-bound='0' upper-bound='511' type-id='type-id-9' id='type-id-124'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-119' size-in-bits='infinite' id='type-id-124'>
-      <subrange length='infinite' id='type-id-125'/>
+    <array-type-def dimensions='1' type-id='type-id-120' size-in-bits='unknown' id='type-id-125'>
+      <subrange length='unknown' lower-bound='0' upper-bound='0' id='type-id-126'/>
     </array-type-def>
-    <qualified-type-def type-id='type-id-38' const='yes' id='type-id-119'/>
-    <var-decl name='_length_code' type-id='type-id-124' visibility='default' filepath='src.d/deflate.h' line='317' column='1'/>
-    <var-decl name='_dist_code' type-id='type-id-124' visibility='default' filepath='src.d/deflate.h' line='318' column='1'/>
+    <qualified-type-def type-id='type-id-68' const='yes' id='type-id-120'/>
+    <var-decl name='_length_code' type-id='type-id-121' visibility='default' filepath='src.d/deflate.h' line='317' column='1'/>
+    <var-decl name='_dist_code' type-id='type-id-123' visibility='default' filepath='src.d/deflate.h' line='318' column='1'/>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/uncompr.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <pointer-type-def type-id='type-id-10' size-in-bits='32' id='type-id-126'/>
+    <pointer-type-def type-id='type-id-13' size-in-bits='32' id='type-id-127'/>
     <function-decl name='uncompress2' mangled-name='uncompress2' filepath='src.d/uncompr.c' line='27' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='uncompress2@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-21' name='dest' filepath='src.d/uncompr.c' line='28' column='1'/>
-      <parameter type-id='type-id-20' name='destLen' filepath='src.d/uncompr.c' line='29' column='1'/>
-      <parameter type-id='type-id-18' name='source' filepath='src.d/uncompr.c' line='30' column='1'/>
-      <parameter type-id='type-id-126' name='sourceLen' filepath='src.d/uncompr.c' line='31' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-19' name='dest' filepath='src.d/uncompr.c' line='28' column='1'/>
+      <parameter type-id='type-id-18' name='destLen' filepath='src.d/uncompr.c' line='29' column='1'/>
+      <parameter type-id='type-id-16' name='source' filepath='src.d/uncompr.c' line='30' column='1'/>
+      <parameter type-id='type-id-127' name='sourceLen' filepath='src.d/uncompr.c' line='31' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='uncompress' mangled-name='uncompress' filepath='src.d/uncompr.c' line='86' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='uncompress'>
-      <parameter type-id='type-id-21' name='dest' filepath='src.d/uncompr.c' line='87' column='1'/>
-      <parameter type-id='type-id-20' name='destLen' filepath='src.d/uncompr.c' line='88' column='1'/>
-      <parameter type-id='type-id-18' name='source' filepath='src.d/uncompr.c' line='89' column='1'/>
-      <parameter type-id='type-id-10' name='sourceLen' filepath='src.d/uncompr.c' line='90' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-19' name='dest' filepath='src.d/uncompr.c' line='87' column='1'/>
+      <parameter type-id='type-id-18' name='destLen' filepath='src.d/uncompr.c' line='88' column='1'/>
+      <parameter type-id='type-id-16' name='source' filepath='src.d/uncompr.c' line='89' column='1'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/uncompr.c' line='90' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/zutil.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <array-type-def dimensions='1' type-id='type-id-127' size-in-bits='320' id='type-id-128'>
-      <subrange length='10' type-id='type-id-4' id='type-id-129'/>
+    <array-type-def dimensions='1' type-id='type-id-128' size-in-bits='320' id='type-id-129'>
+      <subrange length='10' lower-bound='0' upper-bound='9' type-id='type-id-9' id='type-id-130'/>
     </array-type-def>
-    <qualified-type-def type-id='type-id-70' const='yes' id='type-id-127'/>
-    <function-decl name='malloc' filepath='/usr/arm-linux-gnueabi/include/stdlib.h' line='540' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-46'/>
-    </function-decl>
-    <function-decl name='free' filepath='/usr/arm-linux-gnueabi/include/stdlib.h' line='555' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-46'/>
-      <return type-id='type-id-44'/>
-    </function-decl>
+    <qualified-type-def type-id='type-id-54' const='yes' id='type-id-128'/>
     <function-decl name='zlibVersion' mangled-name='zlibVersion' filepath='src.d/zutil.c' line='27' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='zlibVersion'>
-      <return type-id='type-id-80'/>
+      <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='zlibCompileFlags' mangled-name='zlibCompileFlags' filepath='src.d/zutil.c' line='32' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='zlibCompileFlags@@ZLIB_1.2.0.2'>
-      <return type-id='type-id-10'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='zError' mangled-name='zError' filepath='src.d/zutil.c' line='135' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='zError'>
-      <parameter type-id='type-id-22' name='err' filepath='src.d/zutil.c' line='136' column='1'/>
-      <return type-id='type-id-80'/>
+      <parameter type-id='type-id-20' name='err' filepath='src.d/zutil.c' line='136' column='1'/>
+      <return type-id='type-id-22'/>
     </function-decl>
-    <var-decl name='z_errmsg' type-id='type-id-128' visibility='default' filepath='src.d/zutil.h' line='56' column='1'/>
+    <var-decl name='z_errmsg' type-id='type-id-129' visibility='default' filepath='src.d/zutil.h' line='56' column='1'/>
   </abi-instr>
 </abi-corpus>

--- a/test/abi/zlib-04f42ceca40f73e2978b50e93806c2a18c1281fc-arm-unknown-linux-gnueabihf.abi
+++ b/test/abi/zlib-04f42ceca40f73e2978b50e93806c2a18c1281fc-arm-unknown-linux-gnueabihf.abi
@@ -1,4 +1,4 @@
-<abi-corpus version='2.0' path='btmp1/libz.so.1.2.13' architecture='elf-arm' soname='libz.so.1'>
+<abi-corpus version='2.2' path='btmp1/libz.so.1.2.13' architecture='elf-arm' soname='libz.so.1'>
   <elf-needed>
     <dependency name='libc.so.6'/>
     <dependency name='ld-linux-armhf.so.3'/>
@@ -94,75 +94,89 @@
     <elf-symbol name='zlibVersion' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
   </elf-function-symbols>
   <abi-instr address-size='32' path='src.d/adler32.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <type-decl name='long int' size-in-bits='32' id='type-id-1'/>
-    <type-decl name='long long int' size-in-bits='64' id='type-id-2'/>
-    <type-decl name='unsigned char' size-in-bits='8' id='type-id-3'/>
-    <type-decl name='unsigned int' size-in-bits='32' id='type-id-4'/>
-    <type-decl name='unsigned long int' size-in-bits='32' id='type-id-5'/>
-    <typedef-decl name='z_size_t' type-id='type-id-6' filepath='./zconf.h' line='251' column='1' id='type-id-7'/>
-    <typedef-decl name='Byte' type-id='type-id-3' filepath='./zconf.h' line='397' column='1' id='type-id-8'/>
-    <typedef-decl name='uInt' type-id='type-id-4' filepath='./zconf.h' line='399' column='1' id='type-id-9'/>
-    <typedef-decl name='uLong' type-id='type-id-5' filepath='./zconf.h' line='400' column='1' id='type-id-10'/>
-    <typedef-decl name='Bytef' type-id='type-id-8' filepath='./zconf.h' line='406' column='1' id='type-id-11'/>
-    <typedef-decl name='__int64_t' type-id='type-id-2' filepath='/usr/arm-linux-gnueabihf/include/bits/types.h' line='47' column='1' id='type-id-12'/>
-    <typedef-decl name='__off_t' type-id='type-id-1' filepath='/usr/arm-linux-gnueabihf/include/bits/types.h' line='152' column='1' id='type-id-13'/>
-    <typedef-decl name='__off64_t' type-id='type-id-12' filepath='/usr/arm-linux-gnueabihf/include/bits/types.h' line='153' column='1' id='type-id-14'/>
-    <typedef-decl name='off_t' type-id='type-id-13' filepath='/usr/arm-linux-gnueabihf/include/sys/types.h' line='85' column='1' id='type-id-15'/>
-    <typedef-decl name='off64_t' type-id='type-id-14' filepath='/usr/arm-linux-gnueabihf/include/sys/types.h' line='92' column='1' id='type-id-16'/>
-    <typedef-decl name='size_t' type-id='type-id-4' filepath='/usr/lib/gcc-cross/arm-linux-gnueabihf/11/include/stddef.h' line='209' column='1' id='type-id-6'/>
-    <qualified-type-def type-id='type-id-11' const='yes' id='type-id-17'/>
-    <pointer-type-def type-id='type-id-17' size-in-bits='32' id='type-id-18'/>
+    <type-decl name='long long int' size-in-bits='64' id='type-id-1'/>
+    <typedef-decl name='Byte' type-id='type-id-2' filepath='./zconf.h' line='397' column='1' id='type-id-3'/>
+    <typedef-decl name='Bytef' type-id='type-id-3' filepath='./zconf.h' line='406' column='1' id='type-id-4'/>
+    <typedef-decl name='__int64_t' type-id='type-id-1' filepath='/usr/arm-linux-gnueabihf/include/bits/types.h' line='47' column='1' id='type-id-5'/>
+    <typedef-decl name='__off64_t' type-id='type-id-5' filepath='/usr/arm-linux-gnueabihf/include/bits/types.h' line='153' column='1' id='type-id-6'/>
+    <typedef-decl name='off64_t' type-id='type-id-6' filepath='/usr/arm-linux-gnueabihf/include/sys/types.h' line='92' column='1' id='type-id-7'/>
+    <typedef-decl name='off_t' type-id='type-id-6' filepath='/usr/arm-linux-gnueabihf/include/sys/types.h' line='87' column='1' id='type-id-8'/>
+    <typedef-decl name='size_t' type-id='type-id-9' filepath='/usr/lib/gcc-cross/arm-linux-gnueabihf/13/include/stddef.h' line='214' column='1' id='type-id-10'/>
+    <typedef-decl name='uInt' type-id='type-id-9' filepath='./zconf.h' line='399' column='1' id='type-id-11'/>
+    <typedef-decl name='uLong' type-id='type-id-12' filepath='./zconf.h' line='400' column='1' id='type-id-13'/>
+    <typedef-decl name='z_size_t' type-id='type-id-10' filepath='./zconf.h' line='251' column='1' id='type-id-14'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-2'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-9'/>
+    <type-decl name='unsigned long int' size-in-bits='32' id='type-id-12'/>
+    <qualified-type-def type-id='type-id-4' const='yes' id='type-id-15'/>
+    <pointer-type-def type-id='type-id-15' size-in-bits='32' id='type-id-16'/>
     <function-decl name='adler32_z' mangled-name='adler32_z' filepath='src.d/adler32.c' line='63' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='adler32_z@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-10' name='adler' filepath='src.d/adler32.c' line='64' column='1'/>
-      <parameter type-id='type-id-18' name='buf' filepath='src.d/adler32.c' line='65' column='1'/>
-      <parameter type-id='type-id-7' name='len' filepath='src.d/adler32.c' line='66' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-13' name='adler' filepath='src.d/adler32.c' line='64' column='1'/>
+      <parameter type-id='type-id-16' name='buf' filepath='src.d/adler32.c' line='65' column='1'/>
+      <parameter type-id='type-id-14' name='len' filepath='src.d/adler32.c' line='66' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='adler32' mangled-name='adler32' filepath='src.d/adler32.c' line='134' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='adler32'>
-      <parameter type-id='type-id-10' name='adler' filepath='src.d/adler32.c' line='135' column='1'/>
-      <parameter type-id='type-id-18' name='buf' filepath='src.d/adler32.c' line='136' column='1'/>
-      <parameter type-id='type-id-9' name='len' filepath='src.d/adler32.c' line='137' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-13' name='adler' filepath='src.d/adler32.c' line='135' column='1'/>
+      <parameter type-id='type-id-16' name='buf' filepath='src.d/adler32.c' line='136' column='1'/>
+      <parameter type-id='type-id-11' name='len' filepath='src.d/adler32.c' line='137' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='adler32_combine' mangled-name='adler32_combine' filepath='src.d/adler32.c' line='172' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='adler32_combine@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-10' name='adler1' filepath='src.d/adler32.c' line='173' column='1'/>
-      <parameter type-id='type-id-10' name='adler2' filepath='src.d/adler32.c' line='174' column='1'/>
-      <parameter type-id='type-id-15' name='len2' filepath='src.d/adler32.c' line='175' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-13' name='adler1' filepath='src.d/adler32.c' line='173' column='1'/>
+      <parameter type-id='type-id-13' name='adler2' filepath='src.d/adler32.c' line='174' column='1'/>
+      <parameter type-id='type-id-8' name='len2' filepath='src.d/adler32.c' line='175' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='adler32_combine64' mangled-name='adler32_combine64' filepath='src.d/adler32.c' line='180' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='adler32_combine64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-10' name='adler1' filepath='src.d/adler32.c' line='181' column='1'/>
-      <parameter type-id='type-id-10' name='adler2' filepath='src.d/adler32.c' line='182' column='1'/>
-      <parameter type-id='type-id-16' name='len2' filepath='src.d/adler32.c' line='183' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-13' name='adler1' filepath='src.d/adler32.c' line='181' column='1'/>
+      <parameter type-id='type-id-13' name='adler2' filepath='src.d/adler32.c' line='182' column='1'/>
+      <parameter type-id='type-id-7' name='len2' filepath='src.d/adler32.c' line='183' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/compress.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <typedef-decl name='uLongf' type-id='type-id-10' filepath='./zconf.h' line='411' column='1' id='type-id-19'/>
-    <pointer-type-def type-id='type-id-19' size-in-bits='32' id='type-id-20'/>
+    <typedef-decl name='uLongf' type-id='type-id-13' filepath='./zconf.h' line='411' column='1' id='type-id-17'/>
+    <pointer-type-def type-id='type-id-17' size-in-bits='32' id='type-id-18'/>
     <function-decl name='compress2' mangled-name='compress2' filepath='src.d/compress.c' line='22' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='compress2'>
-      <parameter type-id='type-id-21' name='dest' filepath='src.d/compress.c' line='23' column='1'/>
-      <parameter type-id='type-id-20' name='destLen' filepath='src.d/compress.c' line='24' column='1'/>
-      <parameter type-id='type-id-18' name='source' filepath='src.d/compress.c' line='25' column='1'/>
-      <parameter type-id='type-id-10' name='sourceLen' filepath='src.d/compress.c' line='26' column='1'/>
-      <parameter type-id='type-id-22' name='level' filepath='src.d/compress.c' line='27' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-19' name='dest' filepath='src.d/compress.c' line='23' column='1'/>
+      <parameter type-id='type-id-18' name='destLen' filepath='src.d/compress.c' line='24' column='1'/>
+      <parameter type-id='type-id-16' name='source' filepath='src.d/compress.c' line='25' column='1'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/compress.c' line='26' column='1'/>
+      <parameter type-id='type-id-20' name='level' filepath='src.d/compress.c' line='27' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='compress' mangled-name='compress' filepath='src.d/compress.c' line='68' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='compress'>
-      <parameter type-id='type-id-21' name='dest' filepath='src.d/compress.c' line='69' column='1'/>
-      <parameter type-id='type-id-20' name='destLen' filepath='src.d/compress.c' line='70' column='1'/>
-      <parameter type-id='type-id-18' name='source' filepath='src.d/compress.c' line='71' column='1'/>
-      <parameter type-id='type-id-10' name='sourceLen' filepath='src.d/compress.c' line='72' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-19' name='dest' filepath='src.d/compress.c' line='69' column='1'/>
+      <parameter type-id='type-id-18' name='destLen' filepath='src.d/compress.c' line='70' column='1'/>
+      <parameter type-id='type-id-16' name='source' filepath='src.d/compress.c' line='71' column='1'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/compress.c' line='72' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='compressBound' mangled-name='compressBound' filepath='src.d/compress.c' line='81' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='compressBound@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-10' name='sourceLen' filepath='src.d/compress.c' line='82' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/compress.c' line='82' column='1'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+    <function-decl name='deflate' filepath='src.d/zlib.h' line='250' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='deflateEnd' filepath='src.d/zlib.h' line='363' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-21'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='deflateInit_' filepath='src.d/zlib.h' line='1781' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/crc32.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <typedef-decl name='z_crc_t' type-id='type-id-4' filepath='./zconf.h' line='435' column='1' id='type-id-23'/>
-    <qualified-type-def type-id='type-id-3' const='yes' id='type-id-24'/>
+    <typedef-decl name='z_crc_t' type-id='type-id-9' filepath='./zconf.h' line='435' column='1' id='type-id-23'/>
+    <qualified-type-def type-id='type-id-2' const='yes' id='type-id-24'/>
     <pointer-type-def type-id='type-id-24' size-in-bits='32' id='type-id-25'/>
     <qualified-type-def type-id='type-id-23' const='yes' id='type-id-26'/>
     <pointer-type-def type-id='type-id-26' size-in-bits='32' id='type-id-27'/>
@@ -170,1107 +184,1093 @@
       <return type-id='type-id-27'/>
     </function-decl>
     <function-decl name='crc32_z' mangled-name='crc32_z' filepath='src.d/crc32.c' line='748' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='crc32_z@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-5' name='crc' filepath='src.d/crc32.c' line='749' column='1'/>
+      <parameter type-id='type-id-12' name='crc' filepath='src.d/crc32.c' line='749' column='1'/>
       <parameter type-id='type-id-25' name='buf' filepath='src.d/crc32.c' line='750' column='1'/>
-      <parameter type-id='type-id-7' name='len' filepath='src.d/crc32.c' line='751' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-14' name='len' filepath='src.d/crc32.c' line='751' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32' mangled-name='crc32' filepath='src.d/crc32.c' line='1072' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='crc32'>
-      <parameter type-id='type-id-5' name='crc' filepath='src.d/crc32.c' line='1073' column='1'/>
+      <parameter type-id='type-id-12' name='crc' filepath='src.d/crc32.c' line='1073' column='1'/>
       <parameter type-id='type-id-25' name='buf' filepath='src.d/crc32.c' line='1074' column='1'/>
-      <parameter type-id='type-id-9' name='len' filepath='src.d/crc32.c' line='1075' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-11' name='len' filepath='src.d/crc32.c' line='1075' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine64' mangled-name='crc32_combine64' filepath='src.d/crc32.c' line='1081' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='crc32_combine64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-10' name='crc1' filepath='src.d/crc32.c' line='1082' column='1'/>
-      <parameter type-id='type-id-10' name='crc2' filepath='src.d/crc32.c' line='1083' column='1'/>
-      <parameter type-id='type-id-16' name='len2' filepath='src.d/crc32.c' line='1084' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-13' name='crc1' filepath='src.d/crc32.c' line='1082' column='1'/>
+      <parameter type-id='type-id-13' name='crc2' filepath='src.d/crc32.c' line='1083' column='1'/>
+      <parameter type-id='type-id-7' name='len2' filepath='src.d/crc32.c' line='1084' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine' mangled-name='crc32_combine' filepath='src.d/crc32.c' line='1093' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='crc32_combine@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-10' name='crc1' filepath='src.d/crc32.c' line='1094' column='1'/>
-      <parameter type-id='type-id-10' name='crc2' filepath='src.d/crc32.c' line='1095' column='1'/>
-      <parameter type-id='type-id-15' name='len2' filepath='src.d/crc32.c' line='1096' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-13' name='crc1' filepath='src.d/crc32.c' line='1094' column='1'/>
+      <parameter type-id='type-id-13' name='crc2' filepath='src.d/crc32.c' line='1095' column='1'/>
+      <parameter type-id='type-id-8' name='len2' filepath='src.d/crc32.c' line='1096' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine_gen64' mangled-name='crc32_combine_gen64' filepath='src.d/crc32.c' line='1102' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='crc32_combine_gen64@@ZLIB_1.2.12'>
-      <parameter type-id='type-id-16' name='len2' filepath='src.d/crc32.c' line='1103' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-7' name='len2' filepath='src.d/crc32.c' line='1103' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine_gen' mangled-name='crc32_combine_gen' filepath='src.d/crc32.c' line='1112' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='crc32_combine_gen@@ZLIB_1.2.12'>
-      <parameter type-id='type-id-15' name='len2' filepath='src.d/crc32.c' line='1113' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-8' name='len2' filepath='src.d/crc32.c' line='1113' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine_op' mangled-name='crc32_combine_op' filepath='src.d/crc32.c' line='1119' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='crc32_combine_op@@ZLIB_1.2.12'>
-      <parameter type-id='type-id-10' name='crc1' filepath='src.d/crc32.c' line='1120' column='1'/>
-      <parameter type-id='type-id-10' name='crc2' filepath='src.d/crc32.c' line='1121' column='1'/>
-      <parameter type-id='type-id-10' name='op' filepath='src.d/crc32.c' line='1122' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-13' name='crc1' filepath='src.d/crc32.c' line='1120' column='1'/>
+      <parameter type-id='type-id-13' name='crc2' filepath='src.d/crc32.c' line='1121' column='1'/>
+      <parameter type-id='type-id-13' name='op' filepath='src.d/crc32.c' line='1122' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/deflate.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
     <type-decl name='char' size-in-bits='8' id='type-id-28'/>
-    <class-decl name='static_tree_desc_s' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-29'/>
-    <array-type-def dimensions='1' type-id='type-id-30' size-in-bits='1248' id='type-id-31'>
-      <subrange length='39' type-id='type-id-4' id='type-id-32'/>
+    <array-type-def dimensions='1' type-id='type-id-29' size-in-bits='1248' id='type-id-30'>
+      <subrange length='39' lower-bound='0' upper-bound='38' type-id='type-id-9' id='type-id-31'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-30' size-in-bits='18336' id='type-id-33'>
-      <subrange length='573' type-id='type-id-4' id='type-id-34'/>
+    <array-type-def dimensions='1' type-id='type-id-29' size-in-bits='18336' id='type-id-32'>
+      <subrange length='573' lower-bound='0' upper-bound='572' type-id='type-id-9' id='type-id-33'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-30' size-in-bits='1952' id='type-id-35'>
-      <subrange length='61' type-id='type-id-4' id='type-id-36'/>
+    <array-type-def dimensions='1' type-id='type-id-29' size-in-bits='1952' id='type-id-34'>
+      <subrange length='61' lower-bound='0' upper-bound='60' type-id='type-id-9' id='type-id-35'/>
     </array-type-def>
-    <type-decl name='int' size-in-bits='32' id='type-id-22'/>
-    <array-type-def dimensions='1' type-id='type-id-22' size-in-bits='18336' id='type-id-37'>
-      <subrange length='573' type-id='type-id-4' id='type-id-34'/>
+    <type-decl name='int' size-in-bits='32' id='type-id-20'/>
+    <array-type-def dimensions='1' type-id='type-id-20' size-in-bits='18336' id='type-id-36'>
+      <subrange length='573' lower-bound='0' upper-bound='572' type-id='type-id-9' id='type-id-33'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-38' size-in-bits='4584' id='type-id-39'>
-      <subrange length='573' type-id='type-id-4' id='type-id-34'/>
-    </array-type-def>
-    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-40'/>
-    <array-type-def dimensions='1' type-id='type-id-41' size-in-bits='256' id='type-id-42'>
-      <subrange length='16' type-id='type-id-4' id='type-id-43'/>
-    </array-type-def>
-    <type-decl name='void' id='type-id-44'/>
-    <typedef-decl name='charf' type-id='type-id-28' filepath='./zconf.h' line='408' column='1' id='type-id-45'/>
-    <typedef-decl name='voidpf' type-id='type-id-46' filepath='./zconf.h' line='415' column='1' id='type-id-47'/>
-    <class-decl name='ct_data_s' size-in-bits='32' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='68' column='1' id='type-id-30'>
+    <type-decl name='long int' size-in-bits='32' id='type-id-37'/>
+    <class-decl name='ct_data_s' size-in-bits='32' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='68' column='1' id='type-id-29'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='fc' type-id='type-id-48' visibility='default' filepath='src.d/deflate.h' line='72' column='1'/>
+        <var-decl name='fc' type-id='type-id-38' visibility='default' filepath='src.d/deflate.h' line='72' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='16'>
-        <var-decl name='dl' type-id='type-id-49' visibility='default' filepath='src.d/deflate.h' line='76' column='1'/>
+        <var-decl name='dl' type-id='type-id-39' visibility='default' filepath='src.d/deflate.h' line='76' column='1'/>
       </data-member>
     </class-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='69' column='1' id='type-id-48'>
-      <data-member access='public'>
-        <var-decl name='freq' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='70' column='1'/>
-      </data-member>
-      <data-member access='public'>
-        <var-decl name='code' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='71' column='1'/>
-      </data-member>
-    </union-decl>
-    <union-decl name='__anonymous_union__1' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='73' column='1' id='type-id-49'>
-      <data-member access='public'>
-        <var-decl name='dad' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='74' column='1'/>
-      </data-member>
-      <data-member access='public'>
-        <var-decl name='len' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='75' column='1'/>
-      </data-member>
-    </union-decl>
-    <typedef-decl name='ct_data' type-id='type-id-30' filepath='src.d/deflate.h' line='77' column='1' id='type-id-50'/>
-    <typedef-decl name='static_tree_desc' type-id='type-id-29' filepath='src.d/deflate.h' line='84' column='1' id='type-id-51'/>
-    <class-decl name='tree_desc_s' size-in-bits='96' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='86' column='1' id='type-id-52'>
+    <class-decl name='gz_header_s' size-in-bits='416' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='114' column='1' id='type-id-40'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='dyn_tree' type-id='type-id-53' visibility='default' filepath='src.d/deflate.h' line='87' column='1'/>
+        <var-decl name='text' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='115' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='max_code' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='88' column='1'/>
+        <var-decl name='time' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='116' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='stat_desc' type-id='type-id-54' visibility='default' filepath='src.d/deflate.h' line='89' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='Pos' type-id='type-id-41' filepath='src.d/deflate.h' line='92' column='1' id='type-id-55'/>
-    <typedef-decl name='Posf' type-id='type-id-55' filepath='src.d/deflate.h' line='93' column='1' id='type-id-56'/>
-    <typedef-decl name='IPos' type-id='type-id-4' filepath='src.d/deflate.h' line='94' column='1' id='type-id-57'/>
-    <class-decl name='internal_state' size-in-bits='46624' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='100' column='1' id='type-id-58'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='strm' type-id='type-id-59' visibility='default' filepath='src.d/deflate.h' line='101' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='status' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='102' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='pending_buf' type-id='type-id-21' visibility='default' filepath='src.d/deflate.h' line='103' column='1'/>
+        <var-decl name='xflags' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='117' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='pending_buf_size' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='104' column='1'/>
+        <var-decl name='os' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='118' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='pending_out' type-id='type-id-21' visibility='default' filepath='src.d/deflate.h' line='105' column='1'/>
+        <var-decl name='extra' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='119' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='pending' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='106' column='1'/>
+        <var-decl name='extra_len' type-id='type-id-11' visibility='default' filepath='src.d/zlib.h' line='120' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='wrap' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='107' column='1'/>
+        <var-decl name='extra_max' type-id='type-id-11' visibility='default' filepath='src.d/zlib.h' line='121' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='gzhead' type-id='type-id-61' visibility='default' filepath='src.d/deflate.h' line='108' column='1'/>
+        <var-decl name='name' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='122' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='gzindex' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='109' column='1'/>
+        <var-decl name='name_max' type-id='type-id-11' visibility='default' filepath='src.d/zlib.h' line='123' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='method' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='110' column='1'/>
+        <var-decl name='comment' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='124' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='last_flush' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='111' column='1'/>
+        <var-decl name='comm_max' type-id='type-id-11' visibility='default' filepath='src.d/zlib.h' line='125' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='w_size' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='115' column='1'/>
+        <var-decl name='hcrc' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='126' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='w_bits' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='116' column='1'/>
+        <var-decl name='done' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='127' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='internal_state' size-in-bits='46624' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='100' column='1' id='type-id-41'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='strm' type-id='type-id-21' visibility='default' filepath='src.d/deflate.h' line='101' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='status' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='102' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='pending_buf' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='103' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='pending_buf_size' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='104' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='pending_out' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='105' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='pending' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='106' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='wrap' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='107' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='gzhead' type-id='type-id-43' visibility='default' filepath='src.d/deflate.h' line='108' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gzindex' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='109' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='method' type-id='type-id-3' visibility='default' filepath='src.d/deflate.h' line='110' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='last_flush' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='111' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='w_size' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='115' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='w_bits' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='116' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='416'>
-        <var-decl name='w_mask' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='117' column='1'/>
+        <var-decl name='w_mask' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='117' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='window' type-id='type-id-21' visibility='default' filepath='src.d/deflate.h' line='119' column='1'/>
+        <var-decl name='window' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='119' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='480'>
-        <var-decl name='window_size' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='129' column='1'/>
+        <var-decl name='window_size' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='129' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='prev' type-id='type-id-62' visibility='default' filepath='src.d/deflate.h' line='134' column='1'/>
+        <var-decl name='prev' type-id='type-id-44' visibility='default' filepath='src.d/deflate.h' line='134' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='544'>
-        <var-decl name='head' type-id='type-id-62' visibility='default' filepath='src.d/deflate.h' line='140' column='1'/>
+        <var-decl name='head' type-id='type-id-44' visibility='default' filepath='src.d/deflate.h' line='140' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='ins_h' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='142' column='1'/>
+        <var-decl name='ins_h' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='142' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='608'>
-        <var-decl name='hash_size' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='143' column='1'/>
+        <var-decl name='hash_size' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='143' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='hash_bits' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='144' column='1'/>
+        <var-decl name='hash_bits' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='144' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='672'>
-        <var-decl name='hash_mask' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='145' column='1'/>
+        <var-decl name='hash_mask' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='145' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='hash_shift' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='147' column='1'/>
+        <var-decl name='hash_shift' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='147' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='736'>
-        <var-decl name='block_start' type-id='type-id-1' visibility='default' filepath='src.d/deflate.h' line='154' column='1'/>
+        <var-decl name='block_start' type-id='type-id-37' visibility='default' filepath='src.d/deflate.h' line='154' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='match_length' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='159' column='1'/>
+        <var-decl name='match_length' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='159' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='800'>
-        <var-decl name='prev_match' type-id='type-id-57' visibility='default' filepath='src.d/deflate.h' line='160' column='1'/>
+        <var-decl name='prev_match' type-id='type-id-45' visibility='default' filepath='src.d/deflate.h' line='160' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='match_available' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='161' column='1'/>
+        <var-decl name='match_available' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='161' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='864'>
-        <var-decl name='strstart' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='162' column='1'/>
+        <var-decl name='strstart' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='162' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='match_start' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='163' column='1'/>
+        <var-decl name='match_start' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='163' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='928'>
-        <var-decl name='lookahead' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='164' column='1'/>
+        <var-decl name='lookahead' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='164' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='prev_length' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='166' column='1'/>
+        <var-decl name='prev_length' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='166' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='992'>
-        <var-decl name='max_chain_length' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='171' column='1'/>
+        <var-decl name='max_chain_length' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='171' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='max_lazy_match' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='177' column='1'/>
+        <var-decl name='max_lazy_match' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='177' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1056'>
-        <var-decl name='level' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='188' column='1'/>
+        <var-decl name='level' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='188' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1088'>
-        <var-decl name='strategy' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='189' column='1'/>
+        <var-decl name='strategy' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='189' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1120'>
-        <var-decl name='good_match' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='191' column='1'/>
+        <var-decl name='good_match' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='191' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1152'>
-        <var-decl name='nice_match' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='194' column='1'/>
+        <var-decl name='nice_match' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='194' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1184'>
-        <var-decl name='dyn_ltree' type-id='type-id-33' visibility='default' filepath='src.d/deflate.h' line='198' column='1'/>
+        <var-decl name='dyn_ltree' type-id='type-id-32' visibility='default' filepath='src.d/deflate.h' line='198' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='19520'>
-        <var-decl name='dyn_dtree' type-id='type-id-35' visibility='default' filepath='src.d/deflate.h' line='199' column='1'/>
+        <var-decl name='dyn_dtree' type-id='type-id-34' visibility='default' filepath='src.d/deflate.h' line='199' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='21472'>
-        <var-decl name='bl_tree' type-id='type-id-31' visibility='default' filepath='src.d/deflate.h' line='200' column='1'/>
+        <var-decl name='bl_tree' type-id='type-id-30' visibility='default' filepath='src.d/deflate.h' line='200' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='22720'>
-        <var-decl name='l_desc' type-id='type-id-52' visibility='default' filepath='src.d/deflate.h' line='202' column='1'/>
+        <var-decl name='l_desc' type-id='type-id-46' visibility='default' filepath='src.d/deflate.h' line='202' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='22816'>
-        <var-decl name='d_desc' type-id='type-id-52' visibility='default' filepath='src.d/deflate.h' line='203' column='1'/>
+        <var-decl name='d_desc' type-id='type-id-46' visibility='default' filepath='src.d/deflate.h' line='203' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='22912'>
-        <var-decl name='bl_desc' type-id='type-id-52' visibility='default' filepath='src.d/deflate.h' line='204' column='1'/>
+        <var-decl name='bl_desc' type-id='type-id-46' visibility='default' filepath='src.d/deflate.h' line='204' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='23008'>
-        <var-decl name='bl_count' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='206' column='1'/>
+        <var-decl name='bl_count' type-id='type-id-47' visibility='default' filepath='src.d/deflate.h' line='206' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='23264'>
-        <var-decl name='heap' type-id='type-id-37' visibility='default' filepath='src.d/deflate.h' line='209' column='1'/>
+        <var-decl name='heap' type-id='type-id-36' visibility='default' filepath='src.d/deflate.h' line='209' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='41600'>
-        <var-decl name='heap_len' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='210' column='1'/>
+        <var-decl name='heap_len' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='210' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='41632'>
-        <var-decl name='heap_max' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='211' column='1'/>
+        <var-decl name='heap_max' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='211' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='41664'>
-        <var-decl name='depth' type-id='type-id-39' visibility='default' filepath='src.d/deflate.h' line='216' column='1'/>
+        <var-decl name='depth' type-id='type-id-48' visibility='default' filepath='src.d/deflate.h' line='216' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46272'>
-        <var-decl name='sym_buf' type-id='type-id-63' visibility='default' filepath='src.d/deflate.h' line='220' column='1'/>
+        <var-decl name='sym_buf' type-id='type-id-49' visibility='default' filepath='src.d/deflate.h' line='220' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46304'>
-        <var-decl name='lit_bufsize' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='222' column='1'/>
+        <var-decl name='lit_bufsize' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='222' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46336'>
-        <var-decl name='sym_next' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='242' column='1'/>
+        <var-decl name='sym_next' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='242' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46368'>
-        <var-decl name='sym_end' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='243' column='1'/>
+        <var-decl name='sym_end' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='243' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46400'>
-        <var-decl name='opt_len' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='245' column='1'/>
+        <var-decl name='opt_len' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='245' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46432'>
-        <var-decl name='static_len' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='246' column='1'/>
+        <var-decl name='static_len' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='246' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46464'>
-        <var-decl name='matches' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='247' column='1'/>
+        <var-decl name='matches' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='247' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46496'>
-        <var-decl name='insert' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='248' column='1'/>
+        <var-decl name='insert' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='248' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46528'>
-        <var-decl name='bi_buf' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='255' column='1'/>
+        <var-decl name='bi_buf' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='255' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46560'>
-        <var-decl name='bi_valid' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='259' column='1'/>
+        <var-decl name='bi_valid' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='259' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46592'>
-        <var-decl name='high_water' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='264' column='1'/>
+        <var-decl name='high_water' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='264' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='deflate_state' type-id='type-id-58' filepath='src.d/deflate.h' line='271' column='1' id='type-id-64'/>
-    <typedef-decl name='alloc_func' type-id='type-id-65' filepath='src.d/zlib.h' line='81' column='1' id='type-id-66'/>
-    <typedef-decl name='free_func' type-id='type-id-67' filepath='src.d/zlib.h' line='82' column='1' id='type-id-68'/>
-    <class-decl name='z_stream_s' size-in-bits='448' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='86' column='1' id='type-id-69'>
+    <class-decl name='tree_desc_s' size-in-bits='96' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='86' column='1' id='type-id-46'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='next_in' type-id='type-id-21' visibility='default' filepath='src.d/zlib.h' line='87' column='1'/>
+        <var-decl name='dyn_tree' type-id='type-id-51' visibility='default' filepath='src.d/deflate.h' line='87' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='avail_in' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='88' column='1'/>
+        <var-decl name='max_code' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='88' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='total_in' type-id='type-id-10' visibility='default' filepath='src.d/zlib.h' line='89' column='1'/>
+        <var-decl name='stat_desc' type-id='type-id-52' visibility='default' filepath='src.d/deflate.h' line='89' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='z_stream_s' size-in-bits='448' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='86' column='1' id='type-id-53'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next_in' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='87' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='avail_in' type-id='type-id-11' visibility='default' filepath='src.d/zlib.h' line='88' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='total_in' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='89' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='next_out' type-id='type-id-21' visibility='default' filepath='src.d/zlib.h' line='91' column='1'/>
+        <var-decl name='next_out' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='91' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='avail_out' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='92' column='1'/>
+        <var-decl name='avail_out' type-id='type-id-11' visibility='default' filepath='src.d/zlib.h' line='92' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='total_out' type-id='type-id-10' visibility='default' filepath='src.d/zlib.h' line='93' column='1'/>
+        <var-decl name='total_out' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='93' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='msg' type-id='type-id-70' visibility='default' filepath='src.d/zlib.h' line='95' column='1'/>
+        <var-decl name='msg' type-id='type-id-54' visibility='default' filepath='src.d/zlib.h' line='95' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='state' type-id='type-id-71' visibility='default' filepath='src.d/zlib.h' line='96' column='1'/>
+        <var-decl name='state' type-id='type-id-55' visibility='default' filepath='src.d/zlib.h' line='96' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='zalloc' type-id='type-id-66' visibility='default' filepath='src.d/zlib.h' line='98' column='1'/>
+        <var-decl name='zalloc' type-id='type-id-56' visibility='default' filepath='src.d/zlib.h' line='98' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='zfree' type-id='type-id-68' visibility='default' filepath='src.d/zlib.h' line='99' column='1'/>
+        <var-decl name='zfree' type-id='type-id-57' visibility='default' filepath='src.d/zlib.h' line='99' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='opaque' type-id='type-id-47' visibility='default' filepath='src.d/zlib.h' line='100' column='1'/>
+        <var-decl name='opaque' type-id='type-id-58' visibility='default' filepath='src.d/zlib.h' line='100' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='data_type' type-id='type-id-22' visibility='default' filepath='src.d/zlib.h' line='102' column='1'/>
+        <var-decl name='data_type' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='102' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='adler' type-id='type-id-10' visibility='default' filepath='src.d/zlib.h' line='104' column='1'/>
+        <var-decl name='adler' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='104' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='416'>
-        <var-decl name='reserved' type-id='type-id-10' visibility='default' filepath='src.d/zlib.h' line='105' column='1'/>
+        <var-decl name='reserved' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='105' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='z_stream' type-id='type-id-69' filepath='src.d/zlib.h' line='106' column='1' id='type-id-72'/>
-    <typedef-decl name='z_streamp' type-id='type-id-73' filepath='src.d/zlib.h' line='108' column='1' id='type-id-59'/>
-    <class-decl name='gz_header_s' size-in-bits='416' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='114' column='1' id='type-id-74'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='text' type-id='type-id-22' visibility='default' filepath='src.d/zlib.h' line='115' column='1'/>
+    <typedef-decl name='IPos' type-id='type-id-9' filepath='src.d/deflate.h' line='94' column='1' id='type-id-45'/>
+    <typedef-decl name='Pos' type-id='type-id-50' filepath='src.d/deflate.h' line='92' column='1' id='type-id-59'/>
+    <typedef-decl name='Posf' type-id='type-id-59' filepath='src.d/deflate.h' line='93' column='1' id='type-id-60'/>
+    <typedef-decl name='alloc_func' type-id='type-id-61' filepath='src.d/zlib.h' line='81' column='1' id='type-id-56'/>
+    <typedef-decl name='charf' type-id='type-id-28' filepath='./zconf.h' line='408' column='1' id='type-id-62'/>
+    <typedef-decl name='ct_data' type-id='type-id-29' filepath='src.d/deflate.h' line='77' column='1' id='type-id-63'/>
+    <typedef-decl name='deflate_state' type-id='type-id-41' filepath='src.d/deflate.h' line='271' column='1' id='type-id-64'/>
+    <typedef-decl name='free_func' type-id='type-id-65' filepath='src.d/zlib.h' line='82' column='1' id='type-id-57'/>
+    <typedef-decl name='gz_header' type-id='type-id-40' filepath='src.d/zlib.h' line='129' column='1' id='type-id-66'/>
+    <typedef-decl name='gz_headerp' type-id='type-id-67' filepath='src.d/zlib.h' line='131' column='1' id='type-id-43'/>
+    <typedef-decl name='uch' type-id='type-id-2' filepath='src.d/zutil.h' line='39' column='1' id='type-id-68'/>
+    <typedef-decl name='uchf' type-id='type-id-68' filepath='src.d/zutil.h' line='40' column='1' id='type-id-69'/>
+    <typedef-decl name='ulg' type-id='type-id-12' filepath='src.d/zutil.h' line='43' column='1' id='type-id-42'/>
+    <typedef-decl name='ush' type-id='type-id-70' filepath='src.d/zutil.h' line='41' column='1' id='type-id-50'/>
+    <typedef-decl name='z_stream' type-id='type-id-53' filepath='src.d/zlib.h' line='106' column='1' id='type-id-71'/>
+    <typedef-decl name='z_streamp' type-id='type-id-72' filepath='src.d/zlib.h' line='108' column='1' id='type-id-21'/>
+    <array-type-def dimensions='1' type-id='type-id-68' size-in-bits='4584' id='type-id-48'>
+      <subrange length='573' lower-bound='0' upper-bound='572' type-id='type-id-9' id='type-id-33'/>
+    </array-type-def>
+    <union-decl name='__anonymous_union__1' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='73' column='1' id='type-id-39'>
+      <data-member access='public'>
+        <var-decl name='dad' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='74' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='time' type-id='type-id-10' visibility='default' filepath='src.d/zlib.h' line='116' column='1'/>
+      <data-member access='public'>
+        <var-decl name='len' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='75' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='xflags' type-id='type-id-22' visibility='default' filepath='src.d/zlib.h' line='117' column='1'/>
+    </union-decl>
+    <union-decl name='__anonymous_union__' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='69' column='1' id='type-id-38'>
+      <data-member access='public'>
+        <var-decl name='freq' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='70' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='os' type-id='type-id-22' visibility='default' filepath='src.d/zlib.h' line='118' column='1'/>
+      <data-member access='public'>
+        <var-decl name='code' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='71' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='extra' type-id='type-id-21' visibility='default' filepath='src.d/zlib.h' line='119' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='extra_len' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='120' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='extra_max' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='121' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='name' type-id='type-id-21' visibility='default' filepath='src.d/zlib.h' line='122' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='name_max' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='123' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='comment' type-id='type-id-21' visibility='default' filepath='src.d/zlib.h' line='124' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='comm_max' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='125' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='hcrc' type-id='type-id-22' visibility='default' filepath='src.d/zlib.h' line='126' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='done' type-id='type-id-22' visibility='default' filepath='src.d/zlib.h' line='127' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='gz_header' type-id='type-id-74' filepath='src.d/zlib.h' line='129' column='1' id='type-id-75'/>
-    <typedef-decl name='gz_headerp' type-id='type-id-76' filepath='src.d/zlib.h' line='131' column='1' id='type-id-61'/>
-    <typedef-decl name='uch' type-id='type-id-3' filepath='src.d/zutil.h' line='39' column='1' id='type-id-38'/>
-    <typedef-decl name='uchf' type-id='type-id-38' filepath='src.d/zutil.h' line='40' column='1' id='type-id-77'/>
-    <typedef-decl name='ush' type-id='type-id-40' filepath='src.d/zutil.h' line='41' column='1' id='type-id-41'/>
-    <typedef-decl name='ulg' type-id='type-id-5' filepath='src.d/zutil.h' line='43' column='1' id='type-id-60'/>
-    <pointer-type-def type-id='type-id-11' size-in-bits='32' id='type-id-21'/>
-    <pointer-type-def type-id='type-id-56' size-in-bits='32' id='type-id-62'/>
-    <pointer-type-def type-id='type-id-28' size-in-bits='32' id='type-id-70'/>
-    <pointer-type-def type-id='type-id-45' size-in-bits='32' id='type-id-78'/>
-    <qualified-type-def type-id='type-id-28' const='yes' id='type-id-79'/>
-    <pointer-type-def type-id='type-id-79' size-in-bits='32' id='type-id-80'/>
-    <qualified-type-def type-id='type-id-51' const='yes' id='type-id-81'/>
-    <pointer-type-def type-id='type-id-81' size-in-bits='32' id='type-id-54'/>
-    <pointer-type-def type-id='type-id-50' size-in-bits='32' id='type-id-53'/>
-    <pointer-type-def type-id='type-id-64' size-in-bits='32' id='type-id-82'/>
-    <pointer-type-def type-id='type-id-75' size-in-bits='32' id='type-id-76'/>
-    <pointer-type-def type-id='type-id-22' size-in-bits='32' id='type-id-83'/>
-    <pointer-type-def type-id='type-id-58' size-in-bits='32' id='type-id-71'/>
-    <pointer-type-def type-id='type-id-84' size-in-bits='32' id='type-id-65'/>
-    <pointer-type-def type-id='type-id-9' size-in-bits='32' id='type-id-85'/>
-    <pointer-type-def type-id='type-id-77' size-in-bits='32' id='type-id-63'/>
-    <pointer-type-def type-id='type-id-4' size-in-bits='32' id='type-id-86'/>
-    <pointer-type-def type-id='type-id-87' size-in-bits='32' id='type-id-67'/>
-    <pointer-type-def type-id='type-id-44' size-in-bits='32' id='type-id-46'/>
-    <pointer-type-def type-id='type-id-72' size-in-bits='32' id='type-id-73'/>
-    <class-decl name='static_tree_desc_s' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-29'/>
+    </union-decl>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-70'/>
+    <array-type-def dimensions='1' type-id='type-id-50' size-in-bits='256' id='type-id-47'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-9' id='type-id-73'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-4' size-in-bits='32' id='type-id-19'/>
+    <pointer-type-def type-id='type-id-60' size-in-bits='32' id='type-id-44'/>
+    <pointer-type-def type-id='type-id-28' size-in-bits='32' id='type-id-54'/>
+    <pointer-type-def type-id='type-id-62' size-in-bits='32' id='type-id-74'/>
+    <qualified-type-def type-id='type-id-28' const='yes' id='type-id-75'/>
+    <pointer-type-def type-id='type-id-75' size-in-bits='32' id='type-id-22'/>
+    <pointer-type-def type-id='type-id-63' size-in-bits='32' id='type-id-51'/>
+    <pointer-type-def type-id='type-id-64' size-in-bits='32' id='type-id-76'/>
+    <pointer-type-def type-id='type-id-66' size-in-bits='32' id='type-id-67'/>
+    <pointer-type-def type-id='type-id-20' size-in-bits='32' id='type-id-77'/>
+    <pointer-type-def type-id='type-id-41' size-in-bits='32' id='type-id-55'/>
+    <pointer-type-def type-id='type-id-78' size-in-bits='32' id='type-id-61'/>
+    <pointer-type-def type-id='type-id-11' size-in-bits='32' id='type-id-79'/>
+    <pointer-type-def type-id='type-id-69' size-in-bits='32' id='type-id-49'/>
+    <pointer-type-def type-id='type-id-9' size-in-bits='32' id='type-id-80'/>
+    <pointer-type-def type-id='type-id-81' size-in-bits='32' id='type-id-65'/>
+    <pointer-type-def type-id='type-id-71' size-in-bits='32' id='type-id-72'/>
+    <qualified-type-def type-id='type-id-82' const='yes' id='type-id-83'/>
+    <pointer-type-def type-id='type-id-83' size-in-bits='32' id='type-id-52'/>
+    <class-decl name='static_tree_desc_s' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-84'/>
+    <typedef-decl name='voidpf' type-id='type-id-85' filepath='./zconf.h' line='415' column='1' id='type-id-58'/>
     <function-decl name='memcpy' filepath='/usr/arm-linux-gnueabihf/include/string.h' line='43' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-46'/>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-85'/>
     </function-decl>
     <function-decl name='memset' filepath='/usr/arm-linux-gnueabihf/include/string.h' line='61' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-22'/>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-46'/>
-    </function-decl>
-    <function-decl name='deflateInit_' mangled-name='deflateInit_' filepath='src.d/deflate.c' line='225' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateInit_'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='226' column='1'/>
-      <parameter type-id='type-id-22' name='level' filepath='src.d/deflate.c' line='227' column='1'/>
-      <parameter type-id='type-id-80' name='version' filepath='src.d/deflate.c' line='228' column='1'/>
-      <parameter type-id='type-id-22' name='stream_size' filepath='src.d/deflate.c' line='229' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-85'/>
     </function-decl>
     <function-decl name='deflateInit2_' mangled-name='deflateInit2_' filepath='src.d/deflate.c' line='237' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateInit2_'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='239' column='1'/>
-      <parameter type-id='type-id-22' name='level' filepath='src.d/deflate.c' line='240' column='1'/>
-      <parameter type-id='type-id-22' name='method' filepath='src.d/deflate.c' line='241' column='1'/>
-      <parameter type-id='type-id-22' name='windowBits' filepath='src.d/deflate.c' line='242' column='1'/>
-      <parameter type-id='type-id-22' name='memLevel' filepath='src.d/deflate.c' line='243' column='1'/>
-      <parameter type-id='type-id-22' name='strategy' filepath='src.d/deflate.c' line='244' column='1'/>
-      <parameter type-id='type-id-80' name='version' filepath='src.d/deflate.c' line='245' column='1'/>
-      <parameter type-id='type-id-22' name='stream_size' filepath='src.d/deflate.c' line='246' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='239' column='1'/>
+      <parameter type-id='type-id-20' name='level' filepath='src.d/deflate.c' line='240' column='1'/>
+      <parameter type-id='type-id-20' name='method' filepath='src.d/deflate.c' line='241' column='1'/>
+      <parameter type-id='type-id-20' name='windowBits' filepath='src.d/deflate.c' line='242' column='1'/>
+      <parameter type-id='type-id-20' name='memLevel' filepath='src.d/deflate.c' line='243' column='1'/>
+      <parameter type-id='type-id-20' name='strategy' filepath='src.d/deflate.c' line='244' column='1'/>
+      <parameter type-id='type-id-22' name='version' filepath='src.d/deflate.c' line='245' column='1'/>
+      <parameter type-id='type-id-20' name='stream_size' filepath='src.d/deflate.c' line='246' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateSetDictionary' mangled-name='deflateSetDictionary' filepath='src.d/deflate.c' line='412' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateSetDictionary'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='413' column='1'/>
-      <parameter type-id='type-id-18' name='dictionary' filepath='src.d/deflate.c' line='414' column='1'/>
-      <parameter type-id='type-id-9' name='dictLength' filepath='src.d/deflate.c' line='415' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='413' column='1'/>
+      <parameter type-id='type-id-16' name='dictionary' filepath='src.d/deflate.c' line='414' column='1'/>
+      <parameter type-id='type-id-11' name='dictLength' filepath='src.d/deflate.c' line='415' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateGetDictionary' mangled-name='deflateGetDictionary' filepath='src.d/deflate.c' line='481' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateGetDictionary@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='482' column='1'/>
-      <parameter type-id='type-id-21' name='dictionary' filepath='src.d/deflate.c' line='483' column='1'/>
-      <parameter type-id='type-id-85' name='dictLength' filepath='src.d/deflate.c' line='484' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='482' column='1'/>
+      <parameter type-id='type-id-19' name='dictionary' filepath='src.d/deflate.c' line='483' column='1'/>
+      <parameter type-id='type-id-79' name='dictLength' filepath='src.d/deflate.c' line='484' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateResetKeep' mangled-name='deflateResetKeep' filepath='src.d/deflate.c' line='503' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateResetKeep@@ZLIB_1.2.5.2'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='504' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='504' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateReset' mangled-name='deflateReset' filepath='src.d/deflate.c' line='541' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateReset'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='542' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='542' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateSetHeader' mangled-name='deflateSetHeader' filepath='src.d/deflate.c' line='553' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateSetHeader@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='554' column='1'/>
-      <parameter type-id='type-id-61' name='head' filepath='src.d/deflate.c' line='555' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='554' column='1'/>
+      <parameter type-id='type-id-43' name='head' filepath='src.d/deflate.c' line='555' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflatePending' mangled-name='deflatePending' filepath='src.d/deflate.c' line='564' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflatePending@@ZLIB_1.2.5.1'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='567' column='1'/>
-      <parameter type-id='type-id-86' name='pending' filepath='src.d/deflate.c' line='565' column='1'/>
-      <parameter type-id='type-id-83' name='bits' filepath='src.d/deflate.c' line='566' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='567' column='1'/>
+      <parameter type-id='type-id-80' name='pending' filepath='src.d/deflate.c' line='565' column='1'/>
+      <parameter type-id='type-id-77' name='bits' filepath='src.d/deflate.c' line='566' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflatePrime' mangled-name='deflatePrime' filepath='src.d/deflate.c' line='578' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflatePrime@@ZLIB_1.2.0.8'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='579' column='1'/>
-      <parameter type-id='type-id-22' name='bits' filepath='src.d/deflate.c' line='580' column='1'/>
-      <parameter type-id='type-id-22' name='value' filepath='src.d/deflate.c' line='581' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='579' column='1'/>
+      <parameter type-id='type-id-20' name='bits' filepath='src.d/deflate.c' line='580' column='1'/>
+      <parameter type-id='type-id-20' name='value' filepath='src.d/deflate.c' line='581' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateParams' mangled-name='deflateParams' filepath='src.d/deflate.c' line='605' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateParams'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='606' column='1'/>
-      <parameter type-id='type-id-22' name='level' filepath='src.d/deflate.c' line='607' column='1'/>
-      <parameter type-id='type-id-22' name='strategy' filepath='src.d/deflate.c' line='608' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='606' column='1'/>
+      <parameter type-id='type-id-20' name='level' filepath='src.d/deflate.c' line='607' column='1'/>
+      <parameter type-id='type-id-20' name='strategy' filepath='src.d/deflate.c' line='608' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateTune' mangled-name='deflateTune' filepath='src.d/deflate.c' line='654' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateTune@@ZLIB_1.2.2.3'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='655' column='1'/>
-      <parameter type-id='type-id-22' name='good_length' filepath='src.d/deflate.c' line='656' column='1'/>
-      <parameter type-id='type-id-22' name='max_lazy' filepath='src.d/deflate.c' line='657' column='1'/>
-      <parameter type-id='type-id-22' name='nice_length' filepath='src.d/deflate.c' line='658' column='1'/>
-      <parameter type-id='type-id-22' name='max_chain' filepath='src.d/deflate.c' line='659' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='655' column='1'/>
+      <parameter type-id='type-id-20' name='good_length' filepath='src.d/deflate.c' line='656' column='1'/>
+      <parameter type-id='type-id-20' name='max_lazy' filepath='src.d/deflate.c' line='657' column='1'/>
+      <parameter type-id='type-id-20' name='nice_length' filepath='src.d/deflate.c' line='658' column='1'/>
+      <parameter type-id='type-id-20' name='max_chain' filepath='src.d/deflate.c' line='659' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateBound' mangled-name='deflateBound' filepath='src.d/deflate.c' line='696' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateBound@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='697' column='1'/>
-      <parameter type-id='type-id-10' name='sourceLen' filepath='src.d/deflate.c' line='698' column='1'/>
-      <return type-id='type-id-10'/>
-    </function-decl>
-    <function-decl name='deflate' mangled-name='deflate' filepath='src.d/deflate.c' line='815' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflate'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='816' column='1'/>
-      <parameter type-id='type-id-22' name='flush' filepath='src.d/deflate.c' line='817' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='deflateEnd' mangled-name='deflateEnd' filepath='src.d/deflate.c' line='1130' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateEnd'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='1131' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='697' column='1'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/deflate.c' line='698' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='deflateCopy' mangled-name='deflateCopy' filepath='src.d/deflate.c' line='1156' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateCopy'>
-      <parameter type-id='type-id-59' name='dest' filepath='src.d/deflate.c' line='1157' column='1'/>
-      <parameter type-id='type-id-59' name='source' filepath='src.d/deflate.c' line='1158' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='dest' filepath='src.d/deflate.c' line='1157' column='1'/>
+      <parameter type-id='type-id-21' name='source' filepath='src.d/deflate.c' line='1158' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
+    <typedef-decl name='static_tree_desc' type-id='type-id-84' filepath='src.d/deflate.h' line='84' column='1' id='type-id-82'/>
     <function-decl name='_tr_init' filepath='src.d/deflate.h' line='294' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-82'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-76'/>
+      <return type-id='type-id-86'/>
     </function-decl>
     <function-decl name='_tr_flush_block' filepath='src.d/deflate.h' line='296' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-82'/>
-      <parameter type-id='type-id-78'/>
-      <parameter type-id='type-id-60'/>
-      <parameter type-id='type-id-22'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-76'/>
+      <parameter type-id='type-id-74'/>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-86'/>
     </function-decl>
     <function-decl name='_tr_flush_bits' filepath='src.d/deflate.h' line='298' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-82'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-76'/>
+      <return type-id='type-id-86'/>
     </function-decl>
     <function-decl name='_tr_align' filepath='src.d/deflate.h' line='299' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-82'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-76'/>
+      <return type-id='type-id-86'/>
     </function-decl>
     <function-decl name='_tr_stored_block' filepath='src.d/deflate.h' line='300' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-82'/>
-      <parameter type-id='type-id-78'/>
-      <parameter type-id='type-id-60'/>
-      <parameter type-id='type-id-22'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-76'/>
+      <parameter type-id='type-id-74'/>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-86'/>
+    </function-decl>
+    <function-decl name='crc32' filepath='src.d/zlib.h' line='1727' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-13'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-11'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='zcalloc' filepath='src.d/zutil.h' line='261' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-47'/>
-      <parameter type-id='type-id-4'/>
-      <parameter type-id='type-id-4'/>
-      <return type-id='type-id-47'/>
+      <parameter type-id='type-id-58'/>
+      <parameter type-id='type-id-9'/>
+      <parameter type-id='type-id-9'/>
+      <return type-id='type-id-58'/>
     </function-decl>
     <function-decl name='zcfree' filepath='src.d/zutil.h' line='263' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-47'/>
-      <parameter type-id='type-id-47'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-58'/>
+      <parameter type-id='type-id-58'/>
+      <return type-id='type-id-86'/>
     </function-decl>
-    <function-type size-in-bits='32' id='type-id-84'>
-      <parameter type-id='type-id-47'/>
-      <parameter type-id='type-id-9'/>
-      <parameter type-id='type-id-9'/>
-      <return type-id='type-id-47'/>
+    <type-decl name='void' id='type-id-86'/>
+    <pointer-type-def type-id='type-id-86' id='type-id-85'/>
+    <function-type size-in-bits='32' id='type-id-81'>
+      <parameter type-id='type-id-58'/>
+      <parameter type-id='type-id-58'/>
+      <return type-id='type-id-86'/>
     </function-type>
-    <function-type size-in-bits='32' id='type-id-87'>
-      <parameter type-id='type-id-47'/>
-      <parameter type-id='type-id-47'/>
-      <return type-id='type-id-44'/>
+    <function-type size-in-bits='32' id='type-id-78'>
+      <parameter type-id='type-id-58'/>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-11'/>
+      <return type-id='type-id-58'/>
     </function-type>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/gzclose.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <typedef-decl name='gzFile' type-id='type-id-88' filepath='src.d/zlib.h' line='1302' column='1' id='type-id-89'/>
-    <class-decl name='gzFile_s' size-in-bits='128' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='1834' column='1' id='type-id-90'>
+    <class-decl name='gzFile_s' size-in-bits='128' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='1834' column='1' id='type-id-87'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='have' type-id='type-id-4' visibility='default' filepath='src.d/zlib.h' line='1835' column='1'/>
+        <var-decl name='have' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='1835' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='next' type-id='type-id-91' visibility='default' filepath='src.d/zlib.h' line='1836' column='1'/>
+        <var-decl name='next' type-id='type-id-88' visibility='default' filepath='src.d/zlib.h' line='1836' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='pos' type-id='type-id-16' visibility='default' filepath='src.d/zlib.h' line='1837' column='1'/>
+        <var-decl name='pos' type-id='type-id-7' visibility='default' filepath='src.d/zlib.h' line='1837' column='1'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-90' size-in-bits='32' id='type-id-88'/>
+    <typedef-decl name='gzFile' type-id='type-id-89' filepath='src.d/zlib.h' line='1302' column='1' id='type-id-90'/>
+    <pointer-type-def type-id='type-id-87' size-in-bits='32' id='type-id-89'/>
     <function-decl name='gzclose' mangled-name='gzclose' filepath='src.d/gzclose.c' line='11' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzclose'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzclose.c' line='12' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzclose.c' line='12' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='gzclose_r' mangled-name='gzclose_r' filepath='src.d/zlib.h' line='1644' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzclose_r@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-89'/>
-      <return type-id='type-id-22'/>
+    <function-decl name='gzclose_r' filepath='src.d/zlib.h' line='1644' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-90'/>
+      <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='gzclose_w' mangled-name='gzclose_w' filepath='src.d/zlib.h' line='1645' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzclose_w@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-89'/>
-      <return type-id='type-id-22'/>
+    <function-decl name='gzclose_w' filepath='src.d/zlib.h' line='1645' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-90'/>
+      <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/gzlib.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <type-decl name='variadic parameter type' id='type-id-92'/>
-    <function-decl name='open' filepath='/usr/arm-linux-gnueabihf/include/fcntl.h' line='181' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-80'/>
+    <function-decl name='snprintf' filepath='/usr/arm-linux-gnueabihf/include/stdio.h' line='385' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-54'/>
+      <parameter type-id='type-id-10'/>
       <parameter type-id='type-id-22'/>
       <parameter is-variadic='yes'/>
-      <return type-id='type-id-22'/>
+      <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='snprintf' filepath='/usr/arm-linux-gnueabihf/include/stdio.h' line='378' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-70'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-80'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-22'/>
+    <function-decl name='malloc' filepath='/usr/arm-linux-gnueabihf/include/stdlib.h' line='672' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-85'/>
+    </function-decl>
+    <function-decl name='free' filepath='/usr/arm-linux-gnueabihf/include/stdlib.h' line='687' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-85'/>
+      <return type-id='type-id-86'/>
     </function-decl>
     <function-decl name='strlen' filepath='/usr/arm-linux-gnueabihf/include/string.h' line='407' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-80'/>
-      <return type-id='type-id-6'/>
+      <parameter type-id='type-id-22'/>
+      <return type-id='type-id-10'/>
     </function-decl>
     <function-decl name='lseek64' filepath='/usr/arm-linux-gnueabihf/include/unistd.h' line='350' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-22'/>
-      <parameter type-id='type-id-14'/>
-      <parameter type-id='type-id-22'/>
-      <return type-id='type-id-14'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='gzopen' mangled-name='gzopen' filepath='src.d/gzlib.c' line='272' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzopen'>
-      <parameter type-id='type-id-80' name='path' filepath='src.d/gzlib.c' line='273' column='1'/>
-      <parameter type-id='type-id-80' name='mode' filepath='src.d/gzlib.c' line='274' column='1'/>
-      <return type-id='type-id-89'/>
+      <parameter type-id='type-id-22' name='path' filepath='src.d/gzlib.c' line='273' column='1'/>
+      <parameter type-id='type-id-22' name='mode' filepath='src.d/gzlib.c' line='274' column='1'/>
+      <return type-id='type-id-90'/>
     </function-decl>
     <function-decl name='gzopen64' mangled-name='gzopen64' filepath='src.d/gzlib.c' line='280' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzopen64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-80' name='path' filepath='src.d/gzlib.c' line='281' column='1'/>
-      <parameter type-id='type-id-80' name='mode' filepath='src.d/gzlib.c' line='282' column='1'/>
-      <return type-id='type-id-89'/>
+      <parameter type-id='type-id-22' name='path' filepath='src.d/gzlib.c' line='281' column='1'/>
+      <parameter type-id='type-id-22' name='mode' filepath='src.d/gzlib.c' line='282' column='1'/>
+      <return type-id='type-id-90'/>
     </function-decl>
     <function-decl name='gzdopen' mangled-name='gzdopen' filepath='src.d/gzlib.c' line='288' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzdopen'>
-      <parameter type-id='type-id-22' name='fd' filepath='src.d/gzlib.c' line='289' column='1'/>
-      <parameter type-id='type-id-80' name='mode' filepath='src.d/gzlib.c' line='290' column='1'/>
-      <return type-id='type-id-89'/>
+      <parameter type-id='type-id-20' name='fd' filepath='src.d/gzlib.c' line='289' column='1'/>
+      <parameter type-id='type-id-22' name='mode' filepath='src.d/gzlib.c' line='290' column='1'/>
+      <return type-id='type-id-90'/>
     </function-decl>
     <function-decl name='gzbuffer' mangled-name='gzbuffer' filepath='src.d/gzlib.c' line='318' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzbuffer@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='319' column='1'/>
-      <parameter type-id='type-id-4' name='size' filepath='src.d/gzlib.c' line='320' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='319' column='1'/>
+      <parameter type-id='type-id-9' name='size' filepath='src.d/gzlib.c' line='320' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzrewind' mangled-name='gzrewind' filepath='src.d/gzlib.c' line='345' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzrewind'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='346' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='346' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzseek64' mangled-name='gzseek64' filepath='src.d/gzlib.c' line='368' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzseek64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='369' column='1'/>
-      <parameter type-id='type-id-16' name='offset' filepath='src.d/gzlib.c' line='370' column='1'/>
-      <parameter type-id='type-id-22' name='whence' filepath='src.d/gzlib.c' line='371' column='1'/>
-      <return type-id='type-id-16'/>
-    </function-decl>
-    <function-decl name='gzseek' mangled-name='gzseek' filepath='src.d/gzlib.c' line='445' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzseek'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='446' column='1'/>
-      <parameter type-id='type-id-15' name='offset' filepath='src.d/gzlib.c' line='447' column='1'/>
-      <parameter type-id='type-id-22' name='whence' filepath='src.d/gzlib.c' line='448' column='1'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='gztell64' mangled-name='gztell64' filepath='src.d/gzlib.c' line='457' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gztell64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='458' column='1'/>
-      <return type-id='type-id-16'/>
-    </function-decl>
-    <function-decl name='gztell' mangled-name='gztell' filepath='src.d/gzlib.c' line='474' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gztell'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='475' column='1'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='gzoffset64' mangled-name='gzoffset64' filepath='src.d/gzlib.c' line='484' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzoffset64@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='485' column='1'/>
-      <return type-id='type-id-16'/>
-    </function-decl>
-    <function-decl name='gzoffset' mangled-name='gzoffset' filepath='src.d/gzlib.c' line='507' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzoffset@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='508' column='1'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='gzeof' mangled-name='gzeof' filepath='src.d/gzlib.c' line='517' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzeof'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='518' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='gzerror' mangled-name='gzerror' filepath='src.d/gzlib.c' line='534' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzerror'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='535' column='1'/>
-      <parameter type-id='type-id-83' name='errnum' filepath='src.d/gzlib.c' line='536' column='1'/>
-      <return type-id='type-id-80'/>
-    </function-decl>
-    <function-decl name='gzclearerr' mangled-name='gzclearerr' filepath='src.d/gzlib.c' line='555' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzclearerr@@ZLIB_1.2.0.2'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='556' column='1'/>
-      <return type-id='type-id-44'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr address-size='32' path='src.d/gzread.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <typedef-decl name='voidp' type-id='type-id-46' filepath='./zconf.h' line='416' column='1' id='type-id-93'/>
-    <typedef-decl name='__ssize_t' type-id='type-id-22' filepath='/usr/arm-linux-gnueabihf/include/bits/types.h' line='194' column='1' id='type-id-94'/>
-    <typedef-decl name='ssize_t' type-id='type-id-94' filepath='/usr/arm-linux-gnueabihf/include/sys/types.h' line='108' column='1' id='type-id-95'/>
-    <class-decl name='gz_state' size-in-bits='1344' is-struct='yes' naming-typedef-id='type-id-96' visibility='default' filepath='src.d/gzguts.h' line='170' column='1' id='type-id-97'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='x' type-id='type-id-90' visibility='default' filepath='src.d/gzguts.h' line='172' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='mode' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='177' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='fd' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='178' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='path' type-id='type-id-70' visibility='default' filepath='src.d/gzguts.h' line='179' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='size' type-id='type-id-4' visibility='default' filepath='src.d/gzguts.h' line='180' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='want' type-id='type-id-4' visibility='default' filepath='src.d/gzguts.h' line='181' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='in' type-id='type-id-91' visibility='default' filepath='src.d/gzguts.h' line='182' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='out' type-id='type-id-91' visibility='default' filepath='src.d/gzguts.h' line='183' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='direct' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='184' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='how' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='186' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='start' type-id='type-id-16' visibility='default' filepath='src.d/gzguts.h' line='187' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='eof' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='188' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='544'>
-        <var-decl name='past' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='189' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='level' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='191' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='608'>
-        <var-decl name='strategy' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='192' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='reset' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='193' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='skip' type-id='type-id-16' visibility='default' filepath='src.d/gzguts.h' line='195' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='seek' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='196' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='800'>
-        <var-decl name='err' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='198' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='msg' type-id='type-id-70' visibility='default' filepath='src.d/gzguts.h' line='199' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='864'>
-        <var-decl name='strm' type-id='type-id-72' visibility='default' filepath='src.d/gzguts.h' line='201' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='gz_state' type-id='type-id-97' filepath='src.d/gzguts.h' line='202' column='1' id='type-id-96'/>
-    <typedef-decl name='gz_statep' type-id='type-id-98' filepath='src.d/gzguts.h' line='203' column='1' id='type-id-99'/>
-    <pointer-type-def type-id='type-id-96' size-in-bits='32' id='type-id-98'/>
-    <function-decl name='__errno_location' filepath='/usr/arm-linux-gnueabihf/include/errno.h' line='37' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <return type-id='type-id-83'/>
-    </function-decl>
-    <function-decl name='memchr' filepath='/usr/arm-linux-gnueabihf/include/string.h' line='107' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-22'/>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-46'/>
-    </function-decl>
-    <function-decl name='strerror' filepath='/usr/arm-linux-gnueabihf/include/string.h' line='419' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-22'/>
-      <return type-id='type-id-70'/>
-    </function-decl>
-    <function-decl name='close' filepath='/usr/arm-linux-gnueabihf/include/unistd.h' line='358' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-22'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='read' filepath='/usr/arm-linux-gnueabihf/include/unistd.h' line='371' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-22'/>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-95'/>
-    </function-decl>
-    <function-decl name='gz_error' filepath='src.d/gzguts.h' line='206' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-99'/>
-      <parameter type-id='type-id-22'/>
-      <parameter type-id='type-id-80'/>
-      <return type-id='type-id-44'/>
-    </function-decl>
-    <function-decl name='gzread' mangled-name='gzread' filepath='src.d/gzread.c' line='373' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzread'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='374' column='1'/>
-      <parameter type-id='type-id-93' name='buf' filepath='src.d/gzread.c' line='375' column='1'/>
-      <parameter type-id='type-id-4' name='len' filepath='src.d/gzread.c' line='376' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='gzfread' mangled-name='gzfread' filepath='src.d/gzread.c' line='409' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzfread@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-93' name='buf' filepath='src.d/gzread.c' line='410' column='1'/>
-      <parameter type-id='type-id-7' name='size' filepath='src.d/gzread.c' line='411' column='1'/>
-      <parameter type-id='type-id-7' name='nitems' filepath='src.d/gzread.c' line='412' column='1'/>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='413' column='1'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='369' column='1'/>
+      <parameter type-id='type-id-7' name='offset' filepath='src.d/gzlib.c' line='370' column='1'/>
+      <parameter type-id='type-id-20' name='whence' filepath='src.d/gzlib.c' line='371' column='1'/>
       <return type-id='type-id-7'/>
     </function-decl>
-    <function-decl name='gzgetc' mangled-name='gzgetc' filepath='src.d/gzread.c' line='445' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzgetc'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='446' column='1'/>
+    <function-decl name='gzseek' mangled-name='gzseek' filepath='src.d/gzlib.c' line='445' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzseek'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='446' column='1'/>
+      <parameter type-id='type-id-8' name='offset' filepath='src.d/gzlib.c' line='447' column='1'/>
+      <parameter type-id='type-id-20' name='whence' filepath='src.d/gzlib.c' line='448' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='gztell64' mangled-name='gztell64' filepath='src.d/gzlib.c' line='457' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gztell64@@ZLIB_1.2.3.3'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='458' column='1'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='gztell' mangled-name='gztell' filepath='src.d/gzlib.c' line='474' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gztell'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='475' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='gzoffset64' mangled-name='gzoffset64' filepath='src.d/gzlib.c' line='484' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzoffset64@@ZLIB_1.2.3.5'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='485' column='1'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='gzoffset' mangled-name='gzoffset' filepath='src.d/gzlib.c' line='507' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzoffset@@ZLIB_1.2.3.5'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='508' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='gzeof' mangled-name='gzeof' filepath='src.d/gzlib.c' line='517' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzeof'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='518' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzerror' mangled-name='gzerror' filepath='src.d/gzlib.c' line='534' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzerror'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='535' column='1'/>
+      <parameter type-id='type-id-77' name='errnum' filepath='src.d/gzlib.c' line='536' column='1'/>
       <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='gzclearerr' mangled-name='gzclearerr' filepath='src.d/gzlib.c' line='555' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzclearerr@@ZLIB_1.2.0.2'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='556' column='1'/>
+      <return type-id='type-id-86'/>
+    </function-decl>
+    <type-decl name='variadic parameter type' id='type-id-91'/>
+  </abi-instr>
+  <abi-instr address-size='32' path='src.d/gzread.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
+    <class-decl name='gz_state' size-in-bits='1344' is-struct='yes' naming-typedef-id='type-id-92' visibility='default' filepath='src.d/gzguts.h' line='170' column='1' id='type-id-93'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='x' type-id='type-id-87' visibility='default' filepath='src.d/gzguts.h' line='172' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='mode' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='177' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='fd' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='178' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='path' type-id='type-id-54' visibility='default' filepath='src.d/gzguts.h' line='179' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='size' type-id='type-id-9' visibility='default' filepath='src.d/gzguts.h' line='180' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='want' type-id='type-id-9' visibility='default' filepath='src.d/gzguts.h' line='181' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='in' type-id='type-id-88' visibility='default' filepath='src.d/gzguts.h' line='182' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='out' type-id='type-id-88' visibility='default' filepath='src.d/gzguts.h' line='183' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='direct' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='184' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='how' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='186' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='start' type-id='type-id-7' visibility='default' filepath='src.d/gzguts.h' line='187' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='eof' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='188' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='544'>
+        <var-decl name='past' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='189' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='level' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='191' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='608'>
+        <var-decl name='strategy' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='192' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='reset' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='193' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='skip' type-id='type-id-7' visibility='default' filepath='src.d/gzguts.h' line='195' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='seek' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='196' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='800'>
+        <var-decl name='err' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='198' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='msg' type-id='type-id-54' visibility='default' filepath='src.d/gzguts.h' line='199' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='864'>
+        <var-decl name='strm' type-id='type-id-71' visibility='default' filepath='src.d/gzguts.h' line='201' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__ssize_t' type-id='type-id-20' filepath='/usr/arm-linux-gnueabihf/include/bits/types.h' line='194' column='1' id='type-id-94'/>
+    <typedef-decl name='gz_state' type-id='type-id-93' filepath='src.d/gzguts.h' line='202' column='1' id='type-id-92'/>
+    <typedef-decl name='gz_statep' type-id='type-id-95' filepath='src.d/gzguts.h' line='203' column='1' id='type-id-96'/>
+    <typedef-decl name='ssize_t' type-id='type-id-94' filepath='/usr/arm-linux-gnueabihf/include/sys/types.h' line='108' column='1' id='type-id-97'/>
+    <pointer-type-def type-id='type-id-92' size-in-bits='32' id='type-id-95'/>
+    <typedef-decl name='voidp' type-id='type-id-85' filepath='./zconf.h' line='416' column='1' id='type-id-98'/>
+    <function-decl name='__errno_location' filepath='/usr/arm-linux-gnueabihf/include/errno.h' line='37' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <return type-id='type-id-77'/>
+    </function-decl>
+    <function-decl name='memchr' filepath='/usr/arm-linux-gnueabihf/include/string.h' line='107' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-85'/>
+    </function-decl>
+    <function-decl name='strerror' filepath='/usr/arm-linux-gnueabihf/include/string.h' line='419' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-54'/>
+    </function-decl>
+    <function-decl name='close' filepath='/usr/arm-linux-gnueabihf/include/unistd.h' line='358' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='read' filepath='/usr/arm-linux-gnueabihf/include/unistd.h' line='371' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-97'/>
+    </function-decl>
+    <function-decl name='gz_error' filepath='src.d/gzguts.h' line='206' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-96'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-22'/>
+      <return type-id='type-id-86'/>
+    </function-decl>
+    <function-decl name='gzread' mangled-name='gzread' filepath='src.d/gzread.c' line='373' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzread'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzread.c' line='374' column='1'/>
+      <parameter type-id='type-id-98' name='buf' filepath='src.d/gzread.c' line='375' column='1'/>
+      <parameter type-id='type-id-9' name='len' filepath='src.d/gzread.c' line='376' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzfread' mangled-name='gzfread' filepath='src.d/gzread.c' line='409' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzfread@@ZLIB_1.2.9'>
+      <parameter type-id='type-id-98' name='buf' filepath='src.d/gzread.c' line='410' column='1'/>
+      <parameter type-id='type-id-14' name='size' filepath='src.d/gzread.c' line='411' column='1'/>
+      <parameter type-id='type-id-14' name='nitems' filepath='src.d/gzread.c' line='412' column='1'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzread.c' line='413' column='1'/>
+      <return type-id='type-id-14'/>
+    </function-decl>
+    <function-decl name='gzgetc' mangled-name='gzgetc' filepath='src.d/gzread.c' line='445' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzgetc'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzread.c' line='446' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzgetc_' mangled-name='gzgetc_' filepath='src.d/gzread.c' line='472' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzgetc_@@ZLIB_1.2.5.2'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='473' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzread.c' line='473' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzungetc' mangled-name='gzungetc' filepath='src.d/gzread.c' line='479' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzungetc@@ZLIB_1.2.0.2'>
-      <parameter type-id='type-id-22' name='c' filepath='src.d/gzread.c' line='480' column='1'/>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='481' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-20' name='c' filepath='src.d/gzread.c' line='480' column='1'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzread.c' line='481' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzgets' mangled-name='gzgets' filepath='src.d/gzread.c' line='539' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzgets'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='540' column='1'/>
-      <parameter type-id='type-id-70' name='buf' filepath='src.d/gzread.c' line='541' column='1'/>
-      <parameter type-id='type-id-22' name='len' filepath='src.d/gzread.c' line='542' column='1'/>
-      <return type-id='type-id-70'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzread.c' line='540' column='1'/>
+      <parameter type-id='type-id-54' name='buf' filepath='src.d/gzread.c' line='541' column='1'/>
+      <parameter type-id='type-id-20' name='len' filepath='src.d/gzread.c' line='542' column='1'/>
+      <return type-id='type-id-54'/>
     </function-decl>
     <function-decl name='gzdirect' mangled-name='gzdirect' filepath='src.d/gzread.c' line='603' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzdirect@@ZLIB_1.2.2.3'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='604' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzread.c' line='604' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflate' filepath='src.d/zlib.h' line='400' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateEnd' filepath='src.d/zlib.h' line='520' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-21'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateReset' filepath='src.d/zlib.h' line='959' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-21'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateInit2_' filepath='src.d/zlib.h' line='1789' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/gzwrite.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <class-decl name='__va_list' size-in-bits='32' is-struct='yes' visibility='default' id='type-id-100'>
+    <class-decl name='__va_list' size-in-bits='32' is-struct='yes' visibility='default' id='type-id-99'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='__ap' type-id='type-id-46' visibility='default'/>
+        <var-decl name='__ap' type-id='type-id-85' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='voidpc' type-id='type-id-46' filepath='./zconf.h' line='414' column='1' id='type-id-101'/>
-    <typedef-decl name='__gnuc_va_list' type-id='type-id-100' filepath='/usr/lib/gcc-cross/arm-linux-gnueabihf/11/include/stdarg.h' line='40' column='1' id='type-id-102'/>
-    <typedef-decl name='va_list' type-id='type-id-102' filepath='/usr/lib/gcc-cross/arm-linux-gnueabihf/11/include/stdarg.h' line='99' column='1' id='type-id-103'/>
-    <function-decl name='vsnprintf' filepath='/usr/arm-linux-gnueabihf/include/stdio.h' line='382' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-70'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-80'/>
-      <parameter type-id='type-id-102'/>
-      <return type-id='type-id-22'/>
+    <typedef-decl name='__gnuc_va_list' type-id='type-id-99' filepath='/usr/lib/gcc-cross/arm-linux-gnueabihf/13/include/stdarg.h' line='40' column='1' id='type-id-100'/>
+    <typedef-decl name='va_list' type-id='type-id-100' filepath='/usr/lib/gcc-cross/arm-linux-gnueabihf/13/include/stdarg.h' line='103' column='1' id='type-id-101'/>
+    <typedef-decl name='voidpc' type-id='type-id-85' filepath='./zconf.h' line='414' column='1' id='type-id-102'/>
+    <function-decl name='vsnprintf' filepath='/usr/arm-linux-gnueabihf/include/stdio.h' line='389' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-54'/>
+      <parameter type-id='type-id-10'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-100'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='memmove' filepath='/usr/arm-linux-gnueabihf/include/string.h' line='47' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-46'/>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-85'/>
     </function-decl>
     <function-decl name='write' filepath='/usr/arm-linux-gnueabihf/include/unistd.h' line='378' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-22'/>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-95'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-97'/>
     </function-decl>
     <function-decl name='gzwrite' mangled-name='gzwrite' filepath='src.d/gzwrite.c' line='255' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzwrite'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='256' column='1'/>
-      <parameter type-id='type-id-101' name='buf' filepath='src.d/gzwrite.c' line='257' column='1'/>
-      <parameter type-id='type-id-4' name='len' filepath='src.d/gzwrite.c' line='258' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzwrite.c' line='256' column='1'/>
+      <parameter type-id='type-id-102' name='buf' filepath='src.d/gzwrite.c' line='257' column='1'/>
+      <parameter type-id='type-id-9' name='len' filepath='src.d/gzwrite.c' line='258' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzfwrite' mangled-name='gzfwrite' filepath='src.d/gzwrite.c' line='283' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzfwrite@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-101' name='buf' filepath='src.d/gzwrite.c' line='284' column='1'/>
-      <parameter type-id='type-id-7' name='size' filepath='src.d/gzwrite.c' line='285' column='1'/>
-      <parameter type-id='type-id-7' name='nitems' filepath='src.d/gzwrite.c' line='286' column='1'/>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='287' column='1'/>
-      <return type-id='type-id-7'/>
+      <parameter type-id='type-id-102' name='buf' filepath='src.d/gzwrite.c' line='284' column='1'/>
+      <parameter type-id='type-id-14' name='size' filepath='src.d/gzwrite.c' line='285' column='1'/>
+      <parameter type-id='type-id-14' name='nitems' filepath='src.d/gzwrite.c' line='286' column='1'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzwrite.c' line='287' column='1'/>
+      <return type-id='type-id-14'/>
     </function-decl>
     <function-decl name='gzputc' mangled-name='gzputc' filepath='src.d/gzwrite.c' line='313' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzputc'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='314' column='1'/>
-      <parameter type-id='type-id-22' name='c' filepath='src.d/gzwrite.c' line='315' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzwrite.c' line='314' column='1'/>
+      <parameter type-id='type-id-20' name='c' filepath='src.d/gzwrite.c' line='315' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzputs' mangled-name='gzputs' filepath='src.d/gzwrite.c' line='361' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzputs'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='362' column='1'/>
-      <parameter type-id='type-id-80' name='s' filepath='src.d/gzwrite.c' line='363' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzwrite.c' line='362' column='1'/>
+      <parameter type-id='type-id-22' name='s' filepath='src.d/gzwrite.c' line='363' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzvprintf' mangled-name='gzvprintf' filepath='src.d/gzwrite.c' line='391' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzvprintf@@ZLIB_1.2.7.1'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='391' column='1'/>
-      <parameter type-id='type-id-80' name='format' filepath='src.d/gzwrite.c' line='391' column='1'/>
-      <parameter type-id='type-id-103' name='va' filepath='src.d/gzwrite.c' line='391' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzwrite.c' line='391' column='1'/>
+      <parameter type-id='type-id-22' name='format' filepath='src.d/gzwrite.c' line='391' column='1'/>
+      <parameter type-id='type-id-101' name='va' filepath='src.d/gzwrite.c' line='391' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzprintf' mangled-name='gzprintf' filepath='src.d/gzwrite.c' line='463' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzprintf'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='463' column='1'/>
-      <parameter type-id='type-id-80' name='format' filepath='src.d/gzwrite.c' line='463' column='1'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzwrite.c' line='463' column='1'/>
+      <parameter type-id='type-id-22' name='format' filepath='src.d/gzwrite.c' line='463' column='1'/>
       <parameter is-variadic='yes'/>
-      <return type-id='type-id-22'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzflush' mangled-name='gzflush' filepath='src.d/gzwrite.c' line='565' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzflush'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='566' column='1'/>
-      <parameter type-id='type-id-22' name='flush' filepath='src.d/gzwrite.c' line='567' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzwrite.c' line='566' column='1'/>
+      <parameter type-id='type-id-20' name='flush' filepath='src.d/gzwrite.c' line='567' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzsetparams' mangled-name='gzsetparams' filepath='src.d/gzwrite.c' line='597' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzsetparams'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='598' column='1'/>
-      <parameter type-id='type-id-22' name='level' filepath='src.d/gzwrite.c' line='599' column='1'/>
-      <parameter type-id='type-id-22' name='strategy' filepath='src.d/gzwrite.c' line='600' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzwrite.c' line='598' column='1'/>
+      <parameter type-id='type-id-20' name='level' filepath='src.d/gzwrite.c' line='599' column='1'/>
+      <parameter type-id='type-id-20' name='strategy' filepath='src.d/gzwrite.c' line='600' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/infback.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-104'/>
-    <class-decl name='code' size-in-bits='32' is-struct='yes' naming-typedef-id='type-id-105' visibility='default' filepath='src.d/inftrees.h' line='24' column='1' id='type-id-106'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-3' visibility='default' filepath='src.d/inftrees.h' line='25' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='8'>
-        <var-decl name='bits' type-id='type-id-3' visibility='default' filepath='src.d/inftrees.h' line='26' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='16'>
-        <var-decl name='val' type-id='type-id-40' visibility='default' filepath='src.d/inftrees.h' line='27' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='code' type-id='type-id-106' filepath='src.d/inftrees.h' line='28' column='1' id='type-id-105'/>
-    <enum-decl name='codetype' naming-typedef-id='type-id-107' filepath='src.d/inftrees.h' line='54' column='1' id='type-id-108'>
-      <underlying-type type-id='type-id-104'/>
+    <enum-decl name='codetype' naming-typedef-id='type-id-103' filepath='src.d/inftrees.h' line='54' column='1' id='type-id-104'>
+      <underlying-type type-id='type-id-105'/>
       <enumerator name='CODES' value='0'/>
       <enumerator name='LENS' value='1'/>
       <enumerator name='DISTS' value='2'/>
     </enum-decl>
-    <typedef-decl name='codetype' type-id='type-id-108' filepath='src.d/inftrees.h' line='58' column='1' id='type-id-107'/>
-    <typedef-decl name='in_func' type-id='type-id-109' filepath='src.d/zlib.h' line='1094' column='1' id='type-id-110'/>
-    <typedef-decl name='out_func' type-id='type-id-111' filepath='src.d/zlib.h' line='1096' column='1' id='type-id-112'/>
-    <pointer-type-def type-id='type-id-105' size-in-bits='32' id='type-id-113'/>
-    <pointer-type-def type-id='type-id-113' size-in-bits='32' id='type-id-114'/>
-    <pointer-type-def type-id='type-id-115' size-in-bits='32' id='type-id-111'/>
-    <pointer-type-def type-id='type-id-3' size-in-bits='32' id='type-id-91'/>
-    <pointer-type-def type-id='type-id-91' size-in-bits='32' id='type-id-116'/>
-    <pointer-type-def type-id='type-id-117' size-in-bits='32' id='type-id-109'/>
-    <pointer-type-def type-id='type-id-40' size-in-bits='32' id='type-id-118'/>
+    <class-decl name='code' size-in-bits='32' is-struct='yes' naming-typedef-id='type-id-106' visibility='default' filepath='src.d/inftrees.h' line='24' column='1' id='type-id-107'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-2' visibility='default' filepath='src.d/inftrees.h' line='25' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8'>
+        <var-decl name='bits' type-id='type-id-2' visibility='default' filepath='src.d/inftrees.h' line='26' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='val' type-id='type-id-70' visibility='default' filepath='src.d/inftrees.h' line='27' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='code' type-id='type-id-107' filepath='src.d/inftrees.h' line='28' column='1' id='type-id-106'/>
+    <typedef-decl name='codetype' type-id='type-id-104' filepath='src.d/inftrees.h' line='58' column='1' id='type-id-103'/>
+    <typedef-decl name='in_func' type-id='type-id-108' filepath='src.d/zlib.h' line='1094' column='1' id='type-id-109'/>
+    <typedef-decl name='out_func' type-id='type-id-110' filepath='src.d/zlib.h' line='1096' column='1' id='type-id-111'/>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-105'/>
+    <pointer-type-def type-id='type-id-106' size-in-bits='32' id='type-id-112'/>
+    <pointer-type-def type-id='type-id-112' size-in-bits='32' id='type-id-113'/>
+    <pointer-type-def type-id='type-id-114' size-in-bits='32' id='type-id-110'/>
+    <pointer-type-def type-id='type-id-2' size-in-bits='32' id='type-id-88'/>
+    <pointer-type-def type-id='type-id-88' size-in-bits='32' id='type-id-115'/>
+    <pointer-type-def type-id='type-id-116' size-in-bits='32' id='type-id-108'/>
+    <pointer-type-def type-id='type-id-70' size-in-bits='32' id='type-id-117'/>
+    <typedef-decl name='voidpf' type-id='type-id-85' filepath='./zconf.h' line='415' column='1' id='type-id-118'/>
     <function-decl name='inflateBackInit_' mangled-name='inflateBackInit_' filepath='src.d/infback.c' line='28' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateBackInit_@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/infback.c' line='29' column='1'/>
-      <parameter type-id='type-id-22' name='windowBits' filepath='src.d/infback.c' line='30' column='1'/>
-      <parameter type-id='type-id-91' name='window' filepath='src.d/infback.c' line='31' column='1'/>
-      <parameter type-id='type-id-80' name='version' filepath='src.d/infback.c' line='32' column='1'/>
-      <parameter type-id='type-id-22' name='stream_size' filepath='src.d/infback.c' line='33' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/infback.c' line='29' column='1'/>
+      <parameter type-id='type-id-20' name='windowBits' filepath='src.d/infback.c' line='30' column='1'/>
+      <parameter type-id='type-id-88' name='window' filepath='src.d/infback.c' line='31' column='1'/>
+      <parameter type-id='type-id-22' name='version' filepath='src.d/infback.c' line='32' column='1'/>
+      <parameter type-id='type-id-20' name='stream_size' filepath='src.d/infback.c' line='33' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateBack' mangled-name='inflateBack' filepath='src.d/infback.c' line='251' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateBack@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/infback.c' line='252' column='1'/>
-      <parameter type-id='type-id-110' name='in' filepath='src.d/infback.c' line='253' column='1'/>
-      <parameter type-id='type-id-46' name='in_desc' filepath='src.d/infback.c' line='254' column='1'/>
-      <parameter type-id='type-id-112' name='out' filepath='src.d/infback.c' line='255' column='1'/>
-      <parameter type-id='type-id-46' name='out_desc' filepath='src.d/infback.c' line='256' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/infback.c' line='252' column='1'/>
+      <parameter type-id='type-id-109' name='in' filepath='src.d/infback.c' line='253' column='1'/>
+      <parameter type-id='type-id-85' name='in_desc' filepath='src.d/infback.c' line='254' column='1'/>
+      <parameter type-id='type-id-111' name='out' filepath='src.d/infback.c' line='255' column='1'/>
+      <parameter type-id='type-id-85' name='out_desc' filepath='src.d/infback.c' line='256' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateBackEnd' mangled-name='inflateBackEnd' filepath='src.d/infback.c' line='635' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateBackEnd@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/infback.c' line='636' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/infback.c' line='636' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflate_fast' filepath='src.d/inffast.h' line='11' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-59'/>
-      <parameter type-id='type-id-4'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-9'/>
+      <return type-id='type-id-86'/>
     </function-decl>
     <function-decl name='inflate_table' filepath='src.d/inftrees.h' line='60' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-107'/>
-      <parameter type-id='type-id-118'/>
-      <parameter type-id='type-id-4'/>
-      <parameter type-id='type-id-114'/>
-      <parameter type-id='type-id-86'/>
-      <parameter type-id='type-id-118'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-103'/>
+      <parameter type-id='type-id-117'/>
+      <parameter type-id='type-id-9'/>
+      <parameter type-id='type-id-113'/>
+      <parameter type-id='type-id-80'/>
+      <parameter type-id='type-id-117'/>
+      <return type-id='type-id-20'/>
     </function-decl>
-    <function-type size-in-bits='32' id='type-id-115'>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-4'/>
-      <return type-id='type-id-22'/>
+    <function-type size-in-bits='32' id='type-id-114'>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-88'/>
+      <parameter type-id='type-id-9'/>
+      <return type-id='type-id-20'/>
     </function-type>
-    <function-type size-in-bits='32' id='type-id-117'>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-116'/>
-      <return type-id='type-id-4'/>
+    <function-type size-in-bits='32' id='type-id-116'>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-115'/>
+      <return type-id='type-id-9'/>
     </function-type>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/inflate.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
+    <typedef-decl name='voidpf' type-id='type-id-85' filepath='./zconf.h' line='415' column='1' id='type-id-119'/>
     <function-decl name='inflateResetKeep' mangled-name='inflateResetKeep' filepath='src.d/inflate.c' line='119' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateResetKeep@@ZLIB_1.2.5.2'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='120' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='inflateReset' mangled-name='inflateReset' filepath='src.d/inflate.c' line='145' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateReset'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='146' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='120' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateReset2' mangled-name='inflateReset2' filepath='src.d/inflate.c' line='158' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateReset2@@ZLIB_1.2.3.4'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='159' column='1'/>
-      <parameter type-id='type-id-22' name='windowBits' filepath='src.d/inflate.c' line='160' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='inflateInit2_' mangled-name='inflateInit2_' filepath='src.d/inflate.c' line='198' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateInit2_'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='199' column='1'/>
-      <parameter type-id='type-id-22' name='windowBits' filepath='src.d/inflate.c' line='200' column='1'/>
-      <parameter type-id='type-id-80' name='version' filepath='src.d/inflate.c' line='201' column='1'/>
-      <parameter type-id='type-id-22' name='stream_size' filepath='src.d/inflate.c' line='202' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='159' column='1'/>
+      <parameter type-id='type-id-20' name='windowBits' filepath='src.d/inflate.c' line='160' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateInit_' mangled-name='inflateInit_' filepath='src.d/inflate.c' line='242' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateInit_'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='243' column='1'/>
-      <parameter type-id='type-id-80' name='version' filepath='src.d/inflate.c' line='244' column='1'/>
-      <parameter type-id='type-id-22' name='stream_size' filepath='src.d/inflate.c' line='245' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='243' column='1'/>
+      <parameter type-id='type-id-22' name='version' filepath='src.d/inflate.c' line='244' column='1'/>
+      <parameter type-id='type-id-20' name='stream_size' filepath='src.d/inflate.c' line='245' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflatePrime' mangled-name='inflatePrime' filepath='src.d/inflate.c' line='250' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflatePrime@@ZLIB_1.2.2.4'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='251' column='1'/>
-      <parameter type-id='type-id-22' name='bits' filepath='src.d/inflate.c' line='252' column='1'/>
-      <parameter type-id='type-id-22' name='value' filepath='src.d/inflate.c' line='253' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='inflate' mangled-name='inflate' filepath='src.d/inflate.c' line='625' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflate'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='626' column='1'/>
-      <parameter type-id='type-id-22' name='flush' filepath='src.d/inflate.c' line='627' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='inflateEnd' mangled-name='inflateEnd' filepath='src.d/inflate.c' line='1304' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateEnd'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1305' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='251' column='1'/>
+      <parameter type-id='type-id-20' name='bits' filepath='src.d/inflate.c' line='252' column='1'/>
+      <parameter type-id='type-id-20' name='value' filepath='src.d/inflate.c' line='253' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateGetDictionary' mangled-name='inflateGetDictionary' filepath='src.d/inflate.c' line='1318' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateGetDictionary@@ZLIB_1.2.7.1'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1319' column='1'/>
-      <parameter type-id='type-id-21' name='dictionary' filepath='src.d/inflate.c' line='1320' column='1'/>
-      <parameter type-id='type-id-85' name='dictLength' filepath='src.d/inflate.c' line='1321' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1319' column='1'/>
+      <parameter type-id='type-id-19' name='dictionary' filepath='src.d/inflate.c' line='1320' column='1'/>
+      <parameter type-id='type-id-79' name='dictLength' filepath='src.d/inflate.c' line='1321' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateSetDictionary' mangled-name='inflateSetDictionary' filepath='src.d/inflate.c' line='1341' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateSetDictionary'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1342' column='1'/>
-      <parameter type-id='type-id-18' name='dictionary' filepath='src.d/inflate.c' line='1343' column='1'/>
-      <parameter type-id='type-id-9' name='dictLength' filepath='src.d/inflate.c' line='1344' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1342' column='1'/>
+      <parameter type-id='type-id-16' name='dictionary' filepath='src.d/inflate.c' line='1343' column='1'/>
+      <parameter type-id='type-id-11' name='dictLength' filepath='src.d/inflate.c' line='1344' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateGetHeader' mangled-name='inflateGetHeader' filepath='src.d/inflate.c' line='1376' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateGetHeader@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1377' column='1'/>
-      <parameter type-id='type-id-61' name='head' filepath='src.d/inflate.c' line='1378' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1377' column='1'/>
+      <parameter type-id='type-id-43' name='head' filepath='src.d/inflate.c' line='1378' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateSync' mangled-name='inflateSync' filepath='src.d/inflate.c' line='1427' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateSync'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1428' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1428' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateSyncPoint' mangled-name='inflateSyncPoint' filepath='src.d/inflate.c' line='1485' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateSyncPoint'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1486' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1486' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateCopy' mangled-name='inflateCopy' filepath='src.d/inflate.c' line='1495' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateCopy@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-59' name='dest' filepath='src.d/inflate.c' line='1496' column='1'/>
-      <parameter type-id='type-id-59' name='source' filepath='src.d/inflate.c' line='1497' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='dest' filepath='src.d/inflate.c' line='1496' column='1'/>
+      <parameter type-id='type-id-21' name='source' filepath='src.d/inflate.c' line='1497' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateUndermine' mangled-name='inflateUndermine' filepath='src.d/inflate.c' line='1542' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateUndermine@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1543' column='1'/>
-      <parameter type-id='type-id-22' name='subvert' filepath='src.d/inflate.c' line='1544' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1543' column='1'/>
+      <parameter type-id='type-id-20' name='subvert' filepath='src.d/inflate.c' line='1544' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateValidate' mangled-name='inflateValidate' filepath='src.d/inflate.c' line='1560' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateValidate@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1561' column='1'/>
-      <parameter type-id='type-id-22' name='check' filepath='src.d/inflate.c' line='1562' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1561' column='1'/>
+      <parameter type-id='type-id-20' name='check' filepath='src.d/inflate.c' line='1562' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateMark' mangled-name='inflateMark' filepath='src.d/inflate.c' line='1575' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateMark@@ZLIB_1.2.3.4'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1576' column='1'/>
-      <return type-id='type-id-1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1576' column='1'/>
+      <return type-id='type-id-37'/>
     </function-decl>
     <function-decl name='inflateCodesUsed' mangled-name='inflateCodesUsed' filepath='src.d/inflate.c' line='1588' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateCodesUsed@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1589' column='1'/>
-      <return type-id='type-id-5'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1589' column='1'/>
+      <return type-id='type-id-12'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/trees.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <array-type-def dimensions='1' type-id='type-id-119' size-in-bits='2048' id='type-id-120'>
-      <subrange length='256' type-id='type-id-4' id='type-id-121'/>
+    <array-type-def dimensions='1' type-id='type-id-120' size-in-bits='2048' id='type-id-121'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-9' id='type-id-122'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-119' size-in-bits='4096' id='type-id-122'>
-      <subrange length='512' type-id='type-id-4' id='type-id-123'/>
+    <array-type-def dimensions='1' type-id='type-id-120' size-in-bits='4096' id='type-id-123'>
+      <subrange length='512' lower-bound='0' upper-bound='511' type-id='type-id-9' id='type-id-124'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-119' size-in-bits='infinite' id='type-id-124'>
-      <subrange length='infinite' id='type-id-125'/>
+    <array-type-def dimensions='1' type-id='type-id-120' size-in-bits='unknown' id='type-id-125'>
+      <subrange length='unknown' lower-bound='0' upper-bound='0' id='type-id-126'/>
     </array-type-def>
-    <qualified-type-def type-id='type-id-38' const='yes' id='type-id-119'/>
-    <var-decl name='_length_code' type-id='type-id-124' visibility='default' filepath='src.d/deflate.h' line='317' column='1'/>
-    <var-decl name='_dist_code' type-id='type-id-124' visibility='default' filepath='src.d/deflate.h' line='318' column='1'/>
+    <qualified-type-def type-id='type-id-68' const='yes' id='type-id-120'/>
+    <var-decl name='_length_code' type-id='type-id-121' visibility='default' filepath='src.d/deflate.h' line='317' column='1'/>
+    <var-decl name='_dist_code' type-id='type-id-123' visibility='default' filepath='src.d/deflate.h' line='318' column='1'/>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/uncompr.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <pointer-type-def type-id='type-id-10' size-in-bits='32' id='type-id-126'/>
+    <pointer-type-def type-id='type-id-13' size-in-bits='32' id='type-id-127'/>
     <function-decl name='uncompress2' mangled-name='uncompress2' filepath='src.d/uncompr.c' line='27' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='uncompress2@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-21' name='dest' filepath='src.d/uncompr.c' line='28' column='1'/>
-      <parameter type-id='type-id-20' name='destLen' filepath='src.d/uncompr.c' line='29' column='1'/>
-      <parameter type-id='type-id-18' name='source' filepath='src.d/uncompr.c' line='30' column='1'/>
-      <parameter type-id='type-id-126' name='sourceLen' filepath='src.d/uncompr.c' line='31' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-19' name='dest' filepath='src.d/uncompr.c' line='28' column='1'/>
+      <parameter type-id='type-id-18' name='destLen' filepath='src.d/uncompr.c' line='29' column='1'/>
+      <parameter type-id='type-id-16' name='source' filepath='src.d/uncompr.c' line='30' column='1'/>
+      <parameter type-id='type-id-127' name='sourceLen' filepath='src.d/uncompr.c' line='31' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='uncompress' mangled-name='uncompress' filepath='src.d/uncompr.c' line='86' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='uncompress'>
-      <parameter type-id='type-id-21' name='dest' filepath='src.d/uncompr.c' line='87' column='1'/>
-      <parameter type-id='type-id-20' name='destLen' filepath='src.d/uncompr.c' line='88' column='1'/>
-      <parameter type-id='type-id-18' name='source' filepath='src.d/uncompr.c' line='89' column='1'/>
-      <parameter type-id='type-id-10' name='sourceLen' filepath='src.d/uncompr.c' line='90' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-19' name='dest' filepath='src.d/uncompr.c' line='87' column='1'/>
+      <parameter type-id='type-id-18' name='destLen' filepath='src.d/uncompr.c' line='88' column='1'/>
+      <parameter type-id='type-id-16' name='source' filepath='src.d/uncompr.c' line='89' column='1'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/uncompr.c' line='90' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/zutil.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <array-type-def dimensions='1' type-id='type-id-127' size-in-bits='320' id='type-id-128'>
-      <subrange length='10' type-id='type-id-4' id='type-id-129'/>
+    <array-type-def dimensions='1' type-id='type-id-128' size-in-bits='320' id='type-id-129'>
+      <subrange length='10' lower-bound='0' upper-bound='9' type-id='type-id-9' id='type-id-130'/>
     </array-type-def>
-    <qualified-type-def type-id='type-id-70' const='yes' id='type-id-127'/>
-    <function-decl name='malloc' filepath='/usr/arm-linux-gnueabihf/include/stdlib.h' line='540' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-46'/>
-    </function-decl>
-    <function-decl name='free' filepath='/usr/arm-linux-gnueabihf/include/stdlib.h' line='555' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-46'/>
-      <return type-id='type-id-44'/>
-    </function-decl>
+    <qualified-type-def type-id='type-id-54' const='yes' id='type-id-128'/>
     <function-decl name='zlibVersion' mangled-name='zlibVersion' filepath='src.d/zutil.c' line='27' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='zlibVersion'>
-      <return type-id='type-id-80'/>
+      <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='zlibCompileFlags' mangled-name='zlibCompileFlags' filepath='src.d/zutil.c' line='32' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='zlibCompileFlags@@ZLIB_1.2.0.2'>
-      <return type-id='type-id-10'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='zError' mangled-name='zError' filepath='src.d/zutil.c' line='135' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='zError'>
-      <parameter type-id='type-id-22' name='err' filepath='src.d/zutil.c' line='136' column='1'/>
-      <return type-id='type-id-80'/>
+      <parameter type-id='type-id-20' name='err' filepath='src.d/zutil.c' line='136' column='1'/>
+      <return type-id='type-id-22'/>
     </function-decl>
-    <var-decl name='z_errmsg' type-id='type-id-128' visibility='default' filepath='src.d/zutil.h' line='56' column='1'/>
+    <var-decl name='z_errmsg' type-id='type-id-129' visibility='default' filepath='src.d/zutil.h' line='56' column='1'/>
   </abi-instr>
 </abi-corpus>

--- a/test/abi/zlib-04f42ceca40f73e2978b50e93806c2a18c1281fc-mips-unknown-linux-gnu.abi
+++ b/test/abi/zlib-04f42ceca40f73e2978b50e93806c2a18c1281fc-mips-unknown-linux-gnu.abi
@@ -1,4 +1,4 @@
-<abi-corpus version='2.0' path='btmp1/libz.so.1.2.13' architecture='elf-mips-r3000-be' soname='libz.so.1'>
+<abi-corpus version='2.2' path='btmp1/libz.so.1.2.13' architecture='elf-mips-r3000-be' soname='libz.so.1'>
   <elf-needed>
     <dependency name='libc.so.6'/>
     <dependency name='ld.so.1'/>
@@ -93,76 +93,90 @@
     <elf-symbol name='zlibCompileFlags' version='ZLIB_1.2.0.2' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zlibVersion' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
   </elf-function-symbols>
-  <abi-instr address-size='32' path='src.d/adler32.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C99'>
-    <type-decl name='long int' size-in-bits='32' id='type-id-1'/>
-    <type-decl name='long long int' size-in-bits='64' id='type-id-2'/>
-    <type-decl name='unsigned char' size-in-bits='8' id='type-id-3'/>
-    <type-decl name='unsigned int' size-in-bits='32' id='type-id-4'/>
-    <type-decl name='unsigned long int' size-in-bits='32' id='type-id-5'/>
-    <typedef-decl name='z_size_t' type-id='type-id-6' filepath='./zconf.h' line='251' column='1' id='type-id-7'/>
-    <typedef-decl name='Byte' type-id='type-id-3' filepath='./zconf.h' line='397' column='1' id='type-id-8'/>
-    <typedef-decl name='uInt' type-id='type-id-4' filepath='./zconf.h' line='399' column='1' id='type-id-9'/>
-    <typedef-decl name='uLong' type-id='type-id-5' filepath='./zconf.h' line='400' column='1' id='type-id-10'/>
-    <typedef-decl name='Bytef' type-id='type-id-8' filepath='./zconf.h' line='406' column='1' id='type-id-11'/>
-    <typedef-decl name='size_t' type-id='type-id-4' filepath='/usr/lib/gcc-cross/mips-linux-gnu/10/include/stddef.h' line='209' column='1' id='type-id-6'/>
-    <typedef-decl name='__int64_t' type-id='type-id-2' filepath='/usr/mips-linux-gnu/include/bits/types.h' line='47' column='1' id='type-id-12'/>
-    <typedef-decl name='__off_t' type-id='type-id-1' filepath='/usr/mips-linux-gnu/include/bits/types.h' line='152' column='1' id='type-id-13'/>
-    <typedef-decl name='__off64_t' type-id='type-id-12' filepath='/usr/mips-linux-gnu/include/bits/types.h' line='153' column='1' id='type-id-14'/>
-    <typedef-decl name='off_t' type-id='type-id-13' filepath='/usr/mips-linux-gnu/include/sys/types.h' line='85' column='1' id='type-id-15'/>
-    <typedef-decl name='off64_t' type-id='type-id-14' filepath='/usr/mips-linux-gnu/include/sys/types.h' line='92' column='1' id='type-id-16'/>
-    <qualified-type-def type-id='type-id-11' const='yes' id='type-id-17'/>
-    <pointer-type-def type-id='type-id-17' size-in-bits='32' id='type-id-18'/>
+  <abi-instr address-size='32' path='src.d/adler32.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
+    <type-decl name='long long int' size-in-bits='64' id='type-id-1'/>
+    <typedef-decl name='Byte' type-id='type-id-2' filepath='./zconf.h' line='397' column='1' id='type-id-3'/>
+    <typedef-decl name='Bytef' type-id='type-id-3' filepath='./zconf.h' line='406' column='1' id='type-id-4'/>
+    <typedef-decl name='__int64_t' type-id='type-id-1' filepath='/usr/mips-linux-gnu/include/bits/types.h' line='47' column='1' id='type-id-5'/>
+    <typedef-decl name='__off64_t' type-id='type-id-5' filepath='/usr/mips-linux-gnu/include/bits/types.h' line='153' column='1' id='type-id-6'/>
+    <typedef-decl name='off64_t' type-id='type-id-6' filepath='/usr/mips-linux-gnu/include/sys/types.h' line='92' column='1' id='type-id-7'/>
+    <typedef-decl name='off_t' type-id='type-id-6' filepath='/usr/mips-linux-gnu/include/sys/types.h' line='87' column='1' id='type-id-8'/>
+    <typedef-decl name='size_t' type-id='type-id-9' filepath='/usr/lib/gcc-cross/mips-linux-gnu/12/include/stddef.h' line='214' column='1' id='type-id-10'/>
+    <typedef-decl name='uInt' type-id='type-id-9' filepath='./zconf.h' line='399' column='1' id='type-id-11'/>
+    <typedef-decl name='uLong' type-id='type-id-12' filepath='./zconf.h' line='400' column='1' id='type-id-13'/>
+    <typedef-decl name='z_size_t' type-id='type-id-10' filepath='./zconf.h' line='251' column='1' id='type-id-14'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-2'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-9'/>
+    <type-decl name='unsigned long int' size-in-bits='32' id='type-id-12'/>
+    <qualified-type-def type-id='type-id-4' const='yes' id='type-id-15'/>
+    <pointer-type-def type-id='type-id-15' size-in-bits='32' id='type-id-16'/>
     <function-decl name='adler32_z' mangled-name='adler32_z' filepath='src.d/adler32.c' line='63' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='adler32_z@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-10' name='adler' filepath='src.d/adler32.c' line='64' column='1'/>
-      <parameter type-id='type-id-18' name='buf' filepath='src.d/adler32.c' line='65' column='1'/>
-      <parameter type-id='type-id-7' name='len' filepath='src.d/adler32.c' line='66' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-13' name='adler' filepath='src.d/adler32.c' line='64' column='1'/>
+      <parameter type-id='type-id-16' name='buf' filepath='src.d/adler32.c' line='65' column='1'/>
+      <parameter type-id='type-id-14' name='len' filepath='src.d/adler32.c' line='66' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='adler32' mangled-name='adler32' filepath='src.d/adler32.c' line='134' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='adler32'>
-      <parameter type-id='type-id-10' name='adler' filepath='src.d/adler32.c' line='135' column='1'/>
-      <parameter type-id='type-id-18' name='buf' filepath='src.d/adler32.c' line='136' column='1'/>
-      <parameter type-id='type-id-9' name='len' filepath='src.d/adler32.c' line='137' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-13' name='adler' filepath='src.d/adler32.c' line='135' column='1'/>
+      <parameter type-id='type-id-16' name='buf' filepath='src.d/adler32.c' line='136' column='1'/>
+      <parameter type-id='type-id-11' name='len' filepath='src.d/adler32.c' line='137' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='adler32_combine' mangled-name='adler32_combine' filepath='src.d/adler32.c' line='172' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='adler32_combine@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-10' name='adler1' filepath='src.d/adler32.c' line='173' column='1'/>
-      <parameter type-id='type-id-10' name='adler2' filepath='src.d/adler32.c' line='174' column='1'/>
-      <parameter type-id='type-id-15' name='len2' filepath='src.d/adler32.c' line='175' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-13' name='adler1' filepath='src.d/adler32.c' line='173' column='1'/>
+      <parameter type-id='type-id-13' name='adler2' filepath='src.d/adler32.c' line='174' column='1'/>
+      <parameter type-id='type-id-8' name='len2' filepath='src.d/adler32.c' line='175' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='adler32_combine64' mangled-name='adler32_combine64' filepath='src.d/adler32.c' line='180' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='adler32_combine64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-10' name='adler1' filepath='src.d/adler32.c' line='181' column='1'/>
-      <parameter type-id='type-id-10' name='adler2' filepath='src.d/adler32.c' line='182' column='1'/>
-      <parameter type-id='type-id-16' name='len2' filepath='src.d/adler32.c' line='183' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-13' name='adler1' filepath='src.d/adler32.c' line='181' column='1'/>
+      <parameter type-id='type-id-13' name='adler2' filepath='src.d/adler32.c' line='182' column='1'/>
+      <parameter type-id='type-id-7' name='len2' filepath='src.d/adler32.c' line='183' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='32' path='src.d/compress.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C99'>
-    <typedef-decl name='uLongf' type-id='type-id-10' filepath='./zconf.h' line='411' column='1' id='type-id-19'/>
-    <pointer-type-def type-id='type-id-19' size-in-bits='32' id='type-id-20'/>
+  <abi-instr address-size='32' path='src.d/compress.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
+    <typedef-decl name='uLongf' type-id='type-id-13' filepath='./zconf.h' line='411' column='1' id='type-id-17'/>
+    <pointer-type-def type-id='type-id-17' size-in-bits='32' id='type-id-18'/>
     <function-decl name='compress2' mangled-name='compress2' filepath='src.d/compress.c' line='22' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='compress2'>
-      <parameter type-id='type-id-21' name='dest' filepath='src.d/compress.c' line='23' column='1'/>
-      <parameter type-id='type-id-20' name='destLen' filepath='src.d/compress.c' line='24' column='1'/>
-      <parameter type-id='type-id-18' name='source' filepath='src.d/compress.c' line='25' column='1'/>
-      <parameter type-id='type-id-10' name='sourceLen' filepath='src.d/compress.c' line='26' column='1'/>
-      <parameter type-id='type-id-22' name='level' filepath='src.d/compress.c' line='27' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-19' name='dest' filepath='src.d/compress.c' line='23' column='1'/>
+      <parameter type-id='type-id-18' name='destLen' filepath='src.d/compress.c' line='24' column='1'/>
+      <parameter type-id='type-id-16' name='source' filepath='src.d/compress.c' line='25' column='1'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/compress.c' line='26' column='1'/>
+      <parameter type-id='type-id-20' name='level' filepath='src.d/compress.c' line='27' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='compress' mangled-name='compress' filepath='src.d/compress.c' line='68' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='compress'>
-      <parameter type-id='type-id-21' name='dest' filepath='src.d/compress.c' line='69' column='1'/>
-      <parameter type-id='type-id-20' name='destLen' filepath='src.d/compress.c' line='70' column='1'/>
-      <parameter type-id='type-id-18' name='source' filepath='src.d/compress.c' line='71' column='1'/>
-      <parameter type-id='type-id-10' name='sourceLen' filepath='src.d/compress.c' line='72' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-19' name='dest' filepath='src.d/compress.c' line='69' column='1'/>
+      <parameter type-id='type-id-18' name='destLen' filepath='src.d/compress.c' line='70' column='1'/>
+      <parameter type-id='type-id-16' name='source' filepath='src.d/compress.c' line='71' column='1'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/compress.c' line='72' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='compressBound' mangled-name='compressBound' filepath='src.d/compress.c' line='81' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='compressBound@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-10' name='sourceLen' filepath='src.d/compress.c' line='82' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/compress.c' line='82' column='1'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+    <function-decl name='deflate' filepath='src.d/zlib.h' line='250' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='deflateEnd' filepath='src.d/zlib.h' line='363' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-21'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='deflateInit_' filepath='src.d/zlib.h' line='1781' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='32' path='src.d/crc32.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C99'>
-    <typedef-decl name='z_crc_t' type-id='type-id-4' filepath='./zconf.h' line='435' column='1' id='type-id-23'/>
-    <qualified-type-def type-id='type-id-3' const='yes' id='type-id-24'/>
+  <abi-instr address-size='32' path='src.d/crc32.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
+    <typedef-decl name='z_crc_t' type-id='type-id-9' filepath='./zconf.h' line='435' column='1' id='type-id-23'/>
+    <qualified-type-def type-id='type-id-2' const='yes' id='type-id-24'/>
     <pointer-type-def type-id='type-id-24' size-in-bits='32' id='type-id-25'/>
     <qualified-type-def type-id='type-id-23' const='yes' id='type-id-26'/>
     <pointer-type-def type-id='type-id-26' size-in-bits='32' id='type-id-27'/>
@@ -170,863 +184,1088 @@
       <return type-id='type-id-27'/>
     </function-decl>
     <function-decl name='crc32_z' mangled-name='crc32_z' filepath='src.d/crc32.c' line='748' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='crc32_z@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-5' name='crc' filepath='src.d/crc32.c' line='749' column='1'/>
+      <parameter type-id='type-id-12' name='crc' filepath='src.d/crc32.c' line='749' column='1'/>
       <parameter type-id='type-id-25' name='buf' filepath='src.d/crc32.c' line='750' column='1'/>
-      <parameter type-id='type-id-7' name='len' filepath='src.d/crc32.c' line='751' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-14' name='len' filepath='src.d/crc32.c' line='751' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32' mangled-name='crc32' filepath='src.d/crc32.c' line='1072' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='crc32'>
-      <parameter type-id='type-id-5' name='crc' filepath='src.d/crc32.c' line='1073' column='1'/>
+      <parameter type-id='type-id-12' name='crc' filepath='src.d/crc32.c' line='1073' column='1'/>
       <parameter type-id='type-id-25' name='buf' filepath='src.d/crc32.c' line='1074' column='1'/>
-      <parameter type-id='type-id-9' name='len' filepath='src.d/crc32.c' line='1075' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-11' name='len' filepath='src.d/crc32.c' line='1075' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine64' mangled-name='crc32_combine64' filepath='src.d/crc32.c' line='1081' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='crc32_combine64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-10' name='crc1' filepath='src.d/crc32.c' line='1082' column='1'/>
-      <parameter type-id='type-id-10' name='crc2' filepath='src.d/crc32.c' line='1083' column='1'/>
-      <parameter type-id='type-id-16' name='len2' filepath='src.d/crc32.c' line='1084' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-13' name='crc1' filepath='src.d/crc32.c' line='1082' column='1'/>
+      <parameter type-id='type-id-13' name='crc2' filepath='src.d/crc32.c' line='1083' column='1'/>
+      <parameter type-id='type-id-7' name='len2' filepath='src.d/crc32.c' line='1084' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine' mangled-name='crc32_combine' filepath='src.d/crc32.c' line='1093' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='crc32_combine@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-10' name='crc1' filepath='src.d/crc32.c' line='1094' column='1'/>
-      <parameter type-id='type-id-10' name='crc2' filepath='src.d/crc32.c' line='1095' column='1'/>
-      <parameter type-id='type-id-15' name='len2' filepath='src.d/crc32.c' line='1096' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-13' name='crc1' filepath='src.d/crc32.c' line='1094' column='1'/>
+      <parameter type-id='type-id-13' name='crc2' filepath='src.d/crc32.c' line='1095' column='1'/>
+      <parameter type-id='type-id-8' name='len2' filepath='src.d/crc32.c' line='1096' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine_gen64' mangled-name='crc32_combine_gen64' filepath='src.d/crc32.c' line='1102' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='crc32_combine_gen64@@ZLIB_1.2.12'>
-      <parameter type-id='type-id-16' name='len2' filepath='src.d/crc32.c' line='1103' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-7' name='len2' filepath='src.d/crc32.c' line='1103' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine_gen' mangled-name='crc32_combine_gen' filepath='src.d/crc32.c' line='1112' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='crc32_combine_gen@@ZLIB_1.2.12'>
-      <parameter type-id='type-id-15' name='len2' filepath='src.d/crc32.c' line='1113' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-8' name='len2' filepath='src.d/crc32.c' line='1113' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine_op' mangled-name='crc32_combine_op' filepath='src.d/crc32.c' line='1119' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='crc32_combine_op@@ZLIB_1.2.12'>
-      <parameter type-id='type-id-10' name='crc1' filepath='src.d/crc32.c' line='1120' column='1'/>
-      <parameter type-id='type-id-10' name='crc2' filepath='src.d/crc32.c' line='1121' column='1'/>
-      <parameter type-id='type-id-10' name='op' filepath='src.d/crc32.c' line='1122' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-13' name='crc1' filepath='src.d/crc32.c' line='1120' column='1'/>
+      <parameter type-id='type-id-13' name='crc2' filepath='src.d/crc32.c' line='1121' column='1'/>
+      <parameter type-id='type-id-13' name='op' filepath='src.d/crc32.c' line='1122' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='32' path='src.d/deflate.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C99'>
+  <abi-instr address-size='32' path='src.d/deflate.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
     <type-decl name='char' size-in-bits='8' id='type-id-28'/>
-    <class-decl name='static_tree_desc_s' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-29'/>
-    <array-type-def dimensions='1' type-id='type-id-30' size-in-bits='1248' id='type-id-31'>
-      <subrange length='39' type-id='type-id-4' id='type-id-32'/>
+    <array-type-def dimensions='1' type-id='type-id-29' size-in-bits='1248' id='type-id-30'>
+      <subrange length='39' lower-bound='0' upper-bound='38' type-id='type-id-9' id='type-id-31'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-30' size-in-bits='18336' id='type-id-33'>
-      <subrange length='573' type-id='type-id-4' id='type-id-34'/>
+    <array-type-def dimensions='1' type-id='type-id-29' size-in-bits='18336' id='type-id-32'>
+      <subrange length='573' lower-bound='0' upper-bound='572' type-id='type-id-9' id='type-id-33'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-30' size-in-bits='1952' id='type-id-35'>
-      <subrange length='61' type-id='type-id-4' id='type-id-36'/>
+    <array-type-def dimensions='1' type-id='type-id-29' size-in-bits='1952' id='type-id-34'>
+      <subrange length='61' lower-bound='0' upper-bound='60' type-id='type-id-9' id='type-id-35'/>
     </array-type-def>
-    <type-decl name='int' size-in-bits='32' id='type-id-22'/>
-    <array-type-def dimensions='1' type-id='type-id-22' size-in-bits='18336' id='type-id-37'>
-      <subrange length='573' type-id='type-id-4' id='type-id-34'/>
+    <type-decl name='int' size-in-bits='32' id='type-id-20'/>
+    <array-type-def dimensions='1' type-id='type-id-20' size-in-bits='18336' id='type-id-36'>
+      <subrange length='573' lower-bound='0' upper-bound='572' type-id='type-id-9' id='type-id-33'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-38' size-in-bits='4584' id='type-id-39'>
-      <subrange length='573' type-id='type-id-4' id='type-id-34'/>
-    </array-type-def>
-    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-40'/>
-    <array-type-def dimensions='1' type-id='type-id-41' size-in-bits='256' id='type-id-42'>
-      <subrange length='16' type-id='type-id-4' id='type-id-43'/>
-    </array-type-def>
-    <type-decl name='void' id='type-id-44'/>
-    <typedef-decl name='voidpf' type-id='type-id-45' filepath='./zconf.h' line='415' column='1' id='type-id-46'/>
-    <class-decl name='ct_data_s' size-in-bits='32' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='68' column='1' id='type-id-30'>
+    <type-decl name='long int' size-in-bits='32' id='type-id-37'/>
+    <class-decl name='ct_data_s' size-in-bits='32' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='68' column='1' id='type-id-29'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='fc' type-id='type-id-47' visibility='default' filepath='src.d/deflate.h' line='72' column='1'/>
+        <var-decl name='fc' type-id='type-id-38' visibility='default' filepath='src.d/deflate.h' line='72' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='16'>
-        <var-decl name='dl' type-id='type-id-48' visibility='default' filepath='src.d/deflate.h' line='76' column='1'/>
+        <var-decl name='dl' type-id='type-id-39' visibility='default' filepath='src.d/deflate.h' line='76' column='1'/>
       </data-member>
     </class-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='69' column='1' id='type-id-47'>
-      <data-member access='public'>
-        <var-decl name='freq' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='70' column='1'/>
-      </data-member>
-      <data-member access='public'>
-        <var-decl name='code' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='71' column='1'/>
-      </data-member>
-    </union-decl>
-    <union-decl name='__anonymous_union__1' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='73' column='1' id='type-id-48'>
-      <data-member access='public'>
-        <var-decl name='dad' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='74' column='1'/>
-      </data-member>
-      <data-member access='public'>
-        <var-decl name='len' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='75' column='1'/>
-      </data-member>
-    </union-decl>
-    <typedef-decl name='ct_data' type-id='type-id-30' filepath='src.d/deflate.h' line='77' column='1' id='type-id-49'/>
-    <typedef-decl name='static_tree_desc' type-id='type-id-29' filepath='src.d/deflate.h' line='84' column='1' id='type-id-50'/>
-    <class-decl name='tree_desc_s' size-in-bits='96' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='86' column='1' id='type-id-51'>
+    <class-decl name='gz_header_s' size-in-bits='416' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='114' column='1' id='type-id-40'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='dyn_tree' type-id='type-id-52' visibility='default' filepath='src.d/deflate.h' line='87' column='1'/>
+        <var-decl name='text' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='115' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='max_code' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='88' column='1'/>
+        <var-decl name='time' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='116' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='stat_desc' type-id='type-id-53' visibility='default' filepath='src.d/deflate.h' line='89' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='Pos' type-id='type-id-41' filepath='src.d/deflate.h' line='92' column='1' id='type-id-54'/>
-    <typedef-decl name='Posf' type-id='type-id-54' filepath='src.d/deflate.h' line='93' column='1' id='type-id-55'/>
-    <typedef-decl name='IPos' type-id='type-id-4' filepath='src.d/deflate.h' line='94' column='1' id='type-id-56'/>
-    <class-decl name='internal_state' size-in-bits='46624' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='100' column='1' id='type-id-57'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='strm' type-id='type-id-58' visibility='default' filepath='src.d/deflate.h' line='101' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='status' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='102' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='pending_buf' type-id='type-id-21' visibility='default' filepath='src.d/deflate.h' line='103' column='1'/>
+        <var-decl name='xflags' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='117' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='pending_buf_size' type-id='type-id-59' visibility='default' filepath='src.d/deflate.h' line='104' column='1'/>
+        <var-decl name='os' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='118' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='pending_out' type-id='type-id-21' visibility='default' filepath='src.d/deflate.h' line='105' column='1'/>
+        <var-decl name='extra' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='119' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='pending' type-id='type-id-59' visibility='default' filepath='src.d/deflate.h' line='106' column='1'/>
+        <var-decl name='extra_len' type-id='type-id-11' visibility='default' filepath='src.d/zlib.h' line='120' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='wrap' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='107' column='1'/>
+        <var-decl name='extra_max' type-id='type-id-11' visibility='default' filepath='src.d/zlib.h' line='121' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='gzhead' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='108' column='1'/>
+        <var-decl name='name' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='122' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='gzindex' type-id='type-id-59' visibility='default' filepath='src.d/deflate.h' line='109' column='1'/>
+        <var-decl name='name_max' type-id='type-id-11' visibility='default' filepath='src.d/zlib.h' line='123' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='method' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='110' column='1'/>
+        <var-decl name='comment' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='124' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='last_flush' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='111' column='1'/>
+        <var-decl name='comm_max' type-id='type-id-11' visibility='default' filepath='src.d/zlib.h' line='125' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='w_size' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='115' column='1'/>
+        <var-decl name='hcrc' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='126' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='w_bits' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='116' column='1'/>
+        <var-decl name='done' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='127' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='internal_state' size-in-bits='46624' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='100' column='1' id='type-id-41'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='strm' type-id='type-id-21' visibility='default' filepath='src.d/deflate.h' line='101' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='status' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='102' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='pending_buf' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='103' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='pending_buf_size' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='104' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='pending_out' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='105' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='pending' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='106' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='wrap' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='107' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='gzhead' type-id='type-id-43' visibility='default' filepath='src.d/deflate.h' line='108' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gzindex' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='109' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='method' type-id='type-id-3' visibility='default' filepath='src.d/deflate.h' line='110' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='last_flush' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='111' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='w_size' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='115' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='w_bits' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='116' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='416'>
-        <var-decl name='w_mask' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='117' column='1'/>
+        <var-decl name='w_mask' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='117' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='window' type-id='type-id-21' visibility='default' filepath='src.d/deflate.h' line='119' column='1'/>
+        <var-decl name='window' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='119' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='480'>
-        <var-decl name='window_size' type-id='type-id-59' visibility='default' filepath='src.d/deflate.h' line='129' column='1'/>
+        <var-decl name='window_size' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='129' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='prev' type-id='type-id-61' visibility='default' filepath='src.d/deflate.h' line='134' column='1'/>
+        <var-decl name='prev' type-id='type-id-44' visibility='default' filepath='src.d/deflate.h' line='134' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='544'>
-        <var-decl name='head' type-id='type-id-61' visibility='default' filepath='src.d/deflate.h' line='140' column='1'/>
+        <var-decl name='head' type-id='type-id-44' visibility='default' filepath='src.d/deflate.h' line='140' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='ins_h' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='142' column='1'/>
+        <var-decl name='ins_h' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='142' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='608'>
-        <var-decl name='hash_size' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='143' column='1'/>
+        <var-decl name='hash_size' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='143' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='hash_bits' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='144' column='1'/>
+        <var-decl name='hash_bits' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='144' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='672'>
-        <var-decl name='hash_mask' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='145' column='1'/>
+        <var-decl name='hash_mask' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='145' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='hash_shift' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='147' column='1'/>
+        <var-decl name='hash_shift' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='147' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='736'>
-        <var-decl name='block_start' type-id='type-id-1' visibility='default' filepath='src.d/deflate.h' line='154' column='1'/>
+        <var-decl name='block_start' type-id='type-id-37' visibility='default' filepath='src.d/deflate.h' line='154' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='match_length' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='159' column='1'/>
+        <var-decl name='match_length' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='159' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='800'>
-        <var-decl name='prev_match' type-id='type-id-56' visibility='default' filepath='src.d/deflate.h' line='160' column='1'/>
+        <var-decl name='prev_match' type-id='type-id-45' visibility='default' filepath='src.d/deflate.h' line='160' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='match_available' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='161' column='1'/>
+        <var-decl name='match_available' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='161' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='864'>
-        <var-decl name='strstart' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='162' column='1'/>
+        <var-decl name='strstart' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='162' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='match_start' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='163' column='1'/>
+        <var-decl name='match_start' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='163' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='928'>
-        <var-decl name='lookahead' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='164' column='1'/>
+        <var-decl name='lookahead' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='164' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='prev_length' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='166' column='1'/>
+        <var-decl name='prev_length' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='166' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='992'>
-        <var-decl name='max_chain_length' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='171' column='1'/>
+        <var-decl name='max_chain_length' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='171' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='max_lazy_match' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='177' column='1'/>
+        <var-decl name='max_lazy_match' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='177' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1056'>
-        <var-decl name='level' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='188' column='1'/>
+        <var-decl name='level' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='188' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1088'>
-        <var-decl name='strategy' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='189' column='1'/>
+        <var-decl name='strategy' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='189' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1120'>
-        <var-decl name='good_match' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='191' column='1'/>
+        <var-decl name='good_match' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='191' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1152'>
-        <var-decl name='nice_match' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='194' column='1'/>
+        <var-decl name='nice_match' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='194' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1184'>
-        <var-decl name='dyn_ltree' type-id='type-id-33' visibility='default' filepath='src.d/deflate.h' line='198' column='1'/>
+        <var-decl name='dyn_ltree' type-id='type-id-32' visibility='default' filepath='src.d/deflate.h' line='198' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='19520'>
-        <var-decl name='dyn_dtree' type-id='type-id-35' visibility='default' filepath='src.d/deflate.h' line='199' column='1'/>
+        <var-decl name='dyn_dtree' type-id='type-id-34' visibility='default' filepath='src.d/deflate.h' line='199' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='21472'>
-        <var-decl name='bl_tree' type-id='type-id-31' visibility='default' filepath='src.d/deflate.h' line='200' column='1'/>
+        <var-decl name='bl_tree' type-id='type-id-30' visibility='default' filepath='src.d/deflate.h' line='200' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='22720'>
-        <var-decl name='l_desc' type-id='type-id-51' visibility='default' filepath='src.d/deflate.h' line='202' column='1'/>
+        <var-decl name='l_desc' type-id='type-id-46' visibility='default' filepath='src.d/deflate.h' line='202' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='22816'>
-        <var-decl name='d_desc' type-id='type-id-51' visibility='default' filepath='src.d/deflate.h' line='203' column='1'/>
+        <var-decl name='d_desc' type-id='type-id-46' visibility='default' filepath='src.d/deflate.h' line='203' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='22912'>
-        <var-decl name='bl_desc' type-id='type-id-51' visibility='default' filepath='src.d/deflate.h' line='204' column='1'/>
+        <var-decl name='bl_desc' type-id='type-id-46' visibility='default' filepath='src.d/deflate.h' line='204' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='23008'>
-        <var-decl name='bl_count' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='206' column='1'/>
+        <var-decl name='bl_count' type-id='type-id-47' visibility='default' filepath='src.d/deflate.h' line='206' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='23264'>
-        <var-decl name='heap' type-id='type-id-37' visibility='default' filepath='src.d/deflate.h' line='209' column='1'/>
+        <var-decl name='heap' type-id='type-id-36' visibility='default' filepath='src.d/deflate.h' line='209' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='41600'>
-        <var-decl name='heap_len' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='210' column='1'/>
+        <var-decl name='heap_len' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='210' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='41632'>
-        <var-decl name='heap_max' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='211' column='1'/>
+        <var-decl name='heap_max' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='211' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='41664'>
-        <var-decl name='depth' type-id='type-id-39' visibility='default' filepath='src.d/deflate.h' line='216' column='1'/>
+        <var-decl name='depth' type-id='type-id-48' visibility='default' filepath='src.d/deflate.h' line='216' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46272'>
-        <var-decl name='sym_buf' type-id='type-id-62' visibility='default' filepath='src.d/deflate.h' line='220' column='1'/>
+        <var-decl name='sym_buf' type-id='type-id-49' visibility='default' filepath='src.d/deflate.h' line='220' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46304'>
-        <var-decl name='lit_bufsize' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='222' column='1'/>
+        <var-decl name='lit_bufsize' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='222' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46336'>
-        <var-decl name='sym_next' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='242' column='1'/>
+        <var-decl name='sym_next' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='242' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46368'>
-        <var-decl name='sym_end' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='243' column='1'/>
+        <var-decl name='sym_end' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='243' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46400'>
-        <var-decl name='opt_len' type-id='type-id-59' visibility='default' filepath='src.d/deflate.h' line='245' column='1'/>
+        <var-decl name='opt_len' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='245' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46432'>
-        <var-decl name='static_len' type-id='type-id-59' visibility='default' filepath='src.d/deflate.h' line='246' column='1'/>
+        <var-decl name='static_len' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='246' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46464'>
-        <var-decl name='matches' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='247' column='1'/>
+        <var-decl name='matches' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='247' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46496'>
-        <var-decl name='insert' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='248' column='1'/>
+        <var-decl name='insert' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='248' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46528'>
-        <var-decl name='bi_buf' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='255' column='1'/>
+        <var-decl name='bi_buf' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='255' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46560'>
-        <var-decl name='bi_valid' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='259' column='1'/>
+        <var-decl name='bi_valid' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='259' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46592'>
-        <var-decl name='high_water' type-id='type-id-59' visibility='default' filepath='src.d/deflate.h' line='264' column='1'/>
+        <var-decl name='high_water' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='264' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='alloc_func' type-id='type-id-63' filepath='src.d/zlib.h' line='81' column='1' id='type-id-64'/>
-    <typedef-decl name='free_func' type-id='type-id-65' filepath='src.d/zlib.h' line='82' column='1' id='type-id-66'/>
-    <class-decl name='z_stream_s' size-in-bits='448' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='86' column='1' id='type-id-67'>
+    <class-decl name='tree_desc_s' size-in-bits='96' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='86' column='1' id='type-id-46'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='next_in' type-id='type-id-21' visibility='default' filepath='src.d/zlib.h' line='87' column='1'/>
+        <var-decl name='dyn_tree' type-id='type-id-51' visibility='default' filepath='src.d/deflate.h' line='87' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='avail_in' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='88' column='1'/>
+        <var-decl name='max_code' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='88' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='total_in' type-id='type-id-10' visibility='default' filepath='src.d/zlib.h' line='89' column='1'/>
+        <var-decl name='stat_desc' type-id='type-id-52' visibility='default' filepath='src.d/deflate.h' line='89' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='z_stream_s' size-in-bits='448' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='86' column='1' id='type-id-53'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next_in' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='87' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='avail_in' type-id='type-id-11' visibility='default' filepath='src.d/zlib.h' line='88' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='total_in' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='89' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='next_out' type-id='type-id-21' visibility='default' filepath='src.d/zlib.h' line='91' column='1'/>
+        <var-decl name='next_out' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='91' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='avail_out' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='92' column='1'/>
+        <var-decl name='avail_out' type-id='type-id-11' visibility='default' filepath='src.d/zlib.h' line='92' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='total_out' type-id='type-id-10' visibility='default' filepath='src.d/zlib.h' line='93' column='1'/>
+        <var-decl name='total_out' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='93' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='msg' type-id='type-id-68' visibility='default' filepath='src.d/zlib.h' line='95' column='1'/>
+        <var-decl name='msg' type-id='type-id-54' visibility='default' filepath='src.d/zlib.h' line='95' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='state' type-id='type-id-69' visibility='default' filepath='src.d/zlib.h' line='96' column='1'/>
+        <var-decl name='state' type-id='type-id-55' visibility='default' filepath='src.d/zlib.h' line='96' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='zalloc' type-id='type-id-64' visibility='default' filepath='src.d/zlib.h' line='98' column='1'/>
+        <var-decl name='zalloc' type-id='type-id-56' visibility='default' filepath='src.d/zlib.h' line='98' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='zfree' type-id='type-id-66' visibility='default' filepath='src.d/zlib.h' line='99' column='1'/>
+        <var-decl name='zfree' type-id='type-id-57' visibility='default' filepath='src.d/zlib.h' line='99' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='opaque' type-id='type-id-46' visibility='default' filepath='src.d/zlib.h' line='100' column='1'/>
+        <var-decl name='opaque' type-id='type-id-58' visibility='default' filepath='src.d/zlib.h' line='100' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='data_type' type-id='type-id-22' visibility='default' filepath='src.d/zlib.h' line='102' column='1'/>
+        <var-decl name='data_type' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='102' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='adler' type-id='type-id-10' visibility='default' filepath='src.d/zlib.h' line='104' column='1'/>
+        <var-decl name='adler' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='104' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='416'>
-        <var-decl name='reserved' type-id='type-id-10' visibility='default' filepath='src.d/zlib.h' line='105' column='1'/>
+        <var-decl name='reserved' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='105' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='z_stream' type-id='type-id-67' filepath='src.d/zlib.h' line='106' column='1' id='type-id-70'/>
-    <typedef-decl name='z_streamp' type-id='type-id-71' filepath='src.d/zlib.h' line='108' column='1' id='type-id-58'/>
-    <class-decl name='gz_header_s' size-in-bits='416' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='114' column='1' id='type-id-72'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='text' type-id='type-id-22' visibility='default' filepath='src.d/zlib.h' line='115' column='1'/>
+    <typedef-decl name='IPos' type-id='type-id-9' filepath='src.d/deflate.h' line='94' column='1' id='type-id-45'/>
+    <typedef-decl name='Pos' type-id='type-id-50' filepath='src.d/deflate.h' line='92' column='1' id='type-id-59'/>
+    <typedef-decl name='Posf' type-id='type-id-59' filepath='src.d/deflate.h' line='93' column='1' id='type-id-60'/>
+    <typedef-decl name='alloc_func' type-id='type-id-61' filepath='src.d/zlib.h' line='81' column='1' id='type-id-56'/>
+    <typedef-decl name='charf' type-id='type-id-28' filepath='./zconf.h' line='408' column='1' id='type-id-62'/>
+    <typedef-decl name='ct_data' type-id='type-id-29' filepath='src.d/deflate.h' line='77' column='1' id='type-id-63'/>
+    <typedef-decl name='deflate_state' type-id='type-id-41' filepath='src.d/deflate.h' line='271' column='1' id='type-id-64'/>
+    <typedef-decl name='free_func' type-id='type-id-65' filepath='src.d/zlib.h' line='82' column='1' id='type-id-57'/>
+    <typedef-decl name='gz_header' type-id='type-id-40' filepath='src.d/zlib.h' line='129' column='1' id='type-id-66'/>
+    <typedef-decl name='gz_headerp' type-id='type-id-67' filepath='src.d/zlib.h' line='131' column='1' id='type-id-43'/>
+    <typedef-decl name='uch' type-id='type-id-2' filepath='src.d/zutil.h' line='39' column='1' id='type-id-68'/>
+    <typedef-decl name='uchf' type-id='type-id-68' filepath='src.d/zutil.h' line='40' column='1' id='type-id-69'/>
+    <typedef-decl name='ulg' type-id='type-id-12' filepath='src.d/zutil.h' line='43' column='1' id='type-id-42'/>
+    <typedef-decl name='ush' type-id='type-id-70' filepath='src.d/zutil.h' line='41' column='1' id='type-id-50'/>
+    <typedef-decl name='z_stream' type-id='type-id-53' filepath='src.d/zlib.h' line='106' column='1' id='type-id-71'/>
+    <typedef-decl name='z_streamp' type-id='type-id-72' filepath='src.d/zlib.h' line='108' column='1' id='type-id-21'/>
+    <array-type-def dimensions='1' type-id='type-id-68' size-in-bits='4584' id='type-id-48'>
+      <subrange length='573' lower-bound='0' upper-bound='572' type-id='type-id-9' id='type-id-33'/>
+    </array-type-def>
+    <union-decl name='__anonymous_union__1' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='73' column='1' id='type-id-39'>
+      <data-member access='public'>
+        <var-decl name='dad' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='74' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='time' type-id='type-id-10' visibility='default' filepath='src.d/zlib.h' line='116' column='1'/>
+      <data-member access='public'>
+        <var-decl name='len' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='75' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='xflags' type-id='type-id-22' visibility='default' filepath='src.d/zlib.h' line='117' column='1'/>
+    </union-decl>
+    <union-decl name='__anonymous_union__' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='69' column='1' id='type-id-38'>
+      <data-member access='public'>
+        <var-decl name='freq' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='70' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='os' type-id='type-id-22' visibility='default' filepath='src.d/zlib.h' line='118' column='1'/>
+      <data-member access='public'>
+        <var-decl name='code' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='71' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='extra' type-id='type-id-21' visibility='default' filepath='src.d/zlib.h' line='119' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='extra_len' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='120' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='extra_max' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='121' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='name' type-id='type-id-21' visibility='default' filepath='src.d/zlib.h' line='122' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='name_max' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='123' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='comment' type-id='type-id-21' visibility='default' filepath='src.d/zlib.h' line='124' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='comm_max' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='125' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='hcrc' type-id='type-id-22' visibility='default' filepath='src.d/zlib.h' line='126' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='done' type-id='type-id-22' visibility='default' filepath='src.d/zlib.h' line='127' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='gz_header' type-id='type-id-72' filepath='src.d/zlib.h' line='129' column='1' id='type-id-73'/>
-    <typedef-decl name='gz_headerp' type-id='type-id-74' filepath='src.d/zlib.h' line='131' column='1' id='type-id-60'/>
-    <typedef-decl name='uch' type-id='type-id-3' filepath='src.d/zutil.h' line='39' column='1' id='type-id-38'/>
-    <typedef-decl name='uchf' type-id='type-id-38' filepath='src.d/zutil.h' line='40' column='1' id='type-id-75'/>
-    <typedef-decl name='ush' type-id='type-id-40' filepath='src.d/zutil.h' line='41' column='1' id='type-id-41'/>
-    <typedef-decl name='ulg' type-id='type-id-5' filepath='src.d/zutil.h' line='43' column='1' id='type-id-59'/>
-    <pointer-type-def type-id='type-id-11' size-in-bits='32' id='type-id-21'/>
-    <pointer-type-def type-id='type-id-55' size-in-bits='32' id='type-id-61'/>
-    <pointer-type-def type-id='type-id-28' size-in-bits='32' id='type-id-68'/>
-    <qualified-type-def type-id='type-id-28' const='yes' id='type-id-76'/>
-    <pointer-type-def type-id='type-id-76' size-in-bits='32' id='type-id-77'/>
-    <qualified-type-def type-id='type-id-50' const='yes' id='type-id-78'/>
-    <pointer-type-def type-id='type-id-78' size-in-bits='32' id='type-id-53'/>
-    <pointer-type-def type-id='type-id-49' size-in-bits='32' id='type-id-52'/>
-    <pointer-type-def type-id='type-id-73' size-in-bits='32' id='type-id-74'/>
-    <pointer-type-def type-id='type-id-22' size-in-bits='32' id='type-id-79'/>
-    <pointer-type-def type-id='type-id-57' size-in-bits='32' id='type-id-69'/>
-    <pointer-type-def type-id='type-id-80' size-in-bits='32' id='type-id-63'/>
-    <pointer-type-def type-id='type-id-9' size-in-bits='32' id='type-id-81'/>
-    <pointer-type-def type-id='type-id-75' size-in-bits='32' id='type-id-62'/>
-    <pointer-type-def type-id='type-id-4' size-in-bits='32' id='type-id-82'/>
-    <pointer-type-def type-id='type-id-83' size-in-bits='32' id='type-id-65'/>
-    <pointer-type-def type-id='type-id-44' size-in-bits='32' id='type-id-45'/>
-    <pointer-type-def type-id='type-id-70' size-in-bits='32' id='type-id-71'/>
-    <class-decl name='static_tree_desc_s' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-29'/>
-    <function-decl name='deflateInit_' mangled-name='deflateInit_' filepath='src.d/deflate.c' line='225' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateInit_'>
-      <parameter type-id='type-id-58' name='strm' filepath='src.d/deflate.c' line='226' column='1'/>
-      <parameter type-id='type-id-22' name='level' filepath='src.d/deflate.c' line='227' column='1'/>
-      <parameter type-id='type-id-77' name='version' filepath='src.d/deflate.c' line='228' column='1'/>
-      <parameter type-id='type-id-22' name='stream_size' filepath='src.d/deflate.c' line='229' column='1'/>
-      <return type-id='type-id-22'/>
+    </union-decl>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-70'/>
+    <array-type-def dimensions='1' type-id='type-id-50' size-in-bits='256' id='type-id-47'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-9' id='type-id-73'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-4' size-in-bits='32' id='type-id-19'/>
+    <pointer-type-def type-id='type-id-60' size-in-bits='32' id='type-id-44'/>
+    <pointer-type-def type-id='type-id-28' size-in-bits='32' id='type-id-54'/>
+    <pointer-type-def type-id='type-id-62' size-in-bits='32' id='type-id-74'/>
+    <qualified-type-def type-id='type-id-28' const='yes' id='type-id-75'/>
+    <pointer-type-def type-id='type-id-75' size-in-bits='32' id='type-id-22'/>
+    <pointer-type-def type-id='type-id-63' size-in-bits='32' id='type-id-51'/>
+    <pointer-type-def type-id='type-id-64' size-in-bits='32' id='type-id-76'/>
+    <pointer-type-def type-id='type-id-66' size-in-bits='32' id='type-id-67'/>
+    <pointer-type-def type-id='type-id-20' size-in-bits='32' id='type-id-77'/>
+    <pointer-type-def type-id='type-id-41' size-in-bits='32' id='type-id-55'/>
+    <pointer-type-def type-id='type-id-78' size-in-bits='32' id='type-id-61'/>
+    <pointer-type-def type-id='type-id-11' size-in-bits='32' id='type-id-79'/>
+    <pointer-type-def type-id='type-id-69' size-in-bits='32' id='type-id-49'/>
+    <pointer-type-def type-id='type-id-9' size-in-bits='32' id='type-id-80'/>
+    <pointer-type-def type-id='type-id-81' size-in-bits='32' id='type-id-65'/>
+    <pointer-type-def type-id='type-id-71' size-in-bits='32' id='type-id-72'/>
+    <qualified-type-def type-id='type-id-82' const='yes' id='type-id-83'/>
+    <pointer-type-def type-id='type-id-83' size-in-bits='32' id='type-id-52'/>
+    <class-decl name='static_tree_desc_s' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-84'/>
+    <typedef-decl name='voidpf' type-id='type-id-85' filepath='./zconf.h' line='415' column='1' id='type-id-58'/>
+    <function-decl name='memcpy' filepath='/usr/mips-linux-gnu/include/string.h' line='43' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-85'/>
+    </function-decl>
+    <function-decl name='memset' filepath='/usr/mips-linux-gnu/include/string.h' line='61' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-85'/>
     </function-decl>
     <function-decl name='deflateInit2_' mangled-name='deflateInit2_' filepath='src.d/deflate.c' line='237' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateInit2_'>
-      <parameter type-id='type-id-58' name='strm' filepath='src.d/deflate.c' line='239' column='1'/>
-      <parameter type-id='type-id-22' name='level' filepath='src.d/deflate.c' line='240' column='1'/>
-      <parameter type-id='type-id-22' name='method' filepath='src.d/deflate.c' line='241' column='1'/>
-      <parameter type-id='type-id-22' name='windowBits' filepath='src.d/deflate.c' line='242' column='1'/>
-      <parameter type-id='type-id-22' name='memLevel' filepath='src.d/deflate.c' line='243' column='1'/>
-      <parameter type-id='type-id-22' name='strategy' filepath='src.d/deflate.c' line='244' column='1'/>
-      <parameter type-id='type-id-77' name='version' filepath='src.d/deflate.c' line='245' column='1'/>
-      <parameter type-id='type-id-22' name='stream_size' filepath='src.d/deflate.c' line='246' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='239' column='1'/>
+      <parameter type-id='type-id-20' name='level' filepath='src.d/deflate.c' line='240' column='1'/>
+      <parameter type-id='type-id-20' name='method' filepath='src.d/deflate.c' line='241' column='1'/>
+      <parameter type-id='type-id-20' name='windowBits' filepath='src.d/deflate.c' line='242' column='1'/>
+      <parameter type-id='type-id-20' name='memLevel' filepath='src.d/deflate.c' line='243' column='1'/>
+      <parameter type-id='type-id-20' name='strategy' filepath='src.d/deflate.c' line='244' column='1'/>
+      <parameter type-id='type-id-22' name='version' filepath='src.d/deflate.c' line='245' column='1'/>
+      <parameter type-id='type-id-20' name='stream_size' filepath='src.d/deflate.c' line='246' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateSetDictionary' mangled-name='deflateSetDictionary' filepath='src.d/deflate.c' line='412' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateSetDictionary'>
-      <parameter type-id='type-id-58' name='strm' filepath='src.d/deflate.c' line='413' column='1'/>
-      <parameter type-id='type-id-18' name='dictionary' filepath='src.d/deflate.c' line='414' column='1'/>
-      <parameter type-id='type-id-9' name='dictLength' filepath='src.d/deflate.c' line='415' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='413' column='1'/>
+      <parameter type-id='type-id-16' name='dictionary' filepath='src.d/deflate.c' line='414' column='1'/>
+      <parameter type-id='type-id-11' name='dictLength' filepath='src.d/deflate.c' line='415' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateGetDictionary' mangled-name='deflateGetDictionary' filepath='src.d/deflate.c' line='481' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateGetDictionary@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-58' name='strm' filepath='src.d/deflate.c' line='482' column='1'/>
-      <parameter type-id='type-id-21' name='dictionary' filepath='src.d/deflate.c' line='483' column='1'/>
-      <parameter type-id='type-id-81' name='dictLength' filepath='src.d/deflate.c' line='484' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='482' column='1'/>
+      <parameter type-id='type-id-19' name='dictionary' filepath='src.d/deflate.c' line='483' column='1'/>
+      <parameter type-id='type-id-79' name='dictLength' filepath='src.d/deflate.c' line='484' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateResetKeep' mangled-name='deflateResetKeep' filepath='src.d/deflate.c' line='503' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateResetKeep@@ZLIB_1.2.5.2'>
-      <parameter type-id='type-id-58' name='strm' filepath='src.d/deflate.c' line='504' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='504' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateReset' mangled-name='deflateReset' filepath='src.d/deflate.c' line='541' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateReset'>
-      <parameter type-id='type-id-58' name='strm' filepath='src.d/deflate.c' line='542' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='542' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateSetHeader' mangled-name='deflateSetHeader' filepath='src.d/deflate.c' line='553' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateSetHeader@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-58' name='strm' filepath='src.d/deflate.c' line='554' column='1'/>
-      <parameter type-id='type-id-60' name='head' filepath='src.d/deflate.c' line='555' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='554' column='1'/>
+      <parameter type-id='type-id-43' name='head' filepath='src.d/deflate.c' line='555' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflatePending' mangled-name='deflatePending' filepath='src.d/deflate.c' line='564' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflatePending@@ZLIB_1.2.5.1'>
-      <parameter type-id='type-id-58' name='strm' filepath='src.d/deflate.c' line='567' column='1'/>
-      <parameter type-id='type-id-82' name='pending' filepath='src.d/deflate.c' line='565' column='1'/>
-      <parameter type-id='type-id-79' name='bits' filepath='src.d/deflate.c' line='566' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='567' column='1'/>
+      <parameter type-id='type-id-80' name='pending' filepath='src.d/deflate.c' line='565' column='1'/>
+      <parameter type-id='type-id-77' name='bits' filepath='src.d/deflate.c' line='566' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflatePrime' mangled-name='deflatePrime' filepath='src.d/deflate.c' line='578' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflatePrime@@ZLIB_1.2.0.8'>
-      <parameter type-id='type-id-58' name='strm' filepath='src.d/deflate.c' line='579' column='1'/>
-      <parameter type-id='type-id-22' name='bits' filepath='src.d/deflate.c' line='580' column='1'/>
-      <parameter type-id='type-id-22' name='value' filepath='src.d/deflate.c' line='581' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='579' column='1'/>
+      <parameter type-id='type-id-20' name='bits' filepath='src.d/deflate.c' line='580' column='1'/>
+      <parameter type-id='type-id-20' name='value' filepath='src.d/deflate.c' line='581' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateParams' mangled-name='deflateParams' filepath='src.d/deflate.c' line='605' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateParams'>
-      <parameter type-id='type-id-58' name='strm' filepath='src.d/deflate.c' line='606' column='1'/>
-      <parameter type-id='type-id-22' name='level' filepath='src.d/deflate.c' line='607' column='1'/>
-      <parameter type-id='type-id-22' name='strategy' filepath='src.d/deflate.c' line='608' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='606' column='1'/>
+      <parameter type-id='type-id-20' name='level' filepath='src.d/deflate.c' line='607' column='1'/>
+      <parameter type-id='type-id-20' name='strategy' filepath='src.d/deflate.c' line='608' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateTune' mangled-name='deflateTune' filepath='src.d/deflate.c' line='654' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateTune@@ZLIB_1.2.2.3'>
-      <parameter type-id='type-id-58' name='strm' filepath='src.d/deflate.c' line='655' column='1'/>
-      <parameter type-id='type-id-22' name='good_length' filepath='src.d/deflate.c' line='656' column='1'/>
-      <parameter type-id='type-id-22' name='max_lazy' filepath='src.d/deflate.c' line='657' column='1'/>
-      <parameter type-id='type-id-22' name='nice_length' filepath='src.d/deflate.c' line='658' column='1'/>
-      <parameter type-id='type-id-22' name='max_chain' filepath='src.d/deflate.c' line='659' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='655' column='1'/>
+      <parameter type-id='type-id-20' name='good_length' filepath='src.d/deflate.c' line='656' column='1'/>
+      <parameter type-id='type-id-20' name='max_lazy' filepath='src.d/deflate.c' line='657' column='1'/>
+      <parameter type-id='type-id-20' name='nice_length' filepath='src.d/deflate.c' line='658' column='1'/>
+      <parameter type-id='type-id-20' name='max_chain' filepath='src.d/deflate.c' line='659' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateBound' mangled-name='deflateBound' filepath='src.d/deflate.c' line='696' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateBound@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-58' name='strm' filepath='src.d/deflate.c' line='697' column='1'/>
-      <parameter type-id='type-id-10' name='sourceLen' filepath='src.d/deflate.c' line='698' column='1'/>
-      <return type-id='type-id-10'/>
-    </function-decl>
-    <function-decl name='deflate' mangled-name='deflate' filepath='src.d/deflate.c' line='815' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflate'>
-      <parameter type-id='type-id-58' name='strm' filepath='src.d/deflate.c' line='816' column='1'/>
-      <parameter type-id='type-id-22' name='flush' filepath='src.d/deflate.c' line='817' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='deflateEnd' mangled-name='deflateEnd' filepath='src.d/deflate.c' line='1130' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateEnd'>
-      <parameter type-id='type-id-58' name='strm' filepath='src.d/deflate.c' line='1131' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='697' column='1'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/deflate.c' line='698' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='deflateCopy' mangled-name='deflateCopy' filepath='src.d/deflate.c' line='1156' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateCopy'>
-      <parameter type-id='type-id-58' name='dest' filepath='src.d/deflate.c' line='1157' column='1'/>
-      <parameter type-id='type-id-58' name='source' filepath='src.d/deflate.c' line='1158' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='dest' filepath='src.d/deflate.c' line='1157' column='1'/>
+      <parameter type-id='type-id-21' name='source' filepath='src.d/deflate.c' line='1158' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
-    <function-type size-in-bits='32' id='type-id-80'>
-      <parameter type-id='type-id-46'/>
+    <typedef-decl name='static_tree_desc' type-id='type-id-84' filepath='src.d/deflate.h' line='84' column='1' id='type-id-82'/>
+    <function-decl name='_tr_init' filepath='src.d/deflate.h' line='294' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-76'/>
+      <return type-id='type-id-86'/>
+    </function-decl>
+    <function-decl name='_tr_flush_block' filepath='src.d/deflate.h' line='296' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-76'/>
+      <parameter type-id='type-id-74'/>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-86'/>
+    </function-decl>
+    <function-decl name='_tr_flush_bits' filepath='src.d/deflate.h' line='298' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-76'/>
+      <return type-id='type-id-86'/>
+    </function-decl>
+    <function-decl name='_tr_align' filepath='src.d/deflate.h' line='299' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-76'/>
+      <return type-id='type-id-86'/>
+    </function-decl>
+    <function-decl name='_tr_stored_block' filepath='src.d/deflate.h' line='300' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-76'/>
+      <parameter type-id='type-id-74'/>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-86'/>
+    </function-decl>
+    <function-decl name='crc32' filepath='src.d/zlib.h' line='1727' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-13'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-11'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+    <function-decl name='zcalloc' filepath='src.d/zutil.h' line='261' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-58'/>
       <parameter type-id='type-id-9'/>
       <parameter type-id='type-id-9'/>
-      <return type-id='type-id-46'/>
+      <return type-id='type-id-58'/>
+    </function-decl>
+    <function-decl name='zcfree' filepath='src.d/zutil.h' line='263' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-58'/>
+      <parameter type-id='type-id-58'/>
+      <return type-id='type-id-86'/>
+    </function-decl>
+    <type-decl name='void' id='type-id-86'/>
+    <pointer-type-def type-id='type-id-86' id='type-id-85'/>
+    <function-type size-in-bits='32' id='type-id-81'>
+      <parameter type-id='type-id-58'/>
+      <parameter type-id='type-id-58'/>
+      <return type-id='type-id-86'/>
     </function-type>
-    <function-type size-in-bits='32' id='type-id-83'>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-46'/>
-      <return type-id='type-id-44'/>
+    <function-type size-in-bits='32' id='type-id-78'>
+      <parameter type-id='type-id-58'/>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-11'/>
+      <return type-id='type-id-58'/>
     </function-type>
   </abi-instr>
-  <abi-instr address-size='32' path='src.d/gzclose.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C99'>
-    <typedef-decl name='gzFile' type-id='type-id-84' filepath='src.d/zlib.h' line='1302' column='1' id='type-id-85'/>
-    <class-decl name='gzFile_s' size-in-bits='128' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='1834' column='1' id='type-id-86'>
+  <abi-instr address-size='32' path='src.d/gzclose.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
+    <class-decl name='gzFile_s' size-in-bits='128' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='1834' column='1' id='type-id-87'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='have' type-id='type-id-4' visibility='default' filepath='src.d/zlib.h' line='1835' column='1'/>
+        <var-decl name='have' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='1835' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='next' type-id='type-id-87' visibility='default' filepath='src.d/zlib.h' line='1836' column='1'/>
+        <var-decl name='next' type-id='type-id-88' visibility='default' filepath='src.d/zlib.h' line='1836' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='pos' type-id='type-id-16' visibility='default' filepath='src.d/zlib.h' line='1837' column='1'/>
+        <var-decl name='pos' type-id='type-id-7' visibility='default' filepath='src.d/zlib.h' line='1837' column='1'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-86' size-in-bits='32' id='type-id-84'/>
+    <typedef-decl name='gzFile' type-id='type-id-89' filepath='src.d/zlib.h' line='1302' column='1' id='type-id-90'/>
+    <pointer-type-def type-id='type-id-87' size-in-bits='32' id='type-id-89'/>
     <function-decl name='gzclose' mangled-name='gzclose' filepath='src.d/gzclose.c' line='11' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzclose'>
-      <parameter type-id='type-id-85' name='file' filepath='src.d/gzclose.c' line='12' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzclose.c' line='12' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzclose_r' filepath='src.d/zlib.h' line='1644' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-90'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzclose_w' filepath='src.d/zlib.h' line='1645' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-90'/>
+      <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='32' path='src.d/gzlib.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C99'>
-    <function-decl name='gzopen' mangled-name='gzopen' filepath='src.d/gzlib.c' line='272' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzopen'>
-      <parameter type-id='type-id-77' name='path' filepath='src.d/gzlib.c' line='273' column='1'/>
-      <parameter type-id='type-id-77' name='mode' filepath='src.d/gzlib.c' line='274' column='1'/>
-      <return type-id='type-id-85'/>
-    </function-decl>
-    <function-decl name='gzopen64' mangled-name='gzopen64' filepath='src.d/gzlib.c' line='280' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzopen64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-77' name='path' filepath='src.d/gzlib.c' line='281' column='1'/>
-      <parameter type-id='type-id-77' name='mode' filepath='src.d/gzlib.c' line='282' column='1'/>
-      <return type-id='type-id-85'/>
-    </function-decl>
-    <function-decl name='gzdopen' mangled-name='gzdopen' filepath='src.d/gzlib.c' line='288' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzdopen'>
-      <parameter type-id='type-id-22' name='fd' filepath='src.d/gzlib.c' line='289' column='1'/>
-      <parameter type-id='type-id-77' name='mode' filepath='src.d/gzlib.c' line='290' column='1'/>
-      <return type-id='type-id-85'/>
-    </function-decl>
-    <function-decl name='gzbuffer' mangled-name='gzbuffer' filepath='src.d/gzlib.c' line='318' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzbuffer@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-85' name='file' filepath='src.d/gzlib.c' line='319' column='1'/>
-      <parameter type-id='type-id-4' name='size' filepath='src.d/gzlib.c' line='320' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='gzrewind' mangled-name='gzrewind' filepath='src.d/gzlib.c' line='345' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzrewind'>
-      <parameter type-id='type-id-85' name='file' filepath='src.d/gzlib.c' line='346' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='gzseek64' mangled-name='gzseek64' filepath='src.d/gzlib.c' line='368' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzseek64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-85' name='file' filepath='src.d/gzlib.c' line='369' column='1'/>
-      <parameter type-id='type-id-16' name='offset' filepath='src.d/gzlib.c' line='370' column='1'/>
-      <parameter type-id='type-id-22' name='whence' filepath='src.d/gzlib.c' line='371' column='1'/>
-      <return type-id='type-id-16'/>
-    </function-decl>
-    <function-decl name='gzseek' mangled-name='gzseek' filepath='src.d/gzlib.c' line='445' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzseek'>
-      <parameter type-id='type-id-85' name='file' filepath='src.d/gzlib.c' line='446' column='1'/>
-      <parameter type-id='type-id-15' name='offset' filepath='src.d/gzlib.c' line='447' column='1'/>
-      <parameter type-id='type-id-22' name='whence' filepath='src.d/gzlib.c' line='448' column='1'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='gztell64' mangled-name='gztell64' filepath='src.d/gzlib.c' line='457' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gztell64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-85' name='file' filepath='src.d/gzlib.c' line='458' column='1'/>
-      <return type-id='type-id-16'/>
-    </function-decl>
-    <function-decl name='gztell' mangled-name='gztell' filepath='src.d/gzlib.c' line='474' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gztell'>
-      <parameter type-id='type-id-85' name='file' filepath='src.d/gzlib.c' line='475' column='1'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='gzoffset64' mangled-name='gzoffset64' filepath='src.d/gzlib.c' line='484' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzoffset64@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-85' name='file' filepath='src.d/gzlib.c' line='485' column='1'/>
-      <return type-id='type-id-16'/>
-    </function-decl>
-    <function-decl name='gzoffset' mangled-name='gzoffset' filepath='src.d/gzlib.c' line='507' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzoffset@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-85' name='file' filepath='src.d/gzlib.c' line='508' column='1'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='gzeof' mangled-name='gzeof' filepath='src.d/gzlib.c' line='517' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzeof'>
-      <parameter type-id='type-id-85' name='file' filepath='src.d/gzlib.c' line='518' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='gzerror' mangled-name='gzerror' filepath='src.d/gzlib.c' line='534' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzerror'>
-      <parameter type-id='type-id-85' name='file' filepath='src.d/gzlib.c' line='535' column='1'/>
-      <parameter type-id='type-id-79' name='errnum' filepath='src.d/gzlib.c' line='536' column='1'/>
-      <return type-id='type-id-77'/>
-    </function-decl>
-    <function-decl name='gzclearerr' mangled-name='gzclearerr' filepath='src.d/gzlib.c' line='555' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzclearerr@@ZLIB_1.2.0.2'>
-      <parameter type-id='type-id-85' name='file' filepath='src.d/gzlib.c' line='556' column='1'/>
-      <return type-id='type-id-44'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr address-size='32' path='src.d/gzread.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C99'>
-    <typedef-decl name='voidp' type-id='type-id-45' filepath='./zconf.h' line='416' column='1' id='type-id-88'/>
-    <function-decl name='gzread' mangled-name='gzread' filepath='src.d/gzread.c' line='373' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzread'>
-      <parameter type-id='type-id-85' name='file' filepath='src.d/gzread.c' line='374' column='1'/>
-      <parameter type-id='type-id-88' name='buf' filepath='src.d/gzread.c' line='375' column='1'/>
-      <parameter type-id='type-id-4' name='len' filepath='src.d/gzread.c' line='376' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='gzfread' mangled-name='gzfread' filepath='src.d/gzread.c' line='409' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzfread@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-88' name='buf' filepath='src.d/gzread.c' line='410' column='1'/>
-      <parameter type-id='type-id-7' name='size' filepath='src.d/gzread.c' line='411' column='1'/>
-      <parameter type-id='type-id-7' name='nitems' filepath='src.d/gzread.c' line='412' column='1'/>
-      <parameter type-id='type-id-85' name='file' filepath='src.d/gzread.c' line='413' column='1'/>
-      <return type-id='type-id-7'/>
-    </function-decl>
-    <function-decl name='gzgetc' mangled-name='gzgetc' filepath='src.d/gzread.c' line='445' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzgetc'>
-      <parameter type-id='type-id-85' name='file' filepath='src.d/gzread.c' line='446' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='gzgetc_' mangled-name='gzgetc_' filepath='src.d/gzread.c' line='472' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzgetc_@@ZLIB_1.2.5.2'>
-      <parameter type-id='type-id-85' name='file' filepath='src.d/gzread.c' line='473' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='gzungetc' mangled-name='gzungetc' filepath='src.d/gzread.c' line='479' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzungetc@@ZLIB_1.2.0.2'>
-      <parameter type-id='type-id-22' name='c' filepath='src.d/gzread.c' line='480' column='1'/>
-      <parameter type-id='type-id-85' name='file' filepath='src.d/gzread.c' line='481' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='gzgets' mangled-name='gzgets' filepath='src.d/gzread.c' line='539' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzgets'>
-      <parameter type-id='type-id-85' name='file' filepath='src.d/gzread.c' line='540' column='1'/>
-      <parameter type-id='type-id-68' name='buf' filepath='src.d/gzread.c' line='541' column='1'/>
-      <parameter type-id='type-id-22' name='len' filepath='src.d/gzread.c' line='542' column='1'/>
-      <return type-id='type-id-68'/>
-    </function-decl>
-    <function-decl name='gzdirect' mangled-name='gzdirect' filepath='src.d/gzread.c' line='603' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzdirect@@ZLIB_1.2.2.3'>
-      <parameter type-id='type-id-85' name='file' filepath='src.d/gzread.c' line='604' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='gzclose_r' mangled-name='gzclose_r' filepath='src.d/gzread.c' line='623' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzclose_r@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-85' name='file' filepath='src.d/gzread.c' line='624' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr address-size='32' path='src.d/gzwrite.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C99'>
-    <type-decl name='variadic parameter type' id='type-id-89'/>
-    <typedef-decl name='voidpc' type-id='type-id-45' filepath='./zconf.h' line='414' column='1' id='type-id-90'/>
-    <typedef-decl name='__gnuc_va_list' type-id='type-id-45' filepath='/usr/lib/gcc-cross/mips-linux-gnu/10/include/stdarg.h' line='40' column='1' id='type-id-91'/>
-    <typedef-decl name='va_list' type-id='type-id-91' filepath='/usr/lib/gcc-cross/mips-linux-gnu/10/include/stdarg.h' line='99' column='1' id='type-id-92'/>
-    <function-decl name='gzwrite' mangled-name='gzwrite' filepath='src.d/gzwrite.c' line='255' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzwrite'>
-      <parameter type-id='type-id-85' name='file' filepath='src.d/gzwrite.c' line='256' column='1'/>
-      <parameter type-id='type-id-90' name='buf' filepath='src.d/gzwrite.c' line='257' column='1'/>
-      <parameter type-id='type-id-4' name='len' filepath='src.d/gzwrite.c' line='258' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='gzfwrite' mangled-name='gzfwrite' filepath='src.d/gzwrite.c' line='283' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzfwrite@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-90' name='buf' filepath='src.d/gzwrite.c' line='284' column='1'/>
-      <parameter type-id='type-id-7' name='size' filepath='src.d/gzwrite.c' line='285' column='1'/>
-      <parameter type-id='type-id-7' name='nitems' filepath='src.d/gzwrite.c' line='286' column='1'/>
-      <parameter type-id='type-id-85' name='file' filepath='src.d/gzwrite.c' line='287' column='1'/>
-      <return type-id='type-id-7'/>
-    </function-decl>
-    <function-decl name='gzputc' mangled-name='gzputc' filepath='src.d/gzwrite.c' line='313' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzputc'>
-      <parameter type-id='type-id-85' name='file' filepath='src.d/gzwrite.c' line='314' column='1'/>
-      <parameter type-id='type-id-22' name='c' filepath='src.d/gzwrite.c' line='315' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='gzputs' mangled-name='gzputs' filepath='src.d/gzwrite.c' line='361' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzputs'>
-      <parameter type-id='type-id-85' name='file' filepath='src.d/gzwrite.c' line='362' column='1'/>
-      <parameter type-id='type-id-77' name='s' filepath='src.d/gzwrite.c' line='363' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='gzvprintf' mangled-name='gzvprintf' filepath='src.d/gzwrite.c' line='391' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzvprintf@@ZLIB_1.2.7.1'>
-      <parameter type-id='type-id-85' name='file' filepath='src.d/gzwrite.c' line='391' column='1'/>
-      <parameter type-id='type-id-77' name='format' filepath='src.d/gzwrite.c' line='391' column='1'/>
-      <parameter type-id='type-id-92' name='va' filepath='src.d/gzwrite.c' line='391' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='gzprintf' mangled-name='gzprintf' filepath='src.d/gzwrite.c' line='463' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzprintf'>
-      <parameter type-id='type-id-85' name='file' filepath='src.d/gzwrite.c' line='463' column='1'/>
-      <parameter type-id='type-id-77' name='format' filepath='src.d/gzwrite.c' line='463' column='1'/>
+  <abi-instr address-size='32' path='src.d/gzlib.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
+    <function-decl name='snprintf' filepath='/usr/mips-linux-gnu/include/stdio.h' line='385' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-54'/>
+      <parameter type-id='type-id-10'/>
+      <parameter type-id='type-id-22'/>
       <parameter is-variadic='yes'/>
-      <return type-id='type-id-22'/>
+      <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='gzflush' mangled-name='gzflush' filepath='src.d/gzwrite.c' line='565' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzflush'>
-      <parameter type-id='type-id-85' name='file' filepath='src.d/gzwrite.c' line='566' column='1'/>
-      <parameter type-id='type-id-22' name='flush' filepath='src.d/gzwrite.c' line='567' column='1'/>
-      <return type-id='type-id-22'/>
+    <function-decl name='malloc' filepath='/usr/mips-linux-gnu/include/stdlib.h' line='672' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-85'/>
     </function-decl>
-    <function-decl name='gzsetparams' mangled-name='gzsetparams' filepath='src.d/gzwrite.c' line='597' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzsetparams'>
-      <parameter type-id='type-id-85' name='file' filepath='src.d/gzwrite.c' line='598' column='1'/>
-      <parameter type-id='type-id-22' name='level' filepath='src.d/gzwrite.c' line='599' column='1'/>
-      <parameter type-id='type-id-22' name='strategy' filepath='src.d/gzwrite.c' line='600' column='1'/>
-      <return type-id='type-id-22'/>
+    <function-decl name='free' filepath='/usr/mips-linux-gnu/include/stdlib.h' line='687' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-85'/>
+      <return type-id='type-id-86'/>
     </function-decl>
-    <function-decl name='gzclose_w' mangled-name='gzclose_w' filepath='src.d/gzwrite.c' line='639' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzclose_w@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-85' name='file' filepath='src.d/gzwrite.c' line='640' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr address-size='32' path='src.d/infback.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C99'>
-    <typedef-decl name='in_func' type-id='type-id-93' filepath='src.d/zlib.h' line='1094' column='1' id='type-id-94'/>
-    <typedef-decl name='out_func' type-id='type-id-95' filepath='src.d/zlib.h' line='1096' column='1' id='type-id-96'/>
-    <pointer-type-def type-id='type-id-97' size-in-bits='32' id='type-id-95'/>
-    <pointer-type-def type-id='type-id-3' size-in-bits='32' id='type-id-87'/>
-    <pointer-type-def type-id='type-id-87' size-in-bits='32' id='type-id-98'/>
-    <pointer-type-def type-id='type-id-99' size-in-bits='32' id='type-id-93'/>
-    <function-decl name='inflateBackInit_' mangled-name='inflateBackInit_' filepath='src.d/infback.c' line='28' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateBackInit_@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-58' name='strm' filepath='src.d/infback.c' line='29' column='1'/>
-      <parameter type-id='type-id-22' name='windowBits' filepath='src.d/infback.c' line='30' column='1'/>
-      <parameter type-id='type-id-87' name='window' filepath='src.d/infback.c' line='31' column='1'/>
-      <parameter type-id='type-id-77' name='version' filepath='src.d/infback.c' line='32' column='1'/>
-      <parameter type-id='type-id-22' name='stream_size' filepath='src.d/infback.c' line='33' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='inflateBack' mangled-name='inflateBack' filepath='src.d/infback.c' line='251' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateBack@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-58' name='strm' filepath='src.d/infback.c' line='252' column='1'/>
-      <parameter type-id='type-id-94' name='in' filepath='src.d/infback.c' line='253' column='1'/>
-      <parameter type-id='type-id-45' name='in_desc' filepath='src.d/infback.c' line='254' column='1'/>
-      <parameter type-id='type-id-96' name='out' filepath='src.d/infback.c' line='255' column='1'/>
-      <parameter type-id='type-id-45' name='out_desc' filepath='src.d/infback.c' line='256' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='inflateBackEnd' mangled-name='inflateBackEnd' filepath='src.d/infback.c' line='635' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateBackEnd@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-58' name='strm' filepath='src.d/infback.c' line='636' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-type size-in-bits='32' id='type-id-97'>
-      <parameter type-id='type-id-45'/>
-      <parameter type-id='type-id-87'/>
-      <parameter type-id='type-id-4'/>
-      <return type-id='type-id-22'/>
-    </function-type>
-    <function-type size-in-bits='32' id='type-id-99'>
-      <parameter type-id='type-id-45'/>
-      <parameter type-id='type-id-98'/>
-      <return type-id='type-id-4'/>
-    </function-type>
-  </abi-instr>
-  <abi-instr address-size='32' path='src.d/inflate.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C99'>
-    <function-decl name='inflateResetKeep' mangled-name='inflateResetKeep' filepath='src.d/inflate.c' line='119' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateResetKeep@@ZLIB_1.2.5.2'>
-      <parameter type-id='type-id-58' name='strm' filepath='src.d/inflate.c' line='120' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='inflateReset' mangled-name='inflateReset' filepath='src.d/inflate.c' line='145' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateReset'>
-      <parameter type-id='type-id-58' name='strm' filepath='src.d/inflate.c' line='146' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='inflateReset2' mangled-name='inflateReset2' filepath='src.d/inflate.c' line='158' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateReset2@@ZLIB_1.2.3.4'>
-      <parameter type-id='type-id-58' name='strm' filepath='src.d/inflate.c' line='159' column='1'/>
-      <parameter type-id='type-id-22' name='windowBits' filepath='src.d/inflate.c' line='160' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='inflateInit2_' mangled-name='inflateInit2_' filepath='src.d/inflate.c' line='198' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateInit2_'>
-      <parameter type-id='type-id-58' name='strm' filepath='src.d/inflate.c' line='199' column='1'/>
-      <parameter type-id='type-id-22' name='windowBits' filepath='src.d/inflate.c' line='200' column='1'/>
-      <parameter type-id='type-id-77' name='version' filepath='src.d/inflate.c' line='201' column='1'/>
-      <parameter type-id='type-id-22' name='stream_size' filepath='src.d/inflate.c' line='202' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='inflateInit_' mangled-name='inflateInit_' filepath='src.d/inflate.c' line='242' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateInit_'>
-      <parameter type-id='type-id-58' name='strm' filepath='src.d/inflate.c' line='243' column='1'/>
-      <parameter type-id='type-id-77' name='version' filepath='src.d/inflate.c' line='244' column='1'/>
-      <parameter type-id='type-id-22' name='stream_size' filepath='src.d/inflate.c' line='245' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='inflatePrime' mangled-name='inflatePrime' filepath='src.d/inflate.c' line='250' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflatePrime@@ZLIB_1.2.2.4'>
-      <parameter type-id='type-id-58' name='strm' filepath='src.d/inflate.c' line='251' column='1'/>
-      <parameter type-id='type-id-22' name='bits' filepath='src.d/inflate.c' line='252' column='1'/>
-      <parameter type-id='type-id-22' name='value' filepath='src.d/inflate.c' line='253' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='inflate' mangled-name='inflate' filepath='src.d/inflate.c' line='625' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflate'>
-      <parameter type-id='type-id-58' name='strm' filepath='src.d/inflate.c' line='626' column='1'/>
-      <parameter type-id='type-id-22' name='flush' filepath='src.d/inflate.c' line='627' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='inflateEnd' mangled-name='inflateEnd' filepath='src.d/inflate.c' line='1304' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateEnd'>
-      <parameter type-id='type-id-58' name='strm' filepath='src.d/inflate.c' line='1305' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='inflateGetDictionary' mangled-name='inflateGetDictionary' filepath='src.d/inflate.c' line='1318' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateGetDictionary@@ZLIB_1.2.7.1'>
-      <parameter type-id='type-id-58' name='strm' filepath='src.d/inflate.c' line='1319' column='1'/>
-      <parameter type-id='type-id-21' name='dictionary' filepath='src.d/inflate.c' line='1320' column='1'/>
-      <parameter type-id='type-id-81' name='dictLength' filepath='src.d/inflate.c' line='1321' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='inflateSetDictionary' mangled-name='inflateSetDictionary' filepath='src.d/inflate.c' line='1341' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateSetDictionary'>
-      <parameter type-id='type-id-58' name='strm' filepath='src.d/inflate.c' line='1342' column='1'/>
-      <parameter type-id='type-id-18' name='dictionary' filepath='src.d/inflate.c' line='1343' column='1'/>
-      <parameter type-id='type-id-9' name='dictLength' filepath='src.d/inflate.c' line='1344' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='inflateGetHeader' mangled-name='inflateGetHeader' filepath='src.d/inflate.c' line='1376' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateGetHeader@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-58' name='strm' filepath='src.d/inflate.c' line='1377' column='1'/>
-      <parameter type-id='type-id-60' name='head' filepath='src.d/inflate.c' line='1378' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='inflateSync' mangled-name='inflateSync' filepath='src.d/inflate.c' line='1427' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateSync'>
-      <parameter type-id='type-id-58' name='strm' filepath='src.d/inflate.c' line='1428' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='inflateSyncPoint' mangled-name='inflateSyncPoint' filepath='src.d/inflate.c' line='1485' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateSyncPoint'>
-      <parameter type-id='type-id-58' name='strm' filepath='src.d/inflate.c' line='1486' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='inflateCopy' mangled-name='inflateCopy' filepath='src.d/inflate.c' line='1495' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateCopy@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-58' name='dest' filepath='src.d/inflate.c' line='1496' column='1'/>
-      <parameter type-id='type-id-58' name='source' filepath='src.d/inflate.c' line='1497' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='inflateUndermine' mangled-name='inflateUndermine' filepath='src.d/inflate.c' line='1542' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateUndermine@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-58' name='strm' filepath='src.d/inflate.c' line='1543' column='1'/>
-      <parameter type-id='type-id-22' name='subvert' filepath='src.d/inflate.c' line='1544' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='inflateValidate' mangled-name='inflateValidate' filepath='src.d/inflate.c' line='1560' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateValidate@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-58' name='strm' filepath='src.d/inflate.c' line='1561' column='1'/>
-      <parameter type-id='type-id-22' name='check' filepath='src.d/inflate.c' line='1562' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='inflateMark' mangled-name='inflateMark' filepath='src.d/inflate.c' line='1575' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateMark@@ZLIB_1.2.3.4'>
-      <parameter type-id='type-id-58' name='strm' filepath='src.d/inflate.c' line='1576' column='1'/>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <function-decl name='inflateCodesUsed' mangled-name='inflateCodesUsed' filepath='src.d/inflate.c' line='1588' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateCodesUsed@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-58' name='strm' filepath='src.d/inflate.c' line='1589' column='1'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr address-size='32' path='src.d/trees.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C99'>
-    <array-type-def dimensions='1' type-id='type-id-100' size-in-bits='2048' id='type-id-101'>
-      <subrange length='256' type-id='type-id-4' id='type-id-102'/>
-    </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-100' size-in-bits='4096' id='type-id-103'>
-      <subrange length='512' type-id='type-id-4' id='type-id-104'/>
-    </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-100' size-in-bits='infinite' id='type-id-105'>
-      <subrange length='infinite' id='type-id-106'/>
-    </array-type-def>
-    <qualified-type-def type-id='type-id-38' const='yes' id='type-id-100'/>
-    <var-decl name='_length_code' type-id='type-id-105' visibility='default' filepath='src.d/deflate.h' line='317' column='1'/>
-    <var-decl name='_dist_code' type-id='type-id-105' visibility='default' filepath='src.d/deflate.h' line='318' column='1'/>
-  </abi-instr>
-  <abi-instr address-size='32' path='src.d/uncompr.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C99'>
-    <pointer-type-def type-id='type-id-10' size-in-bits='32' id='type-id-107'/>
-    <function-decl name='uncompress2' mangled-name='uncompress2' filepath='src.d/uncompr.c' line='27' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='uncompress2@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-21' name='dest' filepath='src.d/uncompr.c' line='28' column='1'/>
-      <parameter type-id='type-id-20' name='destLen' filepath='src.d/uncompr.c' line='29' column='1'/>
-      <parameter type-id='type-id-18' name='source' filepath='src.d/uncompr.c' line='30' column='1'/>
-      <parameter type-id='type-id-107' name='sourceLen' filepath='src.d/uncompr.c' line='31' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='uncompress' mangled-name='uncompress' filepath='src.d/uncompr.c' line='86' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='uncompress'>
-      <parameter type-id='type-id-21' name='dest' filepath='src.d/uncompr.c' line='87' column='1'/>
-      <parameter type-id='type-id-20' name='destLen' filepath='src.d/uncompr.c' line='88' column='1'/>
-      <parameter type-id='type-id-18' name='source' filepath='src.d/uncompr.c' line='89' column='1'/>
-      <parameter type-id='type-id-10' name='sourceLen' filepath='src.d/uncompr.c' line='90' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr address-size='32' path='src.d/zutil.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C99'>
-    <array-type-def dimensions='1' type-id='type-id-108' size-in-bits='320' id='type-id-109'>
-      <subrange length='10' type-id='type-id-4' id='type-id-110'/>
-    </array-type-def>
-    <qualified-type-def type-id='type-id-68' const='yes' id='type-id-108'/>
-    <function-decl name='zlibVersion' mangled-name='zlibVersion' filepath='src.d/zutil.c' line='27' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='zlibVersion'>
-      <return type-id='type-id-77'/>
-    </function-decl>
-    <function-decl name='zlibCompileFlags' mangled-name='zlibCompileFlags' filepath='src.d/zutil.c' line='32' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='zlibCompileFlags@@ZLIB_1.2.0.2'>
+    <function-decl name='strlen' filepath='/usr/mips-linux-gnu/include/string.h' line='407' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-22'/>
       <return type-id='type-id-10'/>
     </function-decl>
-    <function-decl name='zError' mangled-name='zError' filepath='src.d/zutil.c' line='135' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='zError'>
-      <parameter type-id='type-id-22' name='err' filepath='src.d/zutil.c' line='136' column='1'/>
+    <function-decl name='lseek64' filepath='/usr/mips-linux-gnu/include/unistd.h' line='350' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-6'/>
+    </function-decl>
+    <function-decl name='gzopen' mangled-name='gzopen' filepath='src.d/gzlib.c' line='272' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzopen'>
+      <parameter type-id='type-id-22' name='path' filepath='src.d/gzlib.c' line='273' column='1'/>
+      <parameter type-id='type-id-22' name='mode' filepath='src.d/gzlib.c' line='274' column='1'/>
+      <return type-id='type-id-90'/>
+    </function-decl>
+    <function-decl name='gzopen64' mangled-name='gzopen64' filepath='src.d/gzlib.c' line='280' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzopen64@@ZLIB_1.2.3.3'>
+      <parameter type-id='type-id-22' name='path' filepath='src.d/gzlib.c' line='281' column='1'/>
+      <parameter type-id='type-id-22' name='mode' filepath='src.d/gzlib.c' line='282' column='1'/>
+      <return type-id='type-id-90'/>
+    </function-decl>
+    <function-decl name='gzdopen' mangled-name='gzdopen' filepath='src.d/gzlib.c' line='288' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzdopen'>
+      <parameter type-id='type-id-20' name='fd' filepath='src.d/gzlib.c' line='289' column='1'/>
+      <parameter type-id='type-id-22' name='mode' filepath='src.d/gzlib.c' line='290' column='1'/>
+      <return type-id='type-id-90'/>
+    </function-decl>
+    <function-decl name='gzbuffer' mangled-name='gzbuffer' filepath='src.d/gzlib.c' line='318' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzbuffer@@ZLIB_1.2.3.5'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='319' column='1'/>
+      <parameter type-id='type-id-9' name='size' filepath='src.d/gzlib.c' line='320' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzrewind' mangled-name='gzrewind' filepath='src.d/gzlib.c' line='345' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzrewind'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='346' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzseek64' mangled-name='gzseek64' filepath='src.d/gzlib.c' line='368' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzseek64@@ZLIB_1.2.3.3'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='369' column='1'/>
+      <parameter type-id='type-id-7' name='offset' filepath='src.d/gzlib.c' line='370' column='1'/>
+      <parameter type-id='type-id-20' name='whence' filepath='src.d/gzlib.c' line='371' column='1'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='gzseek' mangled-name='gzseek' filepath='src.d/gzlib.c' line='445' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzseek'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='446' column='1'/>
+      <parameter type-id='type-id-8' name='offset' filepath='src.d/gzlib.c' line='447' column='1'/>
+      <parameter type-id='type-id-20' name='whence' filepath='src.d/gzlib.c' line='448' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='gztell64' mangled-name='gztell64' filepath='src.d/gzlib.c' line='457' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gztell64@@ZLIB_1.2.3.3'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='458' column='1'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='gztell' mangled-name='gztell' filepath='src.d/gzlib.c' line='474' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gztell'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='475' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='gzoffset64' mangled-name='gzoffset64' filepath='src.d/gzlib.c' line='484' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzoffset64@@ZLIB_1.2.3.5'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='485' column='1'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='gzoffset' mangled-name='gzoffset' filepath='src.d/gzlib.c' line='507' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzoffset@@ZLIB_1.2.3.5'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='508' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='gzeof' mangled-name='gzeof' filepath='src.d/gzlib.c' line='517' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzeof'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='518' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzerror' mangled-name='gzerror' filepath='src.d/gzlib.c' line='534' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzerror'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='535' column='1'/>
+      <parameter type-id='type-id-77' name='errnum' filepath='src.d/gzlib.c' line='536' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='gzclearerr' mangled-name='gzclearerr' filepath='src.d/gzlib.c' line='555' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzclearerr@@ZLIB_1.2.0.2'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='556' column='1'/>
+      <return type-id='type-id-86'/>
+    </function-decl>
+    <type-decl name='variadic parameter type' id='type-id-91'/>
+  </abi-instr>
+  <abi-instr address-size='32' path='src.d/gzread.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
+    <class-decl name='gz_state' size-in-bits='1344' is-struct='yes' naming-typedef-id='type-id-92' visibility='default' filepath='src.d/gzguts.h' line='170' column='1' id='type-id-93'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='x' type-id='type-id-87' visibility='default' filepath='src.d/gzguts.h' line='172' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='mode' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='177' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='fd' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='178' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='path' type-id='type-id-54' visibility='default' filepath='src.d/gzguts.h' line='179' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='size' type-id='type-id-9' visibility='default' filepath='src.d/gzguts.h' line='180' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='want' type-id='type-id-9' visibility='default' filepath='src.d/gzguts.h' line='181' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='in' type-id='type-id-88' visibility='default' filepath='src.d/gzguts.h' line='182' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='out' type-id='type-id-88' visibility='default' filepath='src.d/gzguts.h' line='183' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='direct' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='184' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='how' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='186' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='start' type-id='type-id-7' visibility='default' filepath='src.d/gzguts.h' line='187' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='eof' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='188' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='544'>
+        <var-decl name='past' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='189' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='level' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='191' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='608'>
+        <var-decl name='strategy' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='192' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='reset' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='193' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='skip' type-id='type-id-7' visibility='default' filepath='src.d/gzguts.h' line='195' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='seek' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='196' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='800'>
+        <var-decl name='err' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='198' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='msg' type-id='type-id-54' visibility='default' filepath='src.d/gzguts.h' line='199' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='864'>
+        <var-decl name='strm' type-id='type-id-71' visibility='default' filepath='src.d/gzguts.h' line='201' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__ssize_t' type-id='type-id-20' filepath='/usr/mips-linux-gnu/include/bits/types.h' line='194' column='1' id='type-id-94'/>
+    <typedef-decl name='gz_state' type-id='type-id-93' filepath='src.d/gzguts.h' line='202' column='1' id='type-id-92'/>
+    <typedef-decl name='gz_statep' type-id='type-id-95' filepath='src.d/gzguts.h' line='203' column='1' id='type-id-96'/>
+    <typedef-decl name='ssize_t' type-id='type-id-94' filepath='/usr/mips-linux-gnu/include/sys/types.h' line='108' column='1' id='type-id-97'/>
+    <pointer-type-def type-id='type-id-92' size-in-bits='32' id='type-id-95'/>
+    <typedef-decl name='voidp' type-id='type-id-85' filepath='./zconf.h' line='416' column='1' id='type-id-98'/>
+    <function-decl name='__errno_location' filepath='/usr/mips-linux-gnu/include/errno.h' line='37' column='1' visibility='default' binding='global' size-in-bits='32'>
       <return type-id='type-id-77'/>
     </function-decl>
-    <var-decl name='z_errmsg' type-id='type-id-109' visibility='default' filepath='src.d/zutil.h' line='56' column='1'/>
+    <function-decl name='memchr' filepath='/usr/mips-linux-gnu/include/string.h' line='107' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-85'/>
+    </function-decl>
+    <function-decl name='strerror' filepath='/usr/mips-linux-gnu/include/string.h' line='419' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-54'/>
+    </function-decl>
+    <function-decl name='close' filepath='/usr/mips-linux-gnu/include/unistd.h' line='358' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='read' filepath='/usr/mips-linux-gnu/include/unistd.h' line='371' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-97'/>
+    </function-decl>
+    <function-decl name='gz_error' filepath='src.d/gzguts.h' line='206' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-96'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-22'/>
+      <return type-id='type-id-86'/>
+    </function-decl>
+    <function-decl name='gzread' mangled-name='gzread' filepath='src.d/gzread.c' line='373' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzread'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzread.c' line='374' column='1'/>
+      <parameter type-id='type-id-98' name='buf' filepath='src.d/gzread.c' line='375' column='1'/>
+      <parameter type-id='type-id-9' name='len' filepath='src.d/gzread.c' line='376' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzfread' mangled-name='gzfread' filepath='src.d/gzread.c' line='409' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzfread@@ZLIB_1.2.9'>
+      <parameter type-id='type-id-98' name='buf' filepath='src.d/gzread.c' line='410' column='1'/>
+      <parameter type-id='type-id-14' name='size' filepath='src.d/gzread.c' line='411' column='1'/>
+      <parameter type-id='type-id-14' name='nitems' filepath='src.d/gzread.c' line='412' column='1'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzread.c' line='413' column='1'/>
+      <return type-id='type-id-14'/>
+    </function-decl>
+    <function-decl name='gzgetc' mangled-name='gzgetc' filepath='src.d/gzread.c' line='445' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzgetc'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzread.c' line='446' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzgetc_' mangled-name='gzgetc_' filepath='src.d/gzread.c' line='472' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzgetc_@@ZLIB_1.2.5.2'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzread.c' line='473' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzungetc' mangled-name='gzungetc' filepath='src.d/gzread.c' line='479' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzungetc@@ZLIB_1.2.0.2'>
+      <parameter type-id='type-id-20' name='c' filepath='src.d/gzread.c' line='480' column='1'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzread.c' line='481' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzgets' mangled-name='gzgets' filepath='src.d/gzread.c' line='539' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzgets'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzread.c' line='540' column='1'/>
+      <parameter type-id='type-id-54' name='buf' filepath='src.d/gzread.c' line='541' column='1'/>
+      <parameter type-id='type-id-20' name='len' filepath='src.d/gzread.c' line='542' column='1'/>
+      <return type-id='type-id-54'/>
+    </function-decl>
+    <function-decl name='gzdirect' mangled-name='gzdirect' filepath='src.d/gzread.c' line='603' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzdirect@@ZLIB_1.2.2.3'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzread.c' line='604' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflate' filepath='src.d/zlib.h' line='400' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateEnd' filepath='src.d/zlib.h' line='520' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-21'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateReset' filepath='src.d/zlib.h' line='959' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-21'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateInit2_' filepath='src.d/zlib.h' line='1789' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='src.d/gzwrite.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
+    <typedef-decl name='voidpc' type-id='type-id-85' filepath='./zconf.h' line='414' column='1' id='type-id-99'/>
+    <typedef-decl name='__gnuc_va_list' type-id='type-id-85' filepath='/usr/lib/gcc-cross/mips-linux-gnu/12/include/stdarg.h' line='40' column='1' id='type-id-100'/>
+    <typedef-decl name='va_list' type-id='type-id-100' filepath='/usr/lib/gcc-cross/mips-linux-gnu/12/include/stdarg.h' line='99' column='1' id='type-id-101'/>
+    <function-decl name='vsnprintf' filepath='/usr/mips-linux-gnu/include/stdio.h' line='389' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-54'/>
+      <parameter type-id='type-id-10'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-85'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='memmove' filepath='/usr/mips-linux-gnu/include/string.h' line='47' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-85'/>
+    </function-decl>
+    <function-decl name='write' filepath='/usr/mips-linux-gnu/include/unistd.h' line='378' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-97'/>
+    </function-decl>
+    <function-decl name='gzwrite' mangled-name='gzwrite' filepath='src.d/gzwrite.c' line='255' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzwrite'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzwrite.c' line='256' column='1'/>
+      <parameter type-id='type-id-99' name='buf' filepath='src.d/gzwrite.c' line='257' column='1'/>
+      <parameter type-id='type-id-9' name='len' filepath='src.d/gzwrite.c' line='258' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzfwrite' mangled-name='gzfwrite' filepath='src.d/gzwrite.c' line='283' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzfwrite@@ZLIB_1.2.9'>
+      <parameter type-id='type-id-99' name='buf' filepath='src.d/gzwrite.c' line='284' column='1'/>
+      <parameter type-id='type-id-14' name='size' filepath='src.d/gzwrite.c' line='285' column='1'/>
+      <parameter type-id='type-id-14' name='nitems' filepath='src.d/gzwrite.c' line='286' column='1'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzwrite.c' line='287' column='1'/>
+      <return type-id='type-id-14'/>
+    </function-decl>
+    <function-decl name='gzputc' mangled-name='gzputc' filepath='src.d/gzwrite.c' line='313' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzputc'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzwrite.c' line='314' column='1'/>
+      <parameter type-id='type-id-20' name='c' filepath='src.d/gzwrite.c' line='315' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzputs' mangled-name='gzputs' filepath='src.d/gzwrite.c' line='361' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzputs'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzwrite.c' line='362' column='1'/>
+      <parameter type-id='type-id-22' name='s' filepath='src.d/gzwrite.c' line='363' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzvprintf' mangled-name='gzvprintf' filepath='src.d/gzwrite.c' line='391' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzvprintf@@ZLIB_1.2.7.1'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzwrite.c' line='391' column='1'/>
+      <parameter type-id='type-id-22' name='format' filepath='src.d/gzwrite.c' line='391' column='1'/>
+      <parameter type-id='type-id-101' name='va' filepath='src.d/gzwrite.c' line='391' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzprintf' mangled-name='gzprintf' filepath='src.d/gzwrite.c' line='463' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzprintf'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzwrite.c' line='463' column='1'/>
+      <parameter type-id='type-id-22' name='format' filepath='src.d/gzwrite.c' line='463' column='1'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzflush' mangled-name='gzflush' filepath='src.d/gzwrite.c' line='565' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzflush'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzwrite.c' line='566' column='1'/>
+      <parameter type-id='type-id-20' name='flush' filepath='src.d/gzwrite.c' line='567' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzsetparams' mangled-name='gzsetparams' filepath='src.d/gzwrite.c' line='597' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzsetparams'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzwrite.c' line='598' column='1'/>
+      <parameter type-id='type-id-20' name='level' filepath='src.d/gzwrite.c' line='599' column='1'/>
+      <parameter type-id='type-id-20' name='strategy' filepath='src.d/gzwrite.c' line='600' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='src.d/infback.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
+    <enum-decl name='codetype' naming-typedef-id='type-id-102' filepath='src.d/inftrees.h' line='54' column='1' id='type-id-103'>
+      <underlying-type type-id='type-id-104'/>
+      <enumerator name='CODES' value='0'/>
+      <enumerator name='LENS' value='1'/>
+      <enumerator name='DISTS' value='2'/>
+    </enum-decl>
+    <class-decl name='code' size-in-bits='32' is-struct='yes' naming-typedef-id='type-id-105' visibility='default' filepath='src.d/inftrees.h' line='24' column='1' id='type-id-106'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-2' visibility='default' filepath='src.d/inftrees.h' line='25' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8'>
+        <var-decl name='bits' type-id='type-id-2' visibility='default' filepath='src.d/inftrees.h' line='26' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='val' type-id='type-id-70' visibility='default' filepath='src.d/inftrees.h' line='27' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='code' type-id='type-id-106' filepath='src.d/inftrees.h' line='28' column='1' id='type-id-105'/>
+    <typedef-decl name='codetype' type-id='type-id-103' filepath='src.d/inftrees.h' line='58' column='1' id='type-id-102'/>
+    <typedef-decl name='in_func' type-id='type-id-107' filepath='src.d/zlib.h' line='1094' column='1' id='type-id-108'/>
+    <typedef-decl name='out_func' type-id='type-id-109' filepath='src.d/zlib.h' line='1096' column='1' id='type-id-110'/>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-104'/>
+    <pointer-type-def type-id='type-id-105' size-in-bits='32' id='type-id-111'/>
+    <pointer-type-def type-id='type-id-111' size-in-bits='32' id='type-id-112'/>
+    <pointer-type-def type-id='type-id-113' size-in-bits='32' id='type-id-109'/>
+    <pointer-type-def type-id='type-id-2' size-in-bits='32' id='type-id-88'/>
+    <pointer-type-def type-id='type-id-88' size-in-bits='32' id='type-id-114'/>
+    <pointer-type-def type-id='type-id-115' size-in-bits='32' id='type-id-107'/>
+    <pointer-type-def type-id='type-id-70' size-in-bits='32' id='type-id-116'/>
+    <typedef-decl name='voidpf' type-id='type-id-85' filepath='./zconf.h' line='415' column='1' id='type-id-117'/>
+    <function-decl name='inflateBackInit_' mangled-name='inflateBackInit_' filepath='src.d/infback.c' line='28' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateBackInit_@@ZLIB_1.2.0'>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/infback.c' line='29' column='1'/>
+      <parameter type-id='type-id-20' name='windowBits' filepath='src.d/infback.c' line='30' column='1'/>
+      <parameter type-id='type-id-88' name='window' filepath='src.d/infback.c' line='31' column='1'/>
+      <parameter type-id='type-id-22' name='version' filepath='src.d/infback.c' line='32' column='1'/>
+      <parameter type-id='type-id-20' name='stream_size' filepath='src.d/infback.c' line='33' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateBack' mangled-name='inflateBack' filepath='src.d/infback.c' line='251' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateBack@@ZLIB_1.2.0'>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/infback.c' line='252' column='1'/>
+      <parameter type-id='type-id-108' name='in' filepath='src.d/infback.c' line='253' column='1'/>
+      <parameter type-id='type-id-85' name='in_desc' filepath='src.d/infback.c' line='254' column='1'/>
+      <parameter type-id='type-id-110' name='out' filepath='src.d/infback.c' line='255' column='1'/>
+      <parameter type-id='type-id-85' name='out_desc' filepath='src.d/infback.c' line='256' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateBackEnd' mangled-name='inflateBackEnd' filepath='src.d/infback.c' line='635' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateBackEnd@@ZLIB_1.2.0'>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/infback.c' line='636' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflate_fast' filepath='src.d/inffast.h' line='11' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-9'/>
+      <return type-id='type-id-86'/>
+    </function-decl>
+    <function-decl name='inflate_table' filepath='src.d/inftrees.h' line='60' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-102'/>
+      <parameter type-id='type-id-116'/>
+      <parameter type-id='type-id-9'/>
+      <parameter type-id='type-id-112'/>
+      <parameter type-id='type-id-80'/>
+      <parameter type-id='type-id-116'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-type size-in-bits='32' id='type-id-113'>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-88'/>
+      <parameter type-id='type-id-9'/>
+      <return type-id='type-id-20'/>
+    </function-type>
+    <function-type size-in-bits='32' id='type-id-115'>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-114'/>
+      <return type-id='type-id-9'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr address-size='32' path='src.d/inflate.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
+    <typedef-decl name='voidpf' type-id='type-id-85' filepath='./zconf.h' line='415' column='1' id='type-id-118'/>
+    <function-decl name='inflateResetKeep' mangled-name='inflateResetKeep' filepath='src.d/inflate.c' line='119' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateResetKeep@@ZLIB_1.2.5.2'>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='120' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateReset2' mangled-name='inflateReset2' filepath='src.d/inflate.c' line='158' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateReset2@@ZLIB_1.2.3.4'>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='159' column='1'/>
+      <parameter type-id='type-id-20' name='windowBits' filepath='src.d/inflate.c' line='160' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateInit_' mangled-name='inflateInit_' filepath='src.d/inflate.c' line='242' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateInit_'>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='243' column='1'/>
+      <parameter type-id='type-id-22' name='version' filepath='src.d/inflate.c' line='244' column='1'/>
+      <parameter type-id='type-id-20' name='stream_size' filepath='src.d/inflate.c' line='245' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflatePrime' mangled-name='inflatePrime' filepath='src.d/inflate.c' line='250' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflatePrime@@ZLIB_1.2.2.4'>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='251' column='1'/>
+      <parameter type-id='type-id-20' name='bits' filepath='src.d/inflate.c' line='252' column='1'/>
+      <parameter type-id='type-id-20' name='value' filepath='src.d/inflate.c' line='253' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateGetDictionary' mangled-name='inflateGetDictionary' filepath='src.d/inflate.c' line='1318' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateGetDictionary@@ZLIB_1.2.7.1'>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1319' column='1'/>
+      <parameter type-id='type-id-19' name='dictionary' filepath='src.d/inflate.c' line='1320' column='1'/>
+      <parameter type-id='type-id-79' name='dictLength' filepath='src.d/inflate.c' line='1321' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateSetDictionary' mangled-name='inflateSetDictionary' filepath='src.d/inflate.c' line='1341' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateSetDictionary'>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1342' column='1'/>
+      <parameter type-id='type-id-16' name='dictionary' filepath='src.d/inflate.c' line='1343' column='1'/>
+      <parameter type-id='type-id-11' name='dictLength' filepath='src.d/inflate.c' line='1344' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateGetHeader' mangled-name='inflateGetHeader' filepath='src.d/inflate.c' line='1376' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateGetHeader@@ZLIB_1.2.2'>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1377' column='1'/>
+      <parameter type-id='type-id-43' name='head' filepath='src.d/inflate.c' line='1378' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateSync' mangled-name='inflateSync' filepath='src.d/inflate.c' line='1427' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateSync'>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1428' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateSyncPoint' mangled-name='inflateSyncPoint' filepath='src.d/inflate.c' line='1485' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateSyncPoint'>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1486' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateCopy' mangled-name='inflateCopy' filepath='src.d/inflate.c' line='1495' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateCopy@@ZLIB_1.2.0'>
+      <parameter type-id='type-id-21' name='dest' filepath='src.d/inflate.c' line='1496' column='1'/>
+      <parameter type-id='type-id-21' name='source' filepath='src.d/inflate.c' line='1497' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateUndermine' mangled-name='inflateUndermine' filepath='src.d/inflate.c' line='1542' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateUndermine@@ZLIB_1.2.3.3'>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1543' column='1'/>
+      <parameter type-id='type-id-20' name='subvert' filepath='src.d/inflate.c' line='1544' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateValidate' mangled-name='inflateValidate' filepath='src.d/inflate.c' line='1560' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateValidate@@ZLIB_1.2.9'>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1561' column='1'/>
+      <parameter type-id='type-id-20' name='check' filepath='src.d/inflate.c' line='1562' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateMark' mangled-name='inflateMark' filepath='src.d/inflate.c' line='1575' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateMark@@ZLIB_1.2.3.4'>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1576' column='1'/>
+      <return type-id='type-id-37'/>
+    </function-decl>
+    <function-decl name='inflateCodesUsed' mangled-name='inflateCodesUsed' filepath='src.d/inflate.c' line='1588' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateCodesUsed@@ZLIB_1.2.9'>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1589' column='1'/>
+      <return type-id='type-id-12'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='src.d/trees.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
+    <array-type-def dimensions='1' type-id='type-id-119' size-in-bits='2048' id='type-id-120'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-9' id='type-id-121'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-119' size-in-bits='4096' id='type-id-122'>
+      <subrange length='512' lower-bound='0' upper-bound='511' type-id='type-id-9' id='type-id-123'/>
+    </array-type-def>
+    <array-type-def dimensions='1' type-id='type-id-119' size-in-bits='unknown' id='type-id-124'>
+      <subrange length='unknown' lower-bound='0' upper-bound='0' id='type-id-125'/>
+    </array-type-def>
+    <qualified-type-def type-id='type-id-68' const='yes' id='type-id-119'/>
+    <var-decl name='_length_code' type-id='type-id-120' visibility='default' filepath='src.d/deflate.h' line='317' column='1'/>
+    <var-decl name='_dist_code' type-id='type-id-122' visibility='default' filepath='src.d/deflate.h' line='318' column='1'/>
+  </abi-instr>
+  <abi-instr address-size='32' path='src.d/uncompr.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
+    <pointer-type-def type-id='type-id-13' size-in-bits='32' id='type-id-126'/>
+    <function-decl name='uncompress2' mangled-name='uncompress2' filepath='src.d/uncompr.c' line='27' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='uncompress2@@ZLIB_1.2.9'>
+      <parameter type-id='type-id-19' name='dest' filepath='src.d/uncompr.c' line='28' column='1'/>
+      <parameter type-id='type-id-18' name='destLen' filepath='src.d/uncompr.c' line='29' column='1'/>
+      <parameter type-id='type-id-16' name='source' filepath='src.d/uncompr.c' line='30' column='1'/>
+      <parameter type-id='type-id-126' name='sourceLen' filepath='src.d/uncompr.c' line='31' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='uncompress' mangled-name='uncompress' filepath='src.d/uncompr.c' line='86' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='uncompress'>
+      <parameter type-id='type-id-19' name='dest' filepath='src.d/uncompr.c' line='87' column='1'/>
+      <parameter type-id='type-id-18' name='destLen' filepath='src.d/uncompr.c' line='88' column='1'/>
+      <parameter type-id='type-id-16' name='source' filepath='src.d/uncompr.c' line='89' column='1'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/uncompr.c' line='90' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+  </abi-instr>
+  <abi-instr address-size='32' path='src.d/zutil.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
+    <array-type-def dimensions='1' type-id='type-id-127' size-in-bits='320' id='type-id-128'>
+      <subrange length='10' lower-bound='0' upper-bound='9' type-id='type-id-9' id='type-id-129'/>
+    </array-type-def>
+    <qualified-type-def type-id='type-id-54' const='yes' id='type-id-127'/>
+    <function-decl name='zlibVersion' mangled-name='zlibVersion' filepath='src.d/zutil.c' line='27' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='zlibVersion'>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='zlibCompileFlags' mangled-name='zlibCompileFlags' filepath='src.d/zutil.c' line='32' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='zlibCompileFlags@@ZLIB_1.2.0.2'>
+      <return type-id='type-id-13'/>
+    </function-decl>
+    <function-decl name='zError' mangled-name='zError' filepath='src.d/zutil.c' line='135' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='zError'>
+      <parameter type-id='type-id-20' name='err' filepath='src.d/zutil.c' line='136' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <var-decl name='z_errmsg' type-id='type-id-128' visibility='default' filepath='src.d/zutil.h' line='56' column='1'/>
   </abi-instr>
 </abi-corpus>

--- a/test/abi/zlib-04f42ceca40f73e2978b50e93806c2a18c1281fc-mips64-unknown-linux-gnuabi64.abi
+++ b/test/abi/zlib-04f42ceca40f73e2978b50e93806c2a18c1281fc-mips64-unknown-linux-gnuabi64.abi
@@ -1,4 +1,4 @@
-<abi-corpus version='2.0' path='btmp1/libz.so.1.2.13' architecture='elf-mips-r3000-be' soname='libz.so.1'>
+<abi-corpus version='2.2' path='btmp1/libz.so.1.2.13' architecture='elf-mips-r3000-be' soname='libz.so.1'>
   <elf-needed>
     <dependency name='libc.so.6'/>
     <dependency name='ld.so.1'/>
@@ -93,56 +93,56 @@
     <elf-symbol name='zlibCompileFlags' version='ZLIB_1.2.0.2' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='zlibVersion' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
   </elf-function-symbols>
-  <abi-instr address-size='64' path='src.d/adler32.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C99'>
+  <abi-instr address-size='64' path='src.d/adler32.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
     <type-decl name='long int' size-in-bits='64' id='type-id-1'/>
+    <typedef-decl name='Byte' type-id='type-id-2' filepath='./zconf.h' line='397' column='1' id='type-id-3'/>
+    <typedef-decl name='Bytef' type-id='type-id-3' filepath='./zconf.h' line='406' column='1' id='type-id-4'/>
+    <typedef-decl name='__off64_t' type-id='type-id-1' filepath='/usr/mips64-linux-gnuabi64/include/bits/types.h' line='153' column='1' id='type-id-5'/>
+    <typedef-decl name='__off_t' type-id='type-id-1' filepath='/usr/mips64-linux-gnuabi64/include/bits/types.h' line='152' column='1' id='type-id-6'/>
+    <typedef-decl name='off64_t' type-id='type-id-5' filepath='/usr/mips64-linux-gnuabi64/include/sys/types.h' line='92' column='1' id='type-id-7'/>
+    <typedef-decl name='off_t' type-id='type-id-6' filepath='/usr/mips64-linux-gnuabi64/include/sys/types.h' line='85' column='1' id='type-id-8'/>
+    <typedef-decl name='size_t' type-id='type-id-9' filepath='/usr/lib/gcc-cross/mips64-linux-gnuabi64/12/include/stddef.h' line='214' column='1' id='type-id-10'/>
+    <typedef-decl name='uInt' type-id='type-id-11' filepath='./zconf.h' line='399' column='1' id='type-id-12'/>
+    <typedef-decl name='uLong' type-id='type-id-9' filepath='./zconf.h' line='400' column='1' id='type-id-13'/>
+    <typedef-decl name='z_size_t' type-id='type-id-10' filepath='./zconf.h' line='251' column='1' id='type-id-14'/>
     <type-decl name='unsigned char' size-in-bits='8' id='type-id-2'/>
-    <type-decl name='unsigned int' size-in-bits='32' id='type-id-3'/>
-    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-4'/>
-    <typedef-decl name='z_size_t' type-id='type-id-5' filepath='./zconf.h' line='251' column='1' id='type-id-6'/>
-    <typedef-decl name='Byte' type-id='type-id-2' filepath='./zconf.h' line='397' column='1' id='type-id-7'/>
-    <typedef-decl name='uInt' type-id='type-id-3' filepath='./zconf.h' line='399' column='1' id='type-id-8'/>
-    <typedef-decl name='uLong' type-id='type-id-4' filepath='./zconf.h' line='400' column='1' id='type-id-9'/>
-    <typedef-decl name='Bytef' type-id='type-id-7' filepath='./zconf.h' line='406' column='1' id='type-id-10'/>
-    <typedef-decl name='size_t' type-id='type-id-4' filepath='/usr/lib/gcc-cross/mips64-linux-gnuabi64/10/include/stddef.h' line='209' column='1' id='type-id-5'/>
-    <typedef-decl name='__off_t' type-id='type-id-1' filepath='/usr/mips64-linux-gnuabi64/include/bits/types.h' line='152' column='1' id='type-id-11'/>
-    <typedef-decl name='__off64_t' type-id='type-id-1' filepath='/usr/mips64-linux-gnuabi64/include/bits/types.h' line='153' column='1' id='type-id-12'/>
-    <typedef-decl name='off_t' type-id='type-id-11' filepath='/usr/mips64-linux-gnuabi64/include/sys/types.h' line='85' column='1' id='type-id-13'/>
-    <typedef-decl name='off64_t' type-id='type-id-12' filepath='/usr/mips64-linux-gnuabi64/include/sys/types.h' line='92' column='1' id='type-id-14'/>
-    <qualified-type-def type-id='type-id-10' const='yes' id='type-id-15'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-11'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-9'/>
+    <qualified-type-def type-id='type-id-4' const='yes' id='type-id-15'/>
     <pointer-type-def type-id='type-id-15' size-in-bits='64' id='type-id-16'/>
     <function-decl name='adler32_z' mangled-name='adler32_z' filepath='src.d/adler32.c' line='63' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='adler32_z@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-9' name='adler' filepath='src.d/adler32.c' line='64' column='1'/>
+      <parameter type-id='type-id-13' name='adler' filepath='src.d/adler32.c' line='64' column='1'/>
       <parameter type-id='type-id-16' name='buf' filepath='src.d/adler32.c' line='65' column='1'/>
-      <parameter type-id='type-id-6' name='len' filepath='src.d/adler32.c' line='66' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-14' name='len' filepath='src.d/adler32.c' line='66' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='adler32' mangled-name='adler32' filepath='src.d/adler32.c' line='134' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='adler32'>
-      <parameter type-id='type-id-9' name='adler' filepath='src.d/adler32.c' line='135' column='1'/>
+      <parameter type-id='type-id-13' name='adler' filepath='src.d/adler32.c' line='135' column='1'/>
       <parameter type-id='type-id-16' name='buf' filepath='src.d/adler32.c' line='136' column='1'/>
-      <parameter type-id='type-id-8' name='len' filepath='src.d/adler32.c' line='137' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-12' name='len' filepath='src.d/adler32.c' line='137' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='adler32_combine' mangled-name='adler32_combine' filepath='src.d/adler32.c' line='172' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='adler32_combine@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-9' name='adler1' filepath='src.d/adler32.c' line='173' column='1'/>
-      <parameter type-id='type-id-9' name='adler2' filepath='src.d/adler32.c' line='174' column='1'/>
-      <parameter type-id='type-id-13' name='len2' filepath='src.d/adler32.c' line='175' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-13' name='adler1' filepath='src.d/adler32.c' line='173' column='1'/>
+      <parameter type-id='type-id-13' name='adler2' filepath='src.d/adler32.c' line='174' column='1'/>
+      <parameter type-id='type-id-8' name='len2' filepath='src.d/adler32.c' line='175' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='adler32_combine64' mangled-name='adler32_combine64' filepath='src.d/adler32.c' line='180' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='adler32_combine64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-9' name='adler1' filepath='src.d/adler32.c' line='181' column='1'/>
-      <parameter type-id='type-id-9' name='adler2' filepath='src.d/adler32.c' line='182' column='1'/>
-      <parameter type-id='type-id-14' name='len2' filepath='src.d/adler32.c' line='183' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-13' name='adler1' filepath='src.d/adler32.c' line='181' column='1'/>
+      <parameter type-id='type-id-13' name='adler2' filepath='src.d/adler32.c' line='182' column='1'/>
+      <parameter type-id='type-id-7' name='len2' filepath='src.d/adler32.c' line='183' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='src.d/compress.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C99'>
-    <typedef-decl name='uLongf' type-id='type-id-9' filepath='./zconf.h' line='411' column='1' id='type-id-17'/>
+  <abi-instr address-size='64' path='src.d/compress.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
+    <typedef-decl name='uLongf' type-id='type-id-13' filepath='./zconf.h' line='411' column='1' id='type-id-17'/>
     <pointer-type-def type-id='type-id-17' size-in-bits='64' id='type-id-18'/>
     <function-decl name='compress2' mangled-name='compress2' filepath='src.d/compress.c' line='22' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='compress2'>
       <parameter type-id='type-id-19' name='dest' filepath='src.d/compress.c' line='23' column='1'/>
       <parameter type-id='type-id-18' name='destLen' filepath='src.d/compress.c' line='24' column='1'/>
       <parameter type-id='type-id-16' name='source' filepath='src.d/compress.c' line='25' column='1'/>
-      <parameter type-id='type-id-9' name='sourceLen' filepath='src.d/compress.c' line='26' column='1'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/compress.c' line='26' column='1'/>
       <parameter type-id='type-id-20' name='level' filepath='src.d/compress.c' line='27' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
@@ -150,360 +150,108 @@
       <parameter type-id='type-id-19' name='dest' filepath='src.d/compress.c' line='69' column='1'/>
       <parameter type-id='type-id-18' name='destLen' filepath='src.d/compress.c' line='70' column='1'/>
       <parameter type-id='type-id-16' name='source' filepath='src.d/compress.c' line='71' column='1'/>
-      <parameter type-id='type-id-9' name='sourceLen' filepath='src.d/compress.c' line='72' column='1'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/compress.c' line='72' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='compressBound' mangled-name='compressBound' filepath='src.d/compress.c' line='81' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='compressBound@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-9' name='sourceLen' filepath='src.d/compress.c' line='82' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/compress.c' line='82' column='1'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+    <function-decl name='deflate' filepath='src.d/zlib.h' line='250' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='deflateEnd' filepath='src.d/zlib.h' line='363' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-21'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='deflateInit_' filepath='src.d/zlib.h' line='1781' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='src.d/crc32.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C99'>
-    <type-decl name='void' id='type-id-21'/>
-    <typedef-decl name='z_crc_t' type-id='type-id-3' filepath='./zconf.h' line='435' column='1' id='type-id-22'/>
-    <qualified-type-def type-id='type-id-2' const='yes' id='type-id-23'/>
-    <pointer-type-def type-id='type-id-23' size-in-bits='64' id='type-id-24'/>
-    <qualified-type-def type-id='type-id-22' const='yes' id='type-id-25'/>
-    <pointer-type-def type-id='type-id-25' size-in-bits='64' id='type-id-26'/>
+  <abi-instr address-size='64' path='src.d/crc32.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
+    <typedef-decl name='z_crc_t' type-id='type-id-11' filepath='./zconf.h' line='435' column='1' id='type-id-23'/>
+    <qualified-type-def type-id='type-id-2' const='yes' id='type-id-24'/>
+    <pointer-type-def type-id='type-id-24' size-in-bits='64' id='type-id-25'/>
+    <qualified-type-def type-id='type-id-23' const='yes' id='type-id-26'/>
+    <pointer-type-def type-id='type-id-26' size-in-bits='64' id='type-id-27'/>
     <function-decl name='get_crc_table' mangled-name='get_crc_table' filepath='src.d/crc32.c' line='595' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='get_crc_table'>
-      <return type-id='type-id-26'/>
+      <return type-id='type-id-27'/>
     </function-decl>
     <function-decl name='crc32_z' mangled-name='crc32_z' filepath='src.d/crc32.c' line='748' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_z@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-4' name='crc' filepath='src.d/crc32.c' line='749' column='1'/>
-      <parameter type-id='type-id-24' name='buf' filepath='src.d/crc32.c' line='750' column='1'/>
-      <parameter type-id='type-id-6' name='len' filepath='src.d/crc32.c' line='751' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-9' name='crc' filepath='src.d/crc32.c' line='749' column='1'/>
+      <parameter type-id='type-id-25' name='buf' filepath='src.d/crc32.c' line='750' column='1'/>
+      <parameter type-id='type-id-14' name='len' filepath='src.d/crc32.c' line='751' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32' mangled-name='crc32' filepath='src.d/crc32.c' line='1072' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32'>
-      <parameter type-id='type-id-4' name='crc' filepath='src.d/crc32.c' line='1073' column='1'/>
-      <parameter type-id='type-id-24' name='buf' filepath='src.d/crc32.c' line='1074' column='1'/>
-      <parameter type-id='type-id-8' name='len' filepath='src.d/crc32.c' line='1075' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-9' name='crc' filepath='src.d/crc32.c' line='1073' column='1'/>
+      <parameter type-id='type-id-25' name='buf' filepath='src.d/crc32.c' line='1074' column='1'/>
+      <parameter type-id='type-id-12' name='len' filepath='src.d/crc32.c' line='1075' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine64' mangled-name='crc32_combine64' filepath='src.d/crc32.c' line='1081' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_combine64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-9' name='crc1' filepath='src.d/crc32.c' line='1082' column='1'/>
-      <parameter type-id='type-id-9' name='crc2' filepath='src.d/crc32.c' line='1083' column='1'/>
-      <parameter type-id='type-id-14' name='len2' filepath='src.d/crc32.c' line='1084' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-13' name='crc1' filepath='src.d/crc32.c' line='1082' column='1'/>
+      <parameter type-id='type-id-13' name='crc2' filepath='src.d/crc32.c' line='1083' column='1'/>
+      <parameter type-id='type-id-7' name='len2' filepath='src.d/crc32.c' line='1084' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine' mangled-name='crc32_combine' filepath='src.d/crc32.c' line='1093' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_combine@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-9' name='crc1' filepath='src.d/crc32.c' line='1094' column='1'/>
-      <parameter type-id='type-id-9' name='crc2' filepath='src.d/crc32.c' line='1095' column='1'/>
-      <parameter type-id='type-id-13' name='len2' filepath='src.d/crc32.c' line='1096' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-13' name='crc1' filepath='src.d/crc32.c' line='1094' column='1'/>
+      <parameter type-id='type-id-13' name='crc2' filepath='src.d/crc32.c' line='1095' column='1'/>
+      <parameter type-id='type-id-8' name='len2' filepath='src.d/crc32.c' line='1096' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine_gen64' mangled-name='crc32_combine_gen64' filepath='src.d/crc32.c' line='1102' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_combine_gen64@@ZLIB_1.2.12'>
-      <parameter type-id='type-id-14' name='len2' filepath='src.d/crc32.c' line='1103' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-7' name='len2' filepath='src.d/crc32.c' line='1103' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine_gen' mangled-name='crc32_combine_gen' filepath='src.d/crc32.c' line='1112' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_combine_gen@@ZLIB_1.2.12'>
-      <parameter type-id='type-id-13' name='len2' filepath='src.d/crc32.c' line='1113' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-8' name='len2' filepath='src.d/crc32.c' line='1113' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine_op' mangled-name='crc32_combine_op' filepath='src.d/crc32.c' line='1119' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_combine_op@@ZLIB_1.2.12'>
-      <parameter type-id='type-id-9' name='crc1' filepath='src.d/crc32.c' line='1120' column='1'/>
-      <parameter type-id='type-id-9' name='crc2' filepath='src.d/crc32.c' line='1121' column='1'/>
-      <parameter type-id='type-id-9' name='op' filepath='src.d/crc32.c' line='1122' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-13' name='crc1' filepath='src.d/crc32.c' line='1120' column='1'/>
+      <parameter type-id='type-id-13' name='crc2' filepath='src.d/crc32.c' line='1121' column='1'/>
+      <parameter type-id='type-id-13' name='op' filepath='src.d/crc32.c' line='1122' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
+    <type-decl name='void' id='type-id-28'/>
   </abi-instr>
-  <abi-instr address-size='64' path='src.d/deflate.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C99'>
-    <type-decl name='char' size-in-bits='8' id='type-id-27'/>
-    <class-decl name='static_tree_desc_s' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-28'/>
-    <array-type-def dimensions='1' type-id='type-id-29' size-in-bits='1248' id='type-id-30'>
-      <subrange length='39' type-id='type-id-4' id='type-id-31'/>
+  <abi-instr address-size='64' path='src.d/deflate.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
+    <type-decl name='char' size-in-bits='8' id='type-id-29'/>
+    <array-type-def dimensions='1' type-id='type-id-30' size-in-bits='1248' id='type-id-31'>
+      <subrange length='39' lower-bound='0' upper-bound='38' type-id='type-id-9' id='type-id-32'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-29' size-in-bits='18336' id='type-id-32'>
-      <subrange length='573' type-id='type-id-4' id='type-id-33'/>
+    <array-type-def dimensions='1' type-id='type-id-30' size-in-bits='18336' id='type-id-33'>
+      <subrange length='573' lower-bound='0' upper-bound='572' type-id='type-id-9' id='type-id-34'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-29' size-in-bits='1952' id='type-id-34'>
-      <subrange length='61' type-id='type-id-4' id='type-id-35'/>
+    <array-type-def dimensions='1' type-id='type-id-30' size-in-bits='1952' id='type-id-35'>
+      <subrange length='61' lower-bound='0' upper-bound='60' type-id='type-id-9' id='type-id-36'/>
     </array-type-def>
     <type-decl name='int' size-in-bits='32' id='type-id-20'/>
-    <array-type-def dimensions='1' type-id='type-id-20' size-in-bits='18336' id='type-id-36'>
-      <subrange length='573' type-id='type-id-4' id='type-id-33'/>
+    <array-type-def dimensions='1' type-id='type-id-20' size-in-bits='18336' id='type-id-37'>
+      <subrange length='573' lower-bound='0' upper-bound='572' type-id='type-id-9' id='type-id-34'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-37' size-in-bits='4584' id='type-id-38'>
-      <subrange length='573' type-id='type-id-4' id='type-id-33'/>
-    </array-type-def>
-    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-39'/>
-    <array-type-def dimensions='1' type-id='type-id-40' size-in-bits='256' id='type-id-41'>
-      <subrange length='16' type-id='type-id-4' id='type-id-42'/>
-    </array-type-def>
-    <typedef-decl name='voidpf' type-id='type-id-43' filepath='./zconf.h' line='415' column='1' id='type-id-44'/>
-    <class-decl name='ct_data_s' size-in-bits='32' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='68' column='1' id='type-id-29'>
+    <class-decl name='ct_data_s' size-in-bits='32' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='68' column='1' id='type-id-30'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='fc' type-id='type-id-45' visibility='default' filepath='src.d/deflate.h' line='72' column='1'/>
+        <var-decl name='fc' type-id='type-id-38' visibility='default' filepath='src.d/deflate.h' line='72' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='16'>
-        <var-decl name='dl' type-id='type-id-46' visibility='default' filepath='src.d/deflate.h' line='76' column='1'/>
+        <var-decl name='dl' type-id='type-id-39' visibility='default' filepath='src.d/deflate.h' line='76' column='1'/>
       </data-member>
     </class-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='69' column='1' id='type-id-45'>
-      <data-member access='public'>
-        <var-decl name='freq' type-id='type-id-40' visibility='default' filepath='src.d/deflate.h' line='70' column='1'/>
-      </data-member>
-      <data-member access='public'>
-        <var-decl name='code' type-id='type-id-40' visibility='default' filepath='src.d/deflate.h' line='71' column='1'/>
-      </data-member>
-    </union-decl>
-    <union-decl name='__anonymous_union__1' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='73' column='1' id='type-id-46'>
-      <data-member access='public'>
-        <var-decl name='dad' type-id='type-id-40' visibility='default' filepath='src.d/deflate.h' line='74' column='1'/>
-      </data-member>
-      <data-member access='public'>
-        <var-decl name='len' type-id='type-id-40' visibility='default' filepath='src.d/deflate.h' line='75' column='1'/>
-      </data-member>
-    </union-decl>
-    <typedef-decl name='ct_data' type-id='type-id-29' filepath='src.d/deflate.h' line='77' column='1' id='type-id-47'/>
-    <typedef-decl name='static_tree_desc' type-id='type-id-28' filepath='src.d/deflate.h' line='84' column='1' id='type-id-48'/>
-    <class-decl name='tree_desc_s' size-in-bits='192' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='86' column='1' id='type-id-49'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='dyn_tree' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='87' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='max_code' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='88' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='stat_desc' type-id='type-id-51' visibility='default' filepath='src.d/deflate.h' line='89' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='Pos' type-id='type-id-40' filepath='src.d/deflate.h' line='92' column='1' id='type-id-52'/>
-    <typedef-decl name='Posf' type-id='type-id-52' filepath='src.d/deflate.h' line='93' column='1' id='type-id-53'/>
-    <typedef-decl name='IPos' type-id='type-id-3' filepath='src.d/deflate.h' line='94' column='1' id='type-id-54'/>
-    <class-decl name='internal_state' size-in-bits='47616' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='100' column='1' id='type-id-55'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='strm' type-id='type-id-56' visibility='default' filepath='src.d/deflate.h' line='101' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='status' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='102' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='pending_buf' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='103' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='pending_buf_size' type-id='type-id-57' visibility='default' filepath='src.d/deflate.h' line='104' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='pending_out' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='105' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='pending' type-id='type-id-57' visibility='default' filepath='src.d/deflate.h' line='106' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='wrap' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='107' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='gzhead' type-id='type-id-58' visibility='default' filepath='src.d/deflate.h' line='108' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='gzindex' type-id='type-id-57' visibility='default' filepath='src.d/deflate.h' line='109' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='method' type-id='type-id-7' visibility='default' filepath='src.d/deflate.h' line='110' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='608'>
-        <var-decl name='last_flush' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='111' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='w_size' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='115' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='672'>
-        <var-decl name='w_bits' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='116' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='w_mask' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='117' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='window' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='119' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='window_size' type-id='type-id-57' visibility='default' filepath='src.d/deflate.h' line='129' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='prev' type-id='type-id-59' visibility='default' filepath='src.d/deflate.h' line='134' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='head' type-id='type-id-59' visibility='default' filepath='src.d/deflate.h' line='140' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='ins_h' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='142' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1056'>
-        <var-decl name='hash_size' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='143' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1088'>
-        <var-decl name='hash_bits' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='144' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1120'>
-        <var-decl name='hash_mask' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='145' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1152'>
-        <var-decl name='hash_shift' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='147' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='block_start' type-id='type-id-1' visibility='default' filepath='src.d/deflate.h' line='154' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='match_length' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='159' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1312'>
-        <var-decl name='prev_match' type-id='type-id-54' visibility='default' filepath='src.d/deflate.h' line='160' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1344'>
-        <var-decl name='match_available' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='161' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1376'>
-        <var-decl name='strstart' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='162' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1408'>
-        <var-decl name='match_start' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='163' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1440'>
-        <var-decl name='lookahead' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='164' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1472'>
-        <var-decl name='prev_length' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='166' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1504'>
-        <var-decl name='max_chain_length' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='171' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1536'>
-        <var-decl name='max_lazy_match' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='177' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1568'>
-        <var-decl name='level' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='188' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1600'>
-        <var-decl name='strategy' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='189' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1632'>
-        <var-decl name='good_match' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='191' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1664'>
-        <var-decl name='nice_match' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='194' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1696'>
-        <var-decl name='dyn_ltree' type-id='type-id-32' visibility='default' filepath='src.d/deflate.h' line='198' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='20032'>
-        <var-decl name='dyn_dtree' type-id='type-id-34' visibility='default' filepath='src.d/deflate.h' line='199' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='21984'>
-        <var-decl name='bl_tree' type-id='type-id-30' visibility='default' filepath='src.d/deflate.h' line='200' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='23232'>
-        <var-decl name='l_desc' type-id='type-id-49' visibility='default' filepath='src.d/deflate.h' line='202' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='23424'>
-        <var-decl name='d_desc' type-id='type-id-49' visibility='default' filepath='src.d/deflate.h' line='203' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='23616'>
-        <var-decl name='bl_desc' type-id='type-id-49' visibility='default' filepath='src.d/deflate.h' line='204' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='23808'>
-        <var-decl name='bl_count' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='206' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='24064'>
-        <var-decl name='heap' type-id='type-id-36' visibility='default' filepath='src.d/deflate.h' line='209' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='42400'>
-        <var-decl name='heap_len' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='210' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='42432'>
-        <var-decl name='heap_max' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='211' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='42464'>
-        <var-decl name='depth' type-id='type-id-38' visibility='default' filepath='src.d/deflate.h' line='216' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47104'>
-        <var-decl name='sym_buf' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='220' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47168'>
-        <var-decl name='lit_bufsize' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='222' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47200'>
-        <var-decl name='sym_next' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='242' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47232'>
-        <var-decl name='sym_end' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='243' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47296'>
-        <var-decl name='opt_len' type-id='type-id-57' visibility='default' filepath='src.d/deflate.h' line='245' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47360'>
-        <var-decl name='static_len' type-id='type-id-57' visibility='default' filepath='src.d/deflate.h' line='246' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47424'>
-        <var-decl name='matches' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='247' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47456'>
-        <var-decl name='insert' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='248' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47488'>
-        <var-decl name='bi_buf' type-id='type-id-40' visibility='default' filepath='src.d/deflate.h' line='255' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47520'>
-        <var-decl name='bi_valid' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='259' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47552'>
-        <var-decl name='high_water' type-id='type-id-57' visibility='default' filepath='src.d/deflate.h' line='264' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='alloc_func' type-id='type-id-61' filepath='src.d/zlib.h' line='81' column='1' id='type-id-62'/>
-    <typedef-decl name='free_func' type-id='type-id-63' filepath='src.d/zlib.h' line='82' column='1' id='type-id-64'/>
-    <class-decl name='z_stream_s' size-in-bits='896' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='86' column='1' id='type-id-65'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='next_in' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='87' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='avail_in' type-id='type-id-8' visibility='default' filepath='src.d/zlib.h' line='88' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='total_in' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='89' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='next_out' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='91' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='avail_out' type-id='type-id-8' visibility='default' filepath='src.d/zlib.h' line='92' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='total_out' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='93' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='msg' type-id='type-id-66' visibility='default' filepath='src.d/zlib.h' line='95' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='state' type-id='type-id-67' visibility='default' filepath='src.d/zlib.h' line='96' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='zalloc' type-id='type-id-62' visibility='default' filepath='src.d/zlib.h' line='98' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='zfree' type-id='type-id-64' visibility='default' filepath='src.d/zlib.h' line='99' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='opaque' type-id='type-id-44' visibility='default' filepath='src.d/zlib.h' line='100' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='data_type' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='102' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='adler' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='104' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='reserved' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='105' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='z_stream' type-id='type-id-65' filepath='src.d/zlib.h' line='106' column='1' id='type-id-68'/>
-    <typedef-decl name='z_streamp' type-id='type-id-69' filepath='src.d/zlib.h' line='108' column='1' id='type-id-56'/>
-    <class-decl name='gz_header_s' size-in-bits='640' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='114' column='1' id='type-id-70'>
+    <class-decl name='gz_header_s' size-in-bits='640' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='114' column='1' id='type-id-40'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='text' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='115' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='time' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='116' column='1'/>
+        <var-decl name='time' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='116' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
         <var-decl name='xflags' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='117' column='1'/>
@@ -515,22 +263,22 @@
         <var-decl name='extra' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='119' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='extra_len' type-id='type-id-8' visibility='default' filepath='src.d/zlib.h' line='120' column='1'/>
+        <var-decl name='extra_len' type-id='type-id-12' visibility='default' filepath='src.d/zlib.h' line='120' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='extra_max' type-id='type-id-8' visibility='default' filepath='src.d/zlib.h' line='121' column='1'/>
+        <var-decl name='extra_max' type-id='type-id-12' visibility='default' filepath='src.d/zlib.h' line='121' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
         <var-decl name='name' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='122' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='name_max' type-id='type-id-8' visibility='default' filepath='src.d/zlib.h' line='123' column='1'/>
+        <var-decl name='name_max' type-id='type-id-12' visibility='default' filepath='src.d/zlib.h' line='123' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
         <var-decl name='comment' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='124' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='comm_max' type-id='type-id-8' visibility='default' filepath='src.d/zlib.h' line='125' column='1'/>
+        <var-decl name='comm_max' type-id='type-id-12' visibility='default' filepath='src.d/zlib.h' line='125' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='544'>
         <var-decl name='hcrc' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='126' column='1'/>
@@ -539,94 +287,368 @@
         <var-decl name='done' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='127' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='gz_header' type-id='type-id-70' filepath='src.d/zlib.h' line='129' column='1' id='type-id-71'/>
-    <typedef-decl name='gz_headerp' type-id='type-id-72' filepath='src.d/zlib.h' line='131' column='1' id='type-id-58'/>
-    <typedef-decl name='uch' type-id='type-id-2' filepath='src.d/zutil.h' line='39' column='1' id='type-id-37'/>
-    <typedef-decl name='uchf' type-id='type-id-37' filepath='src.d/zutil.h' line='40' column='1' id='type-id-73'/>
-    <typedef-decl name='ush' type-id='type-id-39' filepath='src.d/zutil.h' line='41' column='1' id='type-id-40'/>
-    <typedef-decl name='ulg' type-id='type-id-4' filepath='src.d/zutil.h' line='43' column='1' id='type-id-57'/>
-    <pointer-type-def type-id='type-id-10' size-in-bits='64' id='type-id-19'/>
-    <pointer-type-def type-id='type-id-53' size-in-bits='64' id='type-id-59'/>
-    <pointer-type-def type-id='type-id-27' size-in-bits='64' id='type-id-66'/>
-    <qualified-type-def type-id='type-id-27' const='yes' id='type-id-74'/>
-    <pointer-type-def type-id='type-id-74' size-in-bits='64' id='type-id-75'/>
-    <qualified-type-def type-id='type-id-48' const='yes' id='type-id-76'/>
-    <pointer-type-def type-id='type-id-76' size-in-bits='64' id='type-id-51'/>
-    <pointer-type-def type-id='type-id-47' size-in-bits='64' id='type-id-50'/>
-    <pointer-type-def type-id='type-id-71' size-in-bits='64' id='type-id-72'/>
+    <class-decl name='internal_state' size-in-bits='47616' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='100' column='1' id='type-id-41'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='strm' type-id='type-id-21' visibility='default' filepath='src.d/deflate.h' line='101' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='status' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='102' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='pending_buf' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='103' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='pending_buf_size' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='104' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='pending_out' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='105' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='pending' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='106' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='wrap' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='107' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='gzhead' type-id='type-id-43' visibility='default' filepath='src.d/deflate.h' line='108' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='gzindex' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='109' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='method' type-id='type-id-3' visibility='default' filepath='src.d/deflate.h' line='110' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='608'>
+        <var-decl name='last_flush' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='111' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='w_size' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='115' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='672'>
+        <var-decl name='w_bits' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='116' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='w_mask' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='117' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='window' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='119' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='window_size' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='129' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='prev' type-id='type-id-44' visibility='default' filepath='src.d/deflate.h' line='134' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='head' type-id='type-id-44' visibility='default' filepath='src.d/deflate.h' line='140' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='ins_h' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='142' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1056'>
+        <var-decl name='hash_size' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='143' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1088'>
+        <var-decl name='hash_bits' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='144' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1120'>
+        <var-decl name='hash_mask' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='145' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1152'>
+        <var-decl name='hash_shift' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='147' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1216'>
+        <var-decl name='block_start' type-id='type-id-1' visibility='default' filepath='src.d/deflate.h' line='154' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='match_length' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='159' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1312'>
+        <var-decl name='prev_match' type-id='type-id-45' visibility='default' filepath='src.d/deflate.h' line='160' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1344'>
+        <var-decl name='match_available' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='161' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1376'>
+        <var-decl name='strstart' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='162' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1408'>
+        <var-decl name='match_start' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='163' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1440'>
+        <var-decl name='lookahead' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='164' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1472'>
+        <var-decl name='prev_length' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='166' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1504'>
+        <var-decl name='max_chain_length' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='171' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1536'>
+        <var-decl name='max_lazy_match' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='177' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1568'>
+        <var-decl name='level' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='188' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1600'>
+        <var-decl name='strategy' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='189' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1632'>
+        <var-decl name='good_match' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='191' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1664'>
+        <var-decl name='nice_match' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='194' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1696'>
+        <var-decl name='dyn_ltree' type-id='type-id-33' visibility='default' filepath='src.d/deflate.h' line='198' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='20032'>
+        <var-decl name='dyn_dtree' type-id='type-id-35' visibility='default' filepath='src.d/deflate.h' line='199' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='21984'>
+        <var-decl name='bl_tree' type-id='type-id-31' visibility='default' filepath='src.d/deflate.h' line='200' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='23232'>
+        <var-decl name='l_desc' type-id='type-id-46' visibility='default' filepath='src.d/deflate.h' line='202' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='23424'>
+        <var-decl name='d_desc' type-id='type-id-46' visibility='default' filepath='src.d/deflate.h' line='203' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='23616'>
+        <var-decl name='bl_desc' type-id='type-id-46' visibility='default' filepath='src.d/deflate.h' line='204' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='23808'>
+        <var-decl name='bl_count' type-id='type-id-47' visibility='default' filepath='src.d/deflate.h' line='206' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='24064'>
+        <var-decl name='heap' type-id='type-id-37' visibility='default' filepath='src.d/deflate.h' line='209' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='42400'>
+        <var-decl name='heap_len' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='210' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='42432'>
+        <var-decl name='heap_max' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='211' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='42464'>
+        <var-decl name='depth' type-id='type-id-48' visibility='default' filepath='src.d/deflate.h' line='216' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47104'>
+        <var-decl name='sym_buf' type-id='type-id-49' visibility='default' filepath='src.d/deflate.h' line='220' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47168'>
+        <var-decl name='lit_bufsize' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='222' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47200'>
+        <var-decl name='sym_next' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='242' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47232'>
+        <var-decl name='sym_end' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='243' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47296'>
+        <var-decl name='opt_len' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='245' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47360'>
+        <var-decl name='static_len' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='246' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47424'>
+        <var-decl name='matches' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='247' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47456'>
+        <var-decl name='insert' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='248' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47488'>
+        <var-decl name='bi_buf' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='255' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47520'>
+        <var-decl name='bi_valid' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='259' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47552'>
+        <var-decl name='high_water' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='264' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='tree_desc_s' size-in-bits='192' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='86' column='1' id='type-id-46'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dyn_tree' type-id='type-id-51' visibility='default' filepath='src.d/deflate.h' line='87' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='max_code' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='88' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='stat_desc' type-id='type-id-52' visibility='default' filepath='src.d/deflate.h' line='89' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='z_stream_s' size-in-bits='896' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='86' column='1' id='type-id-53'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next_in' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='87' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='avail_in' type-id='type-id-12' visibility='default' filepath='src.d/zlib.h' line='88' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='total_in' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='89' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='next_out' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='91' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='avail_out' type-id='type-id-12' visibility='default' filepath='src.d/zlib.h' line='92' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='total_out' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='93' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='msg' type-id='type-id-54' visibility='default' filepath='src.d/zlib.h' line='95' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='state' type-id='type-id-55' visibility='default' filepath='src.d/zlib.h' line='96' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='zalloc' type-id='type-id-56' visibility='default' filepath='src.d/zlib.h' line='98' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='zfree' type-id='type-id-57' visibility='default' filepath='src.d/zlib.h' line='99' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='opaque' type-id='type-id-58' visibility='default' filepath='src.d/zlib.h' line='100' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='data_type' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='102' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='adler' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='104' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='reserved' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='105' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='IPos' type-id='type-id-11' filepath='src.d/deflate.h' line='94' column='1' id='type-id-45'/>
+    <typedef-decl name='Pos' type-id='type-id-50' filepath='src.d/deflate.h' line='92' column='1' id='type-id-59'/>
+    <typedef-decl name='Posf' type-id='type-id-59' filepath='src.d/deflate.h' line='93' column='1' id='type-id-60'/>
+    <typedef-decl name='alloc_func' type-id='type-id-61' filepath='src.d/zlib.h' line='81' column='1' id='type-id-56'/>
+    <typedef-decl name='charf' type-id='type-id-29' filepath='./zconf.h' line='408' column='1' id='type-id-62'/>
+    <typedef-decl name='ct_data' type-id='type-id-30' filepath='src.d/deflate.h' line='77' column='1' id='type-id-63'/>
+    <typedef-decl name='deflate_state' type-id='type-id-41' filepath='src.d/deflate.h' line='271' column='1' id='type-id-64'/>
+    <typedef-decl name='free_func' type-id='type-id-65' filepath='src.d/zlib.h' line='82' column='1' id='type-id-57'/>
+    <typedef-decl name='gz_header' type-id='type-id-40' filepath='src.d/zlib.h' line='129' column='1' id='type-id-66'/>
+    <typedef-decl name='gz_headerp' type-id='type-id-67' filepath='src.d/zlib.h' line='131' column='1' id='type-id-43'/>
+    <typedef-decl name='uch' type-id='type-id-2' filepath='src.d/zutil.h' line='39' column='1' id='type-id-68'/>
+    <typedef-decl name='uchf' type-id='type-id-68' filepath='src.d/zutil.h' line='40' column='1' id='type-id-69'/>
+    <typedef-decl name='ulg' type-id='type-id-9' filepath='src.d/zutil.h' line='43' column='1' id='type-id-42'/>
+    <typedef-decl name='ush' type-id='type-id-70' filepath='src.d/zutil.h' line='41' column='1' id='type-id-50'/>
+    <typedef-decl name='z_stream' type-id='type-id-53' filepath='src.d/zlib.h' line='106' column='1' id='type-id-71'/>
+    <typedef-decl name='z_streamp' type-id='type-id-72' filepath='src.d/zlib.h' line='108' column='1' id='type-id-21'/>
+    <array-type-def dimensions='1' type-id='type-id-68' size-in-bits='4584' id='type-id-48'>
+      <subrange length='573' lower-bound='0' upper-bound='572' type-id='type-id-9' id='type-id-34'/>
+    </array-type-def>
+    <union-decl name='__anonymous_union__1' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='73' column='1' id='type-id-39'>
+      <data-member access='public'>
+        <var-decl name='dad' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='74' column='1'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='len' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='75' column='1'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='__anonymous_union__' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='69' column='1' id='type-id-38'>
+      <data-member access='public'>
+        <var-decl name='freq' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='70' column='1'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='code' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='71' column='1'/>
+      </data-member>
+    </union-decl>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-70'/>
+    <array-type-def dimensions='1' type-id='type-id-50' size-in-bits='256' id='type-id-47'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-9' id='type-id-73'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-4' size-in-bits='64' id='type-id-19'/>
+    <pointer-type-def type-id='type-id-60' size-in-bits='64' id='type-id-44'/>
+    <pointer-type-def type-id='type-id-29' size-in-bits='64' id='type-id-54'/>
+    <pointer-type-def type-id='type-id-62' size-in-bits='64' id='type-id-74'/>
+    <qualified-type-def type-id='type-id-29' const='yes' id='type-id-75'/>
+    <pointer-type-def type-id='type-id-75' size-in-bits='64' id='type-id-22'/>
+    <pointer-type-def type-id='type-id-63' size-in-bits='64' id='type-id-51'/>
+    <pointer-type-def type-id='type-id-64' size-in-bits='64' id='type-id-76'/>
+    <pointer-type-def type-id='type-id-66' size-in-bits='64' id='type-id-67'/>
     <pointer-type-def type-id='type-id-20' size-in-bits='64' id='type-id-77'/>
-    <pointer-type-def type-id='type-id-55' size-in-bits='64' id='type-id-67'/>
+    <pointer-type-def type-id='type-id-41' size-in-bits='64' id='type-id-55'/>
     <pointer-type-def type-id='type-id-78' size-in-bits='64' id='type-id-61'/>
-    <pointer-type-def type-id='type-id-8' size-in-bits='64' id='type-id-79'/>
-    <pointer-type-def type-id='type-id-73' size-in-bits='64' id='type-id-60'/>
-    <pointer-type-def type-id='type-id-3' size-in-bits='64' id='type-id-80'/>
-    <pointer-type-def type-id='type-id-81' size-in-bits='64' id='type-id-63'/>
-    <pointer-type-def type-id='type-id-21' size-in-bits='64' id='type-id-43'/>
-    <pointer-type-def type-id='type-id-68' size-in-bits='64' id='type-id-69'/>
-    <class-decl name='static_tree_desc_s' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-28'/>
-    <function-decl name='deflateInit_' mangled-name='deflateInit_' filepath='src.d/deflate.c' line='225' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateInit_'>
-      <parameter type-id='type-id-56' name='strm' filepath='src.d/deflate.c' line='226' column='1'/>
-      <parameter type-id='type-id-20' name='level' filepath='src.d/deflate.c' line='227' column='1'/>
-      <parameter type-id='type-id-75' name='version' filepath='src.d/deflate.c' line='228' column='1'/>
-      <parameter type-id='type-id-20' name='stream_size' filepath='src.d/deflate.c' line='229' column='1'/>
-      <return type-id='type-id-20'/>
+    <pointer-type-def type-id='type-id-12' size-in-bits='64' id='type-id-79'/>
+    <pointer-type-def type-id='type-id-69' size-in-bits='64' id='type-id-49'/>
+    <pointer-type-def type-id='type-id-11' size-in-bits='64' id='type-id-80'/>
+    <pointer-type-def type-id='type-id-81' size-in-bits='64' id='type-id-65'/>
+    <pointer-type-def type-id='type-id-71' size-in-bits='64' id='type-id-72'/>
+    <qualified-type-def type-id='type-id-82' const='yes' id='type-id-83'/>
+    <pointer-type-def type-id='type-id-83' size-in-bits='64' id='type-id-52'/>
+    <class-decl name='static_tree_desc_s' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-84'/>
+    <typedef-decl name='voidpf' type-id='type-id-85' filepath='./zconf.h' line='415' column='1' id='type-id-58'/>
+    <function-decl name='memcpy' filepath='/usr/mips64-linux-gnuabi64/include/string.h' line='43' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-85'/>
+    </function-decl>
+    <function-decl name='memset' filepath='/usr/mips64-linux-gnuabi64/include/string.h' line='61' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-85'/>
     </function-decl>
     <function-decl name='deflateInit2_' mangled-name='deflateInit2_' filepath='src.d/deflate.c' line='237' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateInit2_'>
-      <parameter type-id='type-id-56' name='strm' filepath='src.d/deflate.c' line='239' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='239' column='1'/>
       <parameter type-id='type-id-20' name='level' filepath='src.d/deflate.c' line='240' column='1'/>
       <parameter type-id='type-id-20' name='method' filepath='src.d/deflate.c' line='241' column='1'/>
       <parameter type-id='type-id-20' name='windowBits' filepath='src.d/deflate.c' line='242' column='1'/>
       <parameter type-id='type-id-20' name='memLevel' filepath='src.d/deflate.c' line='243' column='1'/>
       <parameter type-id='type-id-20' name='strategy' filepath='src.d/deflate.c' line='244' column='1'/>
-      <parameter type-id='type-id-75' name='version' filepath='src.d/deflate.c' line='245' column='1'/>
+      <parameter type-id='type-id-22' name='version' filepath='src.d/deflate.c' line='245' column='1'/>
       <parameter type-id='type-id-20' name='stream_size' filepath='src.d/deflate.c' line='246' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateSetDictionary' mangled-name='deflateSetDictionary' filepath='src.d/deflate.c' line='412' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateSetDictionary'>
-      <parameter type-id='type-id-56' name='strm' filepath='src.d/deflate.c' line='413' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='413' column='1'/>
       <parameter type-id='type-id-16' name='dictionary' filepath='src.d/deflate.c' line='414' column='1'/>
-      <parameter type-id='type-id-8' name='dictLength' filepath='src.d/deflate.c' line='415' column='1'/>
+      <parameter type-id='type-id-12' name='dictLength' filepath='src.d/deflate.c' line='415' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateGetDictionary' mangled-name='deflateGetDictionary' filepath='src.d/deflate.c' line='481' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateGetDictionary@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-56' name='strm' filepath='src.d/deflate.c' line='482' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='482' column='1'/>
       <parameter type-id='type-id-19' name='dictionary' filepath='src.d/deflate.c' line='483' column='1'/>
       <parameter type-id='type-id-79' name='dictLength' filepath='src.d/deflate.c' line='484' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateResetKeep' mangled-name='deflateResetKeep' filepath='src.d/deflate.c' line='503' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateResetKeep@@ZLIB_1.2.5.2'>
-      <parameter type-id='type-id-56' name='strm' filepath='src.d/deflate.c' line='504' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='504' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateReset' mangled-name='deflateReset' filepath='src.d/deflate.c' line='541' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateReset'>
-      <parameter type-id='type-id-56' name='strm' filepath='src.d/deflate.c' line='542' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='542' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateSetHeader' mangled-name='deflateSetHeader' filepath='src.d/deflate.c' line='553' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateSetHeader@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-56' name='strm' filepath='src.d/deflate.c' line='554' column='1'/>
-      <parameter type-id='type-id-58' name='head' filepath='src.d/deflate.c' line='555' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='554' column='1'/>
+      <parameter type-id='type-id-43' name='head' filepath='src.d/deflate.c' line='555' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflatePending' mangled-name='deflatePending' filepath='src.d/deflate.c' line='564' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflatePending@@ZLIB_1.2.5.1'>
-      <parameter type-id='type-id-56' name='strm' filepath='src.d/deflate.c' line='567' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='567' column='1'/>
       <parameter type-id='type-id-80' name='pending' filepath='src.d/deflate.c' line='565' column='1'/>
       <parameter type-id='type-id-77' name='bits' filepath='src.d/deflate.c' line='566' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflatePrime' mangled-name='deflatePrime' filepath='src.d/deflate.c' line='578' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflatePrime@@ZLIB_1.2.0.8'>
-      <parameter type-id='type-id-56' name='strm' filepath='src.d/deflate.c' line='579' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='579' column='1'/>
       <parameter type-id='type-id-20' name='bits' filepath='src.d/deflate.c' line='580' column='1'/>
       <parameter type-id='type-id-20' name='value' filepath='src.d/deflate.c' line='581' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateParams' mangled-name='deflateParams' filepath='src.d/deflate.c' line='605' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateParams'>
-      <parameter type-id='type-id-56' name='strm' filepath='src.d/deflate.c' line='606' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='606' column='1'/>
       <parameter type-id='type-id-20' name='level' filepath='src.d/deflate.c' line='607' column='1'/>
       <parameter type-id='type-id-20' name='strategy' filepath='src.d/deflate.c' line='608' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateTune' mangled-name='deflateTune' filepath='src.d/deflate.c' line='654' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateTune@@ZLIB_1.2.2.3'>
-      <parameter type-id='type-id-56' name='strm' filepath='src.d/deflate.c' line='655' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='655' column='1'/>
       <parameter type-id='type-id-20' name='good_length' filepath='src.d/deflate.c' line='656' column='1'/>
       <parameter type-id='type-id-20' name='max_lazy' filepath='src.d/deflate.c' line='657' column='1'/>
       <parameter type-id='type-id-20' name='nice_length' filepath='src.d/deflate.c' line='658' column='1'/>
@@ -634,397 +656,621 @@
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateBound' mangled-name='deflateBound' filepath='src.d/deflate.c' line='696' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateBound@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-56' name='strm' filepath='src.d/deflate.c' line='697' column='1'/>
-      <parameter type-id='type-id-9' name='sourceLen' filepath='src.d/deflate.c' line='698' column='1'/>
-      <return type-id='type-id-9'/>
-    </function-decl>
-    <function-decl name='deflate' mangled-name='deflate' filepath='src.d/deflate.c' line='815' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflate'>
-      <parameter type-id='type-id-56' name='strm' filepath='src.d/deflate.c' line='816' column='1'/>
-      <parameter type-id='type-id-20' name='flush' filepath='src.d/deflate.c' line='817' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
-    <function-decl name='deflateEnd' mangled-name='deflateEnd' filepath='src.d/deflate.c' line='1130' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateEnd'>
-      <parameter type-id='type-id-56' name='strm' filepath='src.d/deflate.c' line='1131' column='1'/>
-      <return type-id='type-id-20'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='697' column='1'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/deflate.c' line='698' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='deflateCopy' mangled-name='deflateCopy' filepath='src.d/deflate.c' line='1156' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateCopy'>
-      <parameter type-id='type-id-56' name='dest' filepath='src.d/deflate.c' line='1157' column='1'/>
-      <parameter type-id='type-id-56' name='source' filepath='src.d/deflate.c' line='1158' column='1'/>
+      <parameter type-id='type-id-21' name='dest' filepath='src.d/deflate.c' line='1157' column='1'/>
+      <parameter type-id='type-id-21' name='source' filepath='src.d/deflate.c' line='1158' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-78'>
-      <parameter type-id='type-id-44'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-44'/>
-    </function-type>
+    <typedef-decl name='static_tree_desc' type-id='type-id-84' filepath='src.d/deflate.h' line='84' column='1' id='type-id-82'/>
+    <function-decl name='_tr_init' filepath='src.d/deflate.h' line='294' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-76'/>
+      <return type-id='type-id-28'/>
+    </function-decl>
+    <function-decl name='_tr_flush_block' filepath='src.d/deflate.h' line='296' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-76'/>
+      <parameter type-id='type-id-74'/>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-28'/>
+    </function-decl>
+    <function-decl name='_tr_flush_bits' filepath='src.d/deflate.h' line='298' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-76'/>
+      <return type-id='type-id-28'/>
+    </function-decl>
+    <function-decl name='_tr_align' filepath='src.d/deflate.h' line='299' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-76'/>
+      <return type-id='type-id-28'/>
+    </function-decl>
+    <function-decl name='_tr_stored_block' filepath='src.d/deflate.h' line='300' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-76'/>
+      <parameter type-id='type-id-74'/>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-28'/>
+    </function-decl>
+    <function-decl name='crc32' filepath='src.d/zlib.h' line='1727' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-13'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-12'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+    <function-decl name='zcalloc' filepath='src.d/zutil.h' line='261' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-58'/>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-11'/>
+      <return type-id='type-id-58'/>
+    </function-decl>
+    <function-decl name='zcfree' filepath='src.d/zutil.h' line='263' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-58'/>
+      <parameter type-id='type-id-58'/>
+      <return type-id='type-id-28'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-28' id='type-id-85'/>
     <function-type size-in-bits='64' id='type-id-81'>
-      <parameter type-id='type-id-44'/>
-      <parameter type-id='type-id-44'/>
-      <return type-id='type-id-21'/>
+      <parameter type-id='type-id-58'/>
+      <parameter type-id='type-id-58'/>
+      <return type-id='type-id-28'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-78'>
+      <parameter type-id='type-id-58'/>
+      <parameter type-id='type-id-12'/>
+      <parameter type-id='type-id-12'/>
+      <return type-id='type-id-58'/>
     </function-type>
   </abi-instr>
-  <abi-instr address-size='64' path='src.d/gzclose.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C99'>
-    <typedef-decl name='gzFile' type-id='type-id-82' filepath='src.d/zlib.h' line='1302' column='1' id='type-id-83'/>
-    <class-decl name='gzFile_s' size-in-bits='192' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='1834' column='1' id='type-id-84'>
+  <abi-instr address-size='64' path='src.d/gzclose.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
+    <class-decl name='gzFile_s' size-in-bits='192' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='1834' column='1' id='type-id-86'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='have' type-id='type-id-3' visibility='default' filepath='src.d/zlib.h' line='1835' column='1'/>
+        <var-decl name='have' type-id='type-id-11' visibility='default' filepath='src.d/zlib.h' line='1835' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='next' type-id='type-id-85' visibility='default' filepath='src.d/zlib.h' line='1836' column='1'/>
+        <var-decl name='next' type-id='type-id-87' visibility='default' filepath='src.d/zlib.h' line='1836' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='pos' type-id='type-id-14' visibility='default' filepath='src.d/zlib.h' line='1837' column='1'/>
+        <var-decl name='pos' type-id='type-id-7' visibility='default' filepath='src.d/zlib.h' line='1837' column='1'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-84' size-in-bits='64' id='type-id-82'/>
+    <typedef-decl name='gzFile' type-id='type-id-88' filepath='src.d/zlib.h' line='1302' column='1' id='type-id-89'/>
+    <pointer-type-def type-id='type-id-86' size-in-bits='64' id='type-id-88'/>
     <function-decl name='gzclose' mangled-name='gzclose' filepath='src.d/gzclose.c' line='11' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzclose'>
-      <parameter type-id='type-id-83' name='file' filepath='src.d/gzclose.c' line='12' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzclose.c' line='12' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzclose_r' filepath='src.d/zlib.h' line='1644' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-89'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzclose_w' filepath='src.d/zlib.h' line='1645' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-89'/>
       <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='src.d/gzlib.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C99'>
+  <abi-instr address-size='64' path='src.d/gzlib.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
+    <function-decl name='open' filepath='/usr/mips64-linux-gnuabi64/include/fcntl.h' line='209' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-20'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='snprintf' filepath='/usr/mips64-linux-gnuabi64/include/stdio.h' line='385' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-54'/>
+      <parameter type-id='type-id-10'/>
+      <parameter type-id='type-id-22'/>
+      <parameter is-variadic='yes'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='malloc' filepath='/usr/mips64-linux-gnuabi64/include/stdlib.h' line='672' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-85'/>
+    </function-decl>
+    <function-decl name='free' filepath='/usr/mips64-linux-gnuabi64/include/stdlib.h' line='687' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-85'/>
+      <return type-id='type-id-28'/>
+    </function-decl>
+    <function-decl name='strlen' filepath='/usr/mips64-linux-gnuabi64/include/string.h' line='407' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-22'/>
+      <return type-id='type-id-10'/>
+    </function-decl>
+    <function-decl name='lseek64' filepath='/usr/mips64-linux-gnuabi64/include/unistd.h' line='350' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-5'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-5'/>
+    </function-decl>
     <function-decl name='gzopen' mangled-name='gzopen' filepath='src.d/gzlib.c' line='272' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzopen'>
-      <parameter type-id='type-id-75' name='path' filepath='src.d/gzlib.c' line='273' column='1'/>
-      <parameter type-id='type-id-75' name='mode' filepath='src.d/gzlib.c' line='274' column='1'/>
-      <return type-id='type-id-83'/>
+      <parameter type-id='type-id-22' name='path' filepath='src.d/gzlib.c' line='273' column='1'/>
+      <parameter type-id='type-id-22' name='mode' filepath='src.d/gzlib.c' line='274' column='1'/>
+      <return type-id='type-id-89'/>
     </function-decl>
     <function-decl name='gzopen64' mangled-name='gzopen64' filepath='src.d/gzlib.c' line='280' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzopen64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-75' name='path' filepath='src.d/gzlib.c' line='281' column='1'/>
-      <parameter type-id='type-id-75' name='mode' filepath='src.d/gzlib.c' line='282' column='1'/>
-      <return type-id='type-id-83'/>
+      <parameter type-id='type-id-22' name='path' filepath='src.d/gzlib.c' line='281' column='1'/>
+      <parameter type-id='type-id-22' name='mode' filepath='src.d/gzlib.c' line='282' column='1'/>
+      <return type-id='type-id-89'/>
     </function-decl>
     <function-decl name='gzdopen' mangled-name='gzdopen' filepath='src.d/gzlib.c' line='288' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzdopen'>
       <parameter type-id='type-id-20' name='fd' filepath='src.d/gzlib.c' line='289' column='1'/>
-      <parameter type-id='type-id-75' name='mode' filepath='src.d/gzlib.c' line='290' column='1'/>
-      <return type-id='type-id-83'/>
+      <parameter type-id='type-id-22' name='mode' filepath='src.d/gzlib.c' line='290' column='1'/>
+      <return type-id='type-id-89'/>
     </function-decl>
     <function-decl name='gzbuffer' mangled-name='gzbuffer' filepath='src.d/gzlib.c' line='318' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzbuffer@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-83' name='file' filepath='src.d/gzlib.c' line='319' column='1'/>
-      <parameter type-id='type-id-3' name='size' filepath='src.d/gzlib.c' line='320' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='319' column='1'/>
+      <parameter type-id='type-id-11' name='size' filepath='src.d/gzlib.c' line='320' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzrewind' mangled-name='gzrewind' filepath='src.d/gzlib.c' line='345' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzrewind'>
-      <parameter type-id='type-id-83' name='file' filepath='src.d/gzlib.c' line='346' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='346' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzseek64' mangled-name='gzseek64' filepath='src.d/gzlib.c' line='368' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzseek64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-83' name='file' filepath='src.d/gzlib.c' line='369' column='1'/>
-      <parameter type-id='type-id-14' name='offset' filepath='src.d/gzlib.c' line='370' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='369' column='1'/>
+      <parameter type-id='type-id-7' name='offset' filepath='src.d/gzlib.c' line='370' column='1'/>
       <parameter type-id='type-id-20' name='whence' filepath='src.d/gzlib.c' line='371' column='1'/>
-      <return type-id='type-id-14'/>
+      <return type-id='type-id-7'/>
     </function-decl>
     <function-decl name='gzseek' mangled-name='gzseek' filepath='src.d/gzlib.c' line='445' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzseek'>
-      <parameter type-id='type-id-83' name='file' filepath='src.d/gzlib.c' line='446' column='1'/>
-      <parameter type-id='type-id-13' name='offset' filepath='src.d/gzlib.c' line='447' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='446' column='1'/>
+      <parameter type-id='type-id-8' name='offset' filepath='src.d/gzlib.c' line='447' column='1'/>
       <parameter type-id='type-id-20' name='whence' filepath='src.d/gzlib.c' line='448' column='1'/>
-      <return type-id='type-id-13'/>
+      <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='gztell64' mangled-name='gztell64' filepath='src.d/gzlib.c' line='457' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gztell64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-83' name='file' filepath='src.d/gzlib.c' line='458' column='1'/>
-      <return type-id='type-id-14'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='458' column='1'/>
+      <return type-id='type-id-7'/>
     </function-decl>
     <function-decl name='gztell' mangled-name='gztell' filepath='src.d/gzlib.c' line='474' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gztell'>
-      <parameter type-id='type-id-83' name='file' filepath='src.d/gzlib.c' line='475' column='1'/>
-      <return type-id='type-id-13'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='475' column='1'/>
+      <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='gzoffset64' mangled-name='gzoffset64' filepath='src.d/gzlib.c' line='484' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzoffset64@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-83' name='file' filepath='src.d/gzlib.c' line='485' column='1'/>
-      <return type-id='type-id-14'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='485' column='1'/>
+      <return type-id='type-id-7'/>
     </function-decl>
     <function-decl name='gzoffset' mangled-name='gzoffset' filepath='src.d/gzlib.c' line='507' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzoffset@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-83' name='file' filepath='src.d/gzlib.c' line='508' column='1'/>
-      <return type-id='type-id-13'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='508' column='1'/>
+      <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='gzeof' mangled-name='gzeof' filepath='src.d/gzlib.c' line='517' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzeof'>
-      <parameter type-id='type-id-83' name='file' filepath='src.d/gzlib.c' line='518' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='518' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzerror' mangled-name='gzerror' filepath='src.d/gzlib.c' line='534' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzerror'>
-      <parameter type-id='type-id-83' name='file' filepath='src.d/gzlib.c' line='535' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='535' column='1'/>
       <parameter type-id='type-id-77' name='errnum' filepath='src.d/gzlib.c' line='536' column='1'/>
-      <return type-id='type-id-75'/>
+      <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='gzclearerr' mangled-name='gzclearerr' filepath='src.d/gzlib.c' line='555' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzclearerr@@ZLIB_1.2.0.2'>
-      <parameter type-id='type-id-83' name='file' filepath='src.d/gzlib.c' line='556' column='1'/>
-      <return type-id='type-id-21'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='556' column='1'/>
+      <return type-id='type-id-28'/>
     </function-decl>
+    <type-decl name='variadic parameter type' id='type-id-90'/>
   </abi-instr>
-  <abi-instr address-size='64' path='src.d/gzread.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C99'>
-    <typedef-decl name='voidp' type-id='type-id-43' filepath='./zconf.h' line='416' column='1' id='type-id-86'/>
+  <abi-instr address-size='64' path='src.d/gzread.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
+    <class-decl name='gz_state' size-in-bits='1920' is-struct='yes' naming-typedef-id='type-id-91' visibility='default' filepath='src.d/gzguts.h' line='170' column='1' id='type-id-92'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='x' type-id='type-id-86' visibility='default' filepath='src.d/gzguts.h' line='172' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='mode' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='177' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='fd' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='178' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='path' type-id='type-id-54' visibility='default' filepath='src.d/gzguts.h' line='179' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='size' type-id='type-id-11' visibility='default' filepath='src.d/gzguts.h' line='180' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='want' type-id='type-id-11' visibility='default' filepath='src.d/gzguts.h' line='181' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='in' type-id='type-id-87' visibility='default' filepath='src.d/gzguts.h' line='182' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='out' type-id='type-id-87' visibility='default' filepath='src.d/gzguts.h' line='183' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='direct' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='184' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='544'>
+        <var-decl name='how' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='186' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='start' type-id='type-id-7' visibility='default' filepath='src.d/gzguts.h' line='187' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='eof' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='188' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='672'>
+        <var-decl name='past' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='189' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='level' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='191' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='736'>
+        <var-decl name='strategy' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='192' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='reset' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='193' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='skip' type-id='type-id-7' visibility='default' filepath='src.d/gzguts.h' line='195' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='seek' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='196' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='928'>
+        <var-decl name='err' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='198' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='msg' type-id='type-id-54' visibility='default' filepath='src.d/gzguts.h' line='199' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='strm' type-id='type-id-71' visibility='default' filepath='src.d/gzguts.h' line='201' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__ssize_t' type-id='type-id-1' filepath='/usr/mips64-linux-gnuabi64/include/bits/types.h' line='194' column='1' id='type-id-93'/>
+    <typedef-decl name='gz_state' type-id='type-id-92' filepath='src.d/gzguts.h' line='202' column='1' id='type-id-91'/>
+    <typedef-decl name='gz_statep' type-id='type-id-94' filepath='src.d/gzguts.h' line='203' column='1' id='type-id-95'/>
+    <typedef-decl name='ssize_t' type-id='type-id-93' filepath='/usr/mips64-linux-gnuabi64/include/sys/types.h' line='108' column='1' id='type-id-96'/>
+    <pointer-type-def type-id='type-id-91' size-in-bits='64' id='type-id-94'/>
+    <typedef-decl name='voidp' type-id='type-id-85' filepath='./zconf.h' line='416' column='1' id='type-id-97'/>
+    <function-decl name='__errno_location' filepath='/usr/mips64-linux-gnuabi64/include/errno.h' line='37' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-77'/>
+    </function-decl>
+    <function-decl name='memchr' filepath='/usr/mips64-linux-gnuabi64/include/string.h' line='107' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-85'/>
+    </function-decl>
+    <function-decl name='strerror' filepath='/usr/mips64-linux-gnuabi64/include/string.h' line='419' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-54'/>
+    </function-decl>
+    <function-decl name='close' filepath='/usr/mips64-linux-gnuabi64/include/unistd.h' line='358' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='read' filepath='/usr/mips64-linux-gnuabi64/include/unistd.h' line='371' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-96'/>
+    </function-decl>
+    <function-decl name='gz_error' filepath='src.d/gzguts.h' line='206' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-95'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-22'/>
+      <return type-id='type-id-28'/>
+    </function-decl>
     <function-decl name='gzread' mangled-name='gzread' filepath='src.d/gzread.c' line='373' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzread'>
-      <parameter type-id='type-id-83' name='file' filepath='src.d/gzread.c' line='374' column='1'/>
-      <parameter type-id='type-id-86' name='buf' filepath='src.d/gzread.c' line='375' column='1'/>
-      <parameter type-id='type-id-3' name='len' filepath='src.d/gzread.c' line='376' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='374' column='1'/>
+      <parameter type-id='type-id-97' name='buf' filepath='src.d/gzread.c' line='375' column='1'/>
+      <parameter type-id='type-id-11' name='len' filepath='src.d/gzread.c' line='376' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzfread' mangled-name='gzfread' filepath='src.d/gzread.c' line='409' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzfread@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-86' name='buf' filepath='src.d/gzread.c' line='410' column='1'/>
-      <parameter type-id='type-id-6' name='size' filepath='src.d/gzread.c' line='411' column='1'/>
-      <parameter type-id='type-id-6' name='nitems' filepath='src.d/gzread.c' line='412' column='1'/>
-      <parameter type-id='type-id-83' name='file' filepath='src.d/gzread.c' line='413' column='1'/>
-      <return type-id='type-id-6'/>
+      <parameter type-id='type-id-97' name='buf' filepath='src.d/gzread.c' line='410' column='1'/>
+      <parameter type-id='type-id-14' name='size' filepath='src.d/gzread.c' line='411' column='1'/>
+      <parameter type-id='type-id-14' name='nitems' filepath='src.d/gzread.c' line='412' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='413' column='1'/>
+      <return type-id='type-id-14'/>
     </function-decl>
     <function-decl name='gzgetc' mangled-name='gzgetc' filepath='src.d/gzread.c' line='445' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzgetc'>
-      <parameter type-id='type-id-83' name='file' filepath='src.d/gzread.c' line='446' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='446' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzgetc_' mangled-name='gzgetc_' filepath='src.d/gzread.c' line='472' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzgetc_@@ZLIB_1.2.5.2'>
-      <parameter type-id='type-id-83' name='file' filepath='src.d/gzread.c' line='473' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='473' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzungetc' mangled-name='gzungetc' filepath='src.d/gzread.c' line='479' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzungetc@@ZLIB_1.2.0.2'>
       <parameter type-id='type-id-20' name='c' filepath='src.d/gzread.c' line='480' column='1'/>
-      <parameter type-id='type-id-83' name='file' filepath='src.d/gzread.c' line='481' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='481' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzgets' mangled-name='gzgets' filepath='src.d/gzread.c' line='539' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzgets'>
-      <parameter type-id='type-id-83' name='file' filepath='src.d/gzread.c' line='540' column='1'/>
-      <parameter type-id='type-id-66' name='buf' filepath='src.d/gzread.c' line='541' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='540' column='1'/>
+      <parameter type-id='type-id-54' name='buf' filepath='src.d/gzread.c' line='541' column='1'/>
       <parameter type-id='type-id-20' name='len' filepath='src.d/gzread.c' line='542' column='1'/>
-      <return type-id='type-id-66'/>
+      <return type-id='type-id-54'/>
     </function-decl>
     <function-decl name='gzdirect' mangled-name='gzdirect' filepath='src.d/gzread.c' line='603' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzdirect@@ZLIB_1.2.2.3'>
-      <parameter type-id='type-id-83' name='file' filepath='src.d/gzread.c' line='604' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='604' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='gzclose_r' mangled-name='gzclose_r' filepath='src.d/gzread.c' line='623' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzclose_r@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-83' name='file' filepath='src.d/gzread.c' line='624' column='1'/>
+    <function-decl name='inflate' filepath='src.d/zlib.h' line='400' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateEnd' filepath='src.d/zlib.h' line='520' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-21'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateReset' filepath='src.d/zlib.h' line='959' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-21'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateInit2_' filepath='src.d/zlib.h' line='1789' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-20'/>
       <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='src.d/gzwrite.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C99'>
-    <type-decl name='variadic parameter type' id='type-id-87'/>
-    <typedef-decl name='voidpc' type-id='type-id-43' filepath='./zconf.h' line='414' column='1' id='type-id-88'/>
-    <typedef-decl name='__gnuc_va_list' type-id='type-id-43' filepath='/usr/lib/gcc-cross/mips64-linux-gnuabi64/10/include/stdarg.h' line='40' column='1' id='type-id-89'/>
-    <typedef-decl name='va_list' type-id='type-id-89' filepath='/usr/lib/gcc-cross/mips64-linux-gnuabi64/10/include/stdarg.h' line='99' column='1' id='type-id-90'/>
+  <abi-instr address-size='64' path='src.d/gzwrite.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
+    <typedef-decl name='voidpc' type-id='type-id-85' filepath='./zconf.h' line='414' column='1' id='type-id-98'/>
+    <typedef-decl name='__gnuc_va_list' type-id='type-id-85' filepath='/usr/lib/gcc-cross/mips64-linux-gnuabi64/12/include/stdarg.h' line='40' column='1' id='type-id-99'/>
+    <typedef-decl name='va_list' type-id='type-id-99' filepath='/usr/lib/gcc-cross/mips64-linux-gnuabi64/12/include/stdarg.h' line='99' column='1' id='type-id-100'/>
+    <function-decl name='vsnprintf' filepath='/usr/mips64-linux-gnuabi64/include/stdio.h' line='389' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-54'/>
+      <parameter type-id='type-id-10'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-85'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='memmove' filepath='/usr/mips64-linux-gnuabi64/include/string.h' line='47' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-85'/>
+    </function-decl>
+    <function-decl name='write' filepath='/usr/mips64-linux-gnuabi64/include/unistd.h' line='378' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-96'/>
+    </function-decl>
     <function-decl name='gzwrite' mangled-name='gzwrite' filepath='src.d/gzwrite.c' line='255' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzwrite'>
-      <parameter type-id='type-id-83' name='file' filepath='src.d/gzwrite.c' line='256' column='1'/>
-      <parameter type-id='type-id-88' name='buf' filepath='src.d/gzwrite.c' line='257' column='1'/>
-      <parameter type-id='type-id-3' name='len' filepath='src.d/gzwrite.c' line='258' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='256' column='1'/>
+      <parameter type-id='type-id-98' name='buf' filepath='src.d/gzwrite.c' line='257' column='1'/>
+      <parameter type-id='type-id-11' name='len' filepath='src.d/gzwrite.c' line='258' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzfwrite' mangled-name='gzfwrite' filepath='src.d/gzwrite.c' line='283' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzfwrite@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-88' name='buf' filepath='src.d/gzwrite.c' line='284' column='1'/>
-      <parameter type-id='type-id-6' name='size' filepath='src.d/gzwrite.c' line='285' column='1'/>
-      <parameter type-id='type-id-6' name='nitems' filepath='src.d/gzwrite.c' line='286' column='1'/>
-      <parameter type-id='type-id-83' name='file' filepath='src.d/gzwrite.c' line='287' column='1'/>
-      <return type-id='type-id-6'/>
+      <parameter type-id='type-id-98' name='buf' filepath='src.d/gzwrite.c' line='284' column='1'/>
+      <parameter type-id='type-id-14' name='size' filepath='src.d/gzwrite.c' line='285' column='1'/>
+      <parameter type-id='type-id-14' name='nitems' filepath='src.d/gzwrite.c' line='286' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='287' column='1'/>
+      <return type-id='type-id-14'/>
     </function-decl>
     <function-decl name='gzputc' mangled-name='gzputc' filepath='src.d/gzwrite.c' line='313' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzputc'>
-      <parameter type-id='type-id-83' name='file' filepath='src.d/gzwrite.c' line='314' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='314' column='1'/>
       <parameter type-id='type-id-20' name='c' filepath='src.d/gzwrite.c' line='315' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzputs' mangled-name='gzputs' filepath='src.d/gzwrite.c' line='361' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzputs'>
-      <parameter type-id='type-id-83' name='file' filepath='src.d/gzwrite.c' line='362' column='1'/>
-      <parameter type-id='type-id-75' name='s' filepath='src.d/gzwrite.c' line='363' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='362' column='1'/>
+      <parameter type-id='type-id-22' name='s' filepath='src.d/gzwrite.c' line='363' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzvprintf' mangled-name='gzvprintf' filepath='src.d/gzwrite.c' line='391' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzvprintf@@ZLIB_1.2.7.1'>
-      <parameter type-id='type-id-83' name='file' filepath='src.d/gzwrite.c' line='391' column='1'/>
-      <parameter type-id='type-id-75' name='format' filepath='src.d/gzwrite.c' line='391' column='1'/>
-      <parameter type-id='type-id-90' name='va' filepath='src.d/gzwrite.c' line='391' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='391' column='1'/>
+      <parameter type-id='type-id-22' name='format' filepath='src.d/gzwrite.c' line='391' column='1'/>
+      <parameter type-id='type-id-100' name='va' filepath='src.d/gzwrite.c' line='391' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzprintf' mangled-name='gzprintf' filepath='src.d/gzwrite.c' line='463' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzprintf'>
-      <parameter type-id='type-id-83' name='file' filepath='src.d/gzwrite.c' line='463' column='1'/>
-      <parameter type-id='type-id-75' name='format' filepath='src.d/gzwrite.c' line='463' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='463' column='1'/>
+      <parameter type-id='type-id-22' name='format' filepath='src.d/gzwrite.c' line='463' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzflush' mangled-name='gzflush' filepath='src.d/gzwrite.c' line='565' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzflush'>
-      <parameter type-id='type-id-83' name='file' filepath='src.d/gzwrite.c' line='566' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='566' column='1'/>
       <parameter type-id='type-id-20' name='flush' filepath='src.d/gzwrite.c' line='567' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzsetparams' mangled-name='gzsetparams' filepath='src.d/gzwrite.c' line='597' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzsetparams'>
-      <parameter type-id='type-id-83' name='file' filepath='src.d/gzwrite.c' line='598' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='598' column='1'/>
       <parameter type-id='type-id-20' name='level' filepath='src.d/gzwrite.c' line='599' column='1'/>
       <parameter type-id='type-id-20' name='strategy' filepath='src.d/gzwrite.c' line='600' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='gzclose_w' mangled-name='gzclose_w' filepath='src.d/gzwrite.c' line='639' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzclose_w@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-83' name='file' filepath='src.d/gzwrite.c' line='640' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='src.d/infback.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C99'>
-    <typedef-decl name='in_func' type-id='type-id-91' filepath='src.d/zlib.h' line='1094' column='1' id='type-id-92'/>
-    <typedef-decl name='out_func' type-id='type-id-93' filepath='src.d/zlib.h' line='1096' column='1' id='type-id-94'/>
-    <pointer-type-def type-id='type-id-95' size-in-bits='64' id='type-id-93'/>
-    <pointer-type-def type-id='type-id-2' size-in-bits='64' id='type-id-85'/>
-    <pointer-type-def type-id='type-id-85' size-in-bits='64' id='type-id-96'/>
-    <pointer-type-def type-id='type-id-97' size-in-bits='64' id='type-id-91'/>
+  <abi-instr address-size='64' path='src.d/infback.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
+    <enum-decl name='codetype' naming-typedef-id='type-id-101' filepath='src.d/inftrees.h' line='54' column='1' id='type-id-102'>
+      <underlying-type type-id='type-id-103'/>
+      <enumerator name='CODES' value='0'/>
+      <enumerator name='LENS' value='1'/>
+      <enumerator name='DISTS' value='2'/>
+    </enum-decl>
+    <class-decl name='code' size-in-bits='32' is-struct='yes' naming-typedef-id='type-id-104' visibility='default' filepath='src.d/inftrees.h' line='24' column='1' id='type-id-105'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-2' visibility='default' filepath='src.d/inftrees.h' line='25' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8'>
+        <var-decl name='bits' type-id='type-id-2' visibility='default' filepath='src.d/inftrees.h' line='26' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='val' type-id='type-id-70' visibility='default' filepath='src.d/inftrees.h' line='27' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='code' type-id='type-id-105' filepath='src.d/inftrees.h' line='28' column='1' id='type-id-104'/>
+    <typedef-decl name='codetype' type-id='type-id-102' filepath='src.d/inftrees.h' line='58' column='1' id='type-id-101'/>
+    <typedef-decl name='in_func' type-id='type-id-106' filepath='src.d/zlib.h' line='1094' column='1' id='type-id-107'/>
+    <typedef-decl name='out_func' type-id='type-id-108' filepath='src.d/zlib.h' line='1096' column='1' id='type-id-109'/>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-103'/>
+    <pointer-type-def type-id='type-id-104' size-in-bits='64' id='type-id-110'/>
+    <pointer-type-def type-id='type-id-110' size-in-bits='64' id='type-id-111'/>
+    <pointer-type-def type-id='type-id-112' size-in-bits='64' id='type-id-108'/>
+    <pointer-type-def type-id='type-id-2' size-in-bits='64' id='type-id-87'/>
+    <pointer-type-def type-id='type-id-87' size-in-bits='64' id='type-id-113'/>
+    <pointer-type-def type-id='type-id-114' size-in-bits='64' id='type-id-106'/>
+    <pointer-type-def type-id='type-id-70' size-in-bits='64' id='type-id-115'/>
+    <typedef-decl name='voidpf' type-id='type-id-85' filepath='./zconf.h' line='415' column='1' id='type-id-116'/>
     <function-decl name='inflateBackInit_' mangled-name='inflateBackInit_' filepath='src.d/infback.c' line='28' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateBackInit_@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-56' name='strm' filepath='src.d/infback.c' line='29' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/infback.c' line='29' column='1'/>
       <parameter type-id='type-id-20' name='windowBits' filepath='src.d/infback.c' line='30' column='1'/>
-      <parameter type-id='type-id-85' name='window' filepath='src.d/infback.c' line='31' column='1'/>
-      <parameter type-id='type-id-75' name='version' filepath='src.d/infback.c' line='32' column='1'/>
+      <parameter type-id='type-id-87' name='window' filepath='src.d/infback.c' line='31' column='1'/>
+      <parameter type-id='type-id-22' name='version' filepath='src.d/infback.c' line='32' column='1'/>
       <parameter type-id='type-id-20' name='stream_size' filepath='src.d/infback.c' line='33' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateBack' mangled-name='inflateBack' filepath='src.d/infback.c' line='251' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateBack@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-56' name='strm' filepath='src.d/infback.c' line='252' column='1'/>
-      <parameter type-id='type-id-92' name='in' filepath='src.d/infback.c' line='253' column='1'/>
-      <parameter type-id='type-id-43' name='in_desc' filepath='src.d/infback.c' line='254' column='1'/>
-      <parameter type-id='type-id-94' name='out' filepath='src.d/infback.c' line='255' column='1'/>
-      <parameter type-id='type-id-43' name='out_desc' filepath='src.d/infback.c' line='256' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/infback.c' line='252' column='1'/>
+      <parameter type-id='type-id-107' name='in' filepath='src.d/infback.c' line='253' column='1'/>
+      <parameter type-id='type-id-85' name='in_desc' filepath='src.d/infback.c' line='254' column='1'/>
+      <parameter type-id='type-id-109' name='out' filepath='src.d/infback.c' line='255' column='1'/>
+      <parameter type-id='type-id-85' name='out_desc' filepath='src.d/infback.c' line='256' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateBackEnd' mangled-name='inflateBackEnd' filepath='src.d/infback.c' line='635' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateBackEnd@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-56' name='strm' filepath='src.d/infback.c' line='636' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/infback.c' line='636' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-95'>
-      <parameter type-id='type-id-43'/>
+    <function-decl name='inflate_fast' filepath='src.d/inffast.h' line='11' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-11'/>
+      <return type-id='type-id-28'/>
+    </function-decl>
+    <function-decl name='inflate_table' filepath='src.d/inftrees.h' line='60' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-101'/>
+      <parameter type-id='type-id-115'/>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-111'/>
+      <parameter type-id='type-id-80'/>
+      <parameter type-id='type-id-115'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-type size-in-bits='64' id='type-id-112'>
       <parameter type-id='type-id-85'/>
-      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-87'/>
+      <parameter type-id='type-id-11'/>
       <return type-id='type-id-20'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-97'>
-      <parameter type-id='type-id-43'/>
-      <parameter type-id='type-id-96'/>
-      <return type-id='type-id-3'/>
+    <function-type size-in-bits='64' id='type-id-114'>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-113'/>
+      <return type-id='type-id-11'/>
     </function-type>
   </abi-instr>
-  <abi-instr address-size='64' path='src.d/inflate.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C99'>
+  <abi-instr address-size='64' path='src.d/inflate.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
+    <typedef-decl name='voidpf' type-id='type-id-85' filepath='./zconf.h' line='415' column='1' id='type-id-117'/>
     <function-decl name='inflateResetKeep' mangled-name='inflateResetKeep' filepath='src.d/inflate.c' line='119' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateResetKeep@@ZLIB_1.2.5.2'>
-      <parameter type-id='type-id-56' name='strm' filepath='src.d/inflate.c' line='120' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
-    <function-decl name='inflateReset' mangled-name='inflateReset' filepath='src.d/inflate.c' line='145' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateReset'>
-      <parameter type-id='type-id-56' name='strm' filepath='src.d/inflate.c' line='146' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='120' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateReset2' mangled-name='inflateReset2' filepath='src.d/inflate.c' line='158' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateReset2@@ZLIB_1.2.3.4'>
-      <parameter type-id='type-id-56' name='strm' filepath='src.d/inflate.c' line='159' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='159' column='1'/>
       <parameter type-id='type-id-20' name='windowBits' filepath='src.d/inflate.c' line='160' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='inflateInit2_' mangled-name='inflateInit2_' filepath='src.d/inflate.c' line='198' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateInit2_'>
-      <parameter type-id='type-id-56' name='strm' filepath='src.d/inflate.c' line='199' column='1'/>
-      <parameter type-id='type-id-20' name='windowBits' filepath='src.d/inflate.c' line='200' column='1'/>
-      <parameter type-id='type-id-75' name='version' filepath='src.d/inflate.c' line='201' column='1'/>
-      <parameter type-id='type-id-20' name='stream_size' filepath='src.d/inflate.c' line='202' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
     <function-decl name='inflateInit_' mangled-name='inflateInit_' filepath='src.d/inflate.c' line='242' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateInit_'>
-      <parameter type-id='type-id-56' name='strm' filepath='src.d/inflate.c' line='243' column='1'/>
-      <parameter type-id='type-id-75' name='version' filepath='src.d/inflate.c' line='244' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='243' column='1'/>
+      <parameter type-id='type-id-22' name='version' filepath='src.d/inflate.c' line='244' column='1'/>
       <parameter type-id='type-id-20' name='stream_size' filepath='src.d/inflate.c' line='245' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflatePrime' mangled-name='inflatePrime' filepath='src.d/inflate.c' line='250' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflatePrime@@ZLIB_1.2.2.4'>
-      <parameter type-id='type-id-56' name='strm' filepath='src.d/inflate.c' line='251' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='251' column='1'/>
       <parameter type-id='type-id-20' name='bits' filepath='src.d/inflate.c' line='252' column='1'/>
       <parameter type-id='type-id-20' name='value' filepath='src.d/inflate.c' line='253' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='inflate' mangled-name='inflate' filepath='src.d/inflate.c' line='625' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflate'>
-      <parameter type-id='type-id-56' name='strm' filepath='src.d/inflate.c' line='626' column='1'/>
-      <parameter type-id='type-id-20' name='flush' filepath='src.d/inflate.c' line='627' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
-    <function-decl name='inflateEnd' mangled-name='inflateEnd' filepath='src.d/inflate.c' line='1304' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateEnd'>
-      <parameter type-id='type-id-56' name='strm' filepath='src.d/inflate.c' line='1305' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
     <function-decl name='inflateGetDictionary' mangled-name='inflateGetDictionary' filepath='src.d/inflate.c' line='1318' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateGetDictionary@@ZLIB_1.2.7.1'>
-      <parameter type-id='type-id-56' name='strm' filepath='src.d/inflate.c' line='1319' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1319' column='1'/>
       <parameter type-id='type-id-19' name='dictionary' filepath='src.d/inflate.c' line='1320' column='1'/>
       <parameter type-id='type-id-79' name='dictLength' filepath='src.d/inflate.c' line='1321' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateSetDictionary' mangled-name='inflateSetDictionary' filepath='src.d/inflate.c' line='1341' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateSetDictionary'>
-      <parameter type-id='type-id-56' name='strm' filepath='src.d/inflate.c' line='1342' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1342' column='1'/>
       <parameter type-id='type-id-16' name='dictionary' filepath='src.d/inflate.c' line='1343' column='1'/>
-      <parameter type-id='type-id-8' name='dictLength' filepath='src.d/inflate.c' line='1344' column='1'/>
+      <parameter type-id='type-id-12' name='dictLength' filepath='src.d/inflate.c' line='1344' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateGetHeader' mangled-name='inflateGetHeader' filepath='src.d/inflate.c' line='1376' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateGetHeader@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-56' name='strm' filepath='src.d/inflate.c' line='1377' column='1'/>
-      <parameter type-id='type-id-58' name='head' filepath='src.d/inflate.c' line='1378' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1377' column='1'/>
+      <parameter type-id='type-id-43' name='head' filepath='src.d/inflate.c' line='1378' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateSync' mangled-name='inflateSync' filepath='src.d/inflate.c' line='1427' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateSync'>
-      <parameter type-id='type-id-56' name='strm' filepath='src.d/inflate.c' line='1428' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1428' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateSyncPoint' mangled-name='inflateSyncPoint' filepath='src.d/inflate.c' line='1485' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateSyncPoint'>
-      <parameter type-id='type-id-56' name='strm' filepath='src.d/inflate.c' line='1486' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1486' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateCopy' mangled-name='inflateCopy' filepath='src.d/inflate.c' line='1495' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateCopy@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-56' name='dest' filepath='src.d/inflate.c' line='1496' column='1'/>
-      <parameter type-id='type-id-56' name='source' filepath='src.d/inflate.c' line='1497' column='1'/>
+      <parameter type-id='type-id-21' name='dest' filepath='src.d/inflate.c' line='1496' column='1'/>
+      <parameter type-id='type-id-21' name='source' filepath='src.d/inflate.c' line='1497' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateUndermine' mangled-name='inflateUndermine' filepath='src.d/inflate.c' line='1542' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateUndermine@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-56' name='strm' filepath='src.d/inflate.c' line='1543' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1543' column='1'/>
       <parameter type-id='type-id-20' name='subvert' filepath='src.d/inflate.c' line='1544' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateValidate' mangled-name='inflateValidate' filepath='src.d/inflate.c' line='1560' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateValidate@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-56' name='strm' filepath='src.d/inflate.c' line='1561' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1561' column='1'/>
       <parameter type-id='type-id-20' name='check' filepath='src.d/inflate.c' line='1562' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateMark' mangled-name='inflateMark' filepath='src.d/inflate.c' line='1575' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateMark@@ZLIB_1.2.3.4'>
-      <parameter type-id='type-id-56' name='strm' filepath='src.d/inflate.c' line='1576' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1576' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='inflateCodesUsed' mangled-name='inflateCodesUsed' filepath='src.d/inflate.c' line='1588' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateCodesUsed@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-56' name='strm' filepath='src.d/inflate.c' line='1589' column='1'/>
-      <return type-id='type-id-4'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1589' column='1'/>
+      <return type-id='type-id-9'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='src.d/trees.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C99'>
-    <array-type-def dimensions='1' type-id='type-id-98' size-in-bits='2048' id='type-id-99'>
-      <subrange length='256' type-id='type-id-4' id='type-id-100'/>
+  <abi-instr address-size='64' path='src.d/trees.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
+    <array-type-def dimensions='1' type-id='type-id-118' size-in-bits='2048' id='type-id-119'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-9' id='type-id-120'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-98' size-in-bits='4096' id='type-id-101'>
-      <subrange length='512' type-id='type-id-4' id='type-id-102'/>
+    <array-type-def dimensions='1' type-id='type-id-118' size-in-bits='4096' id='type-id-121'>
+      <subrange length='512' lower-bound='0' upper-bound='511' type-id='type-id-9' id='type-id-122'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-98' size-in-bits='infinite' id='type-id-103'>
-      <subrange length='infinite' id='type-id-104'/>
+    <array-type-def dimensions='1' type-id='type-id-118' size-in-bits='unknown' id='type-id-123'>
+      <subrange length='unknown' lower-bound='0' upper-bound='0' id='type-id-124'/>
     </array-type-def>
-    <qualified-type-def type-id='type-id-37' const='yes' id='type-id-98'/>
-    <var-decl name='_length_code' type-id='type-id-103' visibility='default' filepath='src.d/deflate.h' line='317' column='1'/>
-    <var-decl name='_dist_code' type-id='type-id-103' visibility='default' filepath='src.d/deflate.h' line='318' column='1'/>
+    <qualified-type-def type-id='type-id-68' const='yes' id='type-id-118'/>
+    <var-decl name='_length_code' type-id='type-id-119' visibility='default' filepath='src.d/deflate.h' line='317' column='1'/>
+    <var-decl name='_dist_code' type-id='type-id-121' visibility='default' filepath='src.d/deflate.h' line='318' column='1'/>
   </abi-instr>
-  <abi-instr address-size='64' path='src.d/uncompr.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C99'>
-    <pointer-type-def type-id='type-id-9' size-in-bits='64' id='type-id-105'/>
+  <abi-instr address-size='64' path='src.d/uncompr.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
+    <pointer-type-def type-id='type-id-13' size-in-bits='64' id='type-id-125'/>
     <function-decl name='uncompress2' mangled-name='uncompress2' filepath='src.d/uncompr.c' line='27' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uncompress2@@ZLIB_1.2.9'>
       <parameter type-id='type-id-19' name='dest' filepath='src.d/uncompr.c' line='28' column='1'/>
       <parameter type-id='type-id-18' name='destLen' filepath='src.d/uncompr.c' line='29' column='1'/>
       <parameter type-id='type-id-16' name='source' filepath='src.d/uncompr.c' line='30' column='1'/>
-      <parameter type-id='type-id-105' name='sourceLen' filepath='src.d/uncompr.c' line='31' column='1'/>
+      <parameter type-id='type-id-125' name='sourceLen' filepath='src.d/uncompr.c' line='31' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='uncompress' mangled-name='uncompress' filepath='src.d/uncompr.c' line='86' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uncompress'>
       <parameter type-id='type-id-19' name='dest' filepath='src.d/uncompr.c' line='87' column='1'/>
       <parameter type-id='type-id-18' name='destLen' filepath='src.d/uncompr.c' line='88' column='1'/>
       <parameter type-id='type-id-16' name='source' filepath='src.d/uncompr.c' line='89' column='1'/>
-      <parameter type-id='type-id-9' name='sourceLen' filepath='src.d/uncompr.c' line='90' column='1'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/uncompr.c' line='90' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
-  <abi-instr address-size='64' path='src.d/zutil.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C99'>
-    <array-type-def dimensions='1' type-id='type-id-106' size-in-bits='640' id='type-id-107'>
-      <subrange length='10' type-id='type-id-4' id='type-id-108'/>
+  <abi-instr address-size='64' path='src.d/zutil.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
+    <array-type-def dimensions='1' type-id='type-id-126' size-in-bits='640' id='type-id-127'>
+      <subrange length='10' lower-bound='0' upper-bound='9' type-id='type-id-9' id='type-id-128'/>
     </array-type-def>
-    <qualified-type-def type-id='type-id-66' const='yes' id='type-id-106'/>
+    <qualified-type-def type-id='type-id-54' const='yes' id='type-id-126'/>
     <function-decl name='zlibVersion' mangled-name='zlibVersion' filepath='src.d/zutil.c' line='27' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zlibVersion'>
-      <return type-id='type-id-75'/>
+      <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='zlibCompileFlags' mangled-name='zlibCompileFlags' filepath='src.d/zutil.c' line='32' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zlibCompileFlags@@ZLIB_1.2.0.2'>
-      <return type-id='type-id-9'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='zError' mangled-name='zError' filepath='src.d/zutil.c' line='135' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zError'>
       <parameter type-id='type-id-20' name='err' filepath='src.d/zutil.c' line='136' column='1'/>
-      <return type-id='type-id-75'/>
+      <return type-id='type-id-22'/>
     </function-decl>
-    <var-decl name='z_errmsg' type-id='type-id-107' visibility='default' filepath='src.d/zutil.h' line='56' column='1'/>
+    <var-decl name='z_errmsg' type-id='type-id-127' visibility='default' filepath='src.d/zutil.h' line='56' column='1'/>
   </abi-instr>
 </abi-corpus>

--- a/test/abi/zlib-04f42ceca40f73e2978b50e93806c2a18c1281fc-powerpc-unknown-linux-gnu.abi
+++ b/test/abi/zlib-04f42ceca40f73e2978b50e93806c2a18c1281fc-powerpc-unknown-linux-gnu.abi
@@ -1,4 +1,4 @@
-<abi-corpus version='2.0' path='btmp1/libz.so.1.2.13' architecture='elf-powerpc' soname='libz.so.1'>
+<abi-corpus version='2.2' path='btmp1/libz.so.1.2.13' architecture='elf-powerpc' soname='libz.so.1'>
   <elf-needed>
     <dependency name='libc.so.6'/>
   </elf-needed>
@@ -93,75 +93,89 @@
     <elf-symbol name='zlibVersion' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
   </elf-function-symbols>
   <abi-instr address-size='32' path='src.d/adler32.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <type-decl name='long int' size-in-bits='32' id='type-id-1'/>
-    <type-decl name='long long int' size-in-bits='64' id='type-id-2'/>
-    <type-decl name='unsigned char' size-in-bits='8' id='type-id-3'/>
-    <type-decl name='unsigned int' size-in-bits='32' id='type-id-4'/>
-    <type-decl name='unsigned long int' size-in-bits='32' id='type-id-5'/>
-    <typedef-decl name='z_size_t' type-id='type-id-6' filepath='./zconf.h' line='251' column='1' id='type-id-7'/>
-    <typedef-decl name='Byte' type-id='type-id-3' filepath='./zconf.h' line='397' column='1' id='type-id-8'/>
-    <typedef-decl name='uInt' type-id='type-id-4' filepath='./zconf.h' line='399' column='1' id='type-id-9'/>
-    <typedef-decl name='uLong' type-id='type-id-5' filepath='./zconf.h' line='400' column='1' id='type-id-10'/>
-    <typedef-decl name='Bytef' type-id='type-id-8' filepath='./zconf.h' line='406' column='1' id='type-id-11'/>
-    <typedef-decl name='size_t' type-id='type-id-4' filepath='/usr/lib/gcc-cross/powerpc-linux-gnu/11/include/stddef.h' line='209' column='1' id='type-id-6'/>
-    <typedef-decl name='__int64_t' type-id='type-id-2' filepath='/usr/powerpc-linux-gnu/include/bits/types.h' line='47' column='1' id='type-id-12'/>
-    <typedef-decl name='__off_t' type-id='type-id-1' filepath='/usr/powerpc-linux-gnu/include/bits/types.h' line='152' column='1' id='type-id-13'/>
-    <typedef-decl name='__off64_t' type-id='type-id-12' filepath='/usr/powerpc-linux-gnu/include/bits/types.h' line='153' column='1' id='type-id-14'/>
-    <typedef-decl name='off_t' type-id='type-id-13' filepath='/usr/powerpc-linux-gnu/include/sys/types.h' line='85' column='1' id='type-id-15'/>
-    <typedef-decl name='off64_t' type-id='type-id-14' filepath='/usr/powerpc-linux-gnu/include/sys/types.h' line='92' column='1' id='type-id-16'/>
-    <qualified-type-def type-id='type-id-11' const='yes' id='type-id-17'/>
-    <pointer-type-def type-id='type-id-17' size-in-bits='32' id='type-id-18'/>
+    <type-decl name='long long int' size-in-bits='64' id='type-id-1'/>
+    <typedef-decl name='Byte' type-id='type-id-2' filepath='./zconf.h' line='397' column='1' id='type-id-3'/>
+    <typedef-decl name='Bytef' type-id='type-id-3' filepath='./zconf.h' line='406' column='1' id='type-id-4'/>
+    <typedef-decl name='__int64_t' type-id='type-id-1' filepath='/usr/powerpc-linux-gnu/include/bits/types.h' line='47' column='1' id='type-id-5'/>
+    <typedef-decl name='__off64_t' type-id='type-id-5' filepath='/usr/powerpc-linux-gnu/include/bits/types.h' line='153' column='1' id='type-id-6'/>
+    <typedef-decl name='off64_t' type-id='type-id-6' filepath='/usr/powerpc-linux-gnu/include/sys/types.h' line='92' column='1' id='type-id-7'/>
+    <typedef-decl name='off_t' type-id='type-id-6' filepath='/usr/powerpc-linux-gnu/include/sys/types.h' line='87' column='1' id='type-id-8'/>
+    <typedef-decl name='size_t' type-id='type-id-9' filepath='/usr/lib/gcc-cross/powerpc-linux-gnu/13/include/stddef.h' line='214' column='1' id='type-id-10'/>
+    <typedef-decl name='uInt' type-id='type-id-9' filepath='./zconf.h' line='399' column='1' id='type-id-11'/>
+    <typedef-decl name='uLong' type-id='type-id-12' filepath='./zconf.h' line='400' column='1' id='type-id-13'/>
+    <typedef-decl name='z_size_t' type-id='type-id-10' filepath='./zconf.h' line='251' column='1' id='type-id-14'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-2'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-9'/>
+    <type-decl name='unsigned long int' size-in-bits='32' id='type-id-12'/>
+    <qualified-type-def type-id='type-id-4' const='yes' id='type-id-15'/>
+    <pointer-type-def type-id='type-id-15' size-in-bits='32' id='type-id-16'/>
     <function-decl name='adler32_z' mangled-name='adler32_z' filepath='src.d/adler32.c' line='63' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='adler32_z@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-10' name='adler' filepath='src.d/adler32.c' line='64' column='1'/>
-      <parameter type-id='type-id-18' name='buf' filepath='src.d/adler32.c' line='65' column='1'/>
-      <parameter type-id='type-id-7' name='len' filepath='src.d/adler32.c' line='66' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-13' name='adler' filepath='src.d/adler32.c' line='64' column='1'/>
+      <parameter type-id='type-id-16' name='buf' filepath='src.d/adler32.c' line='65' column='1'/>
+      <parameter type-id='type-id-14' name='len' filepath='src.d/adler32.c' line='66' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='adler32' mangled-name='adler32' filepath='src.d/adler32.c' line='134' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='adler32'>
-      <parameter type-id='type-id-10' name='adler' filepath='src.d/adler32.c' line='135' column='1'/>
-      <parameter type-id='type-id-18' name='buf' filepath='src.d/adler32.c' line='136' column='1'/>
-      <parameter type-id='type-id-9' name='len' filepath='src.d/adler32.c' line='137' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-13' name='adler' filepath='src.d/adler32.c' line='135' column='1'/>
+      <parameter type-id='type-id-16' name='buf' filepath='src.d/adler32.c' line='136' column='1'/>
+      <parameter type-id='type-id-11' name='len' filepath='src.d/adler32.c' line='137' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='adler32_combine' mangled-name='adler32_combine' filepath='src.d/adler32.c' line='172' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='adler32_combine@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-10' name='adler1' filepath='src.d/adler32.c' line='173' column='1'/>
-      <parameter type-id='type-id-10' name='adler2' filepath='src.d/adler32.c' line='174' column='1'/>
-      <parameter type-id='type-id-15' name='len2' filepath='src.d/adler32.c' line='175' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-13' name='adler1' filepath='src.d/adler32.c' line='173' column='1'/>
+      <parameter type-id='type-id-13' name='adler2' filepath='src.d/adler32.c' line='174' column='1'/>
+      <parameter type-id='type-id-8' name='len2' filepath='src.d/adler32.c' line='175' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='adler32_combine64' mangled-name='adler32_combine64' filepath='src.d/adler32.c' line='180' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='adler32_combine64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-10' name='adler1' filepath='src.d/adler32.c' line='181' column='1'/>
-      <parameter type-id='type-id-10' name='adler2' filepath='src.d/adler32.c' line='182' column='1'/>
-      <parameter type-id='type-id-16' name='len2' filepath='src.d/adler32.c' line='183' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-13' name='adler1' filepath='src.d/adler32.c' line='181' column='1'/>
+      <parameter type-id='type-id-13' name='adler2' filepath='src.d/adler32.c' line='182' column='1'/>
+      <parameter type-id='type-id-7' name='len2' filepath='src.d/adler32.c' line='183' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/compress.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <typedef-decl name='uLongf' type-id='type-id-10' filepath='./zconf.h' line='411' column='1' id='type-id-19'/>
-    <pointer-type-def type-id='type-id-19' size-in-bits='32' id='type-id-20'/>
+    <typedef-decl name='uLongf' type-id='type-id-13' filepath='./zconf.h' line='411' column='1' id='type-id-17'/>
+    <pointer-type-def type-id='type-id-17' size-in-bits='32' id='type-id-18'/>
     <function-decl name='compress2' mangled-name='compress2' filepath='src.d/compress.c' line='22' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='compress2'>
-      <parameter type-id='type-id-21' name='dest' filepath='src.d/compress.c' line='23' column='1'/>
-      <parameter type-id='type-id-20' name='destLen' filepath='src.d/compress.c' line='24' column='1'/>
-      <parameter type-id='type-id-18' name='source' filepath='src.d/compress.c' line='25' column='1'/>
-      <parameter type-id='type-id-10' name='sourceLen' filepath='src.d/compress.c' line='26' column='1'/>
-      <parameter type-id='type-id-22' name='level' filepath='src.d/compress.c' line='27' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-19' name='dest' filepath='src.d/compress.c' line='23' column='1'/>
+      <parameter type-id='type-id-18' name='destLen' filepath='src.d/compress.c' line='24' column='1'/>
+      <parameter type-id='type-id-16' name='source' filepath='src.d/compress.c' line='25' column='1'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/compress.c' line='26' column='1'/>
+      <parameter type-id='type-id-20' name='level' filepath='src.d/compress.c' line='27' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='compress' mangled-name='compress' filepath='src.d/compress.c' line='68' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='compress'>
-      <parameter type-id='type-id-21' name='dest' filepath='src.d/compress.c' line='69' column='1'/>
-      <parameter type-id='type-id-20' name='destLen' filepath='src.d/compress.c' line='70' column='1'/>
-      <parameter type-id='type-id-18' name='source' filepath='src.d/compress.c' line='71' column='1'/>
-      <parameter type-id='type-id-10' name='sourceLen' filepath='src.d/compress.c' line='72' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-19' name='dest' filepath='src.d/compress.c' line='69' column='1'/>
+      <parameter type-id='type-id-18' name='destLen' filepath='src.d/compress.c' line='70' column='1'/>
+      <parameter type-id='type-id-16' name='source' filepath='src.d/compress.c' line='71' column='1'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/compress.c' line='72' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='compressBound' mangled-name='compressBound' filepath='src.d/compress.c' line='81' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='compressBound@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-10' name='sourceLen' filepath='src.d/compress.c' line='82' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/compress.c' line='82' column='1'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+    <function-decl name='deflate' filepath='src.d/zlib.h' line='250' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='deflateEnd' filepath='src.d/zlib.h' line='363' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-21'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='deflateInit_' filepath='src.d/zlib.h' line='1781' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/crc32.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <typedef-decl name='z_crc_t' type-id='type-id-4' filepath='./zconf.h' line='435' column='1' id='type-id-23'/>
-    <qualified-type-def type-id='type-id-3' const='yes' id='type-id-24'/>
+    <typedef-decl name='z_crc_t' type-id='type-id-9' filepath='./zconf.h' line='435' column='1' id='type-id-23'/>
+    <qualified-type-def type-id='type-id-2' const='yes' id='type-id-24'/>
     <pointer-type-def type-id='type-id-24' size-in-bits='32' id='type-id-25'/>
     <qualified-type-def type-id='type-id-23' const='yes' id='type-id-26'/>
     <pointer-type-def type-id='type-id-26' size-in-bits='32' id='type-id-27'/>
@@ -169,1118 +183,1104 @@
       <return type-id='type-id-27'/>
     </function-decl>
     <function-decl name='crc32_z' mangled-name='crc32_z' filepath='src.d/crc32.c' line='748' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='crc32_z@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-5' name='crc' filepath='src.d/crc32.c' line='749' column='1'/>
+      <parameter type-id='type-id-12' name='crc' filepath='src.d/crc32.c' line='749' column='1'/>
       <parameter type-id='type-id-25' name='buf' filepath='src.d/crc32.c' line='750' column='1'/>
-      <parameter type-id='type-id-7' name='len' filepath='src.d/crc32.c' line='751' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-14' name='len' filepath='src.d/crc32.c' line='751' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32' mangled-name='crc32' filepath='src.d/crc32.c' line='1072' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='crc32'>
-      <parameter type-id='type-id-5' name='crc' filepath='src.d/crc32.c' line='1073' column='1'/>
+      <parameter type-id='type-id-12' name='crc' filepath='src.d/crc32.c' line='1073' column='1'/>
       <parameter type-id='type-id-25' name='buf' filepath='src.d/crc32.c' line='1074' column='1'/>
-      <parameter type-id='type-id-9' name='len' filepath='src.d/crc32.c' line='1075' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-11' name='len' filepath='src.d/crc32.c' line='1075' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine64' mangled-name='crc32_combine64' filepath='src.d/crc32.c' line='1081' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='crc32_combine64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-10' name='crc1' filepath='src.d/crc32.c' line='1082' column='1'/>
-      <parameter type-id='type-id-10' name='crc2' filepath='src.d/crc32.c' line='1083' column='1'/>
-      <parameter type-id='type-id-16' name='len2' filepath='src.d/crc32.c' line='1084' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-13' name='crc1' filepath='src.d/crc32.c' line='1082' column='1'/>
+      <parameter type-id='type-id-13' name='crc2' filepath='src.d/crc32.c' line='1083' column='1'/>
+      <parameter type-id='type-id-7' name='len2' filepath='src.d/crc32.c' line='1084' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine' mangled-name='crc32_combine' filepath='src.d/crc32.c' line='1093' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='crc32_combine@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-10' name='crc1' filepath='src.d/crc32.c' line='1094' column='1'/>
-      <parameter type-id='type-id-10' name='crc2' filepath='src.d/crc32.c' line='1095' column='1'/>
-      <parameter type-id='type-id-15' name='len2' filepath='src.d/crc32.c' line='1096' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-13' name='crc1' filepath='src.d/crc32.c' line='1094' column='1'/>
+      <parameter type-id='type-id-13' name='crc2' filepath='src.d/crc32.c' line='1095' column='1'/>
+      <parameter type-id='type-id-8' name='len2' filepath='src.d/crc32.c' line='1096' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine_gen64' mangled-name='crc32_combine_gen64' filepath='src.d/crc32.c' line='1102' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='crc32_combine_gen64@@ZLIB_1.2.12'>
-      <parameter type-id='type-id-16' name='len2' filepath='src.d/crc32.c' line='1103' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-7' name='len2' filepath='src.d/crc32.c' line='1103' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine_gen' mangled-name='crc32_combine_gen' filepath='src.d/crc32.c' line='1112' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='crc32_combine_gen@@ZLIB_1.2.12'>
-      <parameter type-id='type-id-15' name='len2' filepath='src.d/crc32.c' line='1113' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-8' name='len2' filepath='src.d/crc32.c' line='1113' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine_op' mangled-name='crc32_combine_op' filepath='src.d/crc32.c' line='1119' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='crc32_combine_op@@ZLIB_1.2.12'>
-      <parameter type-id='type-id-10' name='crc1' filepath='src.d/crc32.c' line='1120' column='1'/>
-      <parameter type-id='type-id-10' name='crc2' filepath='src.d/crc32.c' line='1121' column='1'/>
-      <parameter type-id='type-id-10' name='op' filepath='src.d/crc32.c' line='1122' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-13' name='crc1' filepath='src.d/crc32.c' line='1120' column='1'/>
+      <parameter type-id='type-id-13' name='crc2' filepath='src.d/crc32.c' line='1121' column='1'/>
+      <parameter type-id='type-id-13' name='op' filepath='src.d/crc32.c' line='1122' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/deflate.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
     <type-decl name='char' size-in-bits='8' id='type-id-28'/>
-    <class-decl name='static_tree_desc_s' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-29'/>
-    <array-type-def dimensions='1' type-id='type-id-30' size-in-bits='1248' id='type-id-31'>
-      <subrange length='39' type-id='type-id-4' id='type-id-32'/>
+    <array-type-def dimensions='1' type-id='type-id-29' size-in-bits='1248' id='type-id-30'>
+      <subrange length='39' lower-bound='0' upper-bound='38' type-id='type-id-9' id='type-id-31'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-30' size-in-bits='18336' id='type-id-33'>
-      <subrange length='573' type-id='type-id-4' id='type-id-34'/>
+    <array-type-def dimensions='1' type-id='type-id-29' size-in-bits='18336' id='type-id-32'>
+      <subrange length='573' lower-bound='0' upper-bound='572' type-id='type-id-9' id='type-id-33'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-30' size-in-bits='1952' id='type-id-35'>
-      <subrange length='61' type-id='type-id-4' id='type-id-36'/>
+    <array-type-def dimensions='1' type-id='type-id-29' size-in-bits='1952' id='type-id-34'>
+      <subrange length='61' lower-bound='0' upper-bound='60' type-id='type-id-9' id='type-id-35'/>
     </array-type-def>
-    <type-decl name='int' size-in-bits='32' id='type-id-22'/>
-    <array-type-def dimensions='1' type-id='type-id-22' size-in-bits='18336' id='type-id-37'>
-      <subrange length='573' type-id='type-id-4' id='type-id-34'/>
+    <type-decl name='int' size-in-bits='32' id='type-id-20'/>
+    <array-type-def dimensions='1' type-id='type-id-20' size-in-bits='18336' id='type-id-36'>
+      <subrange length='573' lower-bound='0' upper-bound='572' type-id='type-id-9' id='type-id-33'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-38' size-in-bits='4584' id='type-id-39'>
-      <subrange length='573' type-id='type-id-4' id='type-id-34'/>
-    </array-type-def>
-    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-40'/>
-    <array-type-def dimensions='1' type-id='type-id-41' size-in-bits='256' id='type-id-42'>
-      <subrange length='16' type-id='type-id-4' id='type-id-43'/>
-    </array-type-def>
-    <type-decl name='void' id='type-id-44'/>
-    <typedef-decl name='charf' type-id='type-id-28' filepath='./zconf.h' line='408' column='1' id='type-id-45'/>
-    <typedef-decl name='voidpf' type-id='type-id-46' filepath='./zconf.h' line='415' column='1' id='type-id-47'/>
-    <class-decl name='ct_data_s' size-in-bits='32' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='68' column='1' id='type-id-30'>
+    <type-decl name='long int' size-in-bits='32' id='type-id-37'/>
+    <class-decl name='ct_data_s' size-in-bits='32' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='68' column='1' id='type-id-29'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='fc' type-id='type-id-48' visibility='default' filepath='src.d/deflate.h' line='72' column='1'/>
+        <var-decl name='fc' type-id='type-id-38' visibility='default' filepath='src.d/deflate.h' line='72' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='16'>
-        <var-decl name='dl' type-id='type-id-49' visibility='default' filepath='src.d/deflate.h' line='76' column='1'/>
+        <var-decl name='dl' type-id='type-id-39' visibility='default' filepath='src.d/deflate.h' line='76' column='1'/>
       </data-member>
     </class-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='69' column='1' id='type-id-48'>
-      <data-member access='public'>
-        <var-decl name='freq' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='70' column='1'/>
-      </data-member>
-      <data-member access='public'>
-        <var-decl name='code' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='71' column='1'/>
-      </data-member>
-    </union-decl>
-    <union-decl name='__anonymous_union__1' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='73' column='1' id='type-id-49'>
-      <data-member access='public'>
-        <var-decl name='dad' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='74' column='1'/>
-      </data-member>
-      <data-member access='public'>
-        <var-decl name='len' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='75' column='1'/>
-      </data-member>
-    </union-decl>
-    <typedef-decl name='ct_data' type-id='type-id-30' filepath='src.d/deflate.h' line='77' column='1' id='type-id-50'/>
-    <typedef-decl name='static_tree_desc' type-id='type-id-29' filepath='src.d/deflate.h' line='84' column='1' id='type-id-51'/>
-    <class-decl name='tree_desc_s' size-in-bits='96' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='86' column='1' id='type-id-52'>
+    <class-decl name='gz_header_s' size-in-bits='416' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='114' column='1' id='type-id-40'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='dyn_tree' type-id='type-id-53' visibility='default' filepath='src.d/deflate.h' line='87' column='1'/>
+        <var-decl name='text' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='115' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='max_code' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='88' column='1'/>
+        <var-decl name='time' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='116' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='stat_desc' type-id='type-id-54' visibility='default' filepath='src.d/deflate.h' line='89' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='Pos' type-id='type-id-41' filepath='src.d/deflate.h' line='92' column='1' id='type-id-55'/>
-    <typedef-decl name='Posf' type-id='type-id-55' filepath='src.d/deflate.h' line='93' column='1' id='type-id-56'/>
-    <typedef-decl name='IPos' type-id='type-id-4' filepath='src.d/deflate.h' line='94' column='1' id='type-id-57'/>
-    <class-decl name='internal_state' size-in-bits='46624' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='100' column='1' id='type-id-58'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='strm' type-id='type-id-59' visibility='default' filepath='src.d/deflate.h' line='101' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='status' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='102' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='pending_buf' type-id='type-id-21' visibility='default' filepath='src.d/deflate.h' line='103' column='1'/>
+        <var-decl name='xflags' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='117' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='pending_buf_size' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='104' column='1'/>
+        <var-decl name='os' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='118' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='pending_out' type-id='type-id-21' visibility='default' filepath='src.d/deflate.h' line='105' column='1'/>
+        <var-decl name='extra' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='119' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='pending' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='106' column='1'/>
+        <var-decl name='extra_len' type-id='type-id-11' visibility='default' filepath='src.d/zlib.h' line='120' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='wrap' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='107' column='1'/>
+        <var-decl name='extra_max' type-id='type-id-11' visibility='default' filepath='src.d/zlib.h' line='121' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='gzhead' type-id='type-id-61' visibility='default' filepath='src.d/deflate.h' line='108' column='1'/>
+        <var-decl name='name' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='122' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='gzindex' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='109' column='1'/>
+        <var-decl name='name_max' type-id='type-id-11' visibility='default' filepath='src.d/zlib.h' line='123' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='method' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='110' column='1'/>
+        <var-decl name='comment' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='124' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='last_flush' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='111' column='1'/>
+        <var-decl name='comm_max' type-id='type-id-11' visibility='default' filepath='src.d/zlib.h' line='125' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='w_size' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='115' column='1'/>
+        <var-decl name='hcrc' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='126' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='w_bits' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='116' column='1'/>
+        <var-decl name='done' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='127' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='internal_state' size-in-bits='46624' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='100' column='1' id='type-id-41'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='strm' type-id='type-id-21' visibility='default' filepath='src.d/deflate.h' line='101' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='status' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='102' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='pending_buf' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='103' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='pending_buf_size' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='104' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='pending_out' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='105' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='pending' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='106' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='wrap' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='107' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='gzhead' type-id='type-id-43' visibility='default' filepath='src.d/deflate.h' line='108' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gzindex' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='109' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='method' type-id='type-id-3' visibility='default' filepath='src.d/deflate.h' line='110' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='last_flush' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='111' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='w_size' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='115' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='w_bits' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='116' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='416'>
-        <var-decl name='w_mask' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='117' column='1'/>
+        <var-decl name='w_mask' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='117' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='window' type-id='type-id-21' visibility='default' filepath='src.d/deflate.h' line='119' column='1'/>
+        <var-decl name='window' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='119' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='480'>
-        <var-decl name='window_size' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='129' column='1'/>
+        <var-decl name='window_size' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='129' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='prev' type-id='type-id-62' visibility='default' filepath='src.d/deflate.h' line='134' column='1'/>
+        <var-decl name='prev' type-id='type-id-44' visibility='default' filepath='src.d/deflate.h' line='134' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='544'>
-        <var-decl name='head' type-id='type-id-62' visibility='default' filepath='src.d/deflate.h' line='140' column='1'/>
+        <var-decl name='head' type-id='type-id-44' visibility='default' filepath='src.d/deflate.h' line='140' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='ins_h' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='142' column='1'/>
+        <var-decl name='ins_h' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='142' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='608'>
-        <var-decl name='hash_size' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='143' column='1'/>
+        <var-decl name='hash_size' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='143' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='hash_bits' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='144' column='1'/>
+        <var-decl name='hash_bits' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='144' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='672'>
-        <var-decl name='hash_mask' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='145' column='1'/>
+        <var-decl name='hash_mask' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='145' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='hash_shift' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='147' column='1'/>
+        <var-decl name='hash_shift' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='147' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='736'>
-        <var-decl name='block_start' type-id='type-id-1' visibility='default' filepath='src.d/deflate.h' line='154' column='1'/>
+        <var-decl name='block_start' type-id='type-id-37' visibility='default' filepath='src.d/deflate.h' line='154' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='match_length' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='159' column='1'/>
+        <var-decl name='match_length' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='159' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='800'>
-        <var-decl name='prev_match' type-id='type-id-57' visibility='default' filepath='src.d/deflate.h' line='160' column='1'/>
+        <var-decl name='prev_match' type-id='type-id-45' visibility='default' filepath='src.d/deflate.h' line='160' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='match_available' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='161' column='1'/>
+        <var-decl name='match_available' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='161' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='864'>
-        <var-decl name='strstart' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='162' column='1'/>
+        <var-decl name='strstart' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='162' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='match_start' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='163' column='1'/>
+        <var-decl name='match_start' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='163' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='928'>
-        <var-decl name='lookahead' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='164' column='1'/>
+        <var-decl name='lookahead' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='164' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='prev_length' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='166' column='1'/>
+        <var-decl name='prev_length' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='166' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='992'>
-        <var-decl name='max_chain_length' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='171' column='1'/>
+        <var-decl name='max_chain_length' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='171' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='max_lazy_match' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='177' column='1'/>
+        <var-decl name='max_lazy_match' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='177' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1056'>
-        <var-decl name='level' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='188' column='1'/>
+        <var-decl name='level' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='188' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1088'>
-        <var-decl name='strategy' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='189' column='1'/>
+        <var-decl name='strategy' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='189' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1120'>
-        <var-decl name='good_match' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='191' column='1'/>
+        <var-decl name='good_match' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='191' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1152'>
-        <var-decl name='nice_match' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='194' column='1'/>
+        <var-decl name='nice_match' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='194' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1184'>
-        <var-decl name='dyn_ltree' type-id='type-id-33' visibility='default' filepath='src.d/deflate.h' line='198' column='1'/>
+        <var-decl name='dyn_ltree' type-id='type-id-32' visibility='default' filepath='src.d/deflate.h' line='198' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='19520'>
-        <var-decl name='dyn_dtree' type-id='type-id-35' visibility='default' filepath='src.d/deflate.h' line='199' column='1'/>
+        <var-decl name='dyn_dtree' type-id='type-id-34' visibility='default' filepath='src.d/deflate.h' line='199' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='21472'>
-        <var-decl name='bl_tree' type-id='type-id-31' visibility='default' filepath='src.d/deflate.h' line='200' column='1'/>
+        <var-decl name='bl_tree' type-id='type-id-30' visibility='default' filepath='src.d/deflate.h' line='200' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='22720'>
-        <var-decl name='l_desc' type-id='type-id-52' visibility='default' filepath='src.d/deflate.h' line='202' column='1'/>
+        <var-decl name='l_desc' type-id='type-id-46' visibility='default' filepath='src.d/deflate.h' line='202' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='22816'>
-        <var-decl name='d_desc' type-id='type-id-52' visibility='default' filepath='src.d/deflate.h' line='203' column='1'/>
+        <var-decl name='d_desc' type-id='type-id-46' visibility='default' filepath='src.d/deflate.h' line='203' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='22912'>
-        <var-decl name='bl_desc' type-id='type-id-52' visibility='default' filepath='src.d/deflate.h' line='204' column='1'/>
+        <var-decl name='bl_desc' type-id='type-id-46' visibility='default' filepath='src.d/deflate.h' line='204' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='23008'>
-        <var-decl name='bl_count' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='206' column='1'/>
+        <var-decl name='bl_count' type-id='type-id-47' visibility='default' filepath='src.d/deflate.h' line='206' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='23264'>
-        <var-decl name='heap' type-id='type-id-37' visibility='default' filepath='src.d/deflate.h' line='209' column='1'/>
+        <var-decl name='heap' type-id='type-id-36' visibility='default' filepath='src.d/deflate.h' line='209' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='41600'>
-        <var-decl name='heap_len' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='210' column='1'/>
+        <var-decl name='heap_len' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='210' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='41632'>
-        <var-decl name='heap_max' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='211' column='1'/>
+        <var-decl name='heap_max' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='211' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='41664'>
-        <var-decl name='depth' type-id='type-id-39' visibility='default' filepath='src.d/deflate.h' line='216' column='1'/>
+        <var-decl name='depth' type-id='type-id-48' visibility='default' filepath='src.d/deflate.h' line='216' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46272'>
-        <var-decl name='sym_buf' type-id='type-id-63' visibility='default' filepath='src.d/deflate.h' line='220' column='1'/>
+        <var-decl name='sym_buf' type-id='type-id-49' visibility='default' filepath='src.d/deflate.h' line='220' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46304'>
-        <var-decl name='lit_bufsize' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='222' column='1'/>
+        <var-decl name='lit_bufsize' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='222' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46336'>
-        <var-decl name='sym_next' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='242' column='1'/>
+        <var-decl name='sym_next' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='242' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46368'>
-        <var-decl name='sym_end' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='243' column='1'/>
+        <var-decl name='sym_end' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='243' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46400'>
-        <var-decl name='opt_len' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='245' column='1'/>
+        <var-decl name='opt_len' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='245' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46432'>
-        <var-decl name='static_len' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='246' column='1'/>
+        <var-decl name='static_len' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='246' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46464'>
-        <var-decl name='matches' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='247' column='1'/>
+        <var-decl name='matches' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='247' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46496'>
-        <var-decl name='insert' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='248' column='1'/>
+        <var-decl name='insert' type-id='type-id-11' visibility='default' filepath='src.d/deflate.h' line='248' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46528'>
-        <var-decl name='bi_buf' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='255' column='1'/>
+        <var-decl name='bi_buf' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='255' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46560'>
-        <var-decl name='bi_valid' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='259' column='1'/>
+        <var-decl name='bi_valid' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='259' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='46592'>
-        <var-decl name='high_water' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='264' column='1'/>
+        <var-decl name='high_water' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='264' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='deflate_state' type-id='type-id-58' filepath='src.d/deflate.h' line='271' column='1' id='type-id-64'/>
-    <typedef-decl name='alloc_func' type-id='type-id-65' filepath='src.d/zlib.h' line='81' column='1' id='type-id-66'/>
-    <typedef-decl name='free_func' type-id='type-id-67' filepath='src.d/zlib.h' line='82' column='1' id='type-id-68'/>
-    <class-decl name='z_stream_s' size-in-bits='448' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='86' column='1' id='type-id-69'>
+    <class-decl name='tree_desc_s' size-in-bits='96' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='86' column='1' id='type-id-46'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='next_in' type-id='type-id-21' visibility='default' filepath='src.d/zlib.h' line='87' column='1'/>
+        <var-decl name='dyn_tree' type-id='type-id-51' visibility='default' filepath='src.d/deflate.h' line='87' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='avail_in' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='88' column='1'/>
+        <var-decl name='max_code' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='88' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='total_in' type-id='type-id-10' visibility='default' filepath='src.d/zlib.h' line='89' column='1'/>
+        <var-decl name='stat_desc' type-id='type-id-52' visibility='default' filepath='src.d/deflate.h' line='89' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='z_stream_s' size-in-bits='448' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='86' column='1' id='type-id-53'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next_in' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='87' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='avail_in' type-id='type-id-11' visibility='default' filepath='src.d/zlib.h' line='88' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='total_in' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='89' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='next_out' type-id='type-id-21' visibility='default' filepath='src.d/zlib.h' line='91' column='1'/>
+        <var-decl name='next_out' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='91' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='avail_out' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='92' column='1'/>
+        <var-decl name='avail_out' type-id='type-id-11' visibility='default' filepath='src.d/zlib.h' line='92' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='total_out' type-id='type-id-10' visibility='default' filepath='src.d/zlib.h' line='93' column='1'/>
+        <var-decl name='total_out' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='93' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='msg' type-id='type-id-70' visibility='default' filepath='src.d/zlib.h' line='95' column='1'/>
+        <var-decl name='msg' type-id='type-id-54' visibility='default' filepath='src.d/zlib.h' line='95' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='state' type-id='type-id-71' visibility='default' filepath='src.d/zlib.h' line='96' column='1'/>
+        <var-decl name='state' type-id='type-id-55' visibility='default' filepath='src.d/zlib.h' line='96' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='zalloc' type-id='type-id-66' visibility='default' filepath='src.d/zlib.h' line='98' column='1'/>
+        <var-decl name='zalloc' type-id='type-id-56' visibility='default' filepath='src.d/zlib.h' line='98' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='zfree' type-id='type-id-68' visibility='default' filepath='src.d/zlib.h' line='99' column='1'/>
+        <var-decl name='zfree' type-id='type-id-57' visibility='default' filepath='src.d/zlib.h' line='99' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='opaque' type-id='type-id-47' visibility='default' filepath='src.d/zlib.h' line='100' column='1'/>
+        <var-decl name='opaque' type-id='type-id-58' visibility='default' filepath='src.d/zlib.h' line='100' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='data_type' type-id='type-id-22' visibility='default' filepath='src.d/zlib.h' line='102' column='1'/>
+        <var-decl name='data_type' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='102' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='adler' type-id='type-id-10' visibility='default' filepath='src.d/zlib.h' line='104' column='1'/>
+        <var-decl name='adler' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='104' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='416'>
-        <var-decl name='reserved' type-id='type-id-10' visibility='default' filepath='src.d/zlib.h' line='105' column='1'/>
+        <var-decl name='reserved' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='105' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='z_stream' type-id='type-id-69' filepath='src.d/zlib.h' line='106' column='1' id='type-id-72'/>
-    <typedef-decl name='z_streamp' type-id='type-id-73' filepath='src.d/zlib.h' line='108' column='1' id='type-id-59'/>
-    <class-decl name='gz_header_s' size-in-bits='416' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='114' column='1' id='type-id-74'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='text' type-id='type-id-22' visibility='default' filepath='src.d/zlib.h' line='115' column='1'/>
+    <typedef-decl name='IPos' type-id='type-id-9' filepath='src.d/deflate.h' line='94' column='1' id='type-id-45'/>
+    <typedef-decl name='Pos' type-id='type-id-50' filepath='src.d/deflate.h' line='92' column='1' id='type-id-59'/>
+    <typedef-decl name='Posf' type-id='type-id-59' filepath='src.d/deflate.h' line='93' column='1' id='type-id-60'/>
+    <typedef-decl name='alloc_func' type-id='type-id-61' filepath='src.d/zlib.h' line='81' column='1' id='type-id-56'/>
+    <typedef-decl name='charf' type-id='type-id-28' filepath='./zconf.h' line='408' column='1' id='type-id-62'/>
+    <typedef-decl name='ct_data' type-id='type-id-29' filepath='src.d/deflate.h' line='77' column='1' id='type-id-63'/>
+    <typedef-decl name='deflate_state' type-id='type-id-41' filepath='src.d/deflate.h' line='271' column='1' id='type-id-64'/>
+    <typedef-decl name='free_func' type-id='type-id-65' filepath='src.d/zlib.h' line='82' column='1' id='type-id-57'/>
+    <typedef-decl name='gz_header' type-id='type-id-40' filepath='src.d/zlib.h' line='129' column='1' id='type-id-66'/>
+    <typedef-decl name='gz_headerp' type-id='type-id-67' filepath='src.d/zlib.h' line='131' column='1' id='type-id-43'/>
+    <typedef-decl name='uch' type-id='type-id-2' filepath='src.d/zutil.h' line='39' column='1' id='type-id-68'/>
+    <typedef-decl name='uchf' type-id='type-id-68' filepath='src.d/zutil.h' line='40' column='1' id='type-id-69'/>
+    <typedef-decl name='ulg' type-id='type-id-12' filepath='src.d/zutil.h' line='43' column='1' id='type-id-42'/>
+    <typedef-decl name='ush' type-id='type-id-70' filepath='src.d/zutil.h' line='41' column='1' id='type-id-50'/>
+    <typedef-decl name='z_stream' type-id='type-id-53' filepath='src.d/zlib.h' line='106' column='1' id='type-id-71'/>
+    <typedef-decl name='z_streamp' type-id='type-id-72' filepath='src.d/zlib.h' line='108' column='1' id='type-id-21'/>
+    <array-type-def dimensions='1' type-id='type-id-68' size-in-bits='4584' id='type-id-48'>
+      <subrange length='573' lower-bound='0' upper-bound='572' type-id='type-id-9' id='type-id-33'/>
+    </array-type-def>
+    <union-decl name='__anonymous_union__1' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='73' column='1' id='type-id-39'>
+      <data-member access='public'>
+        <var-decl name='dad' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='74' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='time' type-id='type-id-10' visibility='default' filepath='src.d/zlib.h' line='116' column='1'/>
+      <data-member access='public'>
+        <var-decl name='len' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='75' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='xflags' type-id='type-id-22' visibility='default' filepath='src.d/zlib.h' line='117' column='1'/>
+    </union-decl>
+    <union-decl name='__anonymous_union__' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='69' column='1' id='type-id-38'>
+      <data-member access='public'>
+        <var-decl name='freq' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='70' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='os' type-id='type-id-22' visibility='default' filepath='src.d/zlib.h' line='118' column='1'/>
+      <data-member access='public'>
+        <var-decl name='code' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='71' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='extra' type-id='type-id-21' visibility='default' filepath='src.d/zlib.h' line='119' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='extra_len' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='120' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='extra_max' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='121' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='name' type-id='type-id-21' visibility='default' filepath='src.d/zlib.h' line='122' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='name_max' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='123' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='comment' type-id='type-id-21' visibility='default' filepath='src.d/zlib.h' line='124' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='comm_max' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='125' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='hcrc' type-id='type-id-22' visibility='default' filepath='src.d/zlib.h' line='126' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='done' type-id='type-id-22' visibility='default' filepath='src.d/zlib.h' line='127' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='gz_header' type-id='type-id-74' filepath='src.d/zlib.h' line='129' column='1' id='type-id-75'/>
-    <typedef-decl name='gz_headerp' type-id='type-id-76' filepath='src.d/zlib.h' line='131' column='1' id='type-id-61'/>
-    <typedef-decl name='uch' type-id='type-id-3' filepath='src.d/zutil.h' line='39' column='1' id='type-id-38'/>
-    <typedef-decl name='uchf' type-id='type-id-38' filepath='src.d/zutil.h' line='40' column='1' id='type-id-77'/>
-    <typedef-decl name='ush' type-id='type-id-40' filepath='src.d/zutil.h' line='41' column='1' id='type-id-41'/>
-    <typedef-decl name='ulg' type-id='type-id-5' filepath='src.d/zutil.h' line='43' column='1' id='type-id-60'/>
-    <pointer-type-def type-id='type-id-11' size-in-bits='32' id='type-id-21'/>
-    <pointer-type-def type-id='type-id-56' size-in-bits='32' id='type-id-62'/>
-    <pointer-type-def type-id='type-id-28' size-in-bits='32' id='type-id-70'/>
-    <pointer-type-def type-id='type-id-45' size-in-bits='32' id='type-id-78'/>
-    <qualified-type-def type-id='type-id-28' const='yes' id='type-id-79'/>
-    <pointer-type-def type-id='type-id-79' size-in-bits='32' id='type-id-80'/>
-    <qualified-type-def type-id='type-id-51' const='yes' id='type-id-81'/>
-    <pointer-type-def type-id='type-id-81' size-in-bits='32' id='type-id-54'/>
-    <pointer-type-def type-id='type-id-50' size-in-bits='32' id='type-id-53'/>
-    <pointer-type-def type-id='type-id-64' size-in-bits='32' id='type-id-82'/>
-    <pointer-type-def type-id='type-id-75' size-in-bits='32' id='type-id-76'/>
-    <pointer-type-def type-id='type-id-22' size-in-bits='32' id='type-id-83'/>
-    <pointer-type-def type-id='type-id-58' size-in-bits='32' id='type-id-71'/>
-    <pointer-type-def type-id='type-id-84' size-in-bits='32' id='type-id-65'/>
-    <pointer-type-def type-id='type-id-9' size-in-bits='32' id='type-id-85'/>
-    <pointer-type-def type-id='type-id-77' size-in-bits='32' id='type-id-63'/>
-    <pointer-type-def type-id='type-id-4' size-in-bits='32' id='type-id-86'/>
-    <pointer-type-def type-id='type-id-87' size-in-bits='32' id='type-id-67'/>
-    <pointer-type-def type-id='type-id-44' size-in-bits='32' id='type-id-46'/>
-    <pointer-type-def type-id='type-id-72' size-in-bits='32' id='type-id-73'/>
-    <class-decl name='static_tree_desc_s' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-29'/>
+    </union-decl>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-70'/>
+    <array-type-def dimensions='1' type-id='type-id-50' size-in-bits='256' id='type-id-47'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-9' id='type-id-73'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-4' size-in-bits='32' id='type-id-19'/>
+    <pointer-type-def type-id='type-id-60' size-in-bits='32' id='type-id-44'/>
+    <pointer-type-def type-id='type-id-28' size-in-bits='32' id='type-id-54'/>
+    <pointer-type-def type-id='type-id-62' size-in-bits='32' id='type-id-74'/>
+    <qualified-type-def type-id='type-id-28' const='yes' id='type-id-75'/>
+    <pointer-type-def type-id='type-id-75' size-in-bits='32' id='type-id-22'/>
+    <pointer-type-def type-id='type-id-63' size-in-bits='32' id='type-id-51'/>
+    <pointer-type-def type-id='type-id-64' size-in-bits='32' id='type-id-76'/>
+    <pointer-type-def type-id='type-id-66' size-in-bits='32' id='type-id-67'/>
+    <pointer-type-def type-id='type-id-20' size-in-bits='32' id='type-id-77'/>
+    <pointer-type-def type-id='type-id-41' size-in-bits='32' id='type-id-55'/>
+    <pointer-type-def type-id='type-id-78' size-in-bits='32' id='type-id-61'/>
+    <pointer-type-def type-id='type-id-11' size-in-bits='32' id='type-id-79'/>
+    <pointer-type-def type-id='type-id-69' size-in-bits='32' id='type-id-49'/>
+    <pointer-type-def type-id='type-id-9' size-in-bits='32' id='type-id-80'/>
+    <pointer-type-def type-id='type-id-81' size-in-bits='32' id='type-id-65'/>
+    <pointer-type-def type-id='type-id-71' size-in-bits='32' id='type-id-72'/>
+    <qualified-type-def type-id='type-id-82' const='yes' id='type-id-83'/>
+    <pointer-type-def type-id='type-id-83' size-in-bits='32' id='type-id-52'/>
+    <class-decl name='static_tree_desc_s' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-84'/>
+    <typedef-decl name='voidpf' type-id='type-id-85' filepath='./zconf.h' line='415' column='1' id='type-id-58'/>
     <function-decl name='memcpy' filepath='/usr/powerpc-linux-gnu/include/string.h' line='43' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-46'/>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-85'/>
     </function-decl>
     <function-decl name='memset' filepath='/usr/powerpc-linux-gnu/include/string.h' line='61' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-22'/>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-46'/>
-    </function-decl>
-    <function-decl name='deflateInit_' mangled-name='deflateInit_' filepath='src.d/deflate.c' line='225' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateInit_'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='226' column='1'/>
-      <parameter type-id='type-id-22' name='level' filepath='src.d/deflate.c' line='227' column='1'/>
-      <parameter type-id='type-id-80' name='version' filepath='src.d/deflate.c' line='228' column='1'/>
-      <parameter type-id='type-id-22' name='stream_size' filepath='src.d/deflate.c' line='229' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-85'/>
     </function-decl>
     <function-decl name='deflateInit2_' mangled-name='deflateInit2_' filepath='src.d/deflate.c' line='237' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateInit2_'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='239' column='1'/>
-      <parameter type-id='type-id-22' name='level' filepath='src.d/deflate.c' line='240' column='1'/>
-      <parameter type-id='type-id-22' name='method' filepath='src.d/deflate.c' line='241' column='1'/>
-      <parameter type-id='type-id-22' name='windowBits' filepath='src.d/deflate.c' line='242' column='1'/>
-      <parameter type-id='type-id-22' name='memLevel' filepath='src.d/deflate.c' line='243' column='1'/>
-      <parameter type-id='type-id-22' name='strategy' filepath='src.d/deflate.c' line='244' column='1'/>
-      <parameter type-id='type-id-80' name='version' filepath='src.d/deflate.c' line='245' column='1'/>
-      <parameter type-id='type-id-22' name='stream_size' filepath='src.d/deflate.c' line='246' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='239' column='1'/>
+      <parameter type-id='type-id-20' name='level' filepath='src.d/deflate.c' line='240' column='1'/>
+      <parameter type-id='type-id-20' name='method' filepath='src.d/deflate.c' line='241' column='1'/>
+      <parameter type-id='type-id-20' name='windowBits' filepath='src.d/deflate.c' line='242' column='1'/>
+      <parameter type-id='type-id-20' name='memLevel' filepath='src.d/deflate.c' line='243' column='1'/>
+      <parameter type-id='type-id-20' name='strategy' filepath='src.d/deflate.c' line='244' column='1'/>
+      <parameter type-id='type-id-22' name='version' filepath='src.d/deflate.c' line='245' column='1'/>
+      <parameter type-id='type-id-20' name='stream_size' filepath='src.d/deflate.c' line='246' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateSetDictionary' mangled-name='deflateSetDictionary' filepath='src.d/deflate.c' line='412' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateSetDictionary'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='413' column='1'/>
-      <parameter type-id='type-id-18' name='dictionary' filepath='src.d/deflate.c' line='414' column='1'/>
-      <parameter type-id='type-id-9' name='dictLength' filepath='src.d/deflate.c' line='415' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='413' column='1'/>
+      <parameter type-id='type-id-16' name='dictionary' filepath='src.d/deflate.c' line='414' column='1'/>
+      <parameter type-id='type-id-11' name='dictLength' filepath='src.d/deflate.c' line='415' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateGetDictionary' mangled-name='deflateGetDictionary' filepath='src.d/deflate.c' line='481' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateGetDictionary@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='482' column='1'/>
-      <parameter type-id='type-id-21' name='dictionary' filepath='src.d/deflate.c' line='483' column='1'/>
-      <parameter type-id='type-id-85' name='dictLength' filepath='src.d/deflate.c' line='484' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='482' column='1'/>
+      <parameter type-id='type-id-19' name='dictionary' filepath='src.d/deflate.c' line='483' column='1'/>
+      <parameter type-id='type-id-79' name='dictLength' filepath='src.d/deflate.c' line='484' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateResetKeep' mangled-name='deflateResetKeep' filepath='src.d/deflate.c' line='503' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateResetKeep@@ZLIB_1.2.5.2'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='504' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='504' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateReset' mangled-name='deflateReset' filepath='src.d/deflate.c' line='541' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateReset'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='542' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='542' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateSetHeader' mangled-name='deflateSetHeader' filepath='src.d/deflate.c' line='553' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateSetHeader@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='554' column='1'/>
-      <parameter type-id='type-id-61' name='head' filepath='src.d/deflate.c' line='555' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='554' column='1'/>
+      <parameter type-id='type-id-43' name='head' filepath='src.d/deflate.c' line='555' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflatePending' mangled-name='deflatePending' filepath='src.d/deflate.c' line='564' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflatePending@@ZLIB_1.2.5.1'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='567' column='1'/>
-      <parameter type-id='type-id-86' name='pending' filepath='src.d/deflate.c' line='565' column='1'/>
-      <parameter type-id='type-id-83' name='bits' filepath='src.d/deflate.c' line='566' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='567' column='1'/>
+      <parameter type-id='type-id-80' name='pending' filepath='src.d/deflate.c' line='565' column='1'/>
+      <parameter type-id='type-id-77' name='bits' filepath='src.d/deflate.c' line='566' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflatePrime' mangled-name='deflatePrime' filepath='src.d/deflate.c' line='578' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflatePrime@@ZLIB_1.2.0.8'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='579' column='1'/>
-      <parameter type-id='type-id-22' name='bits' filepath='src.d/deflate.c' line='580' column='1'/>
-      <parameter type-id='type-id-22' name='value' filepath='src.d/deflate.c' line='581' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='579' column='1'/>
+      <parameter type-id='type-id-20' name='bits' filepath='src.d/deflate.c' line='580' column='1'/>
+      <parameter type-id='type-id-20' name='value' filepath='src.d/deflate.c' line='581' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateParams' mangled-name='deflateParams' filepath='src.d/deflate.c' line='605' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateParams'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='606' column='1'/>
-      <parameter type-id='type-id-22' name='level' filepath='src.d/deflate.c' line='607' column='1'/>
-      <parameter type-id='type-id-22' name='strategy' filepath='src.d/deflate.c' line='608' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='606' column='1'/>
+      <parameter type-id='type-id-20' name='level' filepath='src.d/deflate.c' line='607' column='1'/>
+      <parameter type-id='type-id-20' name='strategy' filepath='src.d/deflate.c' line='608' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateTune' mangled-name='deflateTune' filepath='src.d/deflate.c' line='654' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateTune@@ZLIB_1.2.2.3'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='655' column='1'/>
-      <parameter type-id='type-id-22' name='good_length' filepath='src.d/deflate.c' line='656' column='1'/>
-      <parameter type-id='type-id-22' name='max_lazy' filepath='src.d/deflate.c' line='657' column='1'/>
-      <parameter type-id='type-id-22' name='nice_length' filepath='src.d/deflate.c' line='658' column='1'/>
-      <parameter type-id='type-id-22' name='max_chain' filepath='src.d/deflate.c' line='659' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='655' column='1'/>
+      <parameter type-id='type-id-20' name='good_length' filepath='src.d/deflate.c' line='656' column='1'/>
+      <parameter type-id='type-id-20' name='max_lazy' filepath='src.d/deflate.c' line='657' column='1'/>
+      <parameter type-id='type-id-20' name='nice_length' filepath='src.d/deflate.c' line='658' column='1'/>
+      <parameter type-id='type-id-20' name='max_chain' filepath='src.d/deflate.c' line='659' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateBound' mangled-name='deflateBound' filepath='src.d/deflate.c' line='696' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateBound@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='697' column='1'/>
-      <parameter type-id='type-id-10' name='sourceLen' filepath='src.d/deflate.c' line='698' column='1'/>
-      <return type-id='type-id-10'/>
-    </function-decl>
-    <function-decl name='deflate' mangled-name='deflate' filepath='src.d/deflate.c' line='815' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflate'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='816' column='1'/>
-      <parameter type-id='type-id-22' name='flush' filepath='src.d/deflate.c' line='817' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='deflateEnd' mangled-name='deflateEnd' filepath='src.d/deflate.c' line='1130' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateEnd'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='1131' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='697' column='1'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/deflate.c' line='698' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='deflateCopy' mangled-name='deflateCopy' filepath='src.d/deflate.c' line='1156' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateCopy'>
-      <parameter type-id='type-id-59' name='dest' filepath='src.d/deflate.c' line='1157' column='1'/>
-      <parameter type-id='type-id-59' name='source' filepath='src.d/deflate.c' line='1158' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='dest' filepath='src.d/deflate.c' line='1157' column='1'/>
+      <parameter type-id='type-id-21' name='source' filepath='src.d/deflate.c' line='1158' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
+    <typedef-decl name='static_tree_desc' type-id='type-id-84' filepath='src.d/deflate.h' line='84' column='1' id='type-id-82'/>
     <function-decl name='_tr_init' filepath='src.d/deflate.h' line='294' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-82'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-76'/>
+      <return type-id='type-id-86'/>
     </function-decl>
     <function-decl name='_tr_flush_block' filepath='src.d/deflate.h' line='296' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-82'/>
-      <parameter type-id='type-id-78'/>
-      <parameter type-id='type-id-60'/>
-      <parameter type-id='type-id-22'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-76'/>
+      <parameter type-id='type-id-74'/>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-86'/>
     </function-decl>
     <function-decl name='_tr_flush_bits' filepath='src.d/deflate.h' line='298' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-82'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-76'/>
+      <return type-id='type-id-86'/>
     </function-decl>
     <function-decl name='_tr_align' filepath='src.d/deflate.h' line='299' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-82'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-76'/>
+      <return type-id='type-id-86'/>
     </function-decl>
     <function-decl name='_tr_stored_block' filepath='src.d/deflate.h' line='300' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-82'/>
-      <parameter type-id='type-id-78'/>
-      <parameter type-id='type-id-60'/>
-      <parameter type-id='type-id-22'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-76'/>
+      <parameter type-id='type-id-74'/>
+      <parameter type-id='type-id-42'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-86'/>
+    </function-decl>
+    <function-decl name='crc32' filepath='src.d/zlib.h' line='1727' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-13'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-11'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='zcalloc' filepath='src.d/zutil.h' line='261' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-47'/>
-      <parameter type-id='type-id-4'/>
-      <parameter type-id='type-id-4'/>
-      <return type-id='type-id-47'/>
+      <parameter type-id='type-id-58'/>
+      <parameter type-id='type-id-9'/>
+      <parameter type-id='type-id-9'/>
+      <return type-id='type-id-58'/>
     </function-decl>
     <function-decl name='zcfree' filepath='src.d/zutil.h' line='263' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-47'/>
-      <parameter type-id='type-id-47'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-58'/>
+      <parameter type-id='type-id-58'/>
+      <return type-id='type-id-86'/>
     </function-decl>
-    <function-type size-in-bits='32' id='type-id-84'>
-      <parameter type-id='type-id-47'/>
-      <parameter type-id='type-id-9'/>
-      <parameter type-id='type-id-9'/>
-      <return type-id='type-id-47'/>
+    <type-decl name='void' id='type-id-86'/>
+    <pointer-type-def type-id='type-id-86' id='type-id-85'/>
+    <function-type size-in-bits='32' id='type-id-81'>
+      <parameter type-id='type-id-58'/>
+      <parameter type-id='type-id-58'/>
+      <return type-id='type-id-86'/>
     </function-type>
-    <function-type size-in-bits='32' id='type-id-87'>
-      <parameter type-id='type-id-47'/>
-      <parameter type-id='type-id-47'/>
-      <return type-id='type-id-44'/>
+    <function-type size-in-bits='32' id='type-id-78'>
+      <parameter type-id='type-id-58'/>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-11'/>
+      <return type-id='type-id-58'/>
     </function-type>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/gzclose.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <typedef-decl name='gzFile' type-id='type-id-88' filepath='src.d/zlib.h' line='1302' column='1' id='type-id-89'/>
-    <class-decl name='gzFile_s' size-in-bits='128' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='1834' column='1' id='type-id-90'>
+    <class-decl name='gzFile_s' size-in-bits='128' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='1834' column='1' id='type-id-87'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='have' type-id='type-id-4' visibility='default' filepath='src.d/zlib.h' line='1835' column='1'/>
+        <var-decl name='have' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='1835' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='next' type-id='type-id-91' visibility='default' filepath='src.d/zlib.h' line='1836' column='1'/>
+        <var-decl name='next' type-id='type-id-88' visibility='default' filepath='src.d/zlib.h' line='1836' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='pos' type-id='type-id-16' visibility='default' filepath='src.d/zlib.h' line='1837' column='1'/>
+        <var-decl name='pos' type-id='type-id-7' visibility='default' filepath='src.d/zlib.h' line='1837' column='1'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-90' size-in-bits='32' id='type-id-88'/>
+    <typedef-decl name='gzFile' type-id='type-id-89' filepath='src.d/zlib.h' line='1302' column='1' id='type-id-90'/>
+    <pointer-type-def type-id='type-id-87' size-in-bits='32' id='type-id-89'/>
     <function-decl name='gzclose' mangled-name='gzclose' filepath='src.d/gzclose.c' line='11' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzclose'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzclose.c' line='12' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzclose.c' line='12' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='gzclose_r' mangled-name='gzclose_r' filepath='src.d/zlib.h' line='1644' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzclose_r@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-89'/>
-      <return type-id='type-id-22'/>
+    <function-decl name='gzclose_r' filepath='src.d/zlib.h' line='1644' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-90'/>
+      <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='gzclose_w' mangled-name='gzclose_w' filepath='src.d/zlib.h' line='1645' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzclose_w@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-89'/>
-      <return type-id='type-id-22'/>
+    <function-decl name='gzclose_w' filepath='src.d/zlib.h' line='1645' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-90'/>
+      <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/gzlib.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <type-decl name='variadic parameter type' id='type-id-92'/>
-    <function-decl name='open' filepath='/usr/powerpc-linux-gnu/include/fcntl.h' line='181' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-80'/>
+    <function-decl name='snprintf' filepath='/usr/powerpc-linux-gnu/include/stdio.h' line='385' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-54'/>
+      <parameter type-id='type-id-10'/>
       <parameter type-id='type-id-22'/>
       <parameter is-variadic='yes'/>
-      <return type-id='type-id-22'/>
+      <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='snprintf' filepath='/usr/powerpc-linux-gnu/include/stdio.h' line='378' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-70'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-80'/>
-      <parameter is-variadic='yes'/>
-      <return type-id='type-id-22'/>
+    <function-decl name='malloc' filepath='/usr/powerpc-linux-gnu/include/stdlib.h' line='672' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-85'/>
+    </function-decl>
+    <function-decl name='free' filepath='/usr/powerpc-linux-gnu/include/stdlib.h' line='687' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-85'/>
+      <return type-id='type-id-86'/>
     </function-decl>
     <function-decl name='strlen' filepath='/usr/powerpc-linux-gnu/include/string.h' line='407' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-80'/>
-      <return type-id='type-id-6'/>
+      <parameter type-id='type-id-22'/>
+      <return type-id='type-id-10'/>
     </function-decl>
     <function-decl name='lseek64' filepath='/usr/powerpc-linux-gnu/include/unistd.h' line='350' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-22'/>
-      <parameter type-id='type-id-14'/>
-      <parameter type-id='type-id-22'/>
-      <return type-id='type-id-14'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-6'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-6'/>
     </function-decl>
     <function-decl name='gzopen' mangled-name='gzopen' filepath='src.d/gzlib.c' line='272' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzopen'>
-      <parameter type-id='type-id-80' name='path' filepath='src.d/gzlib.c' line='273' column='1'/>
-      <parameter type-id='type-id-80' name='mode' filepath='src.d/gzlib.c' line='274' column='1'/>
-      <return type-id='type-id-89'/>
+      <parameter type-id='type-id-22' name='path' filepath='src.d/gzlib.c' line='273' column='1'/>
+      <parameter type-id='type-id-22' name='mode' filepath='src.d/gzlib.c' line='274' column='1'/>
+      <return type-id='type-id-90'/>
     </function-decl>
     <function-decl name='gzopen64' mangled-name='gzopen64' filepath='src.d/gzlib.c' line='280' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzopen64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-80' name='path' filepath='src.d/gzlib.c' line='281' column='1'/>
-      <parameter type-id='type-id-80' name='mode' filepath='src.d/gzlib.c' line='282' column='1'/>
-      <return type-id='type-id-89'/>
+      <parameter type-id='type-id-22' name='path' filepath='src.d/gzlib.c' line='281' column='1'/>
+      <parameter type-id='type-id-22' name='mode' filepath='src.d/gzlib.c' line='282' column='1'/>
+      <return type-id='type-id-90'/>
     </function-decl>
     <function-decl name='gzdopen' mangled-name='gzdopen' filepath='src.d/gzlib.c' line='288' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzdopen'>
-      <parameter type-id='type-id-22' name='fd' filepath='src.d/gzlib.c' line='289' column='1'/>
-      <parameter type-id='type-id-80' name='mode' filepath='src.d/gzlib.c' line='290' column='1'/>
-      <return type-id='type-id-89'/>
+      <parameter type-id='type-id-20' name='fd' filepath='src.d/gzlib.c' line='289' column='1'/>
+      <parameter type-id='type-id-22' name='mode' filepath='src.d/gzlib.c' line='290' column='1'/>
+      <return type-id='type-id-90'/>
     </function-decl>
     <function-decl name='gzbuffer' mangled-name='gzbuffer' filepath='src.d/gzlib.c' line='318' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzbuffer@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='319' column='1'/>
-      <parameter type-id='type-id-4' name='size' filepath='src.d/gzlib.c' line='320' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='319' column='1'/>
+      <parameter type-id='type-id-9' name='size' filepath='src.d/gzlib.c' line='320' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzrewind' mangled-name='gzrewind' filepath='src.d/gzlib.c' line='345' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzrewind'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='346' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='346' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzseek64' mangled-name='gzseek64' filepath='src.d/gzlib.c' line='368' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzseek64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='369' column='1'/>
-      <parameter type-id='type-id-16' name='offset' filepath='src.d/gzlib.c' line='370' column='1'/>
-      <parameter type-id='type-id-22' name='whence' filepath='src.d/gzlib.c' line='371' column='1'/>
-      <return type-id='type-id-16'/>
-    </function-decl>
-    <function-decl name='gzseek' mangled-name='gzseek' filepath='src.d/gzlib.c' line='445' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzseek'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='446' column='1'/>
-      <parameter type-id='type-id-15' name='offset' filepath='src.d/gzlib.c' line='447' column='1'/>
-      <parameter type-id='type-id-22' name='whence' filepath='src.d/gzlib.c' line='448' column='1'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='gztell64' mangled-name='gztell64' filepath='src.d/gzlib.c' line='457' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gztell64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='458' column='1'/>
-      <return type-id='type-id-16'/>
-    </function-decl>
-    <function-decl name='gztell' mangled-name='gztell' filepath='src.d/gzlib.c' line='474' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gztell'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='475' column='1'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='gzoffset64' mangled-name='gzoffset64' filepath='src.d/gzlib.c' line='484' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzoffset64@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='485' column='1'/>
-      <return type-id='type-id-16'/>
-    </function-decl>
-    <function-decl name='gzoffset' mangled-name='gzoffset' filepath='src.d/gzlib.c' line='507' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzoffset@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='508' column='1'/>
-      <return type-id='type-id-15'/>
-    </function-decl>
-    <function-decl name='gzeof' mangled-name='gzeof' filepath='src.d/gzlib.c' line='517' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzeof'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='518' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='gzerror' mangled-name='gzerror' filepath='src.d/gzlib.c' line='534' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzerror'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='535' column='1'/>
-      <parameter type-id='type-id-83' name='errnum' filepath='src.d/gzlib.c' line='536' column='1'/>
-      <return type-id='type-id-80'/>
-    </function-decl>
-    <function-decl name='gzclearerr' mangled-name='gzclearerr' filepath='src.d/gzlib.c' line='555' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzclearerr@@ZLIB_1.2.0.2'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='556' column='1'/>
-      <return type-id='type-id-44'/>
-    </function-decl>
-  </abi-instr>
-  <abi-instr address-size='32' path='src.d/gzread.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <typedef-decl name='voidp' type-id='type-id-46' filepath='./zconf.h' line='416' column='1' id='type-id-93'/>
-    <typedef-decl name='__ssize_t' type-id='type-id-22' filepath='/usr/powerpc-linux-gnu/include/bits/types.h' line='194' column='1' id='type-id-94'/>
-    <typedef-decl name='ssize_t' type-id='type-id-94' filepath='/usr/powerpc-linux-gnu/include/sys/types.h' line='108' column='1' id='type-id-95'/>
-    <class-decl name='gz_state' size-in-bits='1344' is-struct='yes' naming-typedef-id='type-id-96' visibility='default' filepath='src.d/gzguts.h' line='170' column='1' id='type-id-97'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='x' type-id='type-id-90' visibility='default' filepath='src.d/gzguts.h' line='172' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='mode' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='177' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='fd' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='178' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='path' type-id='type-id-70' visibility='default' filepath='src.d/gzguts.h' line='179' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='size' type-id='type-id-4' visibility='default' filepath='src.d/gzguts.h' line='180' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='want' type-id='type-id-4' visibility='default' filepath='src.d/gzguts.h' line='181' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='in' type-id='type-id-91' visibility='default' filepath='src.d/gzguts.h' line='182' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='out' type-id='type-id-91' visibility='default' filepath='src.d/gzguts.h' line='183' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='direct' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='184' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='how' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='186' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='start' type-id='type-id-16' visibility='default' filepath='src.d/gzguts.h' line='187' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='eof' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='188' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='544'>
-        <var-decl name='past' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='189' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='level' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='191' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='608'>
-        <var-decl name='strategy' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='192' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='reset' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='193' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='skip' type-id='type-id-16' visibility='default' filepath='src.d/gzguts.h' line='195' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='seek' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='196' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='800'>
-        <var-decl name='err' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='198' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='msg' type-id='type-id-70' visibility='default' filepath='src.d/gzguts.h' line='199' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='864'>
-        <var-decl name='strm' type-id='type-id-72' visibility='default' filepath='src.d/gzguts.h' line='201' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='gz_state' type-id='type-id-97' filepath='src.d/gzguts.h' line='202' column='1' id='type-id-96'/>
-    <typedef-decl name='gz_statep' type-id='type-id-98' filepath='src.d/gzguts.h' line='203' column='1' id='type-id-99'/>
-    <pointer-type-def type-id='type-id-96' size-in-bits='32' id='type-id-98'/>
-    <function-decl name='__errno_location' filepath='/usr/powerpc-linux-gnu/include/errno.h' line='37' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <return type-id='type-id-83'/>
-    </function-decl>
-    <function-decl name='memchr' filepath='/usr/powerpc-linux-gnu/include/string.h' line='107' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-22'/>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-46'/>
-    </function-decl>
-    <function-decl name='strerror' filepath='/usr/powerpc-linux-gnu/include/string.h' line='419' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-22'/>
-      <return type-id='type-id-70'/>
-    </function-decl>
-    <function-decl name='close' filepath='/usr/powerpc-linux-gnu/include/unistd.h' line='358' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-22'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='read' filepath='/usr/powerpc-linux-gnu/include/unistd.h' line='371' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-22'/>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-95'/>
-    </function-decl>
-    <function-decl name='gz_error' filepath='src.d/gzguts.h' line='206' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-99'/>
-      <parameter type-id='type-id-22'/>
-      <parameter type-id='type-id-80'/>
-      <return type-id='type-id-44'/>
-    </function-decl>
-    <function-decl name='gzread' mangled-name='gzread' filepath='src.d/gzread.c' line='373' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzread'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='374' column='1'/>
-      <parameter type-id='type-id-93' name='buf' filepath='src.d/gzread.c' line='375' column='1'/>
-      <parameter type-id='type-id-4' name='len' filepath='src.d/gzread.c' line='376' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='gzfread' mangled-name='gzfread' filepath='src.d/gzread.c' line='409' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzfread@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-93' name='buf' filepath='src.d/gzread.c' line='410' column='1'/>
-      <parameter type-id='type-id-7' name='size' filepath='src.d/gzread.c' line='411' column='1'/>
-      <parameter type-id='type-id-7' name='nitems' filepath='src.d/gzread.c' line='412' column='1'/>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='413' column='1'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='369' column='1'/>
+      <parameter type-id='type-id-7' name='offset' filepath='src.d/gzlib.c' line='370' column='1'/>
+      <parameter type-id='type-id-20' name='whence' filepath='src.d/gzlib.c' line='371' column='1'/>
       <return type-id='type-id-7'/>
     </function-decl>
-    <function-decl name='gzgetc' mangled-name='gzgetc' filepath='src.d/gzread.c' line='445' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzgetc'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='446' column='1'/>
+    <function-decl name='gzseek' mangled-name='gzseek' filepath='src.d/gzlib.c' line='445' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzseek'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='446' column='1'/>
+      <parameter type-id='type-id-8' name='offset' filepath='src.d/gzlib.c' line='447' column='1'/>
+      <parameter type-id='type-id-20' name='whence' filepath='src.d/gzlib.c' line='448' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='gztell64' mangled-name='gztell64' filepath='src.d/gzlib.c' line='457' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gztell64@@ZLIB_1.2.3.3'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='458' column='1'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='gztell' mangled-name='gztell' filepath='src.d/gzlib.c' line='474' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gztell'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='475' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='gzoffset64' mangled-name='gzoffset64' filepath='src.d/gzlib.c' line='484' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzoffset64@@ZLIB_1.2.3.5'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='485' column='1'/>
+      <return type-id='type-id-7'/>
+    </function-decl>
+    <function-decl name='gzoffset' mangled-name='gzoffset' filepath='src.d/gzlib.c' line='507' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzoffset@@ZLIB_1.2.3.5'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='508' column='1'/>
+      <return type-id='type-id-8'/>
+    </function-decl>
+    <function-decl name='gzeof' mangled-name='gzeof' filepath='src.d/gzlib.c' line='517' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzeof'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='518' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzerror' mangled-name='gzerror' filepath='src.d/gzlib.c' line='534' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzerror'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='535' column='1'/>
+      <parameter type-id='type-id-77' name='errnum' filepath='src.d/gzlib.c' line='536' column='1'/>
       <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='gzclearerr' mangled-name='gzclearerr' filepath='src.d/gzlib.c' line='555' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzclearerr@@ZLIB_1.2.0.2'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzlib.c' line='556' column='1'/>
+      <return type-id='type-id-86'/>
+    </function-decl>
+    <type-decl name='variadic parameter type' id='type-id-91'/>
+  </abi-instr>
+  <abi-instr address-size='32' path='src.d/gzread.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
+    <class-decl name='gz_state' size-in-bits='1344' is-struct='yes' naming-typedef-id='type-id-92' visibility='default' filepath='src.d/gzguts.h' line='170' column='1' id='type-id-93'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='x' type-id='type-id-87' visibility='default' filepath='src.d/gzguts.h' line='172' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='mode' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='177' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='fd' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='178' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='path' type-id='type-id-54' visibility='default' filepath='src.d/gzguts.h' line='179' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='size' type-id='type-id-9' visibility='default' filepath='src.d/gzguts.h' line='180' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='want' type-id='type-id-9' visibility='default' filepath='src.d/gzguts.h' line='181' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='in' type-id='type-id-88' visibility='default' filepath='src.d/gzguts.h' line='182' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='out' type-id='type-id-88' visibility='default' filepath='src.d/gzguts.h' line='183' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='direct' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='184' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='how' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='186' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='start' type-id='type-id-7' visibility='default' filepath='src.d/gzguts.h' line='187' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='eof' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='188' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='544'>
+        <var-decl name='past' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='189' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='level' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='191' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='608'>
+        <var-decl name='strategy' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='192' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='reset' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='193' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='skip' type-id='type-id-7' visibility='default' filepath='src.d/gzguts.h' line='195' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='seek' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='196' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='800'>
+        <var-decl name='err' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='198' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='msg' type-id='type-id-54' visibility='default' filepath='src.d/gzguts.h' line='199' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='864'>
+        <var-decl name='strm' type-id='type-id-71' visibility='default' filepath='src.d/gzguts.h' line='201' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__ssize_t' type-id='type-id-20' filepath='/usr/powerpc-linux-gnu/include/bits/types.h' line='194' column='1' id='type-id-94'/>
+    <typedef-decl name='gz_state' type-id='type-id-93' filepath='src.d/gzguts.h' line='202' column='1' id='type-id-92'/>
+    <typedef-decl name='gz_statep' type-id='type-id-95' filepath='src.d/gzguts.h' line='203' column='1' id='type-id-96'/>
+    <typedef-decl name='ssize_t' type-id='type-id-94' filepath='/usr/powerpc-linux-gnu/include/sys/types.h' line='108' column='1' id='type-id-97'/>
+    <pointer-type-def type-id='type-id-92' size-in-bits='32' id='type-id-95'/>
+    <typedef-decl name='voidp' type-id='type-id-85' filepath='./zconf.h' line='416' column='1' id='type-id-98'/>
+    <function-decl name='__errno_location' filepath='/usr/powerpc-linux-gnu/include/errno.h' line='37' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <return type-id='type-id-77'/>
+    </function-decl>
+    <function-decl name='memchr' filepath='/usr/powerpc-linux-gnu/include/string.h' line='107' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-85'/>
+    </function-decl>
+    <function-decl name='strerror' filepath='/usr/powerpc-linux-gnu/include/string.h' line='419' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-54'/>
+    </function-decl>
+    <function-decl name='close' filepath='/usr/powerpc-linux-gnu/include/unistd.h' line='358' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='read' filepath='/usr/powerpc-linux-gnu/include/unistd.h' line='371' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-97'/>
+    </function-decl>
+    <function-decl name='gz_error' filepath='src.d/gzguts.h' line='206' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-96'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-22'/>
+      <return type-id='type-id-86'/>
+    </function-decl>
+    <function-decl name='gzread' mangled-name='gzread' filepath='src.d/gzread.c' line='373' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzread'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzread.c' line='374' column='1'/>
+      <parameter type-id='type-id-98' name='buf' filepath='src.d/gzread.c' line='375' column='1'/>
+      <parameter type-id='type-id-9' name='len' filepath='src.d/gzread.c' line='376' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='gzfread' mangled-name='gzfread' filepath='src.d/gzread.c' line='409' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzfread@@ZLIB_1.2.9'>
+      <parameter type-id='type-id-98' name='buf' filepath='src.d/gzread.c' line='410' column='1'/>
+      <parameter type-id='type-id-14' name='size' filepath='src.d/gzread.c' line='411' column='1'/>
+      <parameter type-id='type-id-14' name='nitems' filepath='src.d/gzread.c' line='412' column='1'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzread.c' line='413' column='1'/>
+      <return type-id='type-id-14'/>
+    </function-decl>
+    <function-decl name='gzgetc' mangled-name='gzgetc' filepath='src.d/gzread.c' line='445' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzgetc'>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzread.c' line='446' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzgetc_' mangled-name='gzgetc_' filepath='src.d/gzread.c' line='472' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzgetc_@@ZLIB_1.2.5.2'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='473' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzread.c' line='473' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzungetc' mangled-name='gzungetc' filepath='src.d/gzread.c' line='479' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzungetc@@ZLIB_1.2.0.2'>
-      <parameter type-id='type-id-22' name='c' filepath='src.d/gzread.c' line='480' column='1'/>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='481' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-20' name='c' filepath='src.d/gzread.c' line='480' column='1'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzread.c' line='481' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzgets' mangled-name='gzgets' filepath='src.d/gzread.c' line='539' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzgets'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='540' column='1'/>
-      <parameter type-id='type-id-70' name='buf' filepath='src.d/gzread.c' line='541' column='1'/>
-      <parameter type-id='type-id-22' name='len' filepath='src.d/gzread.c' line='542' column='1'/>
-      <return type-id='type-id-70'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzread.c' line='540' column='1'/>
+      <parameter type-id='type-id-54' name='buf' filepath='src.d/gzread.c' line='541' column='1'/>
+      <parameter type-id='type-id-20' name='len' filepath='src.d/gzread.c' line='542' column='1'/>
+      <return type-id='type-id-54'/>
     </function-decl>
     <function-decl name='gzdirect' mangled-name='gzdirect' filepath='src.d/gzread.c' line='603' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzdirect@@ZLIB_1.2.2.3'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='604' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzread.c' line='604' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflate' filepath='src.d/zlib.h' line='400' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateEnd' filepath='src.d/zlib.h' line='520' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-21'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateReset' filepath='src.d/zlib.h' line='959' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-21'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateInit2_' filepath='src.d/zlib.h' line='1789' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/gzwrite.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <class-decl name='__va_list_tag' size-in-bits='96' is-struct='yes' visibility='default' id='type-id-100'>
+    <class-decl name='__va_list_tag' size-in-bits='96' is-struct='yes' visibility='default' id='type-id-99'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='gpr' type-id='type-id-3' visibility='default'/>
+        <var-decl name='gpr' type-id='type-id-2' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='8'>
-        <var-decl name='fpr' type-id='type-id-3' visibility='default'/>
+        <var-decl name='fpr' type-id='type-id-2' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='16'>
-        <var-decl name='reserved' type-id='type-id-40' visibility='default'/>
+        <var-decl name='reserved' type-id='type-id-70' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='overflow_arg_area' type-id='type-id-46' visibility='default'/>
+        <var-decl name='overflow_arg_area' type-id='type-id-85' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='reg_save_area' type-id='type-id-46' visibility='default'/>
+        <var-decl name='reg_save_area' type-id='type-id-85' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='voidpc' type-id='type-id-46' filepath='./zconf.h' line='414' column='1' id='type-id-101'/>
-    <pointer-type-def type-id='type-id-100' size-in-bits='32' id='type-id-102'/>
-    <function-decl name='vsnprintf' filepath='/usr/powerpc-linux-gnu/include/stdio.h' line='382' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-70'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-80'/>
-      <parameter type-id='type-id-102'/>
-      <return type-id='type-id-22'/>
+    <pointer-type-def type-id='type-id-99' size-in-bits='32' id='type-id-100'/>
+    <typedef-decl name='voidpc' type-id='type-id-85' filepath='./zconf.h' line='414' column='1' id='type-id-101'/>
+    <function-decl name='vsnprintf' filepath='/usr/powerpc-linux-gnu/include/stdio.h' line='389' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-54'/>
+      <parameter type-id='type-id-10'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-100'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='memmove' filepath='/usr/powerpc-linux-gnu/include/string.h' line='47' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-46'/>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-85'/>
     </function-decl>
     <function-decl name='write' filepath='/usr/powerpc-linux-gnu/include/unistd.h' line='378' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-22'/>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-95'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-97'/>
     </function-decl>
     <function-decl name='gzwrite' mangled-name='gzwrite' filepath='src.d/gzwrite.c' line='255' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzwrite'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='256' column='1'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzwrite.c' line='256' column='1'/>
       <parameter type-id='type-id-101' name='buf' filepath='src.d/gzwrite.c' line='257' column='1'/>
-      <parameter type-id='type-id-4' name='len' filepath='src.d/gzwrite.c' line='258' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-9' name='len' filepath='src.d/gzwrite.c' line='258' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzfwrite' mangled-name='gzfwrite' filepath='src.d/gzwrite.c' line='283' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzfwrite@@ZLIB_1.2.9'>
       <parameter type-id='type-id-101' name='buf' filepath='src.d/gzwrite.c' line='284' column='1'/>
-      <parameter type-id='type-id-7' name='size' filepath='src.d/gzwrite.c' line='285' column='1'/>
-      <parameter type-id='type-id-7' name='nitems' filepath='src.d/gzwrite.c' line='286' column='1'/>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='287' column='1'/>
-      <return type-id='type-id-7'/>
+      <parameter type-id='type-id-14' name='size' filepath='src.d/gzwrite.c' line='285' column='1'/>
+      <parameter type-id='type-id-14' name='nitems' filepath='src.d/gzwrite.c' line='286' column='1'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzwrite.c' line='287' column='1'/>
+      <return type-id='type-id-14'/>
     </function-decl>
     <function-decl name='gzputc' mangled-name='gzputc' filepath='src.d/gzwrite.c' line='313' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzputc'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='314' column='1'/>
-      <parameter type-id='type-id-22' name='c' filepath='src.d/gzwrite.c' line='315' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzwrite.c' line='314' column='1'/>
+      <parameter type-id='type-id-20' name='c' filepath='src.d/gzwrite.c' line='315' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzputs' mangled-name='gzputs' filepath='src.d/gzwrite.c' line='361' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzputs'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='362' column='1'/>
-      <parameter type-id='type-id-80' name='s' filepath='src.d/gzwrite.c' line='363' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzwrite.c' line='362' column='1'/>
+      <parameter type-id='type-id-22' name='s' filepath='src.d/gzwrite.c' line='363' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzvprintf' mangled-name='gzvprintf' filepath='src.d/gzwrite.c' line='391' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzvprintf@@ZLIB_1.2.7.1'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='391' column='1'/>
-      <parameter type-id='type-id-80' name='format' filepath='src.d/gzwrite.c' line='391' column='1'/>
-      <parameter type-id='type-id-102' name='va' filepath='src.d/gzwrite.c' line='391' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzwrite.c' line='391' column='1'/>
+      <parameter type-id='type-id-22' name='format' filepath='src.d/gzwrite.c' line='391' column='1'/>
+      <parameter type-id='type-id-100' name='va' filepath='src.d/gzwrite.c' line='391' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzprintf' mangled-name='gzprintf' filepath='src.d/gzwrite.c' line='463' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzprintf'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='463' column='1'/>
-      <parameter type-id='type-id-80' name='format' filepath='src.d/gzwrite.c' line='463' column='1'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzwrite.c' line='463' column='1'/>
+      <parameter type-id='type-id-22' name='format' filepath='src.d/gzwrite.c' line='463' column='1'/>
       <parameter is-variadic='yes'/>
-      <return type-id='type-id-22'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzflush' mangled-name='gzflush' filepath='src.d/gzwrite.c' line='565' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzflush'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='566' column='1'/>
-      <parameter type-id='type-id-22' name='flush' filepath='src.d/gzwrite.c' line='567' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzwrite.c' line='566' column='1'/>
+      <parameter type-id='type-id-20' name='flush' filepath='src.d/gzwrite.c' line='567' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzsetparams' mangled-name='gzsetparams' filepath='src.d/gzwrite.c' line='597' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzsetparams'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='598' column='1'/>
-      <parameter type-id='type-id-22' name='level' filepath='src.d/gzwrite.c' line='599' column='1'/>
-      <parameter type-id='type-id-22' name='strategy' filepath='src.d/gzwrite.c' line='600' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-90' name='file' filepath='src.d/gzwrite.c' line='598' column='1'/>
+      <parameter type-id='type-id-20' name='level' filepath='src.d/gzwrite.c' line='599' column='1'/>
+      <parameter type-id='type-id-20' name='strategy' filepath='src.d/gzwrite.c' line='600' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/infback.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-103'/>
-    <class-decl name='code' size-in-bits='32' is-struct='yes' naming-typedef-id='type-id-104' visibility='default' filepath='src.d/inftrees.h' line='24' column='1' id='type-id-105'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='op' type-id='type-id-3' visibility='default' filepath='src.d/inftrees.h' line='25' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='8'>
-        <var-decl name='bits' type-id='type-id-3' visibility='default' filepath='src.d/inftrees.h' line='26' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='16'>
-        <var-decl name='val' type-id='type-id-40' visibility='default' filepath='src.d/inftrees.h' line='27' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='code' type-id='type-id-105' filepath='src.d/inftrees.h' line='28' column='1' id='type-id-104'/>
-    <enum-decl name='codetype' naming-typedef-id='type-id-106' filepath='src.d/inftrees.h' line='54' column='1' id='type-id-107'>
-      <underlying-type type-id='type-id-103'/>
+    <enum-decl name='codetype' naming-typedef-id='type-id-102' filepath='src.d/inftrees.h' line='54' column='1' id='type-id-103'>
+      <underlying-type type-id='type-id-104'/>
       <enumerator name='CODES' value='0'/>
       <enumerator name='LENS' value='1'/>
       <enumerator name='DISTS' value='2'/>
     </enum-decl>
-    <typedef-decl name='codetype' type-id='type-id-107' filepath='src.d/inftrees.h' line='58' column='1' id='type-id-106'/>
-    <typedef-decl name='in_func' type-id='type-id-108' filepath='src.d/zlib.h' line='1094' column='1' id='type-id-109'/>
-    <typedef-decl name='out_func' type-id='type-id-110' filepath='src.d/zlib.h' line='1096' column='1' id='type-id-111'/>
-    <pointer-type-def type-id='type-id-104' size-in-bits='32' id='type-id-112'/>
-    <pointer-type-def type-id='type-id-112' size-in-bits='32' id='type-id-113'/>
-    <pointer-type-def type-id='type-id-114' size-in-bits='32' id='type-id-110'/>
-    <pointer-type-def type-id='type-id-3' size-in-bits='32' id='type-id-91'/>
-    <pointer-type-def type-id='type-id-91' size-in-bits='32' id='type-id-115'/>
-    <pointer-type-def type-id='type-id-116' size-in-bits='32' id='type-id-108'/>
-    <pointer-type-def type-id='type-id-40' size-in-bits='32' id='type-id-117'/>
+    <class-decl name='code' size-in-bits='32' is-struct='yes' naming-typedef-id='type-id-105' visibility='default' filepath='src.d/inftrees.h' line='24' column='1' id='type-id-106'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='op' type-id='type-id-2' visibility='default' filepath='src.d/inftrees.h' line='25' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8'>
+        <var-decl name='bits' type-id='type-id-2' visibility='default' filepath='src.d/inftrees.h' line='26' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='val' type-id='type-id-70' visibility='default' filepath='src.d/inftrees.h' line='27' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='code' type-id='type-id-106' filepath='src.d/inftrees.h' line='28' column='1' id='type-id-105'/>
+    <typedef-decl name='codetype' type-id='type-id-103' filepath='src.d/inftrees.h' line='58' column='1' id='type-id-102'/>
+    <typedef-decl name='in_func' type-id='type-id-107' filepath='src.d/zlib.h' line='1094' column='1' id='type-id-108'/>
+    <typedef-decl name='out_func' type-id='type-id-109' filepath='src.d/zlib.h' line='1096' column='1' id='type-id-110'/>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-104'/>
+    <pointer-type-def type-id='type-id-105' size-in-bits='32' id='type-id-111'/>
+    <pointer-type-def type-id='type-id-111' size-in-bits='32' id='type-id-112'/>
+    <pointer-type-def type-id='type-id-113' size-in-bits='32' id='type-id-109'/>
+    <pointer-type-def type-id='type-id-2' size-in-bits='32' id='type-id-88'/>
+    <pointer-type-def type-id='type-id-88' size-in-bits='32' id='type-id-114'/>
+    <pointer-type-def type-id='type-id-115' size-in-bits='32' id='type-id-107'/>
+    <pointer-type-def type-id='type-id-70' size-in-bits='32' id='type-id-116'/>
+    <typedef-decl name='voidpf' type-id='type-id-85' filepath='./zconf.h' line='415' column='1' id='type-id-117'/>
     <function-decl name='inflateBackInit_' mangled-name='inflateBackInit_' filepath='src.d/infback.c' line='28' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateBackInit_@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/infback.c' line='29' column='1'/>
-      <parameter type-id='type-id-22' name='windowBits' filepath='src.d/infback.c' line='30' column='1'/>
-      <parameter type-id='type-id-91' name='window' filepath='src.d/infback.c' line='31' column='1'/>
-      <parameter type-id='type-id-80' name='version' filepath='src.d/infback.c' line='32' column='1'/>
-      <parameter type-id='type-id-22' name='stream_size' filepath='src.d/infback.c' line='33' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/infback.c' line='29' column='1'/>
+      <parameter type-id='type-id-20' name='windowBits' filepath='src.d/infback.c' line='30' column='1'/>
+      <parameter type-id='type-id-88' name='window' filepath='src.d/infback.c' line='31' column='1'/>
+      <parameter type-id='type-id-22' name='version' filepath='src.d/infback.c' line='32' column='1'/>
+      <parameter type-id='type-id-20' name='stream_size' filepath='src.d/infback.c' line='33' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateBack' mangled-name='inflateBack' filepath='src.d/infback.c' line='251' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateBack@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/infback.c' line='252' column='1'/>
-      <parameter type-id='type-id-109' name='in' filepath='src.d/infback.c' line='253' column='1'/>
-      <parameter type-id='type-id-46' name='in_desc' filepath='src.d/infback.c' line='254' column='1'/>
-      <parameter type-id='type-id-111' name='out' filepath='src.d/infback.c' line='255' column='1'/>
-      <parameter type-id='type-id-46' name='out_desc' filepath='src.d/infback.c' line='256' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/infback.c' line='252' column='1'/>
+      <parameter type-id='type-id-108' name='in' filepath='src.d/infback.c' line='253' column='1'/>
+      <parameter type-id='type-id-85' name='in_desc' filepath='src.d/infback.c' line='254' column='1'/>
+      <parameter type-id='type-id-110' name='out' filepath='src.d/infback.c' line='255' column='1'/>
+      <parameter type-id='type-id-85' name='out_desc' filepath='src.d/infback.c' line='256' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateBackEnd' mangled-name='inflateBackEnd' filepath='src.d/infback.c' line='635' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateBackEnd@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/infback.c' line='636' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/infback.c' line='636' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflate_fast' filepath='src.d/inffast.h' line='11' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-59'/>
-      <parameter type-id='type-id-4'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-9'/>
+      <return type-id='type-id-86'/>
     </function-decl>
     <function-decl name='inflate_table' filepath='src.d/inftrees.h' line='60' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-106'/>
-      <parameter type-id='type-id-117'/>
-      <parameter type-id='type-id-4'/>
-      <parameter type-id='type-id-113'/>
-      <parameter type-id='type-id-86'/>
-      <parameter type-id='type-id-117'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-102'/>
+      <parameter type-id='type-id-116'/>
+      <parameter type-id='type-id-9'/>
+      <parameter type-id='type-id-112'/>
+      <parameter type-id='type-id-80'/>
+      <parameter type-id='type-id-116'/>
+      <return type-id='type-id-20'/>
     </function-decl>
-    <function-type size-in-bits='32' id='type-id-114'>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-4'/>
-      <return type-id='type-id-22'/>
+    <function-type size-in-bits='32' id='type-id-113'>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-88'/>
+      <parameter type-id='type-id-9'/>
+      <return type-id='type-id-20'/>
     </function-type>
-    <function-type size-in-bits='32' id='type-id-116'>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-115'/>
-      <return type-id='type-id-4'/>
+    <function-type size-in-bits='32' id='type-id-115'>
+      <parameter type-id='type-id-85'/>
+      <parameter type-id='type-id-114'/>
+      <return type-id='type-id-9'/>
     </function-type>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/inflate.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
+    <typedef-decl name='voidpf' type-id='type-id-85' filepath='./zconf.h' line='415' column='1' id='type-id-118'/>
     <function-decl name='inflateResetKeep' mangled-name='inflateResetKeep' filepath='src.d/inflate.c' line='119' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateResetKeep@@ZLIB_1.2.5.2'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='120' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='inflateReset' mangled-name='inflateReset' filepath='src.d/inflate.c' line='145' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateReset'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='146' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='120' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateReset2' mangled-name='inflateReset2' filepath='src.d/inflate.c' line='158' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateReset2@@ZLIB_1.2.3.4'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='159' column='1'/>
-      <parameter type-id='type-id-22' name='windowBits' filepath='src.d/inflate.c' line='160' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='inflateInit2_' mangled-name='inflateInit2_' filepath='src.d/inflate.c' line='198' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateInit2_'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='199' column='1'/>
-      <parameter type-id='type-id-22' name='windowBits' filepath='src.d/inflate.c' line='200' column='1'/>
-      <parameter type-id='type-id-80' name='version' filepath='src.d/inflate.c' line='201' column='1'/>
-      <parameter type-id='type-id-22' name='stream_size' filepath='src.d/inflate.c' line='202' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='159' column='1'/>
+      <parameter type-id='type-id-20' name='windowBits' filepath='src.d/inflate.c' line='160' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateInit_' mangled-name='inflateInit_' filepath='src.d/inflate.c' line='242' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateInit_'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='243' column='1'/>
-      <parameter type-id='type-id-80' name='version' filepath='src.d/inflate.c' line='244' column='1'/>
-      <parameter type-id='type-id-22' name='stream_size' filepath='src.d/inflate.c' line='245' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='243' column='1'/>
+      <parameter type-id='type-id-22' name='version' filepath='src.d/inflate.c' line='244' column='1'/>
+      <parameter type-id='type-id-20' name='stream_size' filepath='src.d/inflate.c' line='245' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflatePrime' mangled-name='inflatePrime' filepath='src.d/inflate.c' line='250' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflatePrime@@ZLIB_1.2.2.4'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='251' column='1'/>
-      <parameter type-id='type-id-22' name='bits' filepath='src.d/inflate.c' line='252' column='1'/>
-      <parameter type-id='type-id-22' name='value' filepath='src.d/inflate.c' line='253' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='inflate' mangled-name='inflate' filepath='src.d/inflate.c' line='625' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflate'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='626' column='1'/>
-      <parameter type-id='type-id-22' name='flush' filepath='src.d/inflate.c' line='627' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='inflateEnd' mangled-name='inflateEnd' filepath='src.d/inflate.c' line='1304' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateEnd'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1305' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='251' column='1'/>
+      <parameter type-id='type-id-20' name='bits' filepath='src.d/inflate.c' line='252' column='1'/>
+      <parameter type-id='type-id-20' name='value' filepath='src.d/inflate.c' line='253' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateGetDictionary' mangled-name='inflateGetDictionary' filepath='src.d/inflate.c' line='1318' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateGetDictionary@@ZLIB_1.2.7.1'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1319' column='1'/>
-      <parameter type-id='type-id-21' name='dictionary' filepath='src.d/inflate.c' line='1320' column='1'/>
-      <parameter type-id='type-id-85' name='dictLength' filepath='src.d/inflate.c' line='1321' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1319' column='1'/>
+      <parameter type-id='type-id-19' name='dictionary' filepath='src.d/inflate.c' line='1320' column='1'/>
+      <parameter type-id='type-id-79' name='dictLength' filepath='src.d/inflate.c' line='1321' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateSetDictionary' mangled-name='inflateSetDictionary' filepath='src.d/inflate.c' line='1341' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateSetDictionary'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1342' column='1'/>
-      <parameter type-id='type-id-18' name='dictionary' filepath='src.d/inflate.c' line='1343' column='1'/>
-      <parameter type-id='type-id-9' name='dictLength' filepath='src.d/inflate.c' line='1344' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1342' column='1'/>
+      <parameter type-id='type-id-16' name='dictionary' filepath='src.d/inflate.c' line='1343' column='1'/>
+      <parameter type-id='type-id-11' name='dictLength' filepath='src.d/inflate.c' line='1344' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateGetHeader' mangled-name='inflateGetHeader' filepath='src.d/inflate.c' line='1376' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateGetHeader@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1377' column='1'/>
-      <parameter type-id='type-id-61' name='head' filepath='src.d/inflate.c' line='1378' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1377' column='1'/>
+      <parameter type-id='type-id-43' name='head' filepath='src.d/inflate.c' line='1378' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateSync' mangled-name='inflateSync' filepath='src.d/inflate.c' line='1427' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateSync'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1428' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1428' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateSyncPoint' mangled-name='inflateSyncPoint' filepath='src.d/inflate.c' line='1485' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateSyncPoint'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1486' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1486' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateCopy' mangled-name='inflateCopy' filepath='src.d/inflate.c' line='1495' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateCopy@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-59' name='dest' filepath='src.d/inflate.c' line='1496' column='1'/>
-      <parameter type-id='type-id-59' name='source' filepath='src.d/inflate.c' line='1497' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='dest' filepath='src.d/inflate.c' line='1496' column='1'/>
+      <parameter type-id='type-id-21' name='source' filepath='src.d/inflate.c' line='1497' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateUndermine' mangled-name='inflateUndermine' filepath='src.d/inflate.c' line='1542' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateUndermine@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1543' column='1'/>
-      <parameter type-id='type-id-22' name='subvert' filepath='src.d/inflate.c' line='1544' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1543' column='1'/>
+      <parameter type-id='type-id-20' name='subvert' filepath='src.d/inflate.c' line='1544' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateValidate' mangled-name='inflateValidate' filepath='src.d/inflate.c' line='1560' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateValidate@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1561' column='1'/>
-      <parameter type-id='type-id-22' name='check' filepath='src.d/inflate.c' line='1562' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1561' column='1'/>
+      <parameter type-id='type-id-20' name='check' filepath='src.d/inflate.c' line='1562' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateMark' mangled-name='inflateMark' filepath='src.d/inflate.c' line='1575' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateMark@@ZLIB_1.2.3.4'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1576' column='1'/>
-      <return type-id='type-id-1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1576' column='1'/>
+      <return type-id='type-id-37'/>
     </function-decl>
     <function-decl name='inflateCodesUsed' mangled-name='inflateCodesUsed' filepath='src.d/inflate.c' line='1588' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateCodesUsed@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1589' column='1'/>
-      <return type-id='type-id-5'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1589' column='1'/>
+      <return type-id='type-id-12'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/trees.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <array-type-def dimensions='1' type-id='type-id-118' size-in-bits='2048' id='type-id-119'>
-      <subrange length='256' type-id='type-id-4' id='type-id-120'/>
+    <array-type-def dimensions='1' type-id='type-id-119' size-in-bits='2048' id='type-id-120'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-9' id='type-id-121'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-118' size-in-bits='4096' id='type-id-121'>
-      <subrange length='512' type-id='type-id-4' id='type-id-122'/>
+    <array-type-def dimensions='1' type-id='type-id-119' size-in-bits='4096' id='type-id-122'>
+      <subrange length='512' lower-bound='0' upper-bound='511' type-id='type-id-9' id='type-id-123'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-118' size-in-bits='infinite' id='type-id-123'>
-      <subrange length='infinite' id='type-id-124'/>
+    <array-type-def dimensions='1' type-id='type-id-119' size-in-bits='unknown' id='type-id-124'>
+      <subrange length='unknown' lower-bound='0' upper-bound='0' id='type-id-125'/>
     </array-type-def>
-    <qualified-type-def type-id='type-id-38' const='yes' id='type-id-118'/>
-    <var-decl name='_length_code' type-id='type-id-123' visibility='default' filepath='src.d/deflate.h' line='317' column='1'/>
-    <var-decl name='_dist_code' type-id='type-id-123' visibility='default' filepath='src.d/deflate.h' line='318' column='1'/>
+    <qualified-type-def type-id='type-id-68' const='yes' id='type-id-119'/>
+    <var-decl name='_length_code' type-id='type-id-120' visibility='default' filepath='src.d/deflate.h' line='317' column='1'/>
+    <var-decl name='_dist_code' type-id='type-id-122' visibility='default' filepath='src.d/deflate.h' line='318' column='1'/>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/uncompr.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <pointer-type-def type-id='type-id-10' size-in-bits='32' id='type-id-125'/>
+    <pointer-type-def type-id='type-id-13' size-in-bits='32' id='type-id-126'/>
     <function-decl name='uncompress2' mangled-name='uncompress2' filepath='src.d/uncompr.c' line='27' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='uncompress2@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-21' name='dest' filepath='src.d/uncompr.c' line='28' column='1'/>
-      <parameter type-id='type-id-20' name='destLen' filepath='src.d/uncompr.c' line='29' column='1'/>
-      <parameter type-id='type-id-18' name='source' filepath='src.d/uncompr.c' line='30' column='1'/>
-      <parameter type-id='type-id-125' name='sourceLen' filepath='src.d/uncompr.c' line='31' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-19' name='dest' filepath='src.d/uncompr.c' line='28' column='1'/>
+      <parameter type-id='type-id-18' name='destLen' filepath='src.d/uncompr.c' line='29' column='1'/>
+      <parameter type-id='type-id-16' name='source' filepath='src.d/uncompr.c' line='30' column='1'/>
+      <parameter type-id='type-id-126' name='sourceLen' filepath='src.d/uncompr.c' line='31' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='uncompress' mangled-name='uncompress' filepath='src.d/uncompr.c' line='86' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='uncompress'>
-      <parameter type-id='type-id-21' name='dest' filepath='src.d/uncompr.c' line='87' column='1'/>
-      <parameter type-id='type-id-20' name='destLen' filepath='src.d/uncompr.c' line='88' column='1'/>
-      <parameter type-id='type-id-18' name='source' filepath='src.d/uncompr.c' line='89' column='1'/>
-      <parameter type-id='type-id-10' name='sourceLen' filepath='src.d/uncompr.c' line='90' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-19' name='dest' filepath='src.d/uncompr.c' line='87' column='1'/>
+      <parameter type-id='type-id-18' name='destLen' filepath='src.d/uncompr.c' line='88' column='1'/>
+      <parameter type-id='type-id-16' name='source' filepath='src.d/uncompr.c' line='89' column='1'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/uncompr.c' line='90' column='1'/>
+      <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/zutil.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <array-type-def dimensions='1' type-id='type-id-126' size-in-bits='320' id='type-id-127'>
-      <subrange length='10' type-id='type-id-4' id='type-id-128'/>
+    <array-type-def dimensions='1' type-id='type-id-127' size-in-bits='320' id='type-id-128'>
+      <subrange length='10' lower-bound='0' upper-bound='9' type-id='type-id-9' id='type-id-129'/>
     </array-type-def>
-    <qualified-type-def type-id='type-id-70' const='yes' id='type-id-126'/>
-    <function-decl name='malloc' filepath='/usr/powerpc-linux-gnu/include/stdlib.h' line='540' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-46'/>
-    </function-decl>
-    <function-decl name='free' filepath='/usr/powerpc-linux-gnu/include/stdlib.h' line='555' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-46'/>
-      <return type-id='type-id-44'/>
-    </function-decl>
+    <qualified-type-def type-id='type-id-54' const='yes' id='type-id-127'/>
     <function-decl name='zlibVersion' mangled-name='zlibVersion' filepath='src.d/zutil.c' line='27' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='zlibVersion'>
-      <return type-id='type-id-80'/>
+      <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='zlibCompileFlags' mangled-name='zlibCompileFlags' filepath='src.d/zutil.c' line='32' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='zlibCompileFlags@@ZLIB_1.2.0.2'>
-      <return type-id='type-id-10'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='zError' mangled-name='zError' filepath='src.d/zutil.c' line='135' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='zError'>
-      <parameter type-id='type-id-22' name='err' filepath='src.d/zutil.c' line='136' column='1'/>
-      <return type-id='type-id-80'/>
+      <parameter type-id='type-id-20' name='err' filepath='src.d/zutil.c' line='136' column='1'/>
+      <return type-id='type-id-22'/>
     </function-decl>
-    <var-decl name='z_errmsg' type-id='type-id-127' visibility='default' filepath='src.d/zutil.h' line='56' column='1'/>
+    <var-decl name='z_errmsg' type-id='type-id-128' visibility='default' filepath='src.d/zutil.h' line='56' column='1'/>
   </abi-instr>
 </abi-corpus>

--- a/test/abi/zlib-04f42ceca40f73e2978b50e93806c2a18c1281fc-powerpc64-unknown-linux-gnu.abi
+++ b/test/abi/zlib-04f42ceca40f73e2978b50e93806c2a18c1281fc-powerpc64-unknown-linux-gnu.abi
@@ -1,4 +1,4 @@
-<abi-corpus version='2.0' path='btmp1/libz.so.1.2.13' architecture='elf-powerpc-64' soname='libz.so.1'>
+<abi-corpus version='2.2' path='btmp1/libz.so.1.2.13' architecture='elf-powerpc-64' soname='libz.so.1'>
   <elf-needed>
     <dependency name='libc.so.6'/>
   </elf-needed>
@@ -94,54 +94,54 @@
   </elf-function-symbols>
   <abi-instr address-size='64' path='src.d/adler32.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
     <type-decl name='long int' size-in-bits='64' id='type-id-1'/>
+    <typedef-decl name='Byte' type-id='type-id-2' filepath='./zconf.h' line='397' column='1' id='type-id-3'/>
+    <typedef-decl name='Bytef' type-id='type-id-3' filepath='./zconf.h' line='406' column='1' id='type-id-4'/>
+    <typedef-decl name='__off64_t' type-id='type-id-1' filepath='/usr/powerpc64-linux-gnu/include/bits/types.h' line='153' column='1' id='type-id-5'/>
+    <typedef-decl name='__off_t' type-id='type-id-1' filepath='/usr/powerpc64-linux-gnu/include/bits/types.h' line='152' column='1' id='type-id-6'/>
+    <typedef-decl name='off64_t' type-id='type-id-5' filepath='/usr/powerpc64-linux-gnu/include/sys/types.h' line='92' column='1' id='type-id-7'/>
+    <typedef-decl name='off_t' type-id='type-id-6' filepath='/usr/powerpc64-linux-gnu/include/sys/types.h' line='85' column='1' id='type-id-8'/>
+    <typedef-decl name='size_t' type-id='type-id-9' filepath='/usr/lib/gcc-cross/powerpc64-linux-gnu/13/include/stddef.h' line='214' column='1' id='type-id-10'/>
+    <typedef-decl name='uInt' type-id='type-id-11' filepath='./zconf.h' line='399' column='1' id='type-id-12'/>
+    <typedef-decl name='uLong' type-id='type-id-9' filepath='./zconf.h' line='400' column='1' id='type-id-13'/>
+    <typedef-decl name='z_size_t' type-id='type-id-10' filepath='./zconf.h' line='251' column='1' id='type-id-14'/>
     <type-decl name='unsigned char' size-in-bits='8' id='type-id-2'/>
-    <type-decl name='unsigned int' size-in-bits='32' id='type-id-3'/>
-    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-4'/>
-    <typedef-decl name='z_size_t' type-id='type-id-5' filepath='./zconf.h' line='251' column='1' id='type-id-6'/>
-    <typedef-decl name='Byte' type-id='type-id-2' filepath='./zconf.h' line='397' column='1' id='type-id-7'/>
-    <typedef-decl name='uInt' type-id='type-id-3' filepath='./zconf.h' line='399' column='1' id='type-id-8'/>
-    <typedef-decl name='uLong' type-id='type-id-4' filepath='./zconf.h' line='400' column='1' id='type-id-9'/>
-    <typedef-decl name='Bytef' type-id='type-id-7' filepath='./zconf.h' line='406' column='1' id='type-id-10'/>
-    <typedef-decl name='size_t' type-id='type-id-4' filepath='/usr/lib/gcc-cross/powerpc64-linux-gnu/11/include/stddef.h' line='209' column='1' id='type-id-5'/>
-    <typedef-decl name='__off_t' type-id='type-id-1' filepath='/usr/powerpc64-linux-gnu/include/bits/types.h' line='152' column='1' id='type-id-11'/>
-    <typedef-decl name='__off64_t' type-id='type-id-1' filepath='/usr/powerpc64-linux-gnu/include/bits/types.h' line='153' column='1' id='type-id-12'/>
-    <typedef-decl name='off_t' type-id='type-id-11' filepath='/usr/powerpc64-linux-gnu/include/sys/types.h' line='85' column='1' id='type-id-13'/>
-    <typedef-decl name='off64_t' type-id='type-id-12' filepath='/usr/powerpc64-linux-gnu/include/sys/types.h' line='92' column='1' id='type-id-14'/>
-    <qualified-type-def type-id='type-id-10' const='yes' id='type-id-15'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-11'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-9'/>
+    <qualified-type-def type-id='type-id-4' const='yes' id='type-id-15'/>
     <pointer-type-def type-id='type-id-15' size-in-bits='64' id='type-id-16'/>
     <function-decl name='adler32_z' mangled-name='adler32_z' filepath='src.d/adler32.c' line='63' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='adler32_z@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-9' name='adler' filepath='src.d/adler32.c' line='64' column='1'/>
+      <parameter type-id='type-id-13' name='adler' filepath='src.d/adler32.c' line='64' column='1'/>
       <parameter type-id='type-id-16' name='buf' filepath='src.d/adler32.c' line='65' column='1'/>
-      <parameter type-id='type-id-6' name='len' filepath='src.d/adler32.c' line='66' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-14' name='len' filepath='src.d/adler32.c' line='66' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='adler32' mangled-name='adler32' filepath='src.d/adler32.c' line='134' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='adler32'>
-      <parameter type-id='type-id-9' name='adler' filepath='src.d/adler32.c' line='135' column='1'/>
+      <parameter type-id='type-id-13' name='adler' filepath='src.d/adler32.c' line='135' column='1'/>
       <parameter type-id='type-id-16' name='buf' filepath='src.d/adler32.c' line='136' column='1'/>
-      <parameter type-id='type-id-8' name='len' filepath='src.d/adler32.c' line='137' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-12' name='len' filepath='src.d/adler32.c' line='137' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='adler32_combine' mangled-name='adler32_combine' filepath='src.d/adler32.c' line='172' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='adler32_combine@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-9' name='adler1' filepath='src.d/adler32.c' line='173' column='1'/>
-      <parameter type-id='type-id-9' name='adler2' filepath='src.d/adler32.c' line='174' column='1'/>
-      <parameter type-id='type-id-13' name='len2' filepath='src.d/adler32.c' line='175' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-13' name='adler1' filepath='src.d/adler32.c' line='173' column='1'/>
+      <parameter type-id='type-id-13' name='adler2' filepath='src.d/adler32.c' line='174' column='1'/>
+      <parameter type-id='type-id-8' name='len2' filepath='src.d/adler32.c' line='175' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='adler32_combine64' mangled-name='adler32_combine64' filepath='src.d/adler32.c' line='180' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='adler32_combine64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-9' name='adler1' filepath='src.d/adler32.c' line='181' column='1'/>
-      <parameter type-id='type-id-9' name='adler2' filepath='src.d/adler32.c' line='182' column='1'/>
-      <parameter type-id='type-id-14' name='len2' filepath='src.d/adler32.c' line='183' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-13' name='adler1' filepath='src.d/adler32.c' line='181' column='1'/>
+      <parameter type-id='type-id-13' name='adler2' filepath='src.d/adler32.c' line='182' column='1'/>
+      <parameter type-id='type-id-7' name='len2' filepath='src.d/adler32.c' line='183' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/compress.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <typedef-decl name='uLongf' type-id='type-id-9' filepath='./zconf.h' line='411' column='1' id='type-id-17'/>
+    <typedef-decl name='uLongf' type-id='type-id-13' filepath='./zconf.h' line='411' column='1' id='type-id-17'/>
     <pointer-type-def type-id='type-id-17' size-in-bits='64' id='type-id-18'/>
     <function-decl name='compress2' mangled-name='compress2' filepath='src.d/compress.c' line='22' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='compress2'>
       <parameter type-id='type-id-19' name='dest' filepath='src.d/compress.c' line='23' column='1'/>
       <parameter type-id='type-id-18' name='destLen' filepath='src.d/compress.c' line='24' column='1'/>
       <parameter type-id='type-id-16' name='source' filepath='src.d/compress.c' line='25' column='1'/>
-      <parameter type-id='type-id-9' name='sourceLen' filepath='src.d/compress.c' line='26' column='1'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/compress.c' line='26' column='1'/>
       <parameter type-id='type-id-20' name='level' filepath='src.d/compress.c' line='27' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
@@ -149,362 +149,107 @@
       <parameter type-id='type-id-19' name='dest' filepath='src.d/compress.c' line='69' column='1'/>
       <parameter type-id='type-id-18' name='destLen' filepath='src.d/compress.c' line='70' column='1'/>
       <parameter type-id='type-id-16' name='source' filepath='src.d/compress.c' line='71' column='1'/>
-      <parameter type-id='type-id-9' name='sourceLen' filepath='src.d/compress.c' line='72' column='1'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/compress.c' line='72' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='compressBound' mangled-name='compressBound' filepath='src.d/compress.c' line='81' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='compressBound@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-9' name='sourceLen' filepath='src.d/compress.c' line='82' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/compress.c' line='82' column='1'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+    <function-decl name='deflate' filepath='src.d/zlib.h' line='250' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='deflateEnd' filepath='src.d/zlib.h' line='363' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-21'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='deflateInit_' filepath='src.d/zlib.h' line='1781' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/crc32.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <typedef-decl name='z_crc_t' type-id='type-id-3' filepath='./zconf.h' line='435' column='1' id='type-id-21'/>
-    <qualified-type-def type-id='type-id-2' const='yes' id='type-id-22'/>
-    <pointer-type-def type-id='type-id-22' size-in-bits='64' id='type-id-23'/>
-    <qualified-type-def type-id='type-id-21' const='yes' id='type-id-24'/>
+    <typedef-decl name='z_crc_t' type-id='type-id-11' filepath='./zconf.h' line='435' column='1' id='type-id-23'/>
+    <qualified-type-def type-id='type-id-2' const='yes' id='type-id-24'/>
     <pointer-type-def type-id='type-id-24' size-in-bits='64' id='type-id-25'/>
+    <qualified-type-def type-id='type-id-23' const='yes' id='type-id-26'/>
+    <pointer-type-def type-id='type-id-26' size-in-bits='64' id='type-id-27'/>
     <function-decl name='get_crc_table' mangled-name='get_crc_table' filepath='src.d/crc32.c' line='595' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='get_crc_table'>
-      <return type-id='type-id-25'/>
+      <return type-id='type-id-27'/>
     </function-decl>
     <function-decl name='crc32_z' mangled-name='crc32_z' filepath='src.d/crc32.c' line='748' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_z@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-4' name='crc' filepath='src.d/crc32.c' line='749' column='1'/>
-      <parameter type-id='type-id-23' name='buf' filepath='src.d/crc32.c' line='750' column='1'/>
-      <parameter type-id='type-id-6' name='len' filepath='src.d/crc32.c' line='751' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-9' name='crc' filepath='src.d/crc32.c' line='749' column='1'/>
+      <parameter type-id='type-id-25' name='buf' filepath='src.d/crc32.c' line='750' column='1'/>
+      <parameter type-id='type-id-14' name='len' filepath='src.d/crc32.c' line='751' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32' mangled-name='crc32' filepath='src.d/crc32.c' line='1072' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32'>
-      <parameter type-id='type-id-4' name='crc' filepath='src.d/crc32.c' line='1073' column='1'/>
-      <parameter type-id='type-id-23' name='buf' filepath='src.d/crc32.c' line='1074' column='1'/>
-      <parameter type-id='type-id-8' name='len' filepath='src.d/crc32.c' line='1075' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-9' name='crc' filepath='src.d/crc32.c' line='1073' column='1'/>
+      <parameter type-id='type-id-25' name='buf' filepath='src.d/crc32.c' line='1074' column='1'/>
+      <parameter type-id='type-id-12' name='len' filepath='src.d/crc32.c' line='1075' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine64' mangled-name='crc32_combine64' filepath='src.d/crc32.c' line='1081' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_combine64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-9' name='crc1' filepath='src.d/crc32.c' line='1082' column='1'/>
-      <parameter type-id='type-id-9' name='crc2' filepath='src.d/crc32.c' line='1083' column='1'/>
-      <parameter type-id='type-id-14' name='len2' filepath='src.d/crc32.c' line='1084' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-13' name='crc1' filepath='src.d/crc32.c' line='1082' column='1'/>
+      <parameter type-id='type-id-13' name='crc2' filepath='src.d/crc32.c' line='1083' column='1'/>
+      <parameter type-id='type-id-7' name='len2' filepath='src.d/crc32.c' line='1084' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine' mangled-name='crc32_combine' filepath='src.d/crc32.c' line='1093' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_combine@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-9' name='crc1' filepath='src.d/crc32.c' line='1094' column='1'/>
-      <parameter type-id='type-id-9' name='crc2' filepath='src.d/crc32.c' line='1095' column='1'/>
-      <parameter type-id='type-id-13' name='len2' filepath='src.d/crc32.c' line='1096' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-13' name='crc1' filepath='src.d/crc32.c' line='1094' column='1'/>
+      <parameter type-id='type-id-13' name='crc2' filepath='src.d/crc32.c' line='1095' column='1'/>
+      <parameter type-id='type-id-8' name='len2' filepath='src.d/crc32.c' line='1096' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine_gen64' mangled-name='crc32_combine_gen64' filepath='src.d/crc32.c' line='1102' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_combine_gen64@@ZLIB_1.2.12'>
-      <parameter type-id='type-id-14' name='len2' filepath='src.d/crc32.c' line='1103' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-7' name='len2' filepath='src.d/crc32.c' line='1103' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine_gen' mangled-name='crc32_combine_gen' filepath='src.d/crc32.c' line='1112' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_combine_gen@@ZLIB_1.2.12'>
-      <parameter type-id='type-id-13' name='len2' filepath='src.d/crc32.c' line='1113' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-8' name='len2' filepath='src.d/crc32.c' line='1113' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine_op' mangled-name='crc32_combine_op' filepath='src.d/crc32.c' line='1119' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_combine_op@@ZLIB_1.2.12'>
-      <parameter type-id='type-id-9' name='crc1' filepath='src.d/crc32.c' line='1120' column='1'/>
-      <parameter type-id='type-id-9' name='crc2' filepath='src.d/crc32.c' line='1121' column='1'/>
-      <parameter type-id='type-id-9' name='op' filepath='src.d/crc32.c' line='1122' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-13' name='crc1' filepath='src.d/crc32.c' line='1120' column='1'/>
+      <parameter type-id='type-id-13' name='crc2' filepath='src.d/crc32.c' line='1121' column='1'/>
+      <parameter type-id='type-id-13' name='op' filepath='src.d/crc32.c' line='1122' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/deflate.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <type-decl name='char' size-in-bits='8' id='type-id-26'/>
-    <class-decl name='static_tree_desc_s' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-27'/>
-    <array-type-def dimensions='1' type-id='type-id-28' size-in-bits='1248' id='type-id-29'>
-      <subrange length='39' type-id='type-id-4' id='type-id-30'/>
+    <type-decl name='char' size-in-bits='8' id='type-id-28'/>
+    <array-type-def dimensions='1' type-id='type-id-29' size-in-bits='1248' id='type-id-30'>
+      <subrange length='39' lower-bound='0' upper-bound='38' type-id='type-id-9' id='type-id-31'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-28' size-in-bits='18336' id='type-id-31'>
-      <subrange length='573' type-id='type-id-4' id='type-id-32'/>
+    <array-type-def dimensions='1' type-id='type-id-29' size-in-bits='18336' id='type-id-32'>
+      <subrange length='573' lower-bound='0' upper-bound='572' type-id='type-id-9' id='type-id-33'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-28' size-in-bits='1952' id='type-id-33'>
-      <subrange length='61' type-id='type-id-4' id='type-id-34'/>
+    <array-type-def dimensions='1' type-id='type-id-29' size-in-bits='1952' id='type-id-34'>
+      <subrange length='61' lower-bound='0' upper-bound='60' type-id='type-id-9' id='type-id-35'/>
     </array-type-def>
     <type-decl name='int' size-in-bits='32' id='type-id-20'/>
-    <array-type-def dimensions='1' type-id='type-id-20' size-in-bits='18336' id='type-id-35'>
-      <subrange length='573' type-id='type-id-4' id='type-id-32'/>
+    <array-type-def dimensions='1' type-id='type-id-20' size-in-bits='18336' id='type-id-36'>
+      <subrange length='573' lower-bound='0' upper-bound='572' type-id='type-id-9' id='type-id-33'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-36' size-in-bits='4584' id='type-id-37'>
-      <subrange length='573' type-id='type-id-4' id='type-id-32'/>
-    </array-type-def>
-    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-38'/>
-    <array-type-def dimensions='1' type-id='type-id-39' size-in-bits='256' id='type-id-40'>
-      <subrange length='16' type-id='type-id-4' id='type-id-41'/>
-    </array-type-def>
-    <type-decl name='void' id='type-id-42'/>
-    <typedef-decl name='charf' type-id='type-id-26' filepath='./zconf.h' line='408' column='1' id='type-id-43'/>
-    <typedef-decl name='voidpf' type-id='type-id-44' filepath='./zconf.h' line='415' column='1' id='type-id-45'/>
-    <class-decl name='ct_data_s' size-in-bits='32' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='68' column='1' id='type-id-28'>
+    <class-decl name='ct_data_s' size-in-bits='32' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='68' column='1' id='type-id-29'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='fc' type-id='type-id-46' visibility='default' filepath='src.d/deflate.h' line='72' column='1'/>
+        <var-decl name='fc' type-id='type-id-37' visibility='default' filepath='src.d/deflate.h' line='72' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='16'>
-        <var-decl name='dl' type-id='type-id-47' visibility='default' filepath='src.d/deflate.h' line='76' column='1'/>
+        <var-decl name='dl' type-id='type-id-38' visibility='default' filepath='src.d/deflate.h' line='76' column='1'/>
       </data-member>
     </class-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='69' column='1' id='type-id-46'>
-      <data-member access='public'>
-        <var-decl name='freq' type-id='type-id-39' visibility='default' filepath='src.d/deflate.h' line='70' column='1'/>
-      </data-member>
-      <data-member access='public'>
-        <var-decl name='code' type-id='type-id-39' visibility='default' filepath='src.d/deflate.h' line='71' column='1'/>
-      </data-member>
-    </union-decl>
-    <union-decl name='__anonymous_union__1' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='73' column='1' id='type-id-47'>
-      <data-member access='public'>
-        <var-decl name='dad' type-id='type-id-39' visibility='default' filepath='src.d/deflate.h' line='74' column='1'/>
-      </data-member>
-      <data-member access='public'>
-        <var-decl name='len' type-id='type-id-39' visibility='default' filepath='src.d/deflate.h' line='75' column='1'/>
-      </data-member>
-    </union-decl>
-    <typedef-decl name='ct_data' type-id='type-id-28' filepath='src.d/deflate.h' line='77' column='1' id='type-id-48'/>
-    <typedef-decl name='static_tree_desc' type-id='type-id-27' filepath='src.d/deflate.h' line='84' column='1' id='type-id-49'/>
-    <class-decl name='tree_desc_s' size-in-bits='192' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='86' column='1' id='type-id-50'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='dyn_tree' type-id='type-id-51' visibility='default' filepath='src.d/deflate.h' line='87' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='max_code' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='88' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='stat_desc' type-id='type-id-52' visibility='default' filepath='src.d/deflate.h' line='89' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='Pos' type-id='type-id-39' filepath='src.d/deflate.h' line='92' column='1' id='type-id-53'/>
-    <typedef-decl name='Posf' type-id='type-id-53' filepath='src.d/deflate.h' line='93' column='1' id='type-id-54'/>
-    <typedef-decl name='IPos' type-id='type-id-3' filepath='src.d/deflate.h' line='94' column='1' id='type-id-55'/>
-    <class-decl name='internal_state' size-in-bits='47616' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='100' column='1' id='type-id-56'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='strm' type-id='type-id-57' visibility='default' filepath='src.d/deflate.h' line='101' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='status' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='102' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='pending_buf' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='103' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='pending_buf_size' type-id='type-id-58' visibility='default' filepath='src.d/deflate.h' line='104' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='pending_out' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='105' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='pending' type-id='type-id-58' visibility='default' filepath='src.d/deflate.h' line='106' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='wrap' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='107' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='gzhead' type-id='type-id-59' visibility='default' filepath='src.d/deflate.h' line='108' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='gzindex' type-id='type-id-58' visibility='default' filepath='src.d/deflate.h' line='109' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='method' type-id='type-id-7' visibility='default' filepath='src.d/deflate.h' line='110' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='608'>
-        <var-decl name='last_flush' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='111' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='w_size' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='115' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='672'>
-        <var-decl name='w_bits' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='116' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='w_mask' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='117' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='window' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='119' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='window_size' type-id='type-id-58' visibility='default' filepath='src.d/deflate.h' line='129' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='prev' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='134' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='head' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='140' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='ins_h' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='142' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1056'>
-        <var-decl name='hash_size' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='143' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1088'>
-        <var-decl name='hash_bits' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='144' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1120'>
-        <var-decl name='hash_mask' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='145' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1152'>
-        <var-decl name='hash_shift' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='147' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='block_start' type-id='type-id-1' visibility='default' filepath='src.d/deflate.h' line='154' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='match_length' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='159' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1312'>
-        <var-decl name='prev_match' type-id='type-id-55' visibility='default' filepath='src.d/deflate.h' line='160' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1344'>
-        <var-decl name='match_available' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='161' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1376'>
-        <var-decl name='strstart' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='162' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1408'>
-        <var-decl name='match_start' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='163' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1440'>
-        <var-decl name='lookahead' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='164' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1472'>
-        <var-decl name='prev_length' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='166' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1504'>
-        <var-decl name='max_chain_length' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='171' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1536'>
-        <var-decl name='max_lazy_match' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='177' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1568'>
-        <var-decl name='level' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='188' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1600'>
-        <var-decl name='strategy' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='189' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1632'>
-        <var-decl name='good_match' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='191' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1664'>
-        <var-decl name='nice_match' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='194' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1696'>
-        <var-decl name='dyn_ltree' type-id='type-id-31' visibility='default' filepath='src.d/deflate.h' line='198' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='20032'>
-        <var-decl name='dyn_dtree' type-id='type-id-33' visibility='default' filepath='src.d/deflate.h' line='199' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='21984'>
-        <var-decl name='bl_tree' type-id='type-id-29' visibility='default' filepath='src.d/deflate.h' line='200' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='23232'>
-        <var-decl name='l_desc' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='202' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='23424'>
-        <var-decl name='d_desc' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='203' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='23616'>
-        <var-decl name='bl_desc' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='204' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='23808'>
-        <var-decl name='bl_count' type-id='type-id-40' visibility='default' filepath='src.d/deflate.h' line='206' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='24064'>
-        <var-decl name='heap' type-id='type-id-35' visibility='default' filepath='src.d/deflate.h' line='209' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='42400'>
-        <var-decl name='heap_len' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='210' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='42432'>
-        <var-decl name='heap_max' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='211' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='42464'>
-        <var-decl name='depth' type-id='type-id-37' visibility='default' filepath='src.d/deflate.h' line='216' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47104'>
-        <var-decl name='sym_buf' type-id='type-id-61' visibility='default' filepath='src.d/deflate.h' line='220' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47168'>
-        <var-decl name='lit_bufsize' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='222' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47200'>
-        <var-decl name='sym_next' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='242' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47232'>
-        <var-decl name='sym_end' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='243' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47296'>
-        <var-decl name='opt_len' type-id='type-id-58' visibility='default' filepath='src.d/deflate.h' line='245' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47360'>
-        <var-decl name='static_len' type-id='type-id-58' visibility='default' filepath='src.d/deflate.h' line='246' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47424'>
-        <var-decl name='matches' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='247' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47456'>
-        <var-decl name='insert' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='248' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47488'>
-        <var-decl name='bi_buf' type-id='type-id-39' visibility='default' filepath='src.d/deflate.h' line='255' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47520'>
-        <var-decl name='bi_valid' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='259' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47552'>
-        <var-decl name='high_water' type-id='type-id-58' visibility='default' filepath='src.d/deflate.h' line='264' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='deflate_state' type-id='type-id-56' filepath='src.d/deflate.h' line='271' column='1' id='type-id-62'/>
-    <typedef-decl name='alloc_func' type-id='type-id-63' filepath='src.d/zlib.h' line='81' column='1' id='type-id-64'/>
-    <typedef-decl name='free_func' type-id='type-id-65' filepath='src.d/zlib.h' line='82' column='1' id='type-id-66'/>
-    <class-decl name='z_stream_s' size-in-bits='896' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='86' column='1' id='type-id-67'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='next_in' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='87' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='avail_in' type-id='type-id-8' visibility='default' filepath='src.d/zlib.h' line='88' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='total_in' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='89' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='next_out' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='91' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='avail_out' type-id='type-id-8' visibility='default' filepath='src.d/zlib.h' line='92' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='total_out' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='93' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='msg' type-id='type-id-68' visibility='default' filepath='src.d/zlib.h' line='95' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='state' type-id='type-id-69' visibility='default' filepath='src.d/zlib.h' line='96' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='zalloc' type-id='type-id-64' visibility='default' filepath='src.d/zlib.h' line='98' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='zfree' type-id='type-id-66' visibility='default' filepath='src.d/zlib.h' line='99' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='opaque' type-id='type-id-45' visibility='default' filepath='src.d/zlib.h' line='100' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='data_type' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='102' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='adler' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='104' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='reserved' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='105' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='z_stream' type-id='type-id-67' filepath='src.d/zlib.h' line='106' column='1' id='type-id-70'/>
-    <typedef-decl name='z_streamp' type-id='type-id-71' filepath='src.d/zlib.h' line='108' column='1' id='type-id-57'/>
-    <class-decl name='gz_header_s' size-in-bits='640' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='114' column='1' id='type-id-72'>
+    <class-decl name='gz_header_s' size-in-bits='640' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='114' column='1' id='type-id-39'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='text' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='115' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='time' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='116' column='1'/>
+        <var-decl name='time' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='116' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
         <var-decl name='xflags' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='117' column='1'/>
@@ -516,22 +261,22 @@
         <var-decl name='extra' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='119' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='extra_len' type-id='type-id-8' visibility='default' filepath='src.d/zlib.h' line='120' column='1'/>
+        <var-decl name='extra_len' type-id='type-id-12' visibility='default' filepath='src.d/zlib.h' line='120' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='extra_max' type-id='type-id-8' visibility='default' filepath='src.d/zlib.h' line='121' column='1'/>
+        <var-decl name='extra_max' type-id='type-id-12' visibility='default' filepath='src.d/zlib.h' line='121' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
         <var-decl name='name' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='122' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='name_max' type-id='type-id-8' visibility='default' filepath='src.d/zlib.h' line='123' column='1'/>
+        <var-decl name='name_max' type-id='type-id-12' visibility='default' filepath='src.d/zlib.h' line='123' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
         <var-decl name='comment' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='124' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='comm_max' type-id='type-id-8' visibility='default' filepath='src.d/zlib.h' line='125' column='1'/>
+        <var-decl name='comm_max' type-id='type-id-12' visibility='default' filepath='src.d/zlib.h' line='125' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='544'>
         <var-decl name='hcrc' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='126' column='1'/>
@@ -540,108 +285,368 @@
         <var-decl name='done' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='127' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='gz_header' type-id='type-id-72' filepath='src.d/zlib.h' line='129' column='1' id='type-id-73'/>
-    <typedef-decl name='gz_headerp' type-id='type-id-74' filepath='src.d/zlib.h' line='131' column='1' id='type-id-59'/>
-    <typedef-decl name='uch' type-id='type-id-2' filepath='src.d/zutil.h' line='39' column='1' id='type-id-36'/>
-    <typedef-decl name='uchf' type-id='type-id-36' filepath='src.d/zutil.h' line='40' column='1' id='type-id-75'/>
-    <typedef-decl name='ush' type-id='type-id-38' filepath='src.d/zutil.h' line='41' column='1' id='type-id-39'/>
-    <typedef-decl name='ulg' type-id='type-id-4' filepath='src.d/zutil.h' line='43' column='1' id='type-id-58'/>
-    <pointer-type-def type-id='type-id-10' size-in-bits='64' id='type-id-19'/>
-    <pointer-type-def type-id='type-id-54' size-in-bits='64' id='type-id-60'/>
-    <pointer-type-def type-id='type-id-26' size-in-bits='64' id='type-id-68'/>
-    <pointer-type-def type-id='type-id-43' size-in-bits='64' id='type-id-76'/>
-    <qualified-type-def type-id='type-id-26' const='yes' id='type-id-77'/>
-    <pointer-type-def type-id='type-id-77' size-in-bits='64' id='type-id-78'/>
-    <qualified-type-def type-id='type-id-49' const='yes' id='type-id-79'/>
-    <pointer-type-def type-id='type-id-79' size-in-bits='64' id='type-id-52'/>
-    <pointer-type-def type-id='type-id-48' size-in-bits='64' id='type-id-51'/>
-    <pointer-type-def type-id='type-id-62' size-in-bits='64' id='type-id-80'/>
-    <pointer-type-def type-id='type-id-73' size-in-bits='64' id='type-id-74'/>
-    <pointer-type-def type-id='type-id-20' size-in-bits='64' id='type-id-81'/>
-    <pointer-type-def type-id='type-id-56' size-in-bits='64' id='type-id-69'/>
-    <pointer-type-def type-id='type-id-82' size-in-bits='64' id='type-id-63'/>
-    <pointer-type-def type-id='type-id-8' size-in-bits='64' id='type-id-83'/>
-    <pointer-type-def type-id='type-id-75' size-in-bits='64' id='type-id-61'/>
-    <pointer-type-def type-id='type-id-3' size-in-bits='64' id='type-id-84'/>
-    <pointer-type-def type-id='type-id-85' size-in-bits='64' id='type-id-65'/>
-    <pointer-type-def type-id='type-id-42' size-in-bits='64' id='type-id-44'/>
+    <class-decl name='internal_state' size-in-bits='47616' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='100' column='1' id='type-id-40'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='strm' type-id='type-id-21' visibility='default' filepath='src.d/deflate.h' line='101' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='status' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='102' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='pending_buf' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='103' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='pending_buf_size' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='104' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='pending_out' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='105' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='pending' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='106' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='wrap' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='107' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='gzhead' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='108' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='gzindex' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='109' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='method' type-id='type-id-3' visibility='default' filepath='src.d/deflate.h' line='110' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='608'>
+        <var-decl name='last_flush' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='111' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='w_size' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='115' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='672'>
+        <var-decl name='w_bits' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='116' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='w_mask' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='117' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='window' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='119' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='window_size' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='129' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='prev' type-id='type-id-43' visibility='default' filepath='src.d/deflate.h' line='134' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='head' type-id='type-id-43' visibility='default' filepath='src.d/deflate.h' line='140' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='ins_h' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='142' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1056'>
+        <var-decl name='hash_size' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='143' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1088'>
+        <var-decl name='hash_bits' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='144' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1120'>
+        <var-decl name='hash_mask' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='145' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1152'>
+        <var-decl name='hash_shift' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='147' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1216'>
+        <var-decl name='block_start' type-id='type-id-1' visibility='default' filepath='src.d/deflate.h' line='154' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='match_length' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='159' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1312'>
+        <var-decl name='prev_match' type-id='type-id-44' visibility='default' filepath='src.d/deflate.h' line='160' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1344'>
+        <var-decl name='match_available' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='161' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1376'>
+        <var-decl name='strstart' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='162' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1408'>
+        <var-decl name='match_start' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='163' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1440'>
+        <var-decl name='lookahead' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='164' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1472'>
+        <var-decl name='prev_length' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='166' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1504'>
+        <var-decl name='max_chain_length' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='171' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1536'>
+        <var-decl name='max_lazy_match' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='177' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1568'>
+        <var-decl name='level' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='188' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1600'>
+        <var-decl name='strategy' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='189' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1632'>
+        <var-decl name='good_match' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='191' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1664'>
+        <var-decl name='nice_match' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='194' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1696'>
+        <var-decl name='dyn_ltree' type-id='type-id-32' visibility='default' filepath='src.d/deflate.h' line='198' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='20032'>
+        <var-decl name='dyn_dtree' type-id='type-id-34' visibility='default' filepath='src.d/deflate.h' line='199' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='21984'>
+        <var-decl name='bl_tree' type-id='type-id-30' visibility='default' filepath='src.d/deflate.h' line='200' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='23232'>
+        <var-decl name='l_desc' type-id='type-id-45' visibility='default' filepath='src.d/deflate.h' line='202' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='23424'>
+        <var-decl name='d_desc' type-id='type-id-45' visibility='default' filepath='src.d/deflate.h' line='203' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='23616'>
+        <var-decl name='bl_desc' type-id='type-id-45' visibility='default' filepath='src.d/deflate.h' line='204' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='23808'>
+        <var-decl name='bl_count' type-id='type-id-46' visibility='default' filepath='src.d/deflate.h' line='206' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='24064'>
+        <var-decl name='heap' type-id='type-id-36' visibility='default' filepath='src.d/deflate.h' line='209' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='42400'>
+        <var-decl name='heap_len' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='210' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='42432'>
+        <var-decl name='heap_max' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='211' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='42464'>
+        <var-decl name='depth' type-id='type-id-47' visibility='default' filepath='src.d/deflate.h' line='216' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47104'>
+        <var-decl name='sym_buf' type-id='type-id-48' visibility='default' filepath='src.d/deflate.h' line='220' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47168'>
+        <var-decl name='lit_bufsize' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='222' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47200'>
+        <var-decl name='sym_next' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='242' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47232'>
+        <var-decl name='sym_end' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='243' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47296'>
+        <var-decl name='opt_len' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='245' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47360'>
+        <var-decl name='static_len' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='246' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47424'>
+        <var-decl name='matches' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='247' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47456'>
+        <var-decl name='insert' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='248' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47488'>
+        <var-decl name='bi_buf' type-id='type-id-49' visibility='default' filepath='src.d/deflate.h' line='255' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47520'>
+        <var-decl name='bi_valid' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='259' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47552'>
+        <var-decl name='high_water' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='264' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='tree_desc_s' size-in-bits='192' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='86' column='1' id='type-id-45'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dyn_tree' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='87' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='max_code' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='88' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='stat_desc' type-id='type-id-51' visibility='default' filepath='src.d/deflate.h' line='89' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='z_stream_s' size-in-bits='896' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='86' column='1' id='type-id-52'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next_in' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='87' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='avail_in' type-id='type-id-12' visibility='default' filepath='src.d/zlib.h' line='88' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='total_in' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='89' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='next_out' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='91' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='avail_out' type-id='type-id-12' visibility='default' filepath='src.d/zlib.h' line='92' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='total_out' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='93' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='msg' type-id='type-id-53' visibility='default' filepath='src.d/zlib.h' line='95' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='state' type-id='type-id-54' visibility='default' filepath='src.d/zlib.h' line='96' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='zalloc' type-id='type-id-55' visibility='default' filepath='src.d/zlib.h' line='98' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='zfree' type-id='type-id-56' visibility='default' filepath='src.d/zlib.h' line='99' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='opaque' type-id='type-id-57' visibility='default' filepath='src.d/zlib.h' line='100' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='data_type' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='102' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='adler' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='104' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='reserved' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='105' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='IPos' type-id='type-id-11' filepath='src.d/deflate.h' line='94' column='1' id='type-id-44'/>
+    <typedef-decl name='Pos' type-id='type-id-49' filepath='src.d/deflate.h' line='92' column='1' id='type-id-58'/>
+    <typedef-decl name='Posf' type-id='type-id-58' filepath='src.d/deflate.h' line='93' column='1' id='type-id-59'/>
+    <typedef-decl name='alloc_func' type-id='type-id-60' filepath='src.d/zlib.h' line='81' column='1' id='type-id-55'/>
+    <typedef-decl name='charf' type-id='type-id-28' filepath='./zconf.h' line='408' column='1' id='type-id-61'/>
+    <typedef-decl name='ct_data' type-id='type-id-29' filepath='src.d/deflate.h' line='77' column='1' id='type-id-62'/>
+    <typedef-decl name='deflate_state' type-id='type-id-40' filepath='src.d/deflate.h' line='271' column='1' id='type-id-63'/>
+    <typedef-decl name='free_func' type-id='type-id-64' filepath='src.d/zlib.h' line='82' column='1' id='type-id-56'/>
+    <typedef-decl name='gz_header' type-id='type-id-39' filepath='src.d/zlib.h' line='129' column='1' id='type-id-65'/>
+    <typedef-decl name='gz_headerp' type-id='type-id-66' filepath='src.d/zlib.h' line='131' column='1' id='type-id-42'/>
+    <typedef-decl name='uch' type-id='type-id-2' filepath='src.d/zutil.h' line='39' column='1' id='type-id-67'/>
+    <typedef-decl name='uchf' type-id='type-id-67' filepath='src.d/zutil.h' line='40' column='1' id='type-id-68'/>
+    <typedef-decl name='ulg' type-id='type-id-9' filepath='src.d/zutil.h' line='43' column='1' id='type-id-41'/>
+    <typedef-decl name='ush' type-id='type-id-69' filepath='src.d/zutil.h' line='41' column='1' id='type-id-49'/>
+    <typedef-decl name='z_stream' type-id='type-id-52' filepath='src.d/zlib.h' line='106' column='1' id='type-id-70'/>
+    <typedef-decl name='z_streamp' type-id='type-id-71' filepath='src.d/zlib.h' line='108' column='1' id='type-id-21'/>
+    <array-type-def dimensions='1' type-id='type-id-67' size-in-bits='4584' id='type-id-47'>
+      <subrange length='573' lower-bound='0' upper-bound='572' type-id='type-id-9' id='type-id-33'/>
+    </array-type-def>
+    <union-decl name='__anonymous_union__1' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='73' column='1' id='type-id-38'>
+      <data-member access='public'>
+        <var-decl name='dad' type-id='type-id-49' visibility='default' filepath='src.d/deflate.h' line='74' column='1'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='len' type-id='type-id-49' visibility='default' filepath='src.d/deflate.h' line='75' column='1'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='__anonymous_union__' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='69' column='1' id='type-id-37'>
+      <data-member access='public'>
+        <var-decl name='freq' type-id='type-id-49' visibility='default' filepath='src.d/deflate.h' line='70' column='1'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='code' type-id='type-id-49' visibility='default' filepath='src.d/deflate.h' line='71' column='1'/>
+      </data-member>
+    </union-decl>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-69'/>
+    <array-type-def dimensions='1' type-id='type-id-49' size-in-bits='256' id='type-id-46'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-9' id='type-id-72'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-4' size-in-bits='64' id='type-id-19'/>
+    <pointer-type-def type-id='type-id-59' size-in-bits='64' id='type-id-43'/>
+    <pointer-type-def type-id='type-id-28' size-in-bits='64' id='type-id-53'/>
+    <pointer-type-def type-id='type-id-61' size-in-bits='64' id='type-id-73'/>
+    <qualified-type-def type-id='type-id-28' const='yes' id='type-id-74'/>
+    <pointer-type-def type-id='type-id-74' size-in-bits='64' id='type-id-22'/>
+    <pointer-type-def type-id='type-id-62' size-in-bits='64' id='type-id-50'/>
+    <pointer-type-def type-id='type-id-63' size-in-bits='64' id='type-id-75'/>
+    <pointer-type-def type-id='type-id-65' size-in-bits='64' id='type-id-66'/>
+    <pointer-type-def type-id='type-id-20' size-in-bits='64' id='type-id-76'/>
+    <pointer-type-def type-id='type-id-40' size-in-bits='64' id='type-id-54'/>
+    <pointer-type-def type-id='type-id-77' size-in-bits='64' id='type-id-60'/>
+    <pointer-type-def type-id='type-id-12' size-in-bits='64' id='type-id-78'/>
+    <pointer-type-def type-id='type-id-68' size-in-bits='64' id='type-id-48'/>
+    <pointer-type-def type-id='type-id-11' size-in-bits='64' id='type-id-79'/>
+    <pointer-type-def type-id='type-id-80' size-in-bits='64' id='type-id-64'/>
     <pointer-type-def type-id='type-id-70' size-in-bits='64' id='type-id-71'/>
-    <class-decl name='static_tree_desc_s' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-27'/>
+    <qualified-type-def type-id='type-id-81' const='yes' id='type-id-82'/>
+    <pointer-type-def type-id='type-id-82' size-in-bits='64' id='type-id-51'/>
+    <class-decl name='static_tree_desc_s' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-83'/>
+    <typedef-decl name='voidpf' type-id='type-id-84' filepath='./zconf.h' line='415' column='1' id='type-id-57'/>
     <function-decl name='memcpy' filepath='/usr/powerpc64-linux-gnu/include/string.h' line='43' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-44'/>
-      <parameter type-id='type-id-44'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-84'/>
+      <parameter type-id='type-id-84'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-84'/>
     </function-decl>
     <function-decl name='memset' filepath='/usr/powerpc64-linux-gnu/include/string.h' line='61' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-84'/>
       <parameter type-id='type-id-20'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-44'/>
-    </function-decl>
-    <function-decl name='deflateInit_' mangled-name='deflateInit_' filepath='src.d/deflate.c' line='225' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateInit_'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='226' column='1'/>
-      <parameter type-id='type-id-20' name='level' filepath='src.d/deflate.c' line='227' column='1'/>
-      <parameter type-id='type-id-78' name='version' filepath='src.d/deflate.c' line='228' column='1'/>
-      <parameter type-id='type-id-20' name='stream_size' filepath='src.d/deflate.c' line='229' column='1'/>
-      <return type-id='type-id-20'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-84'/>
     </function-decl>
     <function-decl name='deflateInit2_' mangled-name='deflateInit2_' filepath='src.d/deflate.c' line='237' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateInit2_'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='239' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='239' column='1'/>
       <parameter type-id='type-id-20' name='level' filepath='src.d/deflate.c' line='240' column='1'/>
       <parameter type-id='type-id-20' name='method' filepath='src.d/deflate.c' line='241' column='1'/>
       <parameter type-id='type-id-20' name='windowBits' filepath='src.d/deflate.c' line='242' column='1'/>
       <parameter type-id='type-id-20' name='memLevel' filepath='src.d/deflate.c' line='243' column='1'/>
       <parameter type-id='type-id-20' name='strategy' filepath='src.d/deflate.c' line='244' column='1'/>
-      <parameter type-id='type-id-78' name='version' filepath='src.d/deflate.c' line='245' column='1'/>
+      <parameter type-id='type-id-22' name='version' filepath='src.d/deflate.c' line='245' column='1'/>
       <parameter type-id='type-id-20' name='stream_size' filepath='src.d/deflate.c' line='246' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateSetDictionary' mangled-name='deflateSetDictionary' filepath='src.d/deflate.c' line='412' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateSetDictionary'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='413' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='413' column='1'/>
       <parameter type-id='type-id-16' name='dictionary' filepath='src.d/deflate.c' line='414' column='1'/>
-      <parameter type-id='type-id-8' name='dictLength' filepath='src.d/deflate.c' line='415' column='1'/>
+      <parameter type-id='type-id-12' name='dictLength' filepath='src.d/deflate.c' line='415' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateGetDictionary' mangled-name='deflateGetDictionary' filepath='src.d/deflate.c' line='481' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateGetDictionary@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='482' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='482' column='1'/>
       <parameter type-id='type-id-19' name='dictionary' filepath='src.d/deflate.c' line='483' column='1'/>
-      <parameter type-id='type-id-83' name='dictLength' filepath='src.d/deflate.c' line='484' column='1'/>
+      <parameter type-id='type-id-78' name='dictLength' filepath='src.d/deflate.c' line='484' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateResetKeep' mangled-name='deflateResetKeep' filepath='src.d/deflate.c' line='503' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateResetKeep@@ZLIB_1.2.5.2'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='504' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='504' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateReset' mangled-name='deflateReset' filepath='src.d/deflate.c' line='541' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateReset'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='542' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='542' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateSetHeader' mangled-name='deflateSetHeader' filepath='src.d/deflate.c' line='553' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateSetHeader@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='554' column='1'/>
-      <parameter type-id='type-id-59' name='head' filepath='src.d/deflate.c' line='555' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='554' column='1'/>
+      <parameter type-id='type-id-42' name='head' filepath='src.d/deflate.c' line='555' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflatePending' mangled-name='deflatePending' filepath='src.d/deflate.c' line='564' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflatePending@@ZLIB_1.2.5.1'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='567' column='1'/>
-      <parameter type-id='type-id-84' name='pending' filepath='src.d/deflate.c' line='565' column='1'/>
-      <parameter type-id='type-id-81' name='bits' filepath='src.d/deflate.c' line='566' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='567' column='1'/>
+      <parameter type-id='type-id-79' name='pending' filepath='src.d/deflate.c' line='565' column='1'/>
+      <parameter type-id='type-id-76' name='bits' filepath='src.d/deflate.c' line='566' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflatePrime' mangled-name='deflatePrime' filepath='src.d/deflate.c' line='578' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflatePrime@@ZLIB_1.2.0.8'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='579' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='579' column='1'/>
       <parameter type-id='type-id-20' name='bits' filepath='src.d/deflate.c' line='580' column='1'/>
       <parameter type-id='type-id-20' name='value' filepath='src.d/deflate.c' line='581' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateParams' mangled-name='deflateParams' filepath='src.d/deflate.c' line='605' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateParams'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='606' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='606' column='1'/>
       <parameter type-id='type-id-20' name='level' filepath='src.d/deflate.c' line='607' column='1'/>
       <parameter type-id='type-id-20' name='strategy' filepath='src.d/deflate.c' line='608' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateTune' mangled-name='deflateTune' filepath='src.d/deflate.c' line='654' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateTune@@ZLIB_1.2.2.3'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='655' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='655' column='1'/>
       <parameter type-id='type-id-20' name='good_length' filepath='src.d/deflate.c' line='656' column='1'/>
       <parameter type-id='type-id-20' name='max_lazy' filepath='src.d/deflate.c' line='657' column='1'/>
       <parameter type-id='type-id-20' name='nice_length' filepath='src.d/deflate.c' line='658' column='1'/>
@@ -649,198 +654,203 @@
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateBound' mangled-name='deflateBound' filepath='src.d/deflate.c' line='696' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateBound@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='697' column='1'/>
-      <parameter type-id='type-id-9' name='sourceLen' filepath='src.d/deflate.c' line='698' column='1'/>
-      <return type-id='type-id-9'/>
-    </function-decl>
-    <function-decl name='deflate' mangled-name='deflate' filepath='src.d/deflate.c' line='815' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflate'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='816' column='1'/>
-      <parameter type-id='type-id-20' name='flush' filepath='src.d/deflate.c' line='817' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
-    <function-decl name='deflateEnd' mangled-name='deflateEnd' filepath='src.d/deflate.c' line='1130' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateEnd'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='1131' column='1'/>
-      <return type-id='type-id-20'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='697' column='1'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/deflate.c' line='698' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='deflateCopy' mangled-name='deflateCopy' filepath='src.d/deflate.c' line='1156' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateCopy'>
-      <parameter type-id='type-id-57' name='dest' filepath='src.d/deflate.c' line='1157' column='1'/>
-      <parameter type-id='type-id-57' name='source' filepath='src.d/deflate.c' line='1158' column='1'/>
+      <parameter type-id='type-id-21' name='dest' filepath='src.d/deflate.c' line='1157' column='1'/>
+      <parameter type-id='type-id-21' name='source' filepath='src.d/deflate.c' line='1158' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
+    <typedef-decl name='static_tree_desc' type-id='type-id-83' filepath='src.d/deflate.h' line='84' column='1' id='type-id-81'/>
     <function-decl name='_tr_init' filepath='src.d/deflate.h' line='294' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-80'/>
-      <return type-id='type-id-42'/>
+      <parameter type-id='type-id-75'/>
+      <return type-id='type-id-85'/>
     </function-decl>
     <function-decl name='_tr_flush_block' filepath='src.d/deflate.h' line='296' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-80'/>
-      <parameter type-id='type-id-76'/>
-      <parameter type-id='type-id-58'/>
+      <parameter type-id='type-id-75'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-41'/>
       <parameter type-id='type-id-20'/>
-      <return type-id='type-id-42'/>
+      <return type-id='type-id-85'/>
     </function-decl>
     <function-decl name='_tr_flush_bits' filepath='src.d/deflate.h' line='298' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-80'/>
-      <return type-id='type-id-42'/>
+      <parameter type-id='type-id-75'/>
+      <return type-id='type-id-85'/>
     </function-decl>
     <function-decl name='_tr_align' filepath='src.d/deflate.h' line='299' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-80'/>
-      <return type-id='type-id-42'/>
+      <parameter type-id='type-id-75'/>
+      <return type-id='type-id-85'/>
     </function-decl>
     <function-decl name='_tr_stored_block' filepath='src.d/deflate.h' line='300' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-80'/>
-      <parameter type-id='type-id-76'/>
-      <parameter type-id='type-id-58'/>
+      <parameter type-id='type-id-75'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-41'/>
       <parameter type-id='type-id-20'/>
-      <return type-id='type-id-42'/>
+      <return type-id='type-id-85'/>
+    </function-decl>
+    <function-decl name='crc32' filepath='src.d/zlib.h' line='1727' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-13'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-12'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='zcalloc' filepath='src.d/zutil.h' line='261' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-45'/>
-      <parameter type-id='type-id-3'/>
-      <parameter type-id='type-id-3'/>
-      <return type-id='type-id-45'/>
+      <parameter type-id='type-id-57'/>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-11'/>
+      <return type-id='type-id-57'/>
     </function-decl>
     <function-decl name='zcfree' filepath='src.d/zutil.h' line='263' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-45'/>
-      <parameter type-id='type-id-45'/>
-      <return type-id='type-id-42'/>
+      <parameter type-id='type-id-57'/>
+      <parameter type-id='type-id-57'/>
+      <return type-id='type-id-85'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-82'>
-      <parameter type-id='type-id-45'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-45'/>
+    <type-decl name='void' id='type-id-85'/>
+    <pointer-type-def type-id='type-id-85' id='type-id-84'/>
+    <function-type size-in-bits='64' id='type-id-80'>
+      <parameter type-id='type-id-57'/>
+      <parameter type-id='type-id-57'/>
+      <return type-id='type-id-85'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-85'>
-      <parameter type-id='type-id-45'/>
-      <parameter type-id='type-id-45'/>
-      <return type-id='type-id-42'/>
+    <function-type size-in-bits='64' id='type-id-77'>
+      <parameter type-id='type-id-57'/>
+      <parameter type-id='type-id-12'/>
+      <parameter type-id='type-id-12'/>
+      <return type-id='type-id-57'/>
     </function-type>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/gzclose.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <typedef-decl name='gzFile' type-id='type-id-86' filepath='src.d/zlib.h' line='1302' column='1' id='type-id-87'/>
-    <class-decl name='gzFile_s' size-in-bits='192' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='1834' column='1' id='type-id-88'>
+    <class-decl name='gzFile_s' size-in-bits='192' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='1834' column='1' id='type-id-86'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='have' type-id='type-id-3' visibility='default' filepath='src.d/zlib.h' line='1835' column='1'/>
+        <var-decl name='have' type-id='type-id-11' visibility='default' filepath='src.d/zlib.h' line='1835' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='next' type-id='type-id-89' visibility='default' filepath='src.d/zlib.h' line='1836' column='1'/>
+        <var-decl name='next' type-id='type-id-87' visibility='default' filepath='src.d/zlib.h' line='1836' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='pos' type-id='type-id-14' visibility='default' filepath='src.d/zlib.h' line='1837' column='1'/>
+        <var-decl name='pos' type-id='type-id-7' visibility='default' filepath='src.d/zlib.h' line='1837' column='1'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-88' size-in-bits='64' id='type-id-86'/>
+    <typedef-decl name='gzFile' type-id='type-id-88' filepath='src.d/zlib.h' line='1302' column='1' id='type-id-89'/>
+    <pointer-type-def type-id='type-id-86' size-in-bits='64' id='type-id-88'/>
     <function-decl name='gzclose' mangled-name='gzclose' filepath='src.d/gzclose.c' line='11' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzclose'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzclose.c' line='12' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzclose.c' line='12' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='gzclose_r' mangled-name='gzclose_r' filepath='src.d/zlib.h' line='1644' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzclose_r@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-87'/>
+    <function-decl name='gzclose_r' filepath='src.d/zlib.h' line='1644' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-89'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='gzclose_w' mangled-name='gzclose_w' filepath='src.d/zlib.h' line='1645' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzclose_w@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-87'/>
+    <function-decl name='gzclose_w' filepath='src.d/zlib.h' line='1645' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-89'/>
       <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/gzlib.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <type-decl name='variadic parameter type' id='type-id-90'/>
-    <function-decl name='open' filepath='/usr/powerpc64-linux-gnu/include/fcntl.h' line='181' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-78'/>
+    <function-decl name='open' filepath='/usr/powerpc64-linux-gnu/include/fcntl.h' line='209' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-22'/>
       <parameter type-id='type-id-20'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='snprintf' filepath='/usr/powerpc64-linux-gnu/include/stdio.h' line='378' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-68'/>
-      <parameter type-id='type-id-5'/>
-      <parameter type-id='type-id-78'/>
+    <function-decl name='snprintf' filepath='/usr/powerpc64-linux-gnu/include/stdio.h' line='385' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-10'/>
+      <parameter type-id='type-id-22'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-20'/>
     </function-decl>
+    <function-decl name='malloc' filepath='/usr/powerpc64-linux-gnu/include/stdlib.h' line='672' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='free' filepath='/usr/powerpc64-linux-gnu/include/stdlib.h' line='687' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-84'/>
+      <return type-id='type-id-85'/>
+    </function-decl>
     <function-decl name='strlen' filepath='/usr/powerpc64-linux-gnu/include/string.h' line='407' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-78'/>
-      <return type-id='type-id-5'/>
+      <parameter type-id='type-id-22'/>
+      <return type-id='type-id-10'/>
     </function-decl>
     <function-decl name='lseek64' filepath='/usr/powerpc64-linux-gnu/include/unistd.h' line='350' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-20'/>
-      <parameter type-id='type-id-12'/>
+      <parameter type-id='type-id-5'/>
       <parameter type-id='type-id-20'/>
-      <return type-id='type-id-12'/>
+      <return type-id='type-id-5'/>
     </function-decl>
     <function-decl name='gzopen' mangled-name='gzopen' filepath='src.d/gzlib.c' line='272' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzopen'>
-      <parameter type-id='type-id-78' name='path' filepath='src.d/gzlib.c' line='273' column='1'/>
-      <parameter type-id='type-id-78' name='mode' filepath='src.d/gzlib.c' line='274' column='1'/>
-      <return type-id='type-id-87'/>
+      <parameter type-id='type-id-22' name='path' filepath='src.d/gzlib.c' line='273' column='1'/>
+      <parameter type-id='type-id-22' name='mode' filepath='src.d/gzlib.c' line='274' column='1'/>
+      <return type-id='type-id-89'/>
     </function-decl>
     <function-decl name='gzopen64' mangled-name='gzopen64' filepath='src.d/gzlib.c' line='280' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzopen64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-78' name='path' filepath='src.d/gzlib.c' line='281' column='1'/>
-      <parameter type-id='type-id-78' name='mode' filepath='src.d/gzlib.c' line='282' column='1'/>
-      <return type-id='type-id-87'/>
+      <parameter type-id='type-id-22' name='path' filepath='src.d/gzlib.c' line='281' column='1'/>
+      <parameter type-id='type-id-22' name='mode' filepath='src.d/gzlib.c' line='282' column='1'/>
+      <return type-id='type-id-89'/>
     </function-decl>
     <function-decl name='gzdopen' mangled-name='gzdopen' filepath='src.d/gzlib.c' line='288' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzdopen'>
       <parameter type-id='type-id-20' name='fd' filepath='src.d/gzlib.c' line='289' column='1'/>
-      <parameter type-id='type-id-78' name='mode' filepath='src.d/gzlib.c' line='290' column='1'/>
-      <return type-id='type-id-87'/>
+      <parameter type-id='type-id-22' name='mode' filepath='src.d/gzlib.c' line='290' column='1'/>
+      <return type-id='type-id-89'/>
     </function-decl>
     <function-decl name='gzbuffer' mangled-name='gzbuffer' filepath='src.d/gzlib.c' line='318' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzbuffer@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='319' column='1'/>
-      <parameter type-id='type-id-3' name='size' filepath='src.d/gzlib.c' line='320' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='319' column='1'/>
+      <parameter type-id='type-id-11' name='size' filepath='src.d/gzlib.c' line='320' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzrewind' mangled-name='gzrewind' filepath='src.d/gzlib.c' line='345' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzrewind'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='346' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='346' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzseek64' mangled-name='gzseek64' filepath='src.d/gzlib.c' line='368' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzseek64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='369' column='1'/>
-      <parameter type-id='type-id-14' name='offset' filepath='src.d/gzlib.c' line='370' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='369' column='1'/>
+      <parameter type-id='type-id-7' name='offset' filepath='src.d/gzlib.c' line='370' column='1'/>
       <parameter type-id='type-id-20' name='whence' filepath='src.d/gzlib.c' line='371' column='1'/>
-      <return type-id='type-id-14'/>
+      <return type-id='type-id-7'/>
     </function-decl>
     <function-decl name='gzseek' mangled-name='gzseek' filepath='src.d/gzlib.c' line='445' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzseek'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='446' column='1'/>
-      <parameter type-id='type-id-13' name='offset' filepath='src.d/gzlib.c' line='447' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='446' column='1'/>
+      <parameter type-id='type-id-8' name='offset' filepath='src.d/gzlib.c' line='447' column='1'/>
       <parameter type-id='type-id-20' name='whence' filepath='src.d/gzlib.c' line='448' column='1'/>
-      <return type-id='type-id-13'/>
+      <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='gztell64' mangled-name='gztell64' filepath='src.d/gzlib.c' line='457' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gztell64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='458' column='1'/>
-      <return type-id='type-id-14'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='458' column='1'/>
+      <return type-id='type-id-7'/>
     </function-decl>
     <function-decl name='gztell' mangled-name='gztell' filepath='src.d/gzlib.c' line='474' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gztell'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='475' column='1'/>
-      <return type-id='type-id-13'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='475' column='1'/>
+      <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='gzoffset64' mangled-name='gzoffset64' filepath='src.d/gzlib.c' line='484' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzoffset64@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='485' column='1'/>
-      <return type-id='type-id-14'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='485' column='1'/>
+      <return type-id='type-id-7'/>
     </function-decl>
     <function-decl name='gzoffset' mangled-name='gzoffset' filepath='src.d/gzlib.c' line='507' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzoffset@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='508' column='1'/>
-      <return type-id='type-id-13'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='508' column='1'/>
+      <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='gzeof' mangled-name='gzeof' filepath='src.d/gzlib.c' line='517' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzeof'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='518' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='518' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzerror' mangled-name='gzerror' filepath='src.d/gzlib.c' line='534' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzerror'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='535' column='1'/>
-      <parameter type-id='type-id-81' name='errnum' filepath='src.d/gzlib.c' line='536' column='1'/>
-      <return type-id='type-id-78'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='535' column='1'/>
+      <parameter type-id='type-id-76' name='errnum' filepath='src.d/gzlib.c' line='536' column='1'/>
+      <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='gzclearerr' mangled-name='gzclearerr' filepath='src.d/gzlib.c' line='555' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzclearerr@@ZLIB_1.2.0.2'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='556' column='1'/>
-      <return type-id='type-id-42'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='556' column='1'/>
+      <return type-id='type-id-85'/>
     </function-decl>
+    <type-decl name='variadic parameter type' id='type-id-90'/>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/gzread.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <typedef-decl name='voidp' type-id='type-id-44' filepath='./zconf.h' line='416' column='1' id='type-id-91'/>
-    <typedef-decl name='__ssize_t' type-id='type-id-1' filepath='/usr/powerpc64-linux-gnu/include/bits/types.h' line='194' column='1' id='type-id-92'/>
-    <typedef-decl name='ssize_t' type-id='type-id-92' filepath='/usr/powerpc64-linux-gnu/include/sys/types.h' line='108' column='1' id='type-id-93'/>
-    <class-decl name='gz_state' size-in-bits='1920' is-struct='yes' naming-typedef-id='type-id-94' visibility='default' filepath='src.d/gzguts.h' line='170' column='1' id='type-id-95'>
+    <class-decl name='gz_state' size-in-bits='1920' is-struct='yes' naming-typedef-id='type-id-91' visibility='default' filepath='src.d/gzguts.h' line='170' column='1' id='type-id-92'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='x' type-id='type-id-88' visibility='default' filepath='src.d/gzguts.h' line='172' column='1'/>
+        <var-decl name='x' type-id='type-id-86' visibility='default' filepath='src.d/gzguts.h' line='172' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
         <var-decl name='mode' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='177' column='1'/>
@@ -849,19 +859,19 @@
         <var-decl name='fd' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='178' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='path' type-id='type-id-68' visibility='default' filepath='src.d/gzguts.h' line='179' column='1'/>
+        <var-decl name='path' type-id='type-id-53' visibility='default' filepath='src.d/gzguts.h' line='179' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='size' type-id='type-id-3' visibility='default' filepath='src.d/gzguts.h' line='180' column='1'/>
+        <var-decl name='size' type-id='type-id-11' visibility='default' filepath='src.d/gzguts.h' line='180' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='want' type-id='type-id-3' visibility='default' filepath='src.d/gzguts.h' line='181' column='1'/>
+        <var-decl name='want' type-id='type-id-11' visibility='default' filepath='src.d/gzguts.h' line='181' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='in' type-id='type-id-89' visibility='default' filepath='src.d/gzguts.h' line='182' column='1'/>
+        <var-decl name='in' type-id='type-id-87' visibility='default' filepath='src.d/gzguts.h' line='182' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='out' type-id='type-id-89' visibility='default' filepath='src.d/gzguts.h' line='183' column='1'/>
+        <var-decl name='out' type-id='type-id-87' visibility='default' filepath='src.d/gzguts.h' line='183' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
         <var-decl name='direct' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='184' column='1'/>
@@ -870,7 +880,7 @@
         <var-decl name='how' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='186' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='start' type-id='type-id-14' visibility='default' filepath='src.d/gzguts.h' line='187' column='1'/>
+        <var-decl name='start' type-id='type-id-7' visibility='default' filepath='src.d/gzguts.h' line='187' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='640'>
         <var-decl name='eof' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='188' column='1'/>
@@ -888,7 +898,7 @@
         <var-decl name='reset' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='193' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='skip' type-id='type-id-14' visibility='default' filepath='src.d/gzguts.h' line='195' column='1'/>
+        <var-decl name='skip' type-id='type-id-7' visibility='default' filepath='src.d/gzguts.h' line='195' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='896'>
         <var-decl name='seek' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='196' column='1'/>
@@ -897,27 +907,30 @@
         <var-decl name='err' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='198' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='msg' type-id='type-id-68' visibility='default' filepath='src.d/gzguts.h' line='199' column='1'/>
+        <var-decl name='msg' type-id='type-id-53' visibility='default' filepath='src.d/gzguts.h' line='199' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1024'>
         <var-decl name='strm' type-id='type-id-70' visibility='default' filepath='src.d/gzguts.h' line='201' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='gz_state' type-id='type-id-95' filepath='src.d/gzguts.h' line='202' column='1' id='type-id-94'/>
-    <typedef-decl name='gz_statep' type-id='type-id-96' filepath='src.d/gzguts.h' line='203' column='1' id='type-id-97'/>
-    <pointer-type-def type-id='type-id-94' size-in-bits='64' id='type-id-96'/>
+    <typedef-decl name='__ssize_t' type-id='type-id-1' filepath='/usr/powerpc64-linux-gnu/include/bits/types.h' line='194' column='1' id='type-id-93'/>
+    <typedef-decl name='gz_state' type-id='type-id-92' filepath='src.d/gzguts.h' line='202' column='1' id='type-id-91'/>
+    <typedef-decl name='gz_statep' type-id='type-id-94' filepath='src.d/gzguts.h' line='203' column='1' id='type-id-95'/>
+    <typedef-decl name='ssize_t' type-id='type-id-93' filepath='/usr/powerpc64-linux-gnu/include/sys/types.h' line='108' column='1' id='type-id-96'/>
+    <pointer-type-def type-id='type-id-91' size-in-bits='64' id='type-id-94'/>
+    <typedef-decl name='voidp' type-id='type-id-84' filepath='./zconf.h' line='416' column='1' id='type-id-97'/>
     <function-decl name='__errno_location' filepath='/usr/powerpc64-linux-gnu/include/errno.h' line='37' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-81'/>
+      <return type-id='type-id-76'/>
     </function-decl>
     <function-decl name='memchr' filepath='/usr/powerpc64-linux-gnu/include/string.h' line='107' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-84'/>
       <parameter type-id='type-id-20'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-84'/>
     </function-decl>
     <function-decl name='strerror' filepath='/usr/powerpc64-linux-gnu/include/string.h' line='419' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-20'/>
-      <return type-id='type-id-68'/>
+      <return type-id='type-id-53'/>
     </function-decl>
     <function-decl name='close' filepath='/usr/powerpc64-linux-gnu/include/unistd.h' line='358' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-20'/>
@@ -925,126 +938,151 @@
     </function-decl>
     <function-decl name='read' filepath='/usr/powerpc64-linux-gnu/include/unistd.h' line='371' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-20'/>
-      <parameter type-id='type-id-44'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-93'/>
+      <parameter type-id='type-id-84'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-96'/>
     </function-decl>
     <function-decl name='gz_error' filepath='src.d/gzguts.h' line='206' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-97'/>
+      <parameter type-id='type-id-95'/>
       <parameter type-id='type-id-20'/>
-      <parameter type-id='type-id-78'/>
-      <return type-id='type-id-42'/>
+      <parameter type-id='type-id-22'/>
+      <return type-id='type-id-85'/>
     </function-decl>
     <function-decl name='gzread' mangled-name='gzread' filepath='src.d/gzread.c' line='373' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzread'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzread.c' line='374' column='1'/>
-      <parameter type-id='type-id-91' name='buf' filepath='src.d/gzread.c' line='375' column='1'/>
-      <parameter type-id='type-id-3' name='len' filepath='src.d/gzread.c' line='376' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='374' column='1'/>
+      <parameter type-id='type-id-97' name='buf' filepath='src.d/gzread.c' line='375' column='1'/>
+      <parameter type-id='type-id-11' name='len' filepath='src.d/gzread.c' line='376' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzfread' mangled-name='gzfread' filepath='src.d/gzread.c' line='409' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzfread@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-91' name='buf' filepath='src.d/gzread.c' line='410' column='1'/>
-      <parameter type-id='type-id-6' name='size' filepath='src.d/gzread.c' line='411' column='1'/>
-      <parameter type-id='type-id-6' name='nitems' filepath='src.d/gzread.c' line='412' column='1'/>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzread.c' line='413' column='1'/>
-      <return type-id='type-id-6'/>
+      <parameter type-id='type-id-97' name='buf' filepath='src.d/gzread.c' line='410' column='1'/>
+      <parameter type-id='type-id-14' name='size' filepath='src.d/gzread.c' line='411' column='1'/>
+      <parameter type-id='type-id-14' name='nitems' filepath='src.d/gzread.c' line='412' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='413' column='1'/>
+      <return type-id='type-id-14'/>
     </function-decl>
     <function-decl name='gzgetc' mangled-name='gzgetc' filepath='src.d/gzread.c' line='445' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzgetc'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzread.c' line='446' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='446' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzgetc_' mangled-name='gzgetc_' filepath='src.d/gzread.c' line='472' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzgetc_@@ZLIB_1.2.5.2'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzread.c' line='473' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='473' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzungetc' mangled-name='gzungetc' filepath='src.d/gzread.c' line='479' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzungetc@@ZLIB_1.2.0.2'>
       <parameter type-id='type-id-20' name='c' filepath='src.d/gzread.c' line='480' column='1'/>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzread.c' line='481' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='481' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzgets' mangled-name='gzgets' filepath='src.d/gzread.c' line='539' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzgets'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzread.c' line='540' column='1'/>
-      <parameter type-id='type-id-68' name='buf' filepath='src.d/gzread.c' line='541' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='540' column='1'/>
+      <parameter type-id='type-id-53' name='buf' filepath='src.d/gzread.c' line='541' column='1'/>
       <parameter type-id='type-id-20' name='len' filepath='src.d/gzread.c' line='542' column='1'/>
-      <return type-id='type-id-68'/>
+      <return type-id='type-id-53'/>
     </function-decl>
     <function-decl name='gzdirect' mangled-name='gzdirect' filepath='src.d/gzread.c' line='603' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzdirect@@ZLIB_1.2.2.3'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzread.c' line='604' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='604' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflate' filepath='src.d/zlib.h' line='400' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateEnd' filepath='src.d/zlib.h' line='520' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-21'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateReset' filepath='src.d/zlib.h' line='959' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-21'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateInit2_' filepath='src.d/zlib.h' line='1789' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-20'/>
       <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/gzwrite.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <typedef-decl name='voidpc' type-id='type-id-44' filepath='./zconf.h' line='414' column='1' id='type-id-98'/>
-    <typedef-decl name='__gnuc_va_list' type-id='type-id-68' filepath='/usr/lib/gcc-cross/powerpc64-linux-gnu/11/include/stdarg.h' line='40' column='1' id='type-id-99'/>
-    <typedef-decl name='va_list' type-id='type-id-99' filepath='/usr/lib/gcc-cross/powerpc64-linux-gnu/11/include/stdarg.h' line='99' column='1' id='type-id-100'/>
-    <function-decl name='vsnprintf' filepath='/usr/powerpc64-linux-gnu/include/stdio.h' line='382' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-68'/>
-      <parameter type-id='type-id-5'/>
-      <parameter type-id='type-id-78'/>
-      <parameter type-id='type-id-68'/>
+    <typedef-decl name='__gnuc_va_list' type-id='type-id-53' filepath='/usr/lib/gcc-cross/powerpc64-linux-gnu/13/include/stdarg.h' line='40' column='1' id='type-id-98'/>
+    <typedef-decl name='va_list' type-id='type-id-98' filepath='/usr/lib/gcc-cross/powerpc64-linux-gnu/13/include/stdarg.h' line='103' column='1' id='type-id-99'/>
+    <typedef-decl name='voidpc' type-id='type-id-84' filepath='./zconf.h' line='414' column='1' id='type-id-100'/>
+    <function-decl name='vsnprintf' filepath='/usr/powerpc64-linux-gnu/include/stdio.h' line='389' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-10'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-53'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='memmove' filepath='/usr/powerpc64-linux-gnu/include/string.h' line='47' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-44'/>
-      <parameter type-id='type-id-44'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-84'/>
+      <parameter type-id='type-id-84'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-84'/>
     </function-decl>
     <function-decl name='write' filepath='/usr/powerpc64-linux-gnu/include/unistd.h' line='378' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-20'/>
-      <parameter type-id='type-id-44'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-93'/>
+      <parameter type-id='type-id-84'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-96'/>
     </function-decl>
     <function-decl name='gzwrite' mangled-name='gzwrite' filepath='src.d/gzwrite.c' line='255' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzwrite'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='256' column='1'/>
-      <parameter type-id='type-id-98' name='buf' filepath='src.d/gzwrite.c' line='257' column='1'/>
-      <parameter type-id='type-id-3' name='len' filepath='src.d/gzwrite.c' line='258' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='256' column='1'/>
+      <parameter type-id='type-id-100' name='buf' filepath='src.d/gzwrite.c' line='257' column='1'/>
+      <parameter type-id='type-id-11' name='len' filepath='src.d/gzwrite.c' line='258' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzfwrite' mangled-name='gzfwrite' filepath='src.d/gzwrite.c' line='283' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzfwrite@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-98' name='buf' filepath='src.d/gzwrite.c' line='284' column='1'/>
-      <parameter type-id='type-id-6' name='size' filepath='src.d/gzwrite.c' line='285' column='1'/>
-      <parameter type-id='type-id-6' name='nitems' filepath='src.d/gzwrite.c' line='286' column='1'/>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='287' column='1'/>
-      <return type-id='type-id-6'/>
+      <parameter type-id='type-id-100' name='buf' filepath='src.d/gzwrite.c' line='284' column='1'/>
+      <parameter type-id='type-id-14' name='size' filepath='src.d/gzwrite.c' line='285' column='1'/>
+      <parameter type-id='type-id-14' name='nitems' filepath='src.d/gzwrite.c' line='286' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='287' column='1'/>
+      <return type-id='type-id-14'/>
     </function-decl>
     <function-decl name='gzputc' mangled-name='gzputc' filepath='src.d/gzwrite.c' line='313' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzputc'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='314' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='314' column='1'/>
       <parameter type-id='type-id-20' name='c' filepath='src.d/gzwrite.c' line='315' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzputs' mangled-name='gzputs' filepath='src.d/gzwrite.c' line='361' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzputs'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='362' column='1'/>
-      <parameter type-id='type-id-78' name='s' filepath='src.d/gzwrite.c' line='363' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='362' column='1'/>
+      <parameter type-id='type-id-22' name='s' filepath='src.d/gzwrite.c' line='363' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzvprintf' mangled-name='gzvprintf' filepath='src.d/gzwrite.c' line='391' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzvprintf@@ZLIB_1.2.7.1'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='391' column='1'/>
-      <parameter type-id='type-id-78' name='format' filepath='src.d/gzwrite.c' line='391' column='1'/>
-      <parameter type-id='type-id-100' name='va' filepath='src.d/gzwrite.c' line='391' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='391' column='1'/>
+      <parameter type-id='type-id-22' name='format' filepath='src.d/gzwrite.c' line='391' column='1'/>
+      <parameter type-id='type-id-99' name='va' filepath='src.d/gzwrite.c' line='391' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzprintf' mangled-name='gzprintf' filepath='src.d/gzwrite.c' line='463' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzprintf'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='463' column='1'/>
-      <parameter type-id='type-id-78' name='format' filepath='src.d/gzwrite.c' line='463' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='463' column='1'/>
+      <parameter type-id='type-id-22' name='format' filepath='src.d/gzwrite.c' line='463' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzflush' mangled-name='gzflush' filepath='src.d/gzwrite.c' line='565' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzflush'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='566' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='566' column='1'/>
       <parameter type-id='type-id-20' name='flush' filepath='src.d/gzwrite.c' line='567' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzsetparams' mangled-name='gzsetparams' filepath='src.d/gzwrite.c' line='597' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzsetparams'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='598' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='598' column='1'/>
       <parameter type-id='type-id-20' name='level' filepath='src.d/gzwrite.c' line='599' column='1'/>
       <parameter type-id='type-id-20' name='strategy' filepath='src.d/gzwrite.c' line='600' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/infback.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-101'/>
-    <class-decl name='code' size-in-bits='32' is-struct='yes' naming-typedef-id='type-id-102' visibility='default' filepath='src.d/inftrees.h' line='24' column='1' id='type-id-103'>
+    <enum-decl name='codetype' naming-typedef-id='type-id-101' filepath='src.d/inftrees.h' line='54' column='1' id='type-id-102'>
+      <underlying-type type-id='type-id-103'/>
+      <enumerator name='CODES' value='0'/>
+      <enumerator name='LENS' value='1'/>
+      <enumerator name='DISTS' value='2'/>
+    </enum-decl>
+    <class-decl name='code' size-in-bits='32' is-struct='yes' naming-typedef-id='type-id-104' visibility='default' filepath='src.d/inftrees.h' line='24' column='1' id='type-id-105'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='op' type-id='type-id-2' visibility='default' filepath='src.d/inftrees.h' line='25' column='1'/>
       </data-member>
@@ -1052,217 +1090,186 @@
         <var-decl name='bits' type-id='type-id-2' visibility='default' filepath='src.d/inftrees.h' line='26' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='16'>
-        <var-decl name='val' type-id='type-id-38' visibility='default' filepath='src.d/inftrees.h' line='27' column='1'/>
+        <var-decl name='val' type-id='type-id-69' visibility='default' filepath='src.d/inftrees.h' line='27' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='code' type-id='type-id-103' filepath='src.d/inftrees.h' line='28' column='1' id='type-id-102'/>
-    <enum-decl name='codetype' naming-typedef-id='type-id-104' filepath='src.d/inftrees.h' line='54' column='1' id='type-id-105'>
-      <underlying-type type-id='type-id-101'/>
-      <enumerator name='CODES' value='0'/>
-      <enumerator name='LENS' value='1'/>
-      <enumerator name='DISTS' value='2'/>
-    </enum-decl>
-    <typedef-decl name='codetype' type-id='type-id-105' filepath='src.d/inftrees.h' line='58' column='1' id='type-id-104'/>
+    <typedef-decl name='code' type-id='type-id-105' filepath='src.d/inftrees.h' line='28' column='1' id='type-id-104'/>
+    <typedef-decl name='codetype' type-id='type-id-102' filepath='src.d/inftrees.h' line='58' column='1' id='type-id-101'/>
     <typedef-decl name='in_func' type-id='type-id-106' filepath='src.d/zlib.h' line='1094' column='1' id='type-id-107'/>
     <typedef-decl name='out_func' type-id='type-id-108' filepath='src.d/zlib.h' line='1096' column='1' id='type-id-109'/>
-    <pointer-type-def type-id='type-id-102' size-in-bits='64' id='type-id-110'/>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-103'/>
+    <pointer-type-def type-id='type-id-104' size-in-bits='64' id='type-id-110'/>
     <pointer-type-def type-id='type-id-110' size-in-bits='64' id='type-id-111'/>
     <pointer-type-def type-id='type-id-112' size-in-bits='64' id='type-id-108'/>
-    <pointer-type-def type-id='type-id-2' size-in-bits='64' id='type-id-89'/>
-    <pointer-type-def type-id='type-id-89' size-in-bits='64' id='type-id-113'/>
+    <pointer-type-def type-id='type-id-2' size-in-bits='64' id='type-id-87'/>
+    <pointer-type-def type-id='type-id-87' size-in-bits='64' id='type-id-113'/>
     <pointer-type-def type-id='type-id-114' size-in-bits='64' id='type-id-106'/>
-    <pointer-type-def type-id='type-id-38' size-in-bits='64' id='type-id-115'/>
+    <pointer-type-def type-id='type-id-69' size-in-bits='64' id='type-id-115'/>
+    <typedef-decl name='voidpf' type-id='type-id-84' filepath='./zconf.h' line='415' column='1' id='type-id-116'/>
     <function-decl name='inflateBackInit_' mangled-name='inflateBackInit_' filepath='src.d/infback.c' line='28' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateBackInit_@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/infback.c' line='29' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/infback.c' line='29' column='1'/>
       <parameter type-id='type-id-20' name='windowBits' filepath='src.d/infback.c' line='30' column='1'/>
-      <parameter type-id='type-id-89' name='window' filepath='src.d/infback.c' line='31' column='1'/>
-      <parameter type-id='type-id-78' name='version' filepath='src.d/infback.c' line='32' column='1'/>
+      <parameter type-id='type-id-87' name='window' filepath='src.d/infback.c' line='31' column='1'/>
+      <parameter type-id='type-id-22' name='version' filepath='src.d/infback.c' line='32' column='1'/>
       <parameter type-id='type-id-20' name='stream_size' filepath='src.d/infback.c' line='33' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateBack' mangled-name='inflateBack' filepath='src.d/infback.c' line='251' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateBack@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/infback.c' line='252' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/infback.c' line='252' column='1'/>
       <parameter type-id='type-id-107' name='in' filepath='src.d/infback.c' line='253' column='1'/>
-      <parameter type-id='type-id-44' name='in_desc' filepath='src.d/infback.c' line='254' column='1'/>
+      <parameter type-id='type-id-84' name='in_desc' filepath='src.d/infback.c' line='254' column='1'/>
       <parameter type-id='type-id-109' name='out' filepath='src.d/infback.c' line='255' column='1'/>
-      <parameter type-id='type-id-44' name='out_desc' filepath='src.d/infback.c' line='256' column='1'/>
+      <parameter type-id='type-id-84' name='out_desc' filepath='src.d/infback.c' line='256' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateBackEnd' mangled-name='inflateBackEnd' filepath='src.d/infback.c' line='635' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateBackEnd@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/infback.c' line='636' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/infback.c' line='636' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflate_fast' filepath='src.d/inffast.h' line='11' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-57'/>
-      <parameter type-id='type-id-3'/>
-      <return type-id='type-id-42'/>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-11'/>
+      <return type-id='type-id-85'/>
     </function-decl>
     <function-decl name='inflate_table' filepath='src.d/inftrees.h' line='60' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
+      <parameter type-id='type-id-101'/>
       <parameter type-id='type-id-115'/>
-      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-11'/>
       <parameter type-id='type-id-111'/>
-      <parameter type-id='type-id-84'/>
+      <parameter type-id='type-id-79'/>
       <parameter type-id='type-id-115'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-type size-in-bits='64' id='type-id-112'>
-      <parameter type-id='type-id-44'/>
-      <parameter type-id='type-id-89'/>
-      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-84'/>
+      <parameter type-id='type-id-87'/>
+      <parameter type-id='type-id-11'/>
       <return type-id='type-id-20'/>
     </function-type>
     <function-type size-in-bits='64' id='type-id-114'>
-      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-84'/>
       <parameter type-id='type-id-113'/>
-      <return type-id='type-id-3'/>
+      <return type-id='type-id-11'/>
     </function-type>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/inflate.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
+    <typedef-decl name='voidpf' type-id='type-id-84' filepath='./zconf.h' line='415' column='1' id='type-id-117'/>
     <function-decl name='inflateResetKeep' mangled-name='inflateResetKeep' filepath='src.d/inflate.c' line='119' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateResetKeep@@ZLIB_1.2.5.2'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='120' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
-    <function-decl name='inflateReset' mangled-name='inflateReset' filepath='src.d/inflate.c' line='145' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateReset'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='146' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='120' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateReset2' mangled-name='inflateReset2' filepath='src.d/inflate.c' line='158' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateReset2@@ZLIB_1.2.3.4'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='159' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='159' column='1'/>
       <parameter type-id='type-id-20' name='windowBits' filepath='src.d/inflate.c' line='160' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='inflateInit2_' mangled-name='inflateInit2_' filepath='src.d/inflate.c' line='198' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateInit2_'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='199' column='1'/>
-      <parameter type-id='type-id-20' name='windowBits' filepath='src.d/inflate.c' line='200' column='1'/>
-      <parameter type-id='type-id-78' name='version' filepath='src.d/inflate.c' line='201' column='1'/>
-      <parameter type-id='type-id-20' name='stream_size' filepath='src.d/inflate.c' line='202' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
     <function-decl name='inflateInit_' mangled-name='inflateInit_' filepath='src.d/inflate.c' line='242' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateInit_'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='243' column='1'/>
-      <parameter type-id='type-id-78' name='version' filepath='src.d/inflate.c' line='244' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='243' column='1'/>
+      <parameter type-id='type-id-22' name='version' filepath='src.d/inflate.c' line='244' column='1'/>
       <parameter type-id='type-id-20' name='stream_size' filepath='src.d/inflate.c' line='245' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflatePrime' mangled-name='inflatePrime' filepath='src.d/inflate.c' line='250' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflatePrime@@ZLIB_1.2.2.4'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='251' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='251' column='1'/>
       <parameter type-id='type-id-20' name='bits' filepath='src.d/inflate.c' line='252' column='1'/>
       <parameter type-id='type-id-20' name='value' filepath='src.d/inflate.c' line='253' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='inflate' mangled-name='inflate' filepath='src.d/inflate.c' line='625' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflate'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='626' column='1'/>
-      <parameter type-id='type-id-20' name='flush' filepath='src.d/inflate.c' line='627' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
-    <function-decl name='inflateEnd' mangled-name='inflateEnd' filepath='src.d/inflate.c' line='1304' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateEnd'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1305' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
     <function-decl name='inflateGetDictionary' mangled-name='inflateGetDictionary' filepath='src.d/inflate.c' line='1318' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateGetDictionary@@ZLIB_1.2.7.1'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1319' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1319' column='1'/>
       <parameter type-id='type-id-19' name='dictionary' filepath='src.d/inflate.c' line='1320' column='1'/>
-      <parameter type-id='type-id-83' name='dictLength' filepath='src.d/inflate.c' line='1321' column='1'/>
+      <parameter type-id='type-id-78' name='dictLength' filepath='src.d/inflate.c' line='1321' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateSetDictionary' mangled-name='inflateSetDictionary' filepath='src.d/inflate.c' line='1341' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateSetDictionary'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1342' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1342' column='1'/>
       <parameter type-id='type-id-16' name='dictionary' filepath='src.d/inflate.c' line='1343' column='1'/>
-      <parameter type-id='type-id-8' name='dictLength' filepath='src.d/inflate.c' line='1344' column='1'/>
+      <parameter type-id='type-id-12' name='dictLength' filepath='src.d/inflate.c' line='1344' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateGetHeader' mangled-name='inflateGetHeader' filepath='src.d/inflate.c' line='1376' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateGetHeader@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1377' column='1'/>
-      <parameter type-id='type-id-59' name='head' filepath='src.d/inflate.c' line='1378' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1377' column='1'/>
+      <parameter type-id='type-id-42' name='head' filepath='src.d/inflate.c' line='1378' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateSync' mangled-name='inflateSync' filepath='src.d/inflate.c' line='1427' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateSync'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1428' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1428' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateSyncPoint' mangled-name='inflateSyncPoint' filepath='src.d/inflate.c' line='1485' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateSyncPoint'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1486' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1486' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateCopy' mangled-name='inflateCopy' filepath='src.d/inflate.c' line='1495' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateCopy@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-57' name='dest' filepath='src.d/inflate.c' line='1496' column='1'/>
-      <parameter type-id='type-id-57' name='source' filepath='src.d/inflate.c' line='1497' column='1'/>
+      <parameter type-id='type-id-21' name='dest' filepath='src.d/inflate.c' line='1496' column='1'/>
+      <parameter type-id='type-id-21' name='source' filepath='src.d/inflate.c' line='1497' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateUndermine' mangled-name='inflateUndermine' filepath='src.d/inflate.c' line='1542' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateUndermine@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1543' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1543' column='1'/>
       <parameter type-id='type-id-20' name='subvert' filepath='src.d/inflate.c' line='1544' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateValidate' mangled-name='inflateValidate' filepath='src.d/inflate.c' line='1560' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateValidate@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1561' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1561' column='1'/>
       <parameter type-id='type-id-20' name='check' filepath='src.d/inflate.c' line='1562' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateMark' mangled-name='inflateMark' filepath='src.d/inflate.c' line='1575' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateMark@@ZLIB_1.2.3.4'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1576' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1576' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='inflateCodesUsed' mangled-name='inflateCodesUsed' filepath='src.d/inflate.c' line='1588' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateCodesUsed@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1589' column='1'/>
-      <return type-id='type-id-4'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1589' column='1'/>
+      <return type-id='type-id-9'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/trees.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <array-type-def dimensions='1' type-id='type-id-116' size-in-bits='2048' id='type-id-117'>
-      <subrange length='256' type-id='type-id-4' id='type-id-118'/>
+    <array-type-def dimensions='1' type-id='type-id-118' size-in-bits='2048' id='type-id-119'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-9' id='type-id-120'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-116' size-in-bits='4096' id='type-id-119'>
-      <subrange length='512' type-id='type-id-4' id='type-id-120'/>
+    <array-type-def dimensions='1' type-id='type-id-118' size-in-bits='4096' id='type-id-121'>
+      <subrange length='512' lower-bound='0' upper-bound='511' type-id='type-id-9' id='type-id-122'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-116' size-in-bits='infinite' id='type-id-121'>
-      <subrange length='infinite' id='type-id-122'/>
+    <array-type-def dimensions='1' type-id='type-id-118' size-in-bits='unknown' id='type-id-123'>
+      <subrange length='unknown' lower-bound='0' upper-bound='0' id='type-id-124'/>
     </array-type-def>
-    <qualified-type-def type-id='type-id-36' const='yes' id='type-id-116'/>
-    <var-decl name='_length_code' type-id='type-id-121' visibility='default' filepath='src.d/deflate.h' line='317' column='1'/>
+    <qualified-type-def type-id='type-id-67' const='yes' id='type-id-118'/>
+    <var-decl name='_length_code' type-id='type-id-119' visibility='default' filepath='src.d/deflate.h' line='317' column='1'/>
     <var-decl name='_dist_code' type-id='type-id-121' visibility='default' filepath='src.d/deflate.h' line='318' column='1'/>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/uncompr.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <pointer-type-def type-id='type-id-9' size-in-bits='64' id='type-id-123'/>
+    <pointer-type-def type-id='type-id-13' size-in-bits='64' id='type-id-125'/>
     <function-decl name='uncompress2' mangled-name='uncompress2' filepath='src.d/uncompr.c' line='27' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uncompress2@@ZLIB_1.2.9'>
       <parameter type-id='type-id-19' name='dest' filepath='src.d/uncompr.c' line='28' column='1'/>
       <parameter type-id='type-id-18' name='destLen' filepath='src.d/uncompr.c' line='29' column='1'/>
       <parameter type-id='type-id-16' name='source' filepath='src.d/uncompr.c' line='30' column='1'/>
-      <parameter type-id='type-id-123' name='sourceLen' filepath='src.d/uncompr.c' line='31' column='1'/>
+      <parameter type-id='type-id-125' name='sourceLen' filepath='src.d/uncompr.c' line='31' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='uncompress' mangled-name='uncompress' filepath='src.d/uncompr.c' line='86' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uncompress'>
       <parameter type-id='type-id-19' name='dest' filepath='src.d/uncompr.c' line='87' column='1'/>
       <parameter type-id='type-id-18' name='destLen' filepath='src.d/uncompr.c' line='88' column='1'/>
       <parameter type-id='type-id-16' name='source' filepath='src.d/uncompr.c' line='89' column='1'/>
-      <parameter type-id='type-id-9' name='sourceLen' filepath='src.d/uncompr.c' line='90' column='1'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/uncompr.c' line='90' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/zutil.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <array-type-def dimensions='1' type-id='type-id-124' size-in-bits='640' id='type-id-125'>
-      <subrange length='10' type-id='type-id-4' id='type-id-126'/>
+    <array-type-def dimensions='1' type-id='type-id-126' size-in-bits='640' id='type-id-127'>
+      <subrange length='10' lower-bound='0' upper-bound='9' type-id='type-id-9' id='type-id-128'/>
     </array-type-def>
-    <qualified-type-def type-id='type-id-68' const='yes' id='type-id-124'/>
-    <function-decl name='malloc' filepath='/usr/powerpc64-linux-gnu/include/stdlib.h' line='540' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-44'/>
-    </function-decl>
-    <function-decl name='free' filepath='/usr/powerpc64-linux-gnu/include/stdlib.h' line='555' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-44'/>
-      <return type-id='type-id-42'/>
-    </function-decl>
+    <qualified-type-def type-id='type-id-53' const='yes' id='type-id-126'/>
     <function-decl name='zlibVersion' mangled-name='zlibVersion' filepath='src.d/zutil.c' line='27' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zlibVersion'>
-      <return type-id='type-id-78'/>
+      <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='zlibCompileFlags' mangled-name='zlibCompileFlags' filepath='src.d/zutil.c' line='32' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zlibCompileFlags@@ZLIB_1.2.0.2'>
-      <return type-id='type-id-9'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='zError' mangled-name='zError' filepath='src.d/zutil.c' line='135' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zError'>
       <parameter type-id='type-id-20' name='err' filepath='src.d/zutil.c' line='136' column='1'/>
-      <return type-id='type-id-78'/>
+      <return type-id='type-id-22'/>
     </function-decl>
-    <var-decl name='z_errmsg' type-id='type-id-125' visibility='default' filepath='src.d/zutil.h' line='56' column='1'/>
+    <var-decl name='z_errmsg' type-id='type-id-127' visibility='default' filepath='src.d/zutil.h' line='56' column='1'/>
   </abi-instr>
 </abi-corpus>

--- a/test/abi/zlib-04f42ceca40f73e2978b50e93806c2a18c1281fc-powerpc64le-unknown-linux-gnu.abi
+++ b/test/abi/zlib-04f42ceca40f73e2978b50e93806c2a18c1281fc-powerpc64le-unknown-linux-gnu.abi
@@ -1,4 +1,4 @@
-<abi-corpus version='2.0' path='btmp1/libz.so.1.2.13' architecture='elf-powerpc-64' soname='libz.so.1'>
+<abi-corpus version='2.2' path='btmp1/libz.so.1.2.13' architecture='elf-powerpc-64' soname='libz.so.1'>
   <elf-needed>
     <dependency name='libc.so.6'/>
   </elf-needed>
@@ -94,54 +94,54 @@
   </elf-function-symbols>
   <abi-instr address-size='64' path='src.d/adler32.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
     <type-decl name='long int' size-in-bits='64' id='type-id-1'/>
+    <typedef-decl name='Byte' type-id='type-id-2' filepath='./zconf.h' line='397' column='1' id='type-id-3'/>
+    <typedef-decl name='Bytef' type-id='type-id-3' filepath='./zconf.h' line='406' column='1' id='type-id-4'/>
+    <typedef-decl name='__off64_t' type-id='type-id-1' filepath='/usr/powerpc64le-linux-gnu/include/bits/types.h' line='153' column='1' id='type-id-5'/>
+    <typedef-decl name='__off_t' type-id='type-id-1' filepath='/usr/powerpc64le-linux-gnu/include/bits/types.h' line='152' column='1' id='type-id-6'/>
+    <typedef-decl name='off64_t' type-id='type-id-5' filepath='/usr/powerpc64le-linux-gnu/include/sys/types.h' line='92' column='1' id='type-id-7'/>
+    <typedef-decl name='off_t' type-id='type-id-6' filepath='/usr/powerpc64le-linux-gnu/include/sys/types.h' line='85' column='1' id='type-id-8'/>
+    <typedef-decl name='size_t' type-id='type-id-9' filepath='/usr/lib/gcc-cross/powerpc64le-linux-gnu/13/include/stddef.h' line='214' column='1' id='type-id-10'/>
+    <typedef-decl name='uInt' type-id='type-id-11' filepath='./zconf.h' line='399' column='1' id='type-id-12'/>
+    <typedef-decl name='uLong' type-id='type-id-9' filepath='./zconf.h' line='400' column='1' id='type-id-13'/>
+    <typedef-decl name='z_size_t' type-id='type-id-10' filepath='./zconf.h' line='251' column='1' id='type-id-14'/>
     <type-decl name='unsigned char' size-in-bits='8' id='type-id-2'/>
-    <type-decl name='unsigned int' size-in-bits='32' id='type-id-3'/>
-    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-4'/>
-    <typedef-decl name='z_size_t' type-id='type-id-5' filepath='./zconf.h' line='251' column='1' id='type-id-6'/>
-    <typedef-decl name='Byte' type-id='type-id-2' filepath='./zconf.h' line='397' column='1' id='type-id-7'/>
-    <typedef-decl name='uInt' type-id='type-id-3' filepath='./zconf.h' line='399' column='1' id='type-id-8'/>
-    <typedef-decl name='uLong' type-id='type-id-4' filepath='./zconf.h' line='400' column='1' id='type-id-9'/>
-    <typedef-decl name='Bytef' type-id='type-id-7' filepath='./zconf.h' line='406' column='1' id='type-id-10'/>
-    <typedef-decl name='size_t' type-id='type-id-4' filepath='/usr/lib/gcc-cross/powerpc64le-linux-gnu/11/include/stddef.h' line='209' column='1' id='type-id-5'/>
-    <typedef-decl name='__off_t' type-id='type-id-1' filepath='/usr/powerpc64le-linux-gnu/include/bits/types.h' line='152' column='1' id='type-id-11'/>
-    <typedef-decl name='__off64_t' type-id='type-id-1' filepath='/usr/powerpc64le-linux-gnu/include/bits/types.h' line='153' column='1' id='type-id-12'/>
-    <typedef-decl name='off_t' type-id='type-id-11' filepath='/usr/powerpc64le-linux-gnu/include/sys/types.h' line='85' column='1' id='type-id-13'/>
-    <typedef-decl name='off64_t' type-id='type-id-12' filepath='/usr/powerpc64le-linux-gnu/include/sys/types.h' line='92' column='1' id='type-id-14'/>
-    <qualified-type-def type-id='type-id-10' const='yes' id='type-id-15'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-11'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-9'/>
+    <qualified-type-def type-id='type-id-4' const='yes' id='type-id-15'/>
     <pointer-type-def type-id='type-id-15' size-in-bits='64' id='type-id-16'/>
     <function-decl name='adler32_z' mangled-name='adler32_z' filepath='src.d/adler32.c' line='63' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='adler32_z@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-9' name='adler' filepath='src.d/adler32.c' line='64' column='1'/>
+      <parameter type-id='type-id-13' name='adler' filepath='src.d/adler32.c' line='64' column='1'/>
       <parameter type-id='type-id-16' name='buf' filepath='src.d/adler32.c' line='65' column='1'/>
-      <parameter type-id='type-id-6' name='len' filepath='src.d/adler32.c' line='66' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-14' name='len' filepath='src.d/adler32.c' line='66' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='adler32' mangled-name='adler32' filepath='src.d/adler32.c' line='134' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='adler32'>
-      <parameter type-id='type-id-9' name='adler' filepath='src.d/adler32.c' line='135' column='1'/>
+      <parameter type-id='type-id-13' name='adler' filepath='src.d/adler32.c' line='135' column='1'/>
       <parameter type-id='type-id-16' name='buf' filepath='src.d/adler32.c' line='136' column='1'/>
-      <parameter type-id='type-id-8' name='len' filepath='src.d/adler32.c' line='137' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-12' name='len' filepath='src.d/adler32.c' line='137' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='adler32_combine' mangled-name='adler32_combine' filepath='src.d/adler32.c' line='172' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='adler32_combine@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-9' name='adler1' filepath='src.d/adler32.c' line='173' column='1'/>
-      <parameter type-id='type-id-9' name='adler2' filepath='src.d/adler32.c' line='174' column='1'/>
-      <parameter type-id='type-id-13' name='len2' filepath='src.d/adler32.c' line='175' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-13' name='adler1' filepath='src.d/adler32.c' line='173' column='1'/>
+      <parameter type-id='type-id-13' name='adler2' filepath='src.d/adler32.c' line='174' column='1'/>
+      <parameter type-id='type-id-8' name='len2' filepath='src.d/adler32.c' line='175' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='adler32_combine64' mangled-name='adler32_combine64' filepath='src.d/adler32.c' line='180' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='adler32_combine64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-9' name='adler1' filepath='src.d/adler32.c' line='181' column='1'/>
-      <parameter type-id='type-id-9' name='adler2' filepath='src.d/adler32.c' line='182' column='1'/>
-      <parameter type-id='type-id-14' name='len2' filepath='src.d/adler32.c' line='183' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-13' name='adler1' filepath='src.d/adler32.c' line='181' column='1'/>
+      <parameter type-id='type-id-13' name='adler2' filepath='src.d/adler32.c' line='182' column='1'/>
+      <parameter type-id='type-id-7' name='len2' filepath='src.d/adler32.c' line='183' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/compress.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <typedef-decl name='uLongf' type-id='type-id-9' filepath='./zconf.h' line='411' column='1' id='type-id-17'/>
+    <typedef-decl name='uLongf' type-id='type-id-13' filepath='./zconf.h' line='411' column='1' id='type-id-17'/>
     <pointer-type-def type-id='type-id-17' size-in-bits='64' id='type-id-18'/>
     <function-decl name='compress2' mangled-name='compress2' filepath='src.d/compress.c' line='22' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='compress2'>
       <parameter type-id='type-id-19' name='dest' filepath='src.d/compress.c' line='23' column='1'/>
       <parameter type-id='type-id-18' name='destLen' filepath='src.d/compress.c' line='24' column='1'/>
       <parameter type-id='type-id-16' name='source' filepath='src.d/compress.c' line='25' column='1'/>
-      <parameter type-id='type-id-9' name='sourceLen' filepath='src.d/compress.c' line='26' column='1'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/compress.c' line='26' column='1'/>
       <parameter type-id='type-id-20' name='level' filepath='src.d/compress.c' line='27' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
@@ -149,362 +149,107 @@
       <parameter type-id='type-id-19' name='dest' filepath='src.d/compress.c' line='69' column='1'/>
       <parameter type-id='type-id-18' name='destLen' filepath='src.d/compress.c' line='70' column='1'/>
       <parameter type-id='type-id-16' name='source' filepath='src.d/compress.c' line='71' column='1'/>
-      <parameter type-id='type-id-9' name='sourceLen' filepath='src.d/compress.c' line='72' column='1'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/compress.c' line='72' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='compressBound' mangled-name='compressBound' filepath='src.d/compress.c' line='81' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='compressBound@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-9' name='sourceLen' filepath='src.d/compress.c' line='82' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/compress.c' line='82' column='1'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+    <function-decl name='deflate' filepath='src.d/zlib.h' line='250' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='deflateEnd' filepath='src.d/zlib.h' line='363' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-21'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='deflateInit_' filepath='src.d/zlib.h' line='1781' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/crc32.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <typedef-decl name='z_crc_t' type-id='type-id-3' filepath='./zconf.h' line='435' column='1' id='type-id-21'/>
-    <qualified-type-def type-id='type-id-2' const='yes' id='type-id-22'/>
-    <pointer-type-def type-id='type-id-22' size-in-bits='64' id='type-id-23'/>
-    <qualified-type-def type-id='type-id-21' const='yes' id='type-id-24'/>
+    <typedef-decl name='z_crc_t' type-id='type-id-11' filepath='./zconf.h' line='435' column='1' id='type-id-23'/>
+    <qualified-type-def type-id='type-id-2' const='yes' id='type-id-24'/>
     <pointer-type-def type-id='type-id-24' size-in-bits='64' id='type-id-25'/>
+    <qualified-type-def type-id='type-id-23' const='yes' id='type-id-26'/>
+    <pointer-type-def type-id='type-id-26' size-in-bits='64' id='type-id-27'/>
     <function-decl name='get_crc_table' mangled-name='get_crc_table' filepath='src.d/crc32.c' line='595' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='get_crc_table'>
-      <return type-id='type-id-25'/>
+      <return type-id='type-id-27'/>
     </function-decl>
     <function-decl name='crc32_z' mangled-name='crc32_z' filepath='src.d/crc32.c' line='748' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_z@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-4' name='crc' filepath='src.d/crc32.c' line='749' column='1'/>
-      <parameter type-id='type-id-23' name='buf' filepath='src.d/crc32.c' line='750' column='1'/>
-      <parameter type-id='type-id-6' name='len' filepath='src.d/crc32.c' line='751' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-9' name='crc' filepath='src.d/crc32.c' line='749' column='1'/>
+      <parameter type-id='type-id-25' name='buf' filepath='src.d/crc32.c' line='750' column='1'/>
+      <parameter type-id='type-id-14' name='len' filepath='src.d/crc32.c' line='751' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32' mangled-name='crc32' filepath='src.d/crc32.c' line='1072' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32'>
-      <parameter type-id='type-id-4' name='crc' filepath='src.d/crc32.c' line='1073' column='1'/>
-      <parameter type-id='type-id-23' name='buf' filepath='src.d/crc32.c' line='1074' column='1'/>
-      <parameter type-id='type-id-8' name='len' filepath='src.d/crc32.c' line='1075' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-9' name='crc' filepath='src.d/crc32.c' line='1073' column='1'/>
+      <parameter type-id='type-id-25' name='buf' filepath='src.d/crc32.c' line='1074' column='1'/>
+      <parameter type-id='type-id-12' name='len' filepath='src.d/crc32.c' line='1075' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine64' mangled-name='crc32_combine64' filepath='src.d/crc32.c' line='1081' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_combine64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-9' name='crc1' filepath='src.d/crc32.c' line='1082' column='1'/>
-      <parameter type-id='type-id-9' name='crc2' filepath='src.d/crc32.c' line='1083' column='1'/>
-      <parameter type-id='type-id-14' name='len2' filepath='src.d/crc32.c' line='1084' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-13' name='crc1' filepath='src.d/crc32.c' line='1082' column='1'/>
+      <parameter type-id='type-id-13' name='crc2' filepath='src.d/crc32.c' line='1083' column='1'/>
+      <parameter type-id='type-id-7' name='len2' filepath='src.d/crc32.c' line='1084' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine' mangled-name='crc32_combine' filepath='src.d/crc32.c' line='1093' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_combine@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-9' name='crc1' filepath='src.d/crc32.c' line='1094' column='1'/>
-      <parameter type-id='type-id-9' name='crc2' filepath='src.d/crc32.c' line='1095' column='1'/>
-      <parameter type-id='type-id-13' name='len2' filepath='src.d/crc32.c' line='1096' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-13' name='crc1' filepath='src.d/crc32.c' line='1094' column='1'/>
+      <parameter type-id='type-id-13' name='crc2' filepath='src.d/crc32.c' line='1095' column='1'/>
+      <parameter type-id='type-id-8' name='len2' filepath='src.d/crc32.c' line='1096' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine_gen64' mangled-name='crc32_combine_gen64' filepath='src.d/crc32.c' line='1102' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_combine_gen64@@ZLIB_1.2.12'>
-      <parameter type-id='type-id-14' name='len2' filepath='src.d/crc32.c' line='1103' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-7' name='len2' filepath='src.d/crc32.c' line='1103' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine_gen' mangled-name='crc32_combine_gen' filepath='src.d/crc32.c' line='1112' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_combine_gen@@ZLIB_1.2.12'>
-      <parameter type-id='type-id-13' name='len2' filepath='src.d/crc32.c' line='1113' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-8' name='len2' filepath='src.d/crc32.c' line='1113' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine_op' mangled-name='crc32_combine_op' filepath='src.d/crc32.c' line='1119' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_combine_op@@ZLIB_1.2.12'>
-      <parameter type-id='type-id-9' name='crc1' filepath='src.d/crc32.c' line='1120' column='1'/>
-      <parameter type-id='type-id-9' name='crc2' filepath='src.d/crc32.c' line='1121' column='1'/>
-      <parameter type-id='type-id-9' name='op' filepath='src.d/crc32.c' line='1122' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-13' name='crc1' filepath='src.d/crc32.c' line='1120' column='1'/>
+      <parameter type-id='type-id-13' name='crc2' filepath='src.d/crc32.c' line='1121' column='1'/>
+      <parameter type-id='type-id-13' name='op' filepath='src.d/crc32.c' line='1122' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/deflate.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <type-decl name='char' size-in-bits='8' id='type-id-26'/>
-    <class-decl name='static_tree_desc_s' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-27'/>
-    <array-type-def dimensions='1' type-id='type-id-28' size-in-bits='1248' id='type-id-29'>
-      <subrange length='39' type-id='type-id-4' id='type-id-30'/>
+    <type-decl name='char' size-in-bits='8' id='type-id-28'/>
+    <array-type-def dimensions='1' type-id='type-id-29' size-in-bits='1248' id='type-id-30'>
+      <subrange length='39' lower-bound='0' upper-bound='38' type-id='type-id-9' id='type-id-31'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-28' size-in-bits='18336' id='type-id-31'>
-      <subrange length='573' type-id='type-id-4' id='type-id-32'/>
+    <array-type-def dimensions='1' type-id='type-id-29' size-in-bits='18336' id='type-id-32'>
+      <subrange length='573' lower-bound='0' upper-bound='572' type-id='type-id-9' id='type-id-33'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-28' size-in-bits='1952' id='type-id-33'>
-      <subrange length='61' type-id='type-id-4' id='type-id-34'/>
+    <array-type-def dimensions='1' type-id='type-id-29' size-in-bits='1952' id='type-id-34'>
+      <subrange length='61' lower-bound='0' upper-bound='60' type-id='type-id-9' id='type-id-35'/>
     </array-type-def>
     <type-decl name='int' size-in-bits='32' id='type-id-20'/>
-    <array-type-def dimensions='1' type-id='type-id-20' size-in-bits='18336' id='type-id-35'>
-      <subrange length='573' type-id='type-id-4' id='type-id-32'/>
+    <array-type-def dimensions='1' type-id='type-id-20' size-in-bits='18336' id='type-id-36'>
+      <subrange length='573' lower-bound='0' upper-bound='572' type-id='type-id-9' id='type-id-33'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-36' size-in-bits='4584' id='type-id-37'>
-      <subrange length='573' type-id='type-id-4' id='type-id-32'/>
-    </array-type-def>
-    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-38'/>
-    <array-type-def dimensions='1' type-id='type-id-39' size-in-bits='256' id='type-id-40'>
-      <subrange length='16' type-id='type-id-4' id='type-id-41'/>
-    </array-type-def>
-    <type-decl name='void' id='type-id-42'/>
-    <typedef-decl name='charf' type-id='type-id-26' filepath='./zconf.h' line='408' column='1' id='type-id-43'/>
-    <typedef-decl name='voidpf' type-id='type-id-44' filepath='./zconf.h' line='415' column='1' id='type-id-45'/>
-    <class-decl name='ct_data_s' size-in-bits='32' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='68' column='1' id='type-id-28'>
+    <class-decl name='ct_data_s' size-in-bits='32' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='68' column='1' id='type-id-29'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='fc' type-id='type-id-46' visibility='default' filepath='src.d/deflate.h' line='72' column='1'/>
+        <var-decl name='fc' type-id='type-id-37' visibility='default' filepath='src.d/deflate.h' line='72' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='16'>
-        <var-decl name='dl' type-id='type-id-47' visibility='default' filepath='src.d/deflate.h' line='76' column='1'/>
+        <var-decl name='dl' type-id='type-id-38' visibility='default' filepath='src.d/deflate.h' line='76' column='1'/>
       </data-member>
     </class-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='69' column='1' id='type-id-46'>
-      <data-member access='public'>
-        <var-decl name='freq' type-id='type-id-39' visibility='default' filepath='src.d/deflate.h' line='70' column='1'/>
-      </data-member>
-      <data-member access='public'>
-        <var-decl name='code' type-id='type-id-39' visibility='default' filepath='src.d/deflate.h' line='71' column='1'/>
-      </data-member>
-    </union-decl>
-    <union-decl name='__anonymous_union__1' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='73' column='1' id='type-id-47'>
-      <data-member access='public'>
-        <var-decl name='dad' type-id='type-id-39' visibility='default' filepath='src.d/deflate.h' line='74' column='1'/>
-      </data-member>
-      <data-member access='public'>
-        <var-decl name='len' type-id='type-id-39' visibility='default' filepath='src.d/deflate.h' line='75' column='1'/>
-      </data-member>
-    </union-decl>
-    <typedef-decl name='ct_data' type-id='type-id-28' filepath='src.d/deflate.h' line='77' column='1' id='type-id-48'/>
-    <typedef-decl name='static_tree_desc' type-id='type-id-27' filepath='src.d/deflate.h' line='84' column='1' id='type-id-49'/>
-    <class-decl name='tree_desc_s' size-in-bits='192' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='86' column='1' id='type-id-50'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='dyn_tree' type-id='type-id-51' visibility='default' filepath='src.d/deflate.h' line='87' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='max_code' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='88' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='stat_desc' type-id='type-id-52' visibility='default' filepath='src.d/deflate.h' line='89' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='Pos' type-id='type-id-39' filepath='src.d/deflate.h' line='92' column='1' id='type-id-53'/>
-    <typedef-decl name='Posf' type-id='type-id-53' filepath='src.d/deflate.h' line='93' column='1' id='type-id-54'/>
-    <typedef-decl name='IPos' type-id='type-id-3' filepath='src.d/deflate.h' line='94' column='1' id='type-id-55'/>
-    <class-decl name='internal_state' size-in-bits='47616' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='100' column='1' id='type-id-56'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='strm' type-id='type-id-57' visibility='default' filepath='src.d/deflate.h' line='101' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='status' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='102' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='pending_buf' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='103' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='pending_buf_size' type-id='type-id-58' visibility='default' filepath='src.d/deflate.h' line='104' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='pending_out' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='105' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='pending' type-id='type-id-58' visibility='default' filepath='src.d/deflate.h' line='106' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='wrap' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='107' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='gzhead' type-id='type-id-59' visibility='default' filepath='src.d/deflate.h' line='108' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='gzindex' type-id='type-id-58' visibility='default' filepath='src.d/deflate.h' line='109' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='method' type-id='type-id-7' visibility='default' filepath='src.d/deflate.h' line='110' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='608'>
-        <var-decl name='last_flush' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='111' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='w_size' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='115' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='672'>
-        <var-decl name='w_bits' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='116' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='w_mask' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='117' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='window' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='119' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='window_size' type-id='type-id-58' visibility='default' filepath='src.d/deflate.h' line='129' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='prev' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='134' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='head' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='140' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='ins_h' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='142' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1056'>
-        <var-decl name='hash_size' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='143' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1088'>
-        <var-decl name='hash_bits' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='144' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1120'>
-        <var-decl name='hash_mask' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='145' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1152'>
-        <var-decl name='hash_shift' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='147' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='block_start' type-id='type-id-1' visibility='default' filepath='src.d/deflate.h' line='154' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='match_length' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='159' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1312'>
-        <var-decl name='prev_match' type-id='type-id-55' visibility='default' filepath='src.d/deflate.h' line='160' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1344'>
-        <var-decl name='match_available' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='161' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1376'>
-        <var-decl name='strstart' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='162' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1408'>
-        <var-decl name='match_start' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='163' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1440'>
-        <var-decl name='lookahead' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='164' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1472'>
-        <var-decl name='prev_length' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='166' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1504'>
-        <var-decl name='max_chain_length' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='171' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1536'>
-        <var-decl name='max_lazy_match' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='177' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1568'>
-        <var-decl name='level' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='188' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1600'>
-        <var-decl name='strategy' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='189' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1632'>
-        <var-decl name='good_match' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='191' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1664'>
-        <var-decl name='nice_match' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='194' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1696'>
-        <var-decl name='dyn_ltree' type-id='type-id-31' visibility='default' filepath='src.d/deflate.h' line='198' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='20032'>
-        <var-decl name='dyn_dtree' type-id='type-id-33' visibility='default' filepath='src.d/deflate.h' line='199' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='21984'>
-        <var-decl name='bl_tree' type-id='type-id-29' visibility='default' filepath='src.d/deflate.h' line='200' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='23232'>
-        <var-decl name='l_desc' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='202' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='23424'>
-        <var-decl name='d_desc' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='203' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='23616'>
-        <var-decl name='bl_desc' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='204' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='23808'>
-        <var-decl name='bl_count' type-id='type-id-40' visibility='default' filepath='src.d/deflate.h' line='206' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='24064'>
-        <var-decl name='heap' type-id='type-id-35' visibility='default' filepath='src.d/deflate.h' line='209' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='42400'>
-        <var-decl name='heap_len' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='210' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='42432'>
-        <var-decl name='heap_max' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='211' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='42464'>
-        <var-decl name='depth' type-id='type-id-37' visibility='default' filepath='src.d/deflate.h' line='216' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47104'>
-        <var-decl name='sym_buf' type-id='type-id-61' visibility='default' filepath='src.d/deflate.h' line='220' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47168'>
-        <var-decl name='lit_bufsize' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='222' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47200'>
-        <var-decl name='sym_next' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='242' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47232'>
-        <var-decl name='sym_end' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='243' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47296'>
-        <var-decl name='opt_len' type-id='type-id-58' visibility='default' filepath='src.d/deflate.h' line='245' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47360'>
-        <var-decl name='static_len' type-id='type-id-58' visibility='default' filepath='src.d/deflate.h' line='246' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47424'>
-        <var-decl name='matches' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='247' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47456'>
-        <var-decl name='insert' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='248' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47488'>
-        <var-decl name='bi_buf' type-id='type-id-39' visibility='default' filepath='src.d/deflate.h' line='255' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47520'>
-        <var-decl name='bi_valid' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='259' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47552'>
-        <var-decl name='high_water' type-id='type-id-58' visibility='default' filepath='src.d/deflate.h' line='264' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='deflate_state' type-id='type-id-56' filepath='src.d/deflate.h' line='271' column='1' id='type-id-62'/>
-    <typedef-decl name='alloc_func' type-id='type-id-63' filepath='src.d/zlib.h' line='81' column='1' id='type-id-64'/>
-    <typedef-decl name='free_func' type-id='type-id-65' filepath='src.d/zlib.h' line='82' column='1' id='type-id-66'/>
-    <class-decl name='z_stream_s' size-in-bits='896' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='86' column='1' id='type-id-67'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='next_in' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='87' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='avail_in' type-id='type-id-8' visibility='default' filepath='src.d/zlib.h' line='88' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='total_in' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='89' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='next_out' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='91' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='avail_out' type-id='type-id-8' visibility='default' filepath='src.d/zlib.h' line='92' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='total_out' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='93' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='msg' type-id='type-id-68' visibility='default' filepath='src.d/zlib.h' line='95' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='state' type-id='type-id-69' visibility='default' filepath='src.d/zlib.h' line='96' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='zalloc' type-id='type-id-64' visibility='default' filepath='src.d/zlib.h' line='98' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='zfree' type-id='type-id-66' visibility='default' filepath='src.d/zlib.h' line='99' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='opaque' type-id='type-id-45' visibility='default' filepath='src.d/zlib.h' line='100' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='data_type' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='102' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='adler' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='104' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='reserved' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='105' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='z_stream' type-id='type-id-67' filepath='src.d/zlib.h' line='106' column='1' id='type-id-70'/>
-    <typedef-decl name='z_streamp' type-id='type-id-71' filepath='src.d/zlib.h' line='108' column='1' id='type-id-57'/>
-    <class-decl name='gz_header_s' size-in-bits='640' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='114' column='1' id='type-id-72'>
+    <class-decl name='gz_header_s' size-in-bits='640' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='114' column='1' id='type-id-39'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='text' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='115' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='time' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='116' column='1'/>
+        <var-decl name='time' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='116' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
         <var-decl name='xflags' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='117' column='1'/>
@@ -516,22 +261,22 @@
         <var-decl name='extra' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='119' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='extra_len' type-id='type-id-8' visibility='default' filepath='src.d/zlib.h' line='120' column='1'/>
+        <var-decl name='extra_len' type-id='type-id-12' visibility='default' filepath='src.d/zlib.h' line='120' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='extra_max' type-id='type-id-8' visibility='default' filepath='src.d/zlib.h' line='121' column='1'/>
+        <var-decl name='extra_max' type-id='type-id-12' visibility='default' filepath='src.d/zlib.h' line='121' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
         <var-decl name='name' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='122' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='name_max' type-id='type-id-8' visibility='default' filepath='src.d/zlib.h' line='123' column='1'/>
+        <var-decl name='name_max' type-id='type-id-12' visibility='default' filepath='src.d/zlib.h' line='123' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
         <var-decl name='comment' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='124' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='comm_max' type-id='type-id-8' visibility='default' filepath='src.d/zlib.h' line='125' column='1'/>
+        <var-decl name='comm_max' type-id='type-id-12' visibility='default' filepath='src.d/zlib.h' line='125' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='544'>
         <var-decl name='hcrc' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='126' column='1'/>
@@ -540,108 +285,368 @@
         <var-decl name='done' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='127' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='gz_header' type-id='type-id-72' filepath='src.d/zlib.h' line='129' column='1' id='type-id-73'/>
-    <typedef-decl name='gz_headerp' type-id='type-id-74' filepath='src.d/zlib.h' line='131' column='1' id='type-id-59'/>
-    <typedef-decl name='uch' type-id='type-id-2' filepath='src.d/zutil.h' line='39' column='1' id='type-id-36'/>
-    <typedef-decl name='uchf' type-id='type-id-36' filepath='src.d/zutil.h' line='40' column='1' id='type-id-75'/>
-    <typedef-decl name='ush' type-id='type-id-38' filepath='src.d/zutil.h' line='41' column='1' id='type-id-39'/>
-    <typedef-decl name='ulg' type-id='type-id-4' filepath='src.d/zutil.h' line='43' column='1' id='type-id-58'/>
-    <pointer-type-def type-id='type-id-10' size-in-bits='64' id='type-id-19'/>
-    <pointer-type-def type-id='type-id-54' size-in-bits='64' id='type-id-60'/>
-    <pointer-type-def type-id='type-id-26' size-in-bits='64' id='type-id-68'/>
-    <pointer-type-def type-id='type-id-43' size-in-bits='64' id='type-id-76'/>
-    <qualified-type-def type-id='type-id-26' const='yes' id='type-id-77'/>
-    <pointer-type-def type-id='type-id-77' size-in-bits='64' id='type-id-78'/>
-    <qualified-type-def type-id='type-id-49' const='yes' id='type-id-79'/>
-    <pointer-type-def type-id='type-id-79' size-in-bits='64' id='type-id-52'/>
-    <pointer-type-def type-id='type-id-48' size-in-bits='64' id='type-id-51'/>
-    <pointer-type-def type-id='type-id-62' size-in-bits='64' id='type-id-80'/>
-    <pointer-type-def type-id='type-id-73' size-in-bits='64' id='type-id-74'/>
-    <pointer-type-def type-id='type-id-20' size-in-bits='64' id='type-id-81'/>
-    <pointer-type-def type-id='type-id-56' size-in-bits='64' id='type-id-69'/>
-    <pointer-type-def type-id='type-id-82' size-in-bits='64' id='type-id-63'/>
-    <pointer-type-def type-id='type-id-8' size-in-bits='64' id='type-id-83'/>
-    <pointer-type-def type-id='type-id-75' size-in-bits='64' id='type-id-61'/>
-    <pointer-type-def type-id='type-id-3' size-in-bits='64' id='type-id-84'/>
-    <pointer-type-def type-id='type-id-85' size-in-bits='64' id='type-id-65'/>
-    <pointer-type-def type-id='type-id-42' size-in-bits='64' id='type-id-44'/>
+    <class-decl name='internal_state' size-in-bits='47616' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='100' column='1' id='type-id-40'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='strm' type-id='type-id-21' visibility='default' filepath='src.d/deflate.h' line='101' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='status' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='102' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='pending_buf' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='103' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='pending_buf_size' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='104' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='pending_out' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='105' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='pending' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='106' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='wrap' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='107' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='gzhead' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='108' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='gzindex' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='109' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='method' type-id='type-id-3' visibility='default' filepath='src.d/deflate.h' line='110' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='608'>
+        <var-decl name='last_flush' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='111' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='w_size' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='115' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='672'>
+        <var-decl name='w_bits' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='116' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='w_mask' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='117' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='window' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='119' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='window_size' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='129' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='prev' type-id='type-id-43' visibility='default' filepath='src.d/deflate.h' line='134' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='head' type-id='type-id-43' visibility='default' filepath='src.d/deflate.h' line='140' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='ins_h' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='142' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1056'>
+        <var-decl name='hash_size' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='143' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1088'>
+        <var-decl name='hash_bits' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='144' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1120'>
+        <var-decl name='hash_mask' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='145' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1152'>
+        <var-decl name='hash_shift' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='147' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1216'>
+        <var-decl name='block_start' type-id='type-id-1' visibility='default' filepath='src.d/deflate.h' line='154' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='match_length' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='159' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1312'>
+        <var-decl name='prev_match' type-id='type-id-44' visibility='default' filepath='src.d/deflate.h' line='160' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1344'>
+        <var-decl name='match_available' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='161' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1376'>
+        <var-decl name='strstart' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='162' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1408'>
+        <var-decl name='match_start' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='163' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1440'>
+        <var-decl name='lookahead' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='164' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1472'>
+        <var-decl name='prev_length' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='166' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1504'>
+        <var-decl name='max_chain_length' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='171' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1536'>
+        <var-decl name='max_lazy_match' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='177' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1568'>
+        <var-decl name='level' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='188' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1600'>
+        <var-decl name='strategy' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='189' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1632'>
+        <var-decl name='good_match' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='191' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1664'>
+        <var-decl name='nice_match' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='194' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1696'>
+        <var-decl name='dyn_ltree' type-id='type-id-32' visibility='default' filepath='src.d/deflate.h' line='198' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='20032'>
+        <var-decl name='dyn_dtree' type-id='type-id-34' visibility='default' filepath='src.d/deflate.h' line='199' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='21984'>
+        <var-decl name='bl_tree' type-id='type-id-30' visibility='default' filepath='src.d/deflate.h' line='200' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='23232'>
+        <var-decl name='l_desc' type-id='type-id-45' visibility='default' filepath='src.d/deflate.h' line='202' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='23424'>
+        <var-decl name='d_desc' type-id='type-id-45' visibility='default' filepath='src.d/deflate.h' line='203' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='23616'>
+        <var-decl name='bl_desc' type-id='type-id-45' visibility='default' filepath='src.d/deflate.h' line='204' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='23808'>
+        <var-decl name='bl_count' type-id='type-id-46' visibility='default' filepath='src.d/deflate.h' line='206' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='24064'>
+        <var-decl name='heap' type-id='type-id-36' visibility='default' filepath='src.d/deflate.h' line='209' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='42400'>
+        <var-decl name='heap_len' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='210' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='42432'>
+        <var-decl name='heap_max' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='211' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='42464'>
+        <var-decl name='depth' type-id='type-id-47' visibility='default' filepath='src.d/deflate.h' line='216' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47104'>
+        <var-decl name='sym_buf' type-id='type-id-48' visibility='default' filepath='src.d/deflate.h' line='220' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47168'>
+        <var-decl name='lit_bufsize' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='222' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47200'>
+        <var-decl name='sym_next' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='242' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47232'>
+        <var-decl name='sym_end' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='243' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47296'>
+        <var-decl name='opt_len' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='245' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47360'>
+        <var-decl name='static_len' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='246' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47424'>
+        <var-decl name='matches' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='247' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47456'>
+        <var-decl name='insert' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='248' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47488'>
+        <var-decl name='bi_buf' type-id='type-id-49' visibility='default' filepath='src.d/deflate.h' line='255' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47520'>
+        <var-decl name='bi_valid' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='259' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47552'>
+        <var-decl name='high_water' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='264' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='tree_desc_s' size-in-bits='192' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='86' column='1' id='type-id-45'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dyn_tree' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='87' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='max_code' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='88' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='stat_desc' type-id='type-id-51' visibility='default' filepath='src.d/deflate.h' line='89' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='z_stream_s' size-in-bits='896' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='86' column='1' id='type-id-52'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next_in' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='87' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='avail_in' type-id='type-id-12' visibility='default' filepath='src.d/zlib.h' line='88' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='total_in' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='89' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='next_out' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='91' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='avail_out' type-id='type-id-12' visibility='default' filepath='src.d/zlib.h' line='92' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='total_out' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='93' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='msg' type-id='type-id-53' visibility='default' filepath='src.d/zlib.h' line='95' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='state' type-id='type-id-54' visibility='default' filepath='src.d/zlib.h' line='96' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='zalloc' type-id='type-id-55' visibility='default' filepath='src.d/zlib.h' line='98' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='zfree' type-id='type-id-56' visibility='default' filepath='src.d/zlib.h' line='99' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='opaque' type-id='type-id-57' visibility='default' filepath='src.d/zlib.h' line='100' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='data_type' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='102' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='adler' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='104' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='reserved' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='105' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='IPos' type-id='type-id-11' filepath='src.d/deflate.h' line='94' column='1' id='type-id-44'/>
+    <typedef-decl name='Pos' type-id='type-id-49' filepath='src.d/deflate.h' line='92' column='1' id='type-id-58'/>
+    <typedef-decl name='Posf' type-id='type-id-58' filepath='src.d/deflate.h' line='93' column='1' id='type-id-59'/>
+    <typedef-decl name='alloc_func' type-id='type-id-60' filepath='src.d/zlib.h' line='81' column='1' id='type-id-55'/>
+    <typedef-decl name='charf' type-id='type-id-28' filepath='./zconf.h' line='408' column='1' id='type-id-61'/>
+    <typedef-decl name='ct_data' type-id='type-id-29' filepath='src.d/deflate.h' line='77' column='1' id='type-id-62'/>
+    <typedef-decl name='deflate_state' type-id='type-id-40' filepath='src.d/deflate.h' line='271' column='1' id='type-id-63'/>
+    <typedef-decl name='free_func' type-id='type-id-64' filepath='src.d/zlib.h' line='82' column='1' id='type-id-56'/>
+    <typedef-decl name='gz_header' type-id='type-id-39' filepath='src.d/zlib.h' line='129' column='1' id='type-id-65'/>
+    <typedef-decl name='gz_headerp' type-id='type-id-66' filepath='src.d/zlib.h' line='131' column='1' id='type-id-42'/>
+    <typedef-decl name='uch' type-id='type-id-2' filepath='src.d/zutil.h' line='39' column='1' id='type-id-67'/>
+    <typedef-decl name='uchf' type-id='type-id-67' filepath='src.d/zutil.h' line='40' column='1' id='type-id-68'/>
+    <typedef-decl name='ulg' type-id='type-id-9' filepath='src.d/zutil.h' line='43' column='1' id='type-id-41'/>
+    <typedef-decl name='ush' type-id='type-id-69' filepath='src.d/zutil.h' line='41' column='1' id='type-id-49'/>
+    <typedef-decl name='z_stream' type-id='type-id-52' filepath='src.d/zlib.h' line='106' column='1' id='type-id-70'/>
+    <typedef-decl name='z_streamp' type-id='type-id-71' filepath='src.d/zlib.h' line='108' column='1' id='type-id-21'/>
+    <array-type-def dimensions='1' type-id='type-id-67' size-in-bits='4584' id='type-id-47'>
+      <subrange length='573' lower-bound='0' upper-bound='572' type-id='type-id-9' id='type-id-33'/>
+    </array-type-def>
+    <union-decl name='__anonymous_union__1' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='73' column='1' id='type-id-38'>
+      <data-member access='public'>
+        <var-decl name='dad' type-id='type-id-49' visibility='default' filepath='src.d/deflate.h' line='74' column='1'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='len' type-id='type-id-49' visibility='default' filepath='src.d/deflate.h' line='75' column='1'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='__anonymous_union__' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='69' column='1' id='type-id-37'>
+      <data-member access='public'>
+        <var-decl name='freq' type-id='type-id-49' visibility='default' filepath='src.d/deflate.h' line='70' column='1'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='code' type-id='type-id-49' visibility='default' filepath='src.d/deflate.h' line='71' column='1'/>
+      </data-member>
+    </union-decl>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-69'/>
+    <array-type-def dimensions='1' type-id='type-id-49' size-in-bits='256' id='type-id-46'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-9' id='type-id-72'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-4' size-in-bits='64' id='type-id-19'/>
+    <pointer-type-def type-id='type-id-59' size-in-bits='64' id='type-id-43'/>
+    <pointer-type-def type-id='type-id-28' size-in-bits='64' id='type-id-53'/>
+    <pointer-type-def type-id='type-id-61' size-in-bits='64' id='type-id-73'/>
+    <qualified-type-def type-id='type-id-28' const='yes' id='type-id-74'/>
+    <pointer-type-def type-id='type-id-74' size-in-bits='64' id='type-id-22'/>
+    <pointer-type-def type-id='type-id-62' size-in-bits='64' id='type-id-50'/>
+    <pointer-type-def type-id='type-id-63' size-in-bits='64' id='type-id-75'/>
+    <pointer-type-def type-id='type-id-65' size-in-bits='64' id='type-id-66'/>
+    <pointer-type-def type-id='type-id-20' size-in-bits='64' id='type-id-76'/>
+    <pointer-type-def type-id='type-id-40' size-in-bits='64' id='type-id-54'/>
+    <pointer-type-def type-id='type-id-77' size-in-bits='64' id='type-id-60'/>
+    <pointer-type-def type-id='type-id-12' size-in-bits='64' id='type-id-78'/>
+    <pointer-type-def type-id='type-id-68' size-in-bits='64' id='type-id-48'/>
+    <pointer-type-def type-id='type-id-11' size-in-bits='64' id='type-id-79'/>
+    <pointer-type-def type-id='type-id-80' size-in-bits='64' id='type-id-64'/>
     <pointer-type-def type-id='type-id-70' size-in-bits='64' id='type-id-71'/>
-    <class-decl name='static_tree_desc_s' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-27'/>
+    <qualified-type-def type-id='type-id-81' const='yes' id='type-id-82'/>
+    <pointer-type-def type-id='type-id-82' size-in-bits='64' id='type-id-51'/>
+    <class-decl name='static_tree_desc_s' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-83'/>
+    <typedef-decl name='voidpf' type-id='type-id-84' filepath='./zconf.h' line='415' column='1' id='type-id-57'/>
     <function-decl name='memcpy' filepath='/usr/powerpc64le-linux-gnu/include/string.h' line='43' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-44'/>
-      <parameter type-id='type-id-44'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-84'/>
+      <parameter type-id='type-id-84'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-84'/>
     </function-decl>
     <function-decl name='memset' filepath='/usr/powerpc64le-linux-gnu/include/string.h' line='61' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-84'/>
       <parameter type-id='type-id-20'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-44'/>
-    </function-decl>
-    <function-decl name='deflateInit_' mangled-name='deflateInit_' filepath='src.d/deflate.c' line='225' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateInit_'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='226' column='1'/>
-      <parameter type-id='type-id-20' name='level' filepath='src.d/deflate.c' line='227' column='1'/>
-      <parameter type-id='type-id-78' name='version' filepath='src.d/deflate.c' line='228' column='1'/>
-      <parameter type-id='type-id-20' name='stream_size' filepath='src.d/deflate.c' line='229' column='1'/>
-      <return type-id='type-id-20'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-84'/>
     </function-decl>
     <function-decl name='deflateInit2_' mangled-name='deflateInit2_' filepath='src.d/deflate.c' line='237' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateInit2_'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='239' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='239' column='1'/>
       <parameter type-id='type-id-20' name='level' filepath='src.d/deflate.c' line='240' column='1'/>
       <parameter type-id='type-id-20' name='method' filepath='src.d/deflate.c' line='241' column='1'/>
       <parameter type-id='type-id-20' name='windowBits' filepath='src.d/deflate.c' line='242' column='1'/>
       <parameter type-id='type-id-20' name='memLevel' filepath='src.d/deflate.c' line='243' column='1'/>
       <parameter type-id='type-id-20' name='strategy' filepath='src.d/deflate.c' line='244' column='1'/>
-      <parameter type-id='type-id-78' name='version' filepath='src.d/deflate.c' line='245' column='1'/>
+      <parameter type-id='type-id-22' name='version' filepath='src.d/deflate.c' line='245' column='1'/>
       <parameter type-id='type-id-20' name='stream_size' filepath='src.d/deflate.c' line='246' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateSetDictionary' mangled-name='deflateSetDictionary' filepath='src.d/deflate.c' line='412' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateSetDictionary'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='413' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='413' column='1'/>
       <parameter type-id='type-id-16' name='dictionary' filepath='src.d/deflate.c' line='414' column='1'/>
-      <parameter type-id='type-id-8' name='dictLength' filepath='src.d/deflate.c' line='415' column='1'/>
+      <parameter type-id='type-id-12' name='dictLength' filepath='src.d/deflate.c' line='415' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateGetDictionary' mangled-name='deflateGetDictionary' filepath='src.d/deflate.c' line='481' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateGetDictionary@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='482' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='482' column='1'/>
       <parameter type-id='type-id-19' name='dictionary' filepath='src.d/deflate.c' line='483' column='1'/>
-      <parameter type-id='type-id-83' name='dictLength' filepath='src.d/deflate.c' line='484' column='1'/>
+      <parameter type-id='type-id-78' name='dictLength' filepath='src.d/deflate.c' line='484' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateResetKeep' mangled-name='deflateResetKeep' filepath='src.d/deflate.c' line='503' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateResetKeep@@ZLIB_1.2.5.2'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='504' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='504' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateReset' mangled-name='deflateReset' filepath='src.d/deflate.c' line='541' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateReset'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='542' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='542' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateSetHeader' mangled-name='deflateSetHeader' filepath='src.d/deflate.c' line='553' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateSetHeader@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='554' column='1'/>
-      <parameter type-id='type-id-59' name='head' filepath='src.d/deflate.c' line='555' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='554' column='1'/>
+      <parameter type-id='type-id-42' name='head' filepath='src.d/deflate.c' line='555' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflatePending' mangled-name='deflatePending' filepath='src.d/deflate.c' line='564' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflatePending@@ZLIB_1.2.5.1'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='567' column='1'/>
-      <parameter type-id='type-id-84' name='pending' filepath='src.d/deflate.c' line='565' column='1'/>
-      <parameter type-id='type-id-81' name='bits' filepath='src.d/deflate.c' line='566' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='567' column='1'/>
+      <parameter type-id='type-id-79' name='pending' filepath='src.d/deflate.c' line='565' column='1'/>
+      <parameter type-id='type-id-76' name='bits' filepath='src.d/deflate.c' line='566' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflatePrime' mangled-name='deflatePrime' filepath='src.d/deflate.c' line='578' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflatePrime@@ZLIB_1.2.0.8'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='579' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='579' column='1'/>
       <parameter type-id='type-id-20' name='bits' filepath='src.d/deflate.c' line='580' column='1'/>
       <parameter type-id='type-id-20' name='value' filepath='src.d/deflate.c' line='581' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateParams' mangled-name='deflateParams' filepath='src.d/deflate.c' line='605' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateParams'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='606' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='606' column='1'/>
       <parameter type-id='type-id-20' name='level' filepath='src.d/deflate.c' line='607' column='1'/>
       <parameter type-id='type-id-20' name='strategy' filepath='src.d/deflate.c' line='608' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateTune' mangled-name='deflateTune' filepath='src.d/deflate.c' line='654' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateTune@@ZLIB_1.2.2.3'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='655' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='655' column='1'/>
       <parameter type-id='type-id-20' name='good_length' filepath='src.d/deflate.c' line='656' column='1'/>
       <parameter type-id='type-id-20' name='max_lazy' filepath='src.d/deflate.c' line='657' column='1'/>
       <parameter type-id='type-id-20' name='nice_length' filepath='src.d/deflate.c' line='658' column='1'/>
@@ -649,198 +654,203 @@
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateBound' mangled-name='deflateBound' filepath='src.d/deflate.c' line='696' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateBound@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='697' column='1'/>
-      <parameter type-id='type-id-9' name='sourceLen' filepath='src.d/deflate.c' line='698' column='1'/>
-      <return type-id='type-id-9'/>
-    </function-decl>
-    <function-decl name='deflate' mangled-name='deflate' filepath='src.d/deflate.c' line='815' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflate'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='816' column='1'/>
-      <parameter type-id='type-id-20' name='flush' filepath='src.d/deflate.c' line='817' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
-    <function-decl name='deflateEnd' mangled-name='deflateEnd' filepath='src.d/deflate.c' line='1130' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateEnd'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='1131' column='1'/>
-      <return type-id='type-id-20'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='697' column='1'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/deflate.c' line='698' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='deflateCopy' mangled-name='deflateCopy' filepath='src.d/deflate.c' line='1156' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateCopy'>
-      <parameter type-id='type-id-57' name='dest' filepath='src.d/deflate.c' line='1157' column='1'/>
-      <parameter type-id='type-id-57' name='source' filepath='src.d/deflate.c' line='1158' column='1'/>
+      <parameter type-id='type-id-21' name='dest' filepath='src.d/deflate.c' line='1157' column='1'/>
+      <parameter type-id='type-id-21' name='source' filepath='src.d/deflate.c' line='1158' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
+    <typedef-decl name='static_tree_desc' type-id='type-id-83' filepath='src.d/deflate.h' line='84' column='1' id='type-id-81'/>
     <function-decl name='_tr_init' filepath='src.d/deflate.h' line='294' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-80'/>
-      <return type-id='type-id-42'/>
+      <parameter type-id='type-id-75'/>
+      <return type-id='type-id-85'/>
     </function-decl>
     <function-decl name='_tr_flush_block' filepath='src.d/deflate.h' line='296' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-80'/>
-      <parameter type-id='type-id-76'/>
-      <parameter type-id='type-id-58'/>
+      <parameter type-id='type-id-75'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-41'/>
       <parameter type-id='type-id-20'/>
-      <return type-id='type-id-42'/>
+      <return type-id='type-id-85'/>
     </function-decl>
     <function-decl name='_tr_flush_bits' filepath='src.d/deflate.h' line='298' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-80'/>
-      <return type-id='type-id-42'/>
+      <parameter type-id='type-id-75'/>
+      <return type-id='type-id-85'/>
     </function-decl>
     <function-decl name='_tr_align' filepath='src.d/deflate.h' line='299' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-80'/>
-      <return type-id='type-id-42'/>
+      <parameter type-id='type-id-75'/>
+      <return type-id='type-id-85'/>
     </function-decl>
     <function-decl name='_tr_stored_block' filepath='src.d/deflate.h' line='300' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-80'/>
-      <parameter type-id='type-id-76'/>
-      <parameter type-id='type-id-58'/>
+      <parameter type-id='type-id-75'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-41'/>
       <parameter type-id='type-id-20'/>
-      <return type-id='type-id-42'/>
+      <return type-id='type-id-85'/>
+    </function-decl>
+    <function-decl name='crc32' filepath='src.d/zlib.h' line='1727' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-13'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-12'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='zcalloc' filepath='src.d/zutil.h' line='261' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-45'/>
-      <parameter type-id='type-id-3'/>
-      <parameter type-id='type-id-3'/>
-      <return type-id='type-id-45'/>
+      <parameter type-id='type-id-57'/>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-11'/>
+      <return type-id='type-id-57'/>
     </function-decl>
     <function-decl name='zcfree' filepath='src.d/zutil.h' line='263' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-45'/>
-      <parameter type-id='type-id-45'/>
-      <return type-id='type-id-42'/>
+      <parameter type-id='type-id-57'/>
+      <parameter type-id='type-id-57'/>
+      <return type-id='type-id-85'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-82'>
-      <parameter type-id='type-id-45'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-45'/>
+    <type-decl name='void' id='type-id-85'/>
+    <pointer-type-def type-id='type-id-85' id='type-id-84'/>
+    <function-type size-in-bits='64' id='type-id-80'>
+      <parameter type-id='type-id-57'/>
+      <parameter type-id='type-id-57'/>
+      <return type-id='type-id-85'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-85'>
-      <parameter type-id='type-id-45'/>
-      <parameter type-id='type-id-45'/>
-      <return type-id='type-id-42'/>
+    <function-type size-in-bits='64' id='type-id-77'>
+      <parameter type-id='type-id-57'/>
+      <parameter type-id='type-id-12'/>
+      <parameter type-id='type-id-12'/>
+      <return type-id='type-id-57'/>
     </function-type>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/gzclose.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <typedef-decl name='gzFile' type-id='type-id-86' filepath='src.d/zlib.h' line='1302' column='1' id='type-id-87'/>
-    <class-decl name='gzFile_s' size-in-bits='192' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='1834' column='1' id='type-id-88'>
+    <class-decl name='gzFile_s' size-in-bits='192' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='1834' column='1' id='type-id-86'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='have' type-id='type-id-3' visibility='default' filepath='src.d/zlib.h' line='1835' column='1'/>
+        <var-decl name='have' type-id='type-id-11' visibility='default' filepath='src.d/zlib.h' line='1835' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='next' type-id='type-id-89' visibility='default' filepath='src.d/zlib.h' line='1836' column='1'/>
+        <var-decl name='next' type-id='type-id-87' visibility='default' filepath='src.d/zlib.h' line='1836' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='pos' type-id='type-id-14' visibility='default' filepath='src.d/zlib.h' line='1837' column='1'/>
+        <var-decl name='pos' type-id='type-id-7' visibility='default' filepath='src.d/zlib.h' line='1837' column='1'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-88' size-in-bits='64' id='type-id-86'/>
+    <typedef-decl name='gzFile' type-id='type-id-88' filepath='src.d/zlib.h' line='1302' column='1' id='type-id-89'/>
+    <pointer-type-def type-id='type-id-86' size-in-bits='64' id='type-id-88'/>
     <function-decl name='gzclose' mangled-name='gzclose' filepath='src.d/gzclose.c' line='11' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzclose'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzclose.c' line='12' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzclose.c' line='12' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='gzclose_r' mangled-name='gzclose_r' filepath='src.d/zlib.h' line='1644' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzclose_r@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-87'/>
+    <function-decl name='gzclose_r' filepath='src.d/zlib.h' line='1644' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-89'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='gzclose_w' mangled-name='gzclose_w' filepath='src.d/zlib.h' line='1645' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzclose_w@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-87'/>
+    <function-decl name='gzclose_w' filepath='src.d/zlib.h' line='1645' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-89'/>
       <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/gzlib.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <type-decl name='variadic parameter type' id='type-id-90'/>
-    <function-decl name='open' filepath='/usr/powerpc64le-linux-gnu/include/fcntl.h' line='181' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-78'/>
+    <function-decl name='open' filepath='/usr/powerpc64le-linux-gnu/include/fcntl.h' line='209' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-22'/>
       <parameter type-id='type-id-20'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='snprintf' filepath='/usr/powerpc64le-linux-gnu/include/stdio.h' line='378' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-68'/>
-      <parameter type-id='type-id-5'/>
-      <parameter type-id='type-id-78'/>
+    <function-decl name='snprintf' filepath='/usr/powerpc64le-linux-gnu/include/stdio.h' line='385' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-10'/>
+      <parameter type-id='type-id-22'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-20'/>
     </function-decl>
+    <function-decl name='malloc' filepath='/usr/powerpc64le-linux-gnu/include/stdlib.h' line='672' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='free' filepath='/usr/powerpc64le-linux-gnu/include/stdlib.h' line='687' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-84'/>
+      <return type-id='type-id-85'/>
+    </function-decl>
     <function-decl name='strlen' filepath='/usr/powerpc64le-linux-gnu/include/string.h' line='407' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-78'/>
-      <return type-id='type-id-5'/>
+      <parameter type-id='type-id-22'/>
+      <return type-id='type-id-10'/>
     </function-decl>
     <function-decl name='lseek64' filepath='/usr/powerpc64le-linux-gnu/include/unistd.h' line='350' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-20'/>
-      <parameter type-id='type-id-12'/>
+      <parameter type-id='type-id-5'/>
       <parameter type-id='type-id-20'/>
-      <return type-id='type-id-12'/>
+      <return type-id='type-id-5'/>
     </function-decl>
     <function-decl name='gzopen' mangled-name='gzopen' filepath='src.d/gzlib.c' line='272' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzopen'>
-      <parameter type-id='type-id-78' name='path' filepath='src.d/gzlib.c' line='273' column='1'/>
-      <parameter type-id='type-id-78' name='mode' filepath='src.d/gzlib.c' line='274' column='1'/>
-      <return type-id='type-id-87'/>
+      <parameter type-id='type-id-22' name='path' filepath='src.d/gzlib.c' line='273' column='1'/>
+      <parameter type-id='type-id-22' name='mode' filepath='src.d/gzlib.c' line='274' column='1'/>
+      <return type-id='type-id-89'/>
     </function-decl>
     <function-decl name='gzopen64' mangled-name='gzopen64' filepath='src.d/gzlib.c' line='280' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzopen64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-78' name='path' filepath='src.d/gzlib.c' line='281' column='1'/>
-      <parameter type-id='type-id-78' name='mode' filepath='src.d/gzlib.c' line='282' column='1'/>
-      <return type-id='type-id-87'/>
+      <parameter type-id='type-id-22' name='path' filepath='src.d/gzlib.c' line='281' column='1'/>
+      <parameter type-id='type-id-22' name='mode' filepath='src.d/gzlib.c' line='282' column='1'/>
+      <return type-id='type-id-89'/>
     </function-decl>
     <function-decl name='gzdopen' mangled-name='gzdopen' filepath='src.d/gzlib.c' line='288' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzdopen'>
       <parameter type-id='type-id-20' name='fd' filepath='src.d/gzlib.c' line='289' column='1'/>
-      <parameter type-id='type-id-78' name='mode' filepath='src.d/gzlib.c' line='290' column='1'/>
-      <return type-id='type-id-87'/>
+      <parameter type-id='type-id-22' name='mode' filepath='src.d/gzlib.c' line='290' column='1'/>
+      <return type-id='type-id-89'/>
     </function-decl>
     <function-decl name='gzbuffer' mangled-name='gzbuffer' filepath='src.d/gzlib.c' line='318' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzbuffer@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='319' column='1'/>
-      <parameter type-id='type-id-3' name='size' filepath='src.d/gzlib.c' line='320' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='319' column='1'/>
+      <parameter type-id='type-id-11' name='size' filepath='src.d/gzlib.c' line='320' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzrewind' mangled-name='gzrewind' filepath='src.d/gzlib.c' line='345' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzrewind'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='346' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='346' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzseek64' mangled-name='gzseek64' filepath='src.d/gzlib.c' line='368' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzseek64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='369' column='1'/>
-      <parameter type-id='type-id-14' name='offset' filepath='src.d/gzlib.c' line='370' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='369' column='1'/>
+      <parameter type-id='type-id-7' name='offset' filepath='src.d/gzlib.c' line='370' column='1'/>
       <parameter type-id='type-id-20' name='whence' filepath='src.d/gzlib.c' line='371' column='1'/>
-      <return type-id='type-id-14'/>
+      <return type-id='type-id-7'/>
     </function-decl>
     <function-decl name='gzseek' mangled-name='gzseek' filepath='src.d/gzlib.c' line='445' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzseek'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='446' column='1'/>
-      <parameter type-id='type-id-13' name='offset' filepath='src.d/gzlib.c' line='447' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='446' column='1'/>
+      <parameter type-id='type-id-8' name='offset' filepath='src.d/gzlib.c' line='447' column='1'/>
       <parameter type-id='type-id-20' name='whence' filepath='src.d/gzlib.c' line='448' column='1'/>
-      <return type-id='type-id-13'/>
+      <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='gztell64' mangled-name='gztell64' filepath='src.d/gzlib.c' line='457' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gztell64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='458' column='1'/>
-      <return type-id='type-id-14'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='458' column='1'/>
+      <return type-id='type-id-7'/>
     </function-decl>
     <function-decl name='gztell' mangled-name='gztell' filepath='src.d/gzlib.c' line='474' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gztell'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='475' column='1'/>
-      <return type-id='type-id-13'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='475' column='1'/>
+      <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='gzoffset64' mangled-name='gzoffset64' filepath='src.d/gzlib.c' line='484' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzoffset64@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='485' column='1'/>
-      <return type-id='type-id-14'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='485' column='1'/>
+      <return type-id='type-id-7'/>
     </function-decl>
     <function-decl name='gzoffset' mangled-name='gzoffset' filepath='src.d/gzlib.c' line='507' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzoffset@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='508' column='1'/>
-      <return type-id='type-id-13'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='508' column='1'/>
+      <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='gzeof' mangled-name='gzeof' filepath='src.d/gzlib.c' line='517' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzeof'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='518' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='518' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzerror' mangled-name='gzerror' filepath='src.d/gzlib.c' line='534' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzerror'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='535' column='1'/>
-      <parameter type-id='type-id-81' name='errnum' filepath='src.d/gzlib.c' line='536' column='1'/>
-      <return type-id='type-id-78'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='535' column='1'/>
+      <parameter type-id='type-id-76' name='errnum' filepath='src.d/gzlib.c' line='536' column='1'/>
+      <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='gzclearerr' mangled-name='gzclearerr' filepath='src.d/gzlib.c' line='555' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzclearerr@@ZLIB_1.2.0.2'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='556' column='1'/>
-      <return type-id='type-id-42'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='556' column='1'/>
+      <return type-id='type-id-85'/>
     </function-decl>
+    <type-decl name='variadic parameter type' id='type-id-90'/>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/gzread.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <typedef-decl name='voidp' type-id='type-id-44' filepath='./zconf.h' line='416' column='1' id='type-id-91'/>
-    <typedef-decl name='__ssize_t' type-id='type-id-1' filepath='/usr/powerpc64le-linux-gnu/include/bits/types.h' line='194' column='1' id='type-id-92'/>
-    <typedef-decl name='ssize_t' type-id='type-id-92' filepath='/usr/powerpc64le-linux-gnu/include/sys/types.h' line='108' column='1' id='type-id-93'/>
-    <class-decl name='gz_state' size-in-bits='1920' is-struct='yes' naming-typedef-id='type-id-94' visibility='default' filepath='src.d/gzguts.h' line='170' column='1' id='type-id-95'>
+    <class-decl name='gz_state' size-in-bits='1920' is-struct='yes' naming-typedef-id='type-id-91' visibility='default' filepath='src.d/gzguts.h' line='170' column='1' id='type-id-92'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='x' type-id='type-id-88' visibility='default' filepath='src.d/gzguts.h' line='172' column='1'/>
+        <var-decl name='x' type-id='type-id-86' visibility='default' filepath='src.d/gzguts.h' line='172' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
         <var-decl name='mode' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='177' column='1'/>
@@ -849,19 +859,19 @@
         <var-decl name='fd' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='178' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='path' type-id='type-id-68' visibility='default' filepath='src.d/gzguts.h' line='179' column='1'/>
+        <var-decl name='path' type-id='type-id-53' visibility='default' filepath='src.d/gzguts.h' line='179' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='size' type-id='type-id-3' visibility='default' filepath='src.d/gzguts.h' line='180' column='1'/>
+        <var-decl name='size' type-id='type-id-11' visibility='default' filepath='src.d/gzguts.h' line='180' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='want' type-id='type-id-3' visibility='default' filepath='src.d/gzguts.h' line='181' column='1'/>
+        <var-decl name='want' type-id='type-id-11' visibility='default' filepath='src.d/gzguts.h' line='181' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='in' type-id='type-id-89' visibility='default' filepath='src.d/gzguts.h' line='182' column='1'/>
+        <var-decl name='in' type-id='type-id-87' visibility='default' filepath='src.d/gzguts.h' line='182' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='out' type-id='type-id-89' visibility='default' filepath='src.d/gzguts.h' line='183' column='1'/>
+        <var-decl name='out' type-id='type-id-87' visibility='default' filepath='src.d/gzguts.h' line='183' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
         <var-decl name='direct' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='184' column='1'/>
@@ -870,7 +880,7 @@
         <var-decl name='how' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='186' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='start' type-id='type-id-14' visibility='default' filepath='src.d/gzguts.h' line='187' column='1'/>
+        <var-decl name='start' type-id='type-id-7' visibility='default' filepath='src.d/gzguts.h' line='187' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='640'>
         <var-decl name='eof' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='188' column='1'/>
@@ -888,7 +898,7 @@
         <var-decl name='reset' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='193' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='skip' type-id='type-id-14' visibility='default' filepath='src.d/gzguts.h' line='195' column='1'/>
+        <var-decl name='skip' type-id='type-id-7' visibility='default' filepath='src.d/gzguts.h' line='195' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='896'>
         <var-decl name='seek' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='196' column='1'/>
@@ -897,27 +907,30 @@
         <var-decl name='err' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='198' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='msg' type-id='type-id-68' visibility='default' filepath='src.d/gzguts.h' line='199' column='1'/>
+        <var-decl name='msg' type-id='type-id-53' visibility='default' filepath='src.d/gzguts.h' line='199' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1024'>
         <var-decl name='strm' type-id='type-id-70' visibility='default' filepath='src.d/gzguts.h' line='201' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='gz_state' type-id='type-id-95' filepath='src.d/gzguts.h' line='202' column='1' id='type-id-94'/>
-    <typedef-decl name='gz_statep' type-id='type-id-96' filepath='src.d/gzguts.h' line='203' column='1' id='type-id-97'/>
-    <pointer-type-def type-id='type-id-94' size-in-bits='64' id='type-id-96'/>
+    <typedef-decl name='__ssize_t' type-id='type-id-1' filepath='/usr/powerpc64le-linux-gnu/include/bits/types.h' line='194' column='1' id='type-id-93'/>
+    <typedef-decl name='gz_state' type-id='type-id-92' filepath='src.d/gzguts.h' line='202' column='1' id='type-id-91'/>
+    <typedef-decl name='gz_statep' type-id='type-id-94' filepath='src.d/gzguts.h' line='203' column='1' id='type-id-95'/>
+    <typedef-decl name='ssize_t' type-id='type-id-93' filepath='/usr/powerpc64le-linux-gnu/include/sys/types.h' line='108' column='1' id='type-id-96'/>
+    <pointer-type-def type-id='type-id-91' size-in-bits='64' id='type-id-94'/>
+    <typedef-decl name='voidp' type-id='type-id-84' filepath='./zconf.h' line='416' column='1' id='type-id-97'/>
     <function-decl name='__errno_location' filepath='/usr/powerpc64le-linux-gnu/include/errno.h' line='37' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-81'/>
+      <return type-id='type-id-76'/>
     </function-decl>
     <function-decl name='memchr' filepath='/usr/powerpc64le-linux-gnu/include/string.h' line='107' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-84'/>
       <parameter type-id='type-id-20'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-84'/>
     </function-decl>
     <function-decl name='strerror' filepath='/usr/powerpc64le-linux-gnu/include/string.h' line='419' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-20'/>
-      <return type-id='type-id-68'/>
+      <return type-id='type-id-53'/>
     </function-decl>
     <function-decl name='close' filepath='/usr/powerpc64le-linux-gnu/include/unistd.h' line='358' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-20'/>
@@ -925,126 +938,151 @@
     </function-decl>
     <function-decl name='read' filepath='/usr/powerpc64le-linux-gnu/include/unistd.h' line='371' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-20'/>
-      <parameter type-id='type-id-44'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-93'/>
+      <parameter type-id='type-id-84'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-96'/>
     </function-decl>
     <function-decl name='gz_error' filepath='src.d/gzguts.h' line='206' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-97'/>
+      <parameter type-id='type-id-95'/>
       <parameter type-id='type-id-20'/>
-      <parameter type-id='type-id-78'/>
-      <return type-id='type-id-42'/>
+      <parameter type-id='type-id-22'/>
+      <return type-id='type-id-85'/>
     </function-decl>
     <function-decl name='gzread' mangled-name='gzread' filepath='src.d/gzread.c' line='373' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzread'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzread.c' line='374' column='1'/>
-      <parameter type-id='type-id-91' name='buf' filepath='src.d/gzread.c' line='375' column='1'/>
-      <parameter type-id='type-id-3' name='len' filepath='src.d/gzread.c' line='376' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='374' column='1'/>
+      <parameter type-id='type-id-97' name='buf' filepath='src.d/gzread.c' line='375' column='1'/>
+      <parameter type-id='type-id-11' name='len' filepath='src.d/gzread.c' line='376' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzfread' mangled-name='gzfread' filepath='src.d/gzread.c' line='409' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzfread@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-91' name='buf' filepath='src.d/gzread.c' line='410' column='1'/>
-      <parameter type-id='type-id-6' name='size' filepath='src.d/gzread.c' line='411' column='1'/>
-      <parameter type-id='type-id-6' name='nitems' filepath='src.d/gzread.c' line='412' column='1'/>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzread.c' line='413' column='1'/>
-      <return type-id='type-id-6'/>
+      <parameter type-id='type-id-97' name='buf' filepath='src.d/gzread.c' line='410' column='1'/>
+      <parameter type-id='type-id-14' name='size' filepath='src.d/gzread.c' line='411' column='1'/>
+      <parameter type-id='type-id-14' name='nitems' filepath='src.d/gzread.c' line='412' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='413' column='1'/>
+      <return type-id='type-id-14'/>
     </function-decl>
     <function-decl name='gzgetc' mangled-name='gzgetc' filepath='src.d/gzread.c' line='445' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzgetc'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzread.c' line='446' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='446' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzgetc_' mangled-name='gzgetc_' filepath='src.d/gzread.c' line='472' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzgetc_@@ZLIB_1.2.5.2'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzread.c' line='473' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='473' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzungetc' mangled-name='gzungetc' filepath='src.d/gzread.c' line='479' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzungetc@@ZLIB_1.2.0.2'>
       <parameter type-id='type-id-20' name='c' filepath='src.d/gzread.c' line='480' column='1'/>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzread.c' line='481' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='481' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzgets' mangled-name='gzgets' filepath='src.d/gzread.c' line='539' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzgets'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzread.c' line='540' column='1'/>
-      <parameter type-id='type-id-68' name='buf' filepath='src.d/gzread.c' line='541' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='540' column='1'/>
+      <parameter type-id='type-id-53' name='buf' filepath='src.d/gzread.c' line='541' column='1'/>
       <parameter type-id='type-id-20' name='len' filepath='src.d/gzread.c' line='542' column='1'/>
-      <return type-id='type-id-68'/>
+      <return type-id='type-id-53'/>
     </function-decl>
     <function-decl name='gzdirect' mangled-name='gzdirect' filepath='src.d/gzread.c' line='603' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzdirect@@ZLIB_1.2.2.3'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzread.c' line='604' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='604' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflate' filepath='src.d/zlib.h' line='400' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateEnd' filepath='src.d/zlib.h' line='520' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-21'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateReset' filepath='src.d/zlib.h' line='959' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-21'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateInit2_' filepath='src.d/zlib.h' line='1789' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-20'/>
       <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/gzwrite.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <typedef-decl name='voidpc' type-id='type-id-44' filepath='./zconf.h' line='414' column='1' id='type-id-98'/>
-    <typedef-decl name='__gnuc_va_list' type-id='type-id-68' filepath='/usr/lib/gcc-cross/powerpc64le-linux-gnu/11/include/stdarg.h' line='40' column='1' id='type-id-99'/>
-    <typedef-decl name='va_list' type-id='type-id-99' filepath='/usr/lib/gcc-cross/powerpc64le-linux-gnu/11/include/stdarg.h' line='99' column='1' id='type-id-100'/>
-    <function-decl name='vsnprintf' filepath='/usr/powerpc64le-linux-gnu/include/stdio.h' line='382' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-68'/>
-      <parameter type-id='type-id-5'/>
-      <parameter type-id='type-id-78'/>
-      <parameter type-id='type-id-68'/>
+    <typedef-decl name='__gnuc_va_list' type-id='type-id-53' filepath='/usr/lib/gcc-cross/powerpc64le-linux-gnu/13/include/stdarg.h' line='40' column='1' id='type-id-98'/>
+    <typedef-decl name='va_list' type-id='type-id-98' filepath='/usr/lib/gcc-cross/powerpc64le-linux-gnu/13/include/stdarg.h' line='103' column='1' id='type-id-99'/>
+    <typedef-decl name='voidpc' type-id='type-id-84' filepath='./zconf.h' line='414' column='1' id='type-id-100'/>
+    <function-decl name='vsnprintf' filepath='/usr/powerpc64le-linux-gnu/include/stdio.h' line='389' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-10'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-53'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='memmove' filepath='/usr/powerpc64le-linux-gnu/include/string.h' line='47' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-44'/>
-      <parameter type-id='type-id-44'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-84'/>
+      <parameter type-id='type-id-84'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-84'/>
     </function-decl>
     <function-decl name='write' filepath='/usr/powerpc64le-linux-gnu/include/unistd.h' line='378' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-20'/>
-      <parameter type-id='type-id-44'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-93'/>
+      <parameter type-id='type-id-84'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-96'/>
     </function-decl>
     <function-decl name='gzwrite' mangled-name='gzwrite' filepath='src.d/gzwrite.c' line='255' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzwrite'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='256' column='1'/>
-      <parameter type-id='type-id-98' name='buf' filepath='src.d/gzwrite.c' line='257' column='1'/>
-      <parameter type-id='type-id-3' name='len' filepath='src.d/gzwrite.c' line='258' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='256' column='1'/>
+      <parameter type-id='type-id-100' name='buf' filepath='src.d/gzwrite.c' line='257' column='1'/>
+      <parameter type-id='type-id-11' name='len' filepath='src.d/gzwrite.c' line='258' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzfwrite' mangled-name='gzfwrite' filepath='src.d/gzwrite.c' line='283' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzfwrite@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-98' name='buf' filepath='src.d/gzwrite.c' line='284' column='1'/>
-      <parameter type-id='type-id-6' name='size' filepath='src.d/gzwrite.c' line='285' column='1'/>
-      <parameter type-id='type-id-6' name='nitems' filepath='src.d/gzwrite.c' line='286' column='1'/>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='287' column='1'/>
-      <return type-id='type-id-6'/>
+      <parameter type-id='type-id-100' name='buf' filepath='src.d/gzwrite.c' line='284' column='1'/>
+      <parameter type-id='type-id-14' name='size' filepath='src.d/gzwrite.c' line='285' column='1'/>
+      <parameter type-id='type-id-14' name='nitems' filepath='src.d/gzwrite.c' line='286' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='287' column='1'/>
+      <return type-id='type-id-14'/>
     </function-decl>
     <function-decl name='gzputc' mangled-name='gzputc' filepath='src.d/gzwrite.c' line='313' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzputc'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='314' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='314' column='1'/>
       <parameter type-id='type-id-20' name='c' filepath='src.d/gzwrite.c' line='315' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzputs' mangled-name='gzputs' filepath='src.d/gzwrite.c' line='361' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzputs'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='362' column='1'/>
-      <parameter type-id='type-id-78' name='s' filepath='src.d/gzwrite.c' line='363' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='362' column='1'/>
+      <parameter type-id='type-id-22' name='s' filepath='src.d/gzwrite.c' line='363' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzvprintf' mangled-name='gzvprintf' filepath='src.d/gzwrite.c' line='391' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzvprintf@@ZLIB_1.2.7.1'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='391' column='1'/>
-      <parameter type-id='type-id-78' name='format' filepath='src.d/gzwrite.c' line='391' column='1'/>
-      <parameter type-id='type-id-100' name='va' filepath='src.d/gzwrite.c' line='391' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='391' column='1'/>
+      <parameter type-id='type-id-22' name='format' filepath='src.d/gzwrite.c' line='391' column='1'/>
+      <parameter type-id='type-id-99' name='va' filepath='src.d/gzwrite.c' line='391' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzprintf' mangled-name='gzprintf' filepath='src.d/gzwrite.c' line='463' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzprintf'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='463' column='1'/>
-      <parameter type-id='type-id-78' name='format' filepath='src.d/gzwrite.c' line='463' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='463' column='1'/>
+      <parameter type-id='type-id-22' name='format' filepath='src.d/gzwrite.c' line='463' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzflush' mangled-name='gzflush' filepath='src.d/gzwrite.c' line='565' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzflush'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='566' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='566' column='1'/>
       <parameter type-id='type-id-20' name='flush' filepath='src.d/gzwrite.c' line='567' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzsetparams' mangled-name='gzsetparams' filepath='src.d/gzwrite.c' line='597' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzsetparams'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='598' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='598' column='1'/>
       <parameter type-id='type-id-20' name='level' filepath='src.d/gzwrite.c' line='599' column='1'/>
       <parameter type-id='type-id-20' name='strategy' filepath='src.d/gzwrite.c' line='600' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/infback.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-101'/>
-    <class-decl name='code' size-in-bits='32' is-struct='yes' naming-typedef-id='type-id-102' visibility='default' filepath='src.d/inftrees.h' line='24' column='1' id='type-id-103'>
+    <enum-decl name='codetype' naming-typedef-id='type-id-101' filepath='src.d/inftrees.h' line='54' column='1' id='type-id-102'>
+      <underlying-type type-id='type-id-103'/>
+      <enumerator name='CODES' value='0'/>
+      <enumerator name='LENS' value='1'/>
+      <enumerator name='DISTS' value='2'/>
+    </enum-decl>
+    <class-decl name='code' size-in-bits='32' is-struct='yes' naming-typedef-id='type-id-104' visibility='default' filepath='src.d/inftrees.h' line='24' column='1' id='type-id-105'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='op' type-id='type-id-2' visibility='default' filepath='src.d/inftrees.h' line='25' column='1'/>
       </data-member>
@@ -1052,217 +1090,186 @@
         <var-decl name='bits' type-id='type-id-2' visibility='default' filepath='src.d/inftrees.h' line='26' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='16'>
-        <var-decl name='val' type-id='type-id-38' visibility='default' filepath='src.d/inftrees.h' line='27' column='1'/>
+        <var-decl name='val' type-id='type-id-69' visibility='default' filepath='src.d/inftrees.h' line='27' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='code' type-id='type-id-103' filepath='src.d/inftrees.h' line='28' column='1' id='type-id-102'/>
-    <enum-decl name='codetype' naming-typedef-id='type-id-104' filepath='src.d/inftrees.h' line='54' column='1' id='type-id-105'>
-      <underlying-type type-id='type-id-101'/>
-      <enumerator name='CODES' value='0'/>
-      <enumerator name='LENS' value='1'/>
-      <enumerator name='DISTS' value='2'/>
-    </enum-decl>
-    <typedef-decl name='codetype' type-id='type-id-105' filepath='src.d/inftrees.h' line='58' column='1' id='type-id-104'/>
+    <typedef-decl name='code' type-id='type-id-105' filepath='src.d/inftrees.h' line='28' column='1' id='type-id-104'/>
+    <typedef-decl name='codetype' type-id='type-id-102' filepath='src.d/inftrees.h' line='58' column='1' id='type-id-101'/>
     <typedef-decl name='in_func' type-id='type-id-106' filepath='src.d/zlib.h' line='1094' column='1' id='type-id-107'/>
     <typedef-decl name='out_func' type-id='type-id-108' filepath='src.d/zlib.h' line='1096' column='1' id='type-id-109'/>
-    <pointer-type-def type-id='type-id-102' size-in-bits='64' id='type-id-110'/>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-103'/>
+    <pointer-type-def type-id='type-id-104' size-in-bits='64' id='type-id-110'/>
     <pointer-type-def type-id='type-id-110' size-in-bits='64' id='type-id-111'/>
     <pointer-type-def type-id='type-id-112' size-in-bits='64' id='type-id-108'/>
-    <pointer-type-def type-id='type-id-2' size-in-bits='64' id='type-id-89'/>
-    <pointer-type-def type-id='type-id-89' size-in-bits='64' id='type-id-113'/>
+    <pointer-type-def type-id='type-id-2' size-in-bits='64' id='type-id-87'/>
+    <pointer-type-def type-id='type-id-87' size-in-bits='64' id='type-id-113'/>
     <pointer-type-def type-id='type-id-114' size-in-bits='64' id='type-id-106'/>
-    <pointer-type-def type-id='type-id-38' size-in-bits='64' id='type-id-115'/>
+    <pointer-type-def type-id='type-id-69' size-in-bits='64' id='type-id-115'/>
+    <typedef-decl name='voidpf' type-id='type-id-84' filepath='./zconf.h' line='415' column='1' id='type-id-116'/>
     <function-decl name='inflateBackInit_' mangled-name='inflateBackInit_' filepath='src.d/infback.c' line='28' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateBackInit_@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/infback.c' line='29' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/infback.c' line='29' column='1'/>
       <parameter type-id='type-id-20' name='windowBits' filepath='src.d/infback.c' line='30' column='1'/>
-      <parameter type-id='type-id-89' name='window' filepath='src.d/infback.c' line='31' column='1'/>
-      <parameter type-id='type-id-78' name='version' filepath='src.d/infback.c' line='32' column='1'/>
+      <parameter type-id='type-id-87' name='window' filepath='src.d/infback.c' line='31' column='1'/>
+      <parameter type-id='type-id-22' name='version' filepath='src.d/infback.c' line='32' column='1'/>
       <parameter type-id='type-id-20' name='stream_size' filepath='src.d/infback.c' line='33' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateBack' mangled-name='inflateBack' filepath='src.d/infback.c' line='251' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateBack@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/infback.c' line='252' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/infback.c' line='252' column='1'/>
       <parameter type-id='type-id-107' name='in' filepath='src.d/infback.c' line='253' column='1'/>
-      <parameter type-id='type-id-44' name='in_desc' filepath='src.d/infback.c' line='254' column='1'/>
+      <parameter type-id='type-id-84' name='in_desc' filepath='src.d/infback.c' line='254' column='1'/>
       <parameter type-id='type-id-109' name='out' filepath='src.d/infback.c' line='255' column='1'/>
-      <parameter type-id='type-id-44' name='out_desc' filepath='src.d/infback.c' line='256' column='1'/>
+      <parameter type-id='type-id-84' name='out_desc' filepath='src.d/infback.c' line='256' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateBackEnd' mangled-name='inflateBackEnd' filepath='src.d/infback.c' line='635' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateBackEnd@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/infback.c' line='636' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/infback.c' line='636' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflate_fast' filepath='src.d/inffast.h' line='11' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-57'/>
-      <parameter type-id='type-id-3'/>
-      <return type-id='type-id-42'/>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-11'/>
+      <return type-id='type-id-85'/>
     </function-decl>
     <function-decl name='inflate_table' filepath='src.d/inftrees.h' line='60' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
+      <parameter type-id='type-id-101'/>
       <parameter type-id='type-id-115'/>
-      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-11'/>
       <parameter type-id='type-id-111'/>
-      <parameter type-id='type-id-84'/>
+      <parameter type-id='type-id-79'/>
       <parameter type-id='type-id-115'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-type size-in-bits='64' id='type-id-112'>
-      <parameter type-id='type-id-44'/>
-      <parameter type-id='type-id-89'/>
-      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-84'/>
+      <parameter type-id='type-id-87'/>
+      <parameter type-id='type-id-11'/>
       <return type-id='type-id-20'/>
     </function-type>
     <function-type size-in-bits='64' id='type-id-114'>
-      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-84'/>
       <parameter type-id='type-id-113'/>
-      <return type-id='type-id-3'/>
+      <return type-id='type-id-11'/>
     </function-type>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/inflate.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
+    <typedef-decl name='voidpf' type-id='type-id-84' filepath='./zconf.h' line='415' column='1' id='type-id-117'/>
     <function-decl name='inflateResetKeep' mangled-name='inflateResetKeep' filepath='src.d/inflate.c' line='119' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateResetKeep@@ZLIB_1.2.5.2'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='120' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
-    <function-decl name='inflateReset' mangled-name='inflateReset' filepath='src.d/inflate.c' line='145' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateReset'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='146' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='120' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateReset2' mangled-name='inflateReset2' filepath='src.d/inflate.c' line='158' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateReset2@@ZLIB_1.2.3.4'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='159' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='159' column='1'/>
       <parameter type-id='type-id-20' name='windowBits' filepath='src.d/inflate.c' line='160' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='inflateInit2_' mangled-name='inflateInit2_' filepath='src.d/inflate.c' line='198' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateInit2_'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='199' column='1'/>
-      <parameter type-id='type-id-20' name='windowBits' filepath='src.d/inflate.c' line='200' column='1'/>
-      <parameter type-id='type-id-78' name='version' filepath='src.d/inflate.c' line='201' column='1'/>
-      <parameter type-id='type-id-20' name='stream_size' filepath='src.d/inflate.c' line='202' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
     <function-decl name='inflateInit_' mangled-name='inflateInit_' filepath='src.d/inflate.c' line='242' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateInit_'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='243' column='1'/>
-      <parameter type-id='type-id-78' name='version' filepath='src.d/inflate.c' line='244' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='243' column='1'/>
+      <parameter type-id='type-id-22' name='version' filepath='src.d/inflate.c' line='244' column='1'/>
       <parameter type-id='type-id-20' name='stream_size' filepath='src.d/inflate.c' line='245' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflatePrime' mangled-name='inflatePrime' filepath='src.d/inflate.c' line='250' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflatePrime@@ZLIB_1.2.2.4'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='251' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='251' column='1'/>
       <parameter type-id='type-id-20' name='bits' filepath='src.d/inflate.c' line='252' column='1'/>
       <parameter type-id='type-id-20' name='value' filepath='src.d/inflate.c' line='253' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='inflate' mangled-name='inflate' filepath='src.d/inflate.c' line='625' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflate'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='626' column='1'/>
-      <parameter type-id='type-id-20' name='flush' filepath='src.d/inflate.c' line='627' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
-    <function-decl name='inflateEnd' mangled-name='inflateEnd' filepath='src.d/inflate.c' line='1304' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateEnd'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1305' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
     <function-decl name='inflateGetDictionary' mangled-name='inflateGetDictionary' filepath='src.d/inflate.c' line='1318' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateGetDictionary@@ZLIB_1.2.7.1'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1319' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1319' column='1'/>
       <parameter type-id='type-id-19' name='dictionary' filepath='src.d/inflate.c' line='1320' column='1'/>
-      <parameter type-id='type-id-83' name='dictLength' filepath='src.d/inflate.c' line='1321' column='1'/>
+      <parameter type-id='type-id-78' name='dictLength' filepath='src.d/inflate.c' line='1321' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateSetDictionary' mangled-name='inflateSetDictionary' filepath='src.d/inflate.c' line='1341' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateSetDictionary'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1342' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1342' column='1'/>
       <parameter type-id='type-id-16' name='dictionary' filepath='src.d/inflate.c' line='1343' column='1'/>
-      <parameter type-id='type-id-8' name='dictLength' filepath='src.d/inflate.c' line='1344' column='1'/>
+      <parameter type-id='type-id-12' name='dictLength' filepath='src.d/inflate.c' line='1344' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateGetHeader' mangled-name='inflateGetHeader' filepath='src.d/inflate.c' line='1376' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateGetHeader@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1377' column='1'/>
-      <parameter type-id='type-id-59' name='head' filepath='src.d/inflate.c' line='1378' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1377' column='1'/>
+      <parameter type-id='type-id-42' name='head' filepath='src.d/inflate.c' line='1378' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateSync' mangled-name='inflateSync' filepath='src.d/inflate.c' line='1427' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateSync'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1428' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1428' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateSyncPoint' mangled-name='inflateSyncPoint' filepath='src.d/inflate.c' line='1485' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateSyncPoint'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1486' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1486' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateCopy' mangled-name='inflateCopy' filepath='src.d/inflate.c' line='1495' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateCopy@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-57' name='dest' filepath='src.d/inflate.c' line='1496' column='1'/>
-      <parameter type-id='type-id-57' name='source' filepath='src.d/inflate.c' line='1497' column='1'/>
+      <parameter type-id='type-id-21' name='dest' filepath='src.d/inflate.c' line='1496' column='1'/>
+      <parameter type-id='type-id-21' name='source' filepath='src.d/inflate.c' line='1497' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateUndermine' mangled-name='inflateUndermine' filepath='src.d/inflate.c' line='1542' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateUndermine@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1543' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1543' column='1'/>
       <parameter type-id='type-id-20' name='subvert' filepath='src.d/inflate.c' line='1544' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateValidate' mangled-name='inflateValidate' filepath='src.d/inflate.c' line='1560' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateValidate@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1561' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1561' column='1'/>
       <parameter type-id='type-id-20' name='check' filepath='src.d/inflate.c' line='1562' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateMark' mangled-name='inflateMark' filepath='src.d/inflate.c' line='1575' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateMark@@ZLIB_1.2.3.4'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1576' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1576' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='inflateCodesUsed' mangled-name='inflateCodesUsed' filepath='src.d/inflate.c' line='1588' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateCodesUsed@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1589' column='1'/>
-      <return type-id='type-id-4'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1589' column='1'/>
+      <return type-id='type-id-9'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/trees.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <array-type-def dimensions='1' type-id='type-id-116' size-in-bits='2048' id='type-id-117'>
-      <subrange length='256' type-id='type-id-4' id='type-id-118'/>
+    <array-type-def dimensions='1' type-id='type-id-118' size-in-bits='2048' id='type-id-119'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-9' id='type-id-120'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-116' size-in-bits='4096' id='type-id-119'>
-      <subrange length='512' type-id='type-id-4' id='type-id-120'/>
+    <array-type-def dimensions='1' type-id='type-id-118' size-in-bits='4096' id='type-id-121'>
+      <subrange length='512' lower-bound='0' upper-bound='511' type-id='type-id-9' id='type-id-122'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-116' size-in-bits='infinite' id='type-id-121'>
-      <subrange length='infinite' id='type-id-122'/>
+    <array-type-def dimensions='1' type-id='type-id-118' size-in-bits='unknown' id='type-id-123'>
+      <subrange length='unknown' lower-bound='0' upper-bound='0' id='type-id-124'/>
     </array-type-def>
-    <qualified-type-def type-id='type-id-36' const='yes' id='type-id-116'/>
-    <var-decl name='_length_code' type-id='type-id-121' visibility='default' filepath='src.d/deflate.h' line='317' column='1'/>
+    <qualified-type-def type-id='type-id-67' const='yes' id='type-id-118'/>
+    <var-decl name='_length_code' type-id='type-id-119' visibility='default' filepath='src.d/deflate.h' line='317' column='1'/>
     <var-decl name='_dist_code' type-id='type-id-121' visibility='default' filepath='src.d/deflate.h' line='318' column='1'/>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/uncompr.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <pointer-type-def type-id='type-id-9' size-in-bits='64' id='type-id-123'/>
+    <pointer-type-def type-id='type-id-13' size-in-bits='64' id='type-id-125'/>
     <function-decl name='uncompress2' mangled-name='uncompress2' filepath='src.d/uncompr.c' line='27' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uncompress2@@ZLIB_1.2.9'>
       <parameter type-id='type-id-19' name='dest' filepath='src.d/uncompr.c' line='28' column='1'/>
       <parameter type-id='type-id-18' name='destLen' filepath='src.d/uncompr.c' line='29' column='1'/>
       <parameter type-id='type-id-16' name='source' filepath='src.d/uncompr.c' line='30' column='1'/>
-      <parameter type-id='type-id-123' name='sourceLen' filepath='src.d/uncompr.c' line='31' column='1'/>
+      <parameter type-id='type-id-125' name='sourceLen' filepath='src.d/uncompr.c' line='31' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='uncompress' mangled-name='uncompress' filepath='src.d/uncompr.c' line='86' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uncompress'>
       <parameter type-id='type-id-19' name='dest' filepath='src.d/uncompr.c' line='87' column='1'/>
       <parameter type-id='type-id-18' name='destLen' filepath='src.d/uncompr.c' line='88' column='1'/>
       <parameter type-id='type-id-16' name='source' filepath='src.d/uncompr.c' line='89' column='1'/>
-      <parameter type-id='type-id-9' name='sourceLen' filepath='src.d/uncompr.c' line='90' column='1'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/uncompr.c' line='90' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/zutil.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <array-type-def dimensions='1' type-id='type-id-124' size-in-bits='640' id='type-id-125'>
-      <subrange length='10' type-id='type-id-4' id='type-id-126'/>
+    <array-type-def dimensions='1' type-id='type-id-126' size-in-bits='640' id='type-id-127'>
+      <subrange length='10' lower-bound='0' upper-bound='9' type-id='type-id-9' id='type-id-128'/>
     </array-type-def>
-    <qualified-type-def type-id='type-id-68' const='yes' id='type-id-124'/>
-    <function-decl name='malloc' filepath='/usr/powerpc64le-linux-gnu/include/stdlib.h' line='540' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-44'/>
-    </function-decl>
-    <function-decl name='free' filepath='/usr/powerpc64le-linux-gnu/include/stdlib.h' line='555' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-44'/>
-      <return type-id='type-id-42'/>
-    </function-decl>
+    <qualified-type-def type-id='type-id-53' const='yes' id='type-id-126'/>
     <function-decl name='zlibVersion' mangled-name='zlibVersion' filepath='src.d/zutil.c' line='27' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zlibVersion'>
-      <return type-id='type-id-78'/>
+      <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='zlibCompileFlags' mangled-name='zlibCompileFlags' filepath='src.d/zutil.c' line='32' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zlibCompileFlags@@ZLIB_1.2.0.2'>
-      <return type-id='type-id-9'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='zError' mangled-name='zError' filepath='src.d/zutil.c' line='135' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zError'>
       <parameter type-id='type-id-20' name='err' filepath='src.d/zutil.c' line='136' column='1'/>
-      <return type-id='type-id-78'/>
+      <return type-id='type-id-22'/>
     </function-decl>
-    <var-decl name='z_errmsg' type-id='type-id-125' visibility='default' filepath='src.d/zutil.h' line='56' column='1'/>
+    <var-decl name='z_errmsg' type-id='type-id-127' visibility='default' filepath='src.d/zutil.h' line='56' column='1'/>
   </abi-instr>
 </abi-corpus>

--- a/test/abi/zlib-04f42ceca40f73e2978b50e93806c2a18c1281fc-x86_64-pc-linux-gnu-m32.abi
+++ b/test/abi/zlib-04f42ceca40f73e2978b50e93806c2a18c1281fc-x86_64-pc-linux-gnu-m32.abi
@@ -1,4 +1,4 @@
-<abi-corpus version='2.0' path='btmp1/libz.so.1.2.13' architecture='elf-intel-80386' soname='libz.so.1'>
+<abi-corpus version='2.2' path='btmp1/libz.so.1.2.13' architecture='elf-intel-80386' soname='libz.so.1'>
   <elf-needed>
     <dependency name='libc.so.6'/>
   </elf-needed>
@@ -95,55 +95,55 @@
   <abi-instr address-size='32' path='src.d/adler32.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
     <type-decl name='long int' size-in-bits='32' id='type-id-1'/>
     <type-decl name='long long int' size-in-bits='64' id='type-id-2'/>
+    <typedef-decl name='Byte' type-id='type-id-3' filepath='./zconf.h' line='397' column='1' id='type-id-4'/>
+    <typedef-decl name='Bytef' type-id='type-id-4' filepath='./zconf.h' line='406' column='1' id='type-id-5'/>
+    <typedef-decl name='__int64_t' type-id='type-id-2' filepath='/usr/include/bits/types.h' line='47' column='1' id='type-id-6'/>
+    <typedef-decl name='__off64_t' type-id='type-id-6' filepath='/usr/include/bits/types.h' line='153' column='1' id='type-id-7'/>
+    <typedef-decl name='__off_t' type-id='type-id-1' filepath='/usr/include/bits/types.h' line='152' column='1' id='type-id-8'/>
+    <typedef-decl name='off64_t' type-id='type-id-7' filepath='/usr/include/sys/types.h' line='92' column='1' id='type-id-9'/>
+    <typedef-decl name='off_t' type-id='type-id-8' filepath='/usr/include/sys/types.h' line='85' column='1' id='type-id-10'/>
+    <typedef-decl name='size_t' type-id='type-id-11' filepath='/usr/lib/gcc/x86_64-linux-gnu/13/include/stddef.h' line='214' column='1' id='type-id-12'/>
+    <typedef-decl name='uInt' type-id='type-id-11' filepath='./zconf.h' line='399' column='1' id='type-id-13'/>
+    <typedef-decl name='uLong' type-id='type-id-14' filepath='./zconf.h' line='400' column='1' id='type-id-15'/>
+    <typedef-decl name='z_size_t' type-id='type-id-12' filepath='./zconf.h' line='251' column='1' id='type-id-16'/>
     <type-decl name='unsigned char' size-in-bits='8' id='type-id-3'/>
-    <type-decl name='unsigned int' size-in-bits='32' id='type-id-4'/>
-    <type-decl name='unsigned long int' size-in-bits='32' id='type-id-5'/>
-    <typedef-decl name='z_size_t' type-id='type-id-6' filepath='./zconf.h' line='251' column='1' id='type-id-7'/>
-    <typedef-decl name='Byte' type-id='type-id-3' filepath='./zconf.h' line='397' column='1' id='type-id-8'/>
-    <typedef-decl name='uInt' type-id='type-id-4' filepath='./zconf.h' line='399' column='1' id='type-id-9'/>
-    <typedef-decl name='uLong' type-id='type-id-5' filepath='./zconf.h' line='400' column='1' id='type-id-10'/>
-    <typedef-decl name='Bytef' type-id='type-id-8' filepath='./zconf.h' line='406' column='1' id='type-id-11'/>
-    <typedef-decl name='__int64_t' type-id='type-id-2' filepath='/usr/include/bits/types.h' line='47' column='1' id='type-id-12'/>
-    <typedef-decl name='__off_t' type-id='type-id-1' filepath='/usr/include/bits/types.h' line='152' column='1' id='type-id-13'/>
-    <typedef-decl name='__off64_t' type-id='type-id-12' filepath='/usr/include/bits/types.h' line='153' column='1' id='type-id-14'/>
-    <typedef-decl name='off_t' type-id='type-id-13' filepath='/usr/include/sys/types.h' line='85' column='1' id='type-id-15'/>
-    <typedef-decl name='off64_t' type-id='type-id-14' filepath='/usr/include/sys/types.h' line='92' column='1' id='type-id-16'/>
-    <typedef-decl name='size_t' type-id='type-id-4' filepath='/usr/lib/gcc/x86_64-linux-gnu/11/include/stddef.h' line='209' column='1' id='type-id-6'/>
-    <qualified-type-def type-id='type-id-11' const='yes' id='type-id-17'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-11'/>
+    <type-decl name='unsigned long int' size-in-bits='32' id='type-id-14'/>
+    <qualified-type-def type-id='type-id-5' const='yes' id='type-id-17'/>
     <pointer-type-def type-id='type-id-17' size-in-bits='32' id='type-id-18'/>
     <function-decl name='adler32_z' mangled-name='adler32_z' filepath='src.d/adler32.c' line='63' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='adler32_z@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-10' name='adler' filepath='src.d/adler32.c' line='64' column='1'/>
+      <parameter type-id='type-id-15' name='adler' filepath='src.d/adler32.c' line='64' column='1'/>
       <parameter type-id='type-id-18' name='buf' filepath='src.d/adler32.c' line='65' column='1'/>
-      <parameter type-id='type-id-7' name='len' filepath='src.d/adler32.c' line='66' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-16' name='len' filepath='src.d/adler32.c' line='66' column='1'/>
+      <return type-id='type-id-15'/>
     </function-decl>
     <function-decl name='adler32' mangled-name='adler32' filepath='src.d/adler32.c' line='134' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='adler32'>
-      <parameter type-id='type-id-10' name='adler' filepath='src.d/adler32.c' line='135' column='1'/>
+      <parameter type-id='type-id-15' name='adler' filepath='src.d/adler32.c' line='135' column='1'/>
       <parameter type-id='type-id-18' name='buf' filepath='src.d/adler32.c' line='136' column='1'/>
-      <parameter type-id='type-id-9' name='len' filepath='src.d/adler32.c' line='137' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-13' name='len' filepath='src.d/adler32.c' line='137' column='1'/>
+      <return type-id='type-id-15'/>
     </function-decl>
     <function-decl name='adler32_combine' mangled-name='adler32_combine' filepath='src.d/adler32.c' line='172' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='adler32_combine@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-10' name='adler1' filepath='src.d/adler32.c' line='173' column='1'/>
-      <parameter type-id='type-id-10' name='adler2' filepath='src.d/adler32.c' line='174' column='1'/>
-      <parameter type-id='type-id-15' name='len2' filepath='src.d/adler32.c' line='175' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-15' name='adler1' filepath='src.d/adler32.c' line='173' column='1'/>
+      <parameter type-id='type-id-15' name='adler2' filepath='src.d/adler32.c' line='174' column='1'/>
+      <parameter type-id='type-id-10' name='len2' filepath='src.d/adler32.c' line='175' column='1'/>
+      <return type-id='type-id-15'/>
     </function-decl>
     <function-decl name='adler32_combine64' mangled-name='adler32_combine64' filepath='src.d/adler32.c' line='180' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='adler32_combine64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-10' name='adler1' filepath='src.d/adler32.c' line='181' column='1'/>
-      <parameter type-id='type-id-10' name='adler2' filepath='src.d/adler32.c' line='182' column='1'/>
-      <parameter type-id='type-id-16' name='len2' filepath='src.d/adler32.c' line='183' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-15' name='adler1' filepath='src.d/adler32.c' line='181' column='1'/>
+      <parameter type-id='type-id-15' name='adler2' filepath='src.d/adler32.c' line='182' column='1'/>
+      <parameter type-id='type-id-9' name='len2' filepath='src.d/adler32.c' line='183' column='1'/>
+      <return type-id='type-id-15'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/compress.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <typedef-decl name='uLongf' type-id='type-id-10' filepath='./zconf.h' line='411' column='1' id='type-id-19'/>
+    <typedef-decl name='uLongf' type-id='type-id-15' filepath='./zconf.h' line='411' column='1' id='type-id-19'/>
     <pointer-type-def type-id='type-id-19' size-in-bits='32' id='type-id-20'/>
     <function-decl name='compress2' mangled-name='compress2' filepath='src.d/compress.c' line='22' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='compress2'>
       <parameter type-id='type-id-21' name='dest' filepath='src.d/compress.c' line='23' column='1'/>
       <parameter type-id='type-id-20' name='destLen' filepath='src.d/compress.c' line='24' column='1'/>
       <parameter type-id='type-id-18' name='source' filepath='src.d/compress.c' line='25' column='1'/>
-      <parameter type-id='type-id-10' name='sourceLen' filepath='src.d/compress.c' line='26' column='1'/>
+      <parameter type-id='type-id-15' name='sourceLen' filepath='src.d/compress.c' line='26' column='1'/>
       <parameter type-id='type-id-22' name='level' filepath='src.d/compress.c' line='27' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
@@ -151,362 +151,107 @@
       <parameter type-id='type-id-21' name='dest' filepath='src.d/compress.c' line='69' column='1'/>
       <parameter type-id='type-id-20' name='destLen' filepath='src.d/compress.c' line='70' column='1'/>
       <parameter type-id='type-id-18' name='source' filepath='src.d/compress.c' line='71' column='1'/>
-      <parameter type-id='type-id-10' name='sourceLen' filepath='src.d/compress.c' line='72' column='1'/>
+      <parameter type-id='type-id-15' name='sourceLen' filepath='src.d/compress.c' line='72' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='compressBound' mangled-name='compressBound' filepath='src.d/compress.c' line='81' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='compressBound@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-10' name='sourceLen' filepath='src.d/compress.c' line='82' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-15' name='sourceLen' filepath='src.d/compress.c' line='82' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='deflate' filepath='src.d/zlib.h' line='250' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-23'/>
+      <parameter type-id='type-id-22'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='deflateEnd' filepath='src.d/zlib.h' line='363' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-23'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='deflateInit_' filepath='src.d/zlib.h' line='1781' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-23'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-24'/>
+      <parameter type-id='type-id-22'/>
+      <return type-id='type-id-22'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/crc32.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <typedef-decl name='z_crc_t' type-id='type-id-4' filepath='./zconf.h' line='435' column='1' id='type-id-23'/>
-    <qualified-type-def type-id='type-id-3' const='yes' id='type-id-24'/>
-    <pointer-type-def type-id='type-id-24' size-in-bits='32' id='type-id-25'/>
-    <qualified-type-def type-id='type-id-23' const='yes' id='type-id-26'/>
+    <typedef-decl name='z_crc_t' type-id='type-id-11' filepath='./zconf.h' line='435' column='1' id='type-id-25'/>
+    <qualified-type-def type-id='type-id-3' const='yes' id='type-id-26'/>
     <pointer-type-def type-id='type-id-26' size-in-bits='32' id='type-id-27'/>
+    <qualified-type-def type-id='type-id-25' const='yes' id='type-id-28'/>
+    <pointer-type-def type-id='type-id-28' size-in-bits='32' id='type-id-29'/>
     <function-decl name='get_crc_table' mangled-name='get_crc_table' filepath='src.d/crc32.c' line='595' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='get_crc_table'>
-      <return type-id='type-id-27'/>
+      <return type-id='type-id-29'/>
     </function-decl>
     <function-decl name='crc32_z' mangled-name='crc32_z' filepath='src.d/crc32.c' line='748' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='crc32_z@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-5' name='crc' filepath='src.d/crc32.c' line='749' column='1'/>
-      <parameter type-id='type-id-25' name='buf' filepath='src.d/crc32.c' line='750' column='1'/>
-      <parameter type-id='type-id-7' name='len' filepath='src.d/crc32.c' line='751' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-14' name='crc' filepath='src.d/crc32.c' line='749' column='1'/>
+      <parameter type-id='type-id-27' name='buf' filepath='src.d/crc32.c' line='750' column='1'/>
+      <parameter type-id='type-id-16' name='len' filepath='src.d/crc32.c' line='751' column='1'/>
+      <return type-id='type-id-15'/>
     </function-decl>
     <function-decl name='crc32' mangled-name='crc32' filepath='src.d/crc32.c' line='1072' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='crc32'>
-      <parameter type-id='type-id-5' name='crc' filepath='src.d/crc32.c' line='1073' column='1'/>
-      <parameter type-id='type-id-25' name='buf' filepath='src.d/crc32.c' line='1074' column='1'/>
-      <parameter type-id='type-id-9' name='len' filepath='src.d/crc32.c' line='1075' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-14' name='crc' filepath='src.d/crc32.c' line='1073' column='1'/>
+      <parameter type-id='type-id-27' name='buf' filepath='src.d/crc32.c' line='1074' column='1'/>
+      <parameter type-id='type-id-13' name='len' filepath='src.d/crc32.c' line='1075' column='1'/>
+      <return type-id='type-id-15'/>
     </function-decl>
     <function-decl name='crc32_combine64' mangled-name='crc32_combine64' filepath='src.d/crc32.c' line='1081' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='crc32_combine64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-10' name='crc1' filepath='src.d/crc32.c' line='1082' column='1'/>
-      <parameter type-id='type-id-10' name='crc2' filepath='src.d/crc32.c' line='1083' column='1'/>
-      <parameter type-id='type-id-16' name='len2' filepath='src.d/crc32.c' line='1084' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-15' name='crc1' filepath='src.d/crc32.c' line='1082' column='1'/>
+      <parameter type-id='type-id-15' name='crc2' filepath='src.d/crc32.c' line='1083' column='1'/>
+      <parameter type-id='type-id-9' name='len2' filepath='src.d/crc32.c' line='1084' column='1'/>
+      <return type-id='type-id-15'/>
     </function-decl>
     <function-decl name='crc32_combine' mangled-name='crc32_combine' filepath='src.d/crc32.c' line='1093' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='crc32_combine@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-10' name='crc1' filepath='src.d/crc32.c' line='1094' column='1'/>
-      <parameter type-id='type-id-10' name='crc2' filepath='src.d/crc32.c' line='1095' column='1'/>
-      <parameter type-id='type-id-15' name='len2' filepath='src.d/crc32.c' line='1096' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-15' name='crc1' filepath='src.d/crc32.c' line='1094' column='1'/>
+      <parameter type-id='type-id-15' name='crc2' filepath='src.d/crc32.c' line='1095' column='1'/>
+      <parameter type-id='type-id-10' name='len2' filepath='src.d/crc32.c' line='1096' column='1'/>
+      <return type-id='type-id-15'/>
     </function-decl>
     <function-decl name='crc32_combine_gen64' mangled-name='crc32_combine_gen64' filepath='src.d/crc32.c' line='1102' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='crc32_combine_gen64@@ZLIB_1.2.12'>
-      <parameter type-id='type-id-16' name='len2' filepath='src.d/crc32.c' line='1103' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-9' name='len2' filepath='src.d/crc32.c' line='1103' column='1'/>
+      <return type-id='type-id-15'/>
     </function-decl>
     <function-decl name='crc32_combine_gen' mangled-name='crc32_combine_gen' filepath='src.d/crc32.c' line='1112' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='crc32_combine_gen@@ZLIB_1.2.12'>
-      <parameter type-id='type-id-15' name='len2' filepath='src.d/crc32.c' line='1113' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-10' name='len2' filepath='src.d/crc32.c' line='1113' column='1'/>
+      <return type-id='type-id-15'/>
     </function-decl>
     <function-decl name='crc32_combine_op' mangled-name='crc32_combine_op' filepath='src.d/crc32.c' line='1119' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='crc32_combine_op@@ZLIB_1.2.12'>
-      <parameter type-id='type-id-10' name='crc1' filepath='src.d/crc32.c' line='1120' column='1'/>
-      <parameter type-id='type-id-10' name='crc2' filepath='src.d/crc32.c' line='1121' column='1'/>
-      <parameter type-id='type-id-10' name='op' filepath='src.d/crc32.c' line='1122' column='1'/>
-      <return type-id='type-id-10'/>
+      <parameter type-id='type-id-15' name='crc1' filepath='src.d/crc32.c' line='1120' column='1'/>
+      <parameter type-id='type-id-15' name='crc2' filepath='src.d/crc32.c' line='1121' column='1'/>
+      <parameter type-id='type-id-15' name='op' filepath='src.d/crc32.c' line='1122' column='1'/>
+      <return type-id='type-id-15'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/deflate.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <type-decl name='char' size-in-bits='8' id='type-id-28'/>
-    <class-decl name='static_tree_desc_s' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-29'/>
-    <array-type-def dimensions='1' type-id='type-id-30' size-in-bits='1248' id='type-id-31'>
-      <subrange length='39' type-id='type-id-4' id='type-id-32'/>
+    <type-decl name='char' size-in-bits='8' id='type-id-30'/>
+    <array-type-def dimensions='1' type-id='type-id-31' size-in-bits='1248' id='type-id-32'>
+      <subrange length='39' lower-bound='0' upper-bound='38' type-id='type-id-11' id='type-id-33'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-30' size-in-bits='18336' id='type-id-33'>
-      <subrange length='573' type-id='type-id-4' id='type-id-34'/>
+    <array-type-def dimensions='1' type-id='type-id-31' size-in-bits='18336' id='type-id-34'>
+      <subrange length='573' lower-bound='0' upper-bound='572' type-id='type-id-11' id='type-id-35'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-30' size-in-bits='1952' id='type-id-35'>
-      <subrange length='61' type-id='type-id-4' id='type-id-36'/>
+    <array-type-def dimensions='1' type-id='type-id-31' size-in-bits='1952' id='type-id-36'>
+      <subrange length='61' lower-bound='0' upper-bound='60' type-id='type-id-11' id='type-id-37'/>
     </array-type-def>
     <type-decl name='int' size-in-bits='32' id='type-id-22'/>
-    <array-type-def dimensions='1' type-id='type-id-22' size-in-bits='18336' id='type-id-37'>
-      <subrange length='573' type-id='type-id-4' id='type-id-34'/>
+    <array-type-def dimensions='1' type-id='type-id-22' size-in-bits='18336' id='type-id-38'>
+      <subrange length='573' lower-bound='0' upper-bound='572' type-id='type-id-11' id='type-id-35'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-38' size-in-bits='4584' id='type-id-39'>
-      <subrange length='573' type-id='type-id-4' id='type-id-34'/>
-    </array-type-def>
-    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-40'/>
-    <array-type-def dimensions='1' type-id='type-id-41' size-in-bits='256' id='type-id-42'>
-      <subrange length='16' type-id='type-id-4' id='type-id-43'/>
-    </array-type-def>
-    <type-decl name='void' id='type-id-44'/>
-    <typedef-decl name='charf' type-id='type-id-28' filepath='./zconf.h' line='408' column='1' id='type-id-45'/>
-    <typedef-decl name='voidpf' type-id='type-id-46' filepath='./zconf.h' line='415' column='1' id='type-id-47'/>
-    <class-decl name='ct_data_s' size-in-bits='32' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='68' column='1' id='type-id-30'>
+    <class-decl name='ct_data_s' size-in-bits='32' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='68' column='1' id='type-id-31'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='fc' type-id='type-id-48' visibility='default' filepath='src.d/deflate.h' line='72' column='1'/>
+        <var-decl name='fc' type-id='type-id-39' visibility='default' filepath='src.d/deflate.h' line='72' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='16'>
-        <var-decl name='dl' type-id='type-id-49' visibility='default' filepath='src.d/deflate.h' line='76' column='1'/>
+        <var-decl name='dl' type-id='type-id-40' visibility='default' filepath='src.d/deflate.h' line='76' column='1'/>
       </data-member>
     </class-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='69' column='1' id='type-id-48'>
-      <data-member access='public'>
-        <var-decl name='freq' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='70' column='1'/>
-      </data-member>
-      <data-member access='public'>
-        <var-decl name='code' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='71' column='1'/>
-      </data-member>
-    </union-decl>
-    <union-decl name='__anonymous_union__1' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='73' column='1' id='type-id-49'>
-      <data-member access='public'>
-        <var-decl name='dad' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='74' column='1'/>
-      </data-member>
-      <data-member access='public'>
-        <var-decl name='len' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='75' column='1'/>
-      </data-member>
-    </union-decl>
-    <typedef-decl name='ct_data' type-id='type-id-30' filepath='src.d/deflate.h' line='77' column='1' id='type-id-50'/>
-    <typedef-decl name='static_tree_desc' type-id='type-id-29' filepath='src.d/deflate.h' line='84' column='1' id='type-id-51'/>
-    <class-decl name='tree_desc_s' size-in-bits='96' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='86' column='1' id='type-id-52'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='dyn_tree' type-id='type-id-53' visibility='default' filepath='src.d/deflate.h' line='87' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='max_code' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='88' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='stat_desc' type-id='type-id-54' visibility='default' filepath='src.d/deflate.h' line='89' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='Pos' type-id='type-id-41' filepath='src.d/deflate.h' line='92' column='1' id='type-id-55'/>
-    <typedef-decl name='Posf' type-id='type-id-55' filepath='src.d/deflate.h' line='93' column='1' id='type-id-56'/>
-    <typedef-decl name='IPos' type-id='type-id-4' filepath='src.d/deflate.h' line='94' column='1' id='type-id-57'/>
-    <class-decl name='internal_state' size-in-bits='46624' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='100' column='1' id='type-id-58'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='strm' type-id='type-id-59' visibility='default' filepath='src.d/deflate.h' line='101' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='status' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='102' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='pending_buf' type-id='type-id-21' visibility='default' filepath='src.d/deflate.h' line='103' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='pending_buf_size' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='104' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='pending_out' type-id='type-id-21' visibility='default' filepath='src.d/deflate.h' line='105' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='pending' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='106' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='wrap' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='107' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='gzhead' type-id='type-id-61' visibility='default' filepath='src.d/deflate.h' line='108' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='gzindex' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='109' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='method' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='110' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='last_flush' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='111' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='w_size' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='115' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='w_bits' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='116' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='416'>
-        <var-decl name='w_mask' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='117' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='window' type-id='type-id-21' visibility='default' filepath='src.d/deflate.h' line='119' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='480'>
-        <var-decl name='window_size' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='129' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='prev' type-id='type-id-62' visibility='default' filepath='src.d/deflate.h' line='134' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='544'>
-        <var-decl name='head' type-id='type-id-62' visibility='default' filepath='src.d/deflate.h' line='140' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='ins_h' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='142' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='608'>
-        <var-decl name='hash_size' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='143' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='hash_bits' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='144' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='672'>
-        <var-decl name='hash_mask' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='145' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='hash_shift' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='147' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='736'>
-        <var-decl name='block_start' type-id='type-id-1' visibility='default' filepath='src.d/deflate.h' line='154' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='match_length' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='159' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='800'>
-        <var-decl name='prev_match' type-id='type-id-57' visibility='default' filepath='src.d/deflate.h' line='160' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='match_available' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='161' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='864'>
-        <var-decl name='strstart' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='162' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='match_start' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='163' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='928'>
-        <var-decl name='lookahead' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='164' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='prev_length' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='166' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='992'>
-        <var-decl name='max_chain_length' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='171' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='max_lazy_match' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='177' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1056'>
-        <var-decl name='level' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='188' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1088'>
-        <var-decl name='strategy' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='189' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1120'>
-        <var-decl name='good_match' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='191' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1152'>
-        <var-decl name='nice_match' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='194' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1184'>
-        <var-decl name='dyn_ltree' type-id='type-id-33' visibility='default' filepath='src.d/deflate.h' line='198' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='19520'>
-        <var-decl name='dyn_dtree' type-id='type-id-35' visibility='default' filepath='src.d/deflate.h' line='199' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='21472'>
-        <var-decl name='bl_tree' type-id='type-id-31' visibility='default' filepath='src.d/deflate.h' line='200' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='22720'>
-        <var-decl name='l_desc' type-id='type-id-52' visibility='default' filepath='src.d/deflate.h' line='202' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='22816'>
-        <var-decl name='d_desc' type-id='type-id-52' visibility='default' filepath='src.d/deflate.h' line='203' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='22912'>
-        <var-decl name='bl_desc' type-id='type-id-52' visibility='default' filepath='src.d/deflate.h' line='204' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='23008'>
-        <var-decl name='bl_count' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='206' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='23264'>
-        <var-decl name='heap' type-id='type-id-37' visibility='default' filepath='src.d/deflate.h' line='209' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='41600'>
-        <var-decl name='heap_len' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='210' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='41632'>
-        <var-decl name='heap_max' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='211' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='41664'>
-        <var-decl name='depth' type-id='type-id-39' visibility='default' filepath='src.d/deflate.h' line='216' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='46272'>
-        <var-decl name='sym_buf' type-id='type-id-63' visibility='default' filepath='src.d/deflate.h' line='220' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='46304'>
-        <var-decl name='lit_bufsize' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='222' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='46336'>
-        <var-decl name='sym_next' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='242' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='46368'>
-        <var-decl name='sym_end' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='243' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='46400'>
-        <var-decl name='opt_len' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='245' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='46432'>
-        <var-decl name='static_len' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='246' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='46464'>
-        <var-decl name='matches' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='247' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='46496'>
-        <var-decl name='insert' type-id='type-id-9' visibility='default' filepath='src.d/deflate.h' line='248' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='46528'>
-        <var-decl name='bi_buf' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='255' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='46560'>
-        <var-decl name='bi_valid' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='259' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='46592'>
-        <var-decl name='high_water' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='264' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='deflate_state' type-id='type-id-58' filepath='src.d/deflate.h' line='271' column='1' id='type-id-64'/>
-    <typedef-decl name='alloc_func' type-id='type-id-65' filepath='src.d/zlib.h' line='81' column='1' id='type-id-66'/>
-    <typedef-decl name='free_func' type-id='type-id-67' filepath='src.d/zlib.h' line='82' column='1' id='type-id-68'/>
-    <class-decl name='z_stream_s' size-in-bits='448' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='86' column='1' id='type-id-69'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='next_in' type-id='type-id-21' visibility='default' filepath='src.d/zlib.h' line='87' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='avail_in' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='88' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='total_in' type-id='type-id-10' visibility='default' filepath='src.d/zlib.h' line='89' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='next_out' type-id='type-id-21' visibility='default' filepath='src.d/zlib.h' line='91' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='avail_out' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='92' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='total_out' type-id='type-id-10' visibility='default' filepath='src.d/zlib.h' line='93' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='msg' type-id='type-id-70' visibility='default' filepath='src.d/zlib.h' line='95' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='state' type-id='type-id-71' visibility='default' filepath='src.d/zlib.h' line='96' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='zalloc' type-id='type-id-66' visibility='default' filepath='src.d/zlib.h' line='98' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='zfree' type-id='type-id-68' visibility='default' filepath='src.d/zlib.h' line='99' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='opaque' type-id='type-id-47' visibility='default' filepath='src.d/zlib.h' line='100' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='data_type' type-id='type-id-22' visibility='default' filepath='src.d/zlib.h' line='102' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='adler' type-id='type-id-10' visibility='default' filepath='src.d/zlib.h' line='104' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='416'>
-        <var-decl name='reserved' type-id='type-id-10' visibility='default' filepath='src.d/zlib.h' line='105' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='z_stream' type-id='type-id-69' filepath='src.d/zlib.h' line='106' column='1' id='type-id-72'/>
-    <typedef-decl name='z_streamp' type-id='type-id-73' filepath='src.d/zlib.h' line='108' column='1' id='type-id-59'/>
-    <class-decl name='gz_header_s' size-in-bits='416' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='114' column='1' id='type-id-74'>
+    <class-decl name='gz_header_s' size-in-bits='416' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='114' column='1' id='type-id-41'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='text' type-id='type-id-22' visibility='default' filepath='src.d/zlib.h' line='115' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='time' type-id='type-id-10' visibility='default' filepath='src.d/zlib.h' line='116' column='1'/>
+        <var-decl name='time' type-id='type-id-15' visibility='default' filepath='src.d/zlib.h' line='116' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
         <var-decl name='xflags' type-id='type-id-22' visibility='default' filepath='src.d/zlib.h' line='117' column='1'/>
@@ -518,22 +263,22 @@
         <var-decl name='extra' type-id='type-id-21' visibility='default' filepath='src.d/zlib.h' line='119' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='extra_len' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='120' column='1'/>
+        <var-decl name='extra_len' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='120' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='extra_max' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='121' column='1'/>
+        <var-decl name='extra_max' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='121' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='224'>
         <var-decl name='name' type-id='type-id-21' visibility='default' filepath='src.d/zlib.h' line='122' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='name_max' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='123' column='1'/>
+        <var-decl name='name_max' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='123' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
         <var-decl name='comment' type-id='type-id-21' visibility='default' filepath='src.d/zlib.h' line='124' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='comm_max' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='125' column='1'/>
+        <var-decl name='comm_max' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='125' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='352'>
         <var-decl name='hcrc' type-id='type-id-22' visibility='default' filepath='src.d/zlib.h' line='126' column='1'/>
@@ -542,108 +287,368 @@
         <var-decl name='done' type-id='type-id-22' visibility='default' filepath='src.d/zlib.h' line='127' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='gz_header' type-id='type-id-74' filepath='src.d/zlib.h' line='129' column='1' id='type-id-75'/>
-    <typedef-decl name='gz_headerp' type-id='type-id-76' filepath='src.d/zlib.h' line='131' column='1' id='type-id-61'/>
-    <typedef-decl name='uch' type-id='type-id-3' filepath='src.d/zutil.h' line='39' column='1' id='type-id-38'/>
-    <typedef-decl name='uchf' type-id='type-id-38' filepath='src.d/zutil.h' line='40' column='1' id='type-id-77'/>
-    <typedef-decl name='ush' type-id='type-id-40' filepath='src.d/zutil.h' line='41' column='1' id='type-id-41'/>
-    <typedef-decl name='ulg' type-id='type-id-5' filepath='src.d/zutil.h' line='43' column='1' id='type-id-60'/>
-    <pointer-type-def type-id='type-id-11' size-in-bits='32' id='type-id-21'/>
-    <pointer-type-def type-id='type-id-56' size-in-bits='32' id='type-id-62'/>
-    <pointer-type-def type-id='type-id-28' size-in-bits='32' id='type-id-70'/>
-    <pointer-type-def type-id='type-id-45' size-in-bits='32' id='type-id-78'/>
-    <qualified-type-def type-id='type-id-28' const='yes' id='type-id-79'/>
-    <pointer-type-def type-id='type-id-79' size-in-bits='32' id='type-id-80'/>
-    <qualified-type-def type-id='type-id-51' const='yes' id='type-id-81'/>
-    <pointer-type-def type-id='type-id-81' size-in-bits='32' id='type-id-54'/>
-    <pointer-type-def type-id='type-id-50' size-in-bits='32' id='type-id-53'/>
-    <pointer-type-def type-id='type-id-64' size-in-bits='32' id='type-id-82'/>
-    <pointer-type-def type-id='type-id-75' size-in-bits='32' id='type-id-76'/>
-    <pointer-type-def type-id='type-id-22' size-in-bits='32' id='type-id-83'/>
-    <pointer-type-def type-id='type-id-58' size-in-bits='32' id='type-id-71'/>
-    <pointer-type-def type-id='type-id-84' size-in-bits='32' id='type-id-65'/>
-    <pointer-type-def type-id='type-id-9' size-in-bits='32' id='type-id-85'/>
-    <pointer-type-def type-id='type-id-77' size-in-bits='32' id='type-id-63'/>
-    <pointer-type-def type-id='type-id-4' size-in-bits='32' id='type-id-86'/>
-    <pointer-type-def type-id='type-id-87' size-in-bits='32' id='type-id-67'/>
-    <pointer-type-def type-id='type-id-44' size-in-bits='32' id='type-id-46'/>
+    <class-decl name='internal_state' size-in-bits='46624' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='100' column='1' id='type-id-42'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='strm' type-id='type-id-23' visibility='default' filepath='src.d/deflate.h' line='101' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='status' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='102' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='pending_buf' type-id='type-id-21' visibility='default' filepath='src.d/deflate.h' line='103' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='pending_buf_size' type-id='type-id-43' visibility='default' filepath='src.d/deflate.h' line='104' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='pending_out' type-id='type-id-21' visibility='default' filepath='src.d/deflate.h' line='105' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='pending' type-id='type-id-43' visibility='default' filepath='src.d/deflate.h' line='106' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='wrap' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='107' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='gzhead' type-id='type-id-44' visibility='default' filepath='src.d/deflate.h' line='108' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='gzindex' type-id='type-id-43' visibility='default' filepath='src.d/deflate.h' line='109' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='method' type-id='type-id-4' visibility='default' filepath='src.d/deflate.h' line='110' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='last_flush' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='111' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='w_size' type-id='type-id-13' visibility='default' filepath='src.d/deflate.h' line='115' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='w_bits' type-id='type-id-13' visibility='default' filepath='src.d/deflate.h' line='116' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='w_mask' type-id='type-id-13' visibility='default' filepath='src.d/deflate.h' line='117' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='window' type-id='type-id-21' visibility='default' filepath='src.d/deflate.h' line='119' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='480'>
+        <var-decl name='window_size' type-id='type-id-43' visibility='default' filepath='src.d/deflate.h' line='129' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='prev' type-id='type-id-45' visibility='default' filepath='src.d/deflate.h' line='134' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='544'>
+        <var-decl name='head' type-id='type-id-45' visibility='default' filepath='src.d/deflate.h' line='140' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='ins_h' type-id='type-id-13' visibility='default' filepath='src.d/deflate.h' line='142' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='608'>
+        <var-decl name='hash_size' type-id='type-id-13' visibility='default' filepath='src.d/deflate.h' line='143' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='hash_bits' type-id='type-id-13' visibility='default' filepath='src.d/deflate.h' line='144' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='672'>
+        <var-decl name='hash_mask' type-id='type-id-13' visibility='default' filepath='src.d/deflate.h' line='145' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='hash_shift' type-id='type-id-13' visibility='default' filepath='src.d/deflate.h' line='147' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='736'>
+        <var-decl name='block_start' type-id='type-id-1' visibility='default' filepath='src.d/deflate.h' line='154' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='match_length' type-id='type-id-13' visibility='default' filepath='src.d/deflate.h' line='159' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='800'>
+        <var-decl name='prev_match' type-id='type-id-46' visibility='default' filepath='src.d/deflate.h' line='160' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='match_available' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='161' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='864'>
+        <var-decl name='strstart' type-id='type-id-13' visibility='default' filepath='src.d/deflate.h' line='162' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='match_start' type-id='type-id-13' visibility='default' filepath='src.d/deflate.h' line='163' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='928'>
+        <var-decl name='lookahead' type-id='type-id-13' visibility='default' filepath='src.d/deflate.h' line='164' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='prev_length' type-id='type-id-13' visibility='default' filepath='src.d/deflate.h' line='166' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='992'>
+        <var-decl name='max_chain_length' type-id='type-id-13' visibility='default' filepath='src.d/deflate.h' line='171' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='max_lazy_match' type-id='type-id-13' visibility='default' filepath='src.d/deflate.h' line='177' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1056'>
+        <var-decl name='level' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='188' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1088'>
+        <var-decl name='strategy' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='189' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1120'>
+        <var-decl name='good_match' type-id='type-id-13' visibility='default' filepath='src.d/deflate.h' line='191' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1152'>
+        <var-decl name='nice_match' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='194' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1184'>
+        <var-decl name='dyn_ltree' type-id='type-id-34' visibility='default' filepath='src.d/deflate.h' line='198' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='19520'>
+        <var-decl name='dyn_dtree' type-id='type-id-36' visibility='default' filepath='src.d/deflate.h' line='199' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='21472'>
+        <var-decl name='bl_tree' type-id='type-id-32' visibility='default' filepath='src.d/deflate.h' line='200' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='22720'>
+        <var-decl name='l_desc' type-id='type-id-47' visibility='default' filepath='src.d/deflate.h' line='202' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='22816'>
+        <var-decl name='d_desc' type-id='type-id-47' visibility='default' filepath='src.d/deflate.h' line='203' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='22912'>
+        <var-decl name='bl_desc' type-id='type-id-47' visibility='default' filepath='src.d/deflate.h' line='204' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='23008'>
+        <var-decl name='bl_count' type-id='type-id-48' visibility='default' filepath='src.d/deflate.h' line='206' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='23264'>
+        <var-decl name='heap' type-id='type-id-38' visibility='default' filepath='src.d/deflate.h' line='209' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='41600'>
+        <var-decl name='heap_len' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='210' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='41632'>
+        <var-decl name='heap_max' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='211' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='41664'>
+        <var-decl name='depth' type-id='type-id-49' visibility='default' filepath='src.d/deflate.h' line='216' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='46272'>
+        <var-decl name='sym_buf' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='220' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='46304'>
+        <var-decl name='lit_bufsize' type-id='type-id-13' visibility='default' filepath='src.d/deflate.h' line='222' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='46336'>
+        <var-decl name='sym_next' type-id='type-id-13' visibility='default' filepath='src.d/deflate.h' line='242' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='46368'>
+        <var-decl name='sym_end' type-id='type-id-13' visibility='default' filepath='src.d/deflate.h' line='243' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='46400'>
+        <var-decl name='opt_len' type-id='type-id-43' visibility='default' filepath='src.d/deflate.h' line='245' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='46432'>
+        <var-decl name='static_len' type-id='type-id-43' visibility='default' filepath='src.d/deflate.h' line='246' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='46464'>
+        <var-decl name='matches' type-id='type-id-13' visibility='default' filepath='src.d/deflate.h' line='247' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='46496'>
+        <var-decl name='insert' type-id='type-id-13' visibility='default' filepath='src.d/deflate.h' line='248' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='46528'>
+        <var-decl name='bi_buf' type-id='type-id-51' visibility='default' filepath='src.d/deflate.h' line='255' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='46560'>
+        <var-decl name='bi_valid' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='259' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='46592'>
+        <var-decl name='high_water' type-id='type-id-43' visibility='default' filepath='src.d/deflate.h' line='264' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='tree_desc_s' size-in-bits='96' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='86' column='1' id='type-id-47'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dyn_tree' type-id='type-id-52' visibility='default' filepath='src.d/deflate.h' line='87' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='max_code' type-id='type-id-22' visibility='default' filepath='src.d/deflate.h' line='88' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='stat_desc' type-id='type-id-53' visibility='default' filepath='src.d/deflate.h' line='89' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='z_stream_s' size-in-bits='448' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='86' column='1' id='type-id-54'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next_in' type-id='type-id-21' visibility='default' filepath='src.d/zlib.h' line='87' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='avail_in' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='88' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='total_in' type-id='type-id-15' visibility='default' filepath='src.d/zlib.h' line='89' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='next_out' type-id='type-id-21' visibility='default' filepath='src.d/zlib.h' line='91' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='avail_out' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='92' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='total_out' type-id='type-id-15' visibility='default' filepath='src.d/zlib.h' line='93' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='msg' type-id='type-id-55' visibility='default' filepath='src.d/zlib.h' line='95' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='state' type-id='type-id-56' visibility='default' filepath='src.d/zlib.h' line='96' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='zalloc' type-id='type-id-57' visibility='default' filepath='src.d/zlib.h' line='98' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='zfree' type-id='type-id-58' visibility='default' filepath='src.d/zlib.h' line='99' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='opaque' type-id='type-id-59' visibility='default' filepath='src.d/zlib.h' line='100' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='data_type' type-id='type-id-22' visibility='default' filepath='src.d/zlib.h' line='102' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='adler' type-id='type-id-15' visibility='default' filepath='src.d/zlib.h' line='104' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='416'>
+        <var-decl name='reserved' type-id='type-id-15' visibility='default' filepath='src.d/zlib.h' line='105' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='IPos' type-id='type-id-11' filepath='src.d/deflate.h' line='94' column='1' id='type-id-46'/>
+    <typedef-decl name='Pos' type-id='type-id-51' filepath='src.d/deflate.h' line='92' column='1' id='type-id-60'/>
+    <typedef-decl name='Posf' type-id='type-id-60' filepath='src.d/deflate.h' line='93' column='1' id='type-id-61'/>
+    <typedef-decl name='alloc_func' type-id='type-id-62' filepath='src.d/zlib.h' line='81' column='1' id='type-id-57'/>
+    <typedef-decl name='charf' type-id='type-id-30' filepath='./zconf.h' line='408' column='1' id='type-id-63'/>
+    <typedef-decl name='ct_data' type-id='type-id-31' filepath='src.d/deflate.h' line='77' column='1' id='type-id-64'/>
+    <typedef-decl name='deflate_state' type-id='type-id-42' filepath='src.d/deflate.h' line='271' column='1' id='type-id-65'/>
+    <typedef-decl name='free_func' type-id='type-id-66' filepath='src.d/zlib.h' line='82' column='1' id='type-id-58'/>
+    <typedef-decl name='gz_header' type-id='type-id-41' filepath='src.d/zlib.h' line='129' column='1' id='type-id-67'/>
+    <typedef-decl name='gz_headerp' type-id='type-id-68' filepath='src.d/zlib.h' line='131' column='1' id='type-id-44'/>
+    <typedef-decl name='uch' type-id='type-id-3' filepath='src.d/zutil.h' line='39' column='1' id='type-id-69'/>
+    <typedef-decl name='uchf' type-id='type-id-69' filepath='src.d/zutil.h' line='40' column='1' id='type-id-70'/>
+    <typedef-decl name='ulg' type-id='type-id-14' filepath='src.d/zutil.h' line='43' column='1' id='type-id-43'/>
+    <typedef-decl name='ush' type-id='type-id-71' filepath='src.d/zutil.h' line='41' column='1' id='type-id-51'/>
+    <typedef-decl name='z_stream' type-id='type-id-54' filepath='src.d/zlib.h' line='106' column='1' id='type-id-72'/>
+    <typedef-decl name='z_streamp' type-id='type-id-73' filepath='src.d/zlib.h' line='108' column='1' id='type-id-23'/>
+    <array-type-def dimensions='1' type-id='type-id-69' size-in-bits='4584' id='type-id-49'>
+      <subrange length='573' lower-bound='0' upper-bound='572' type-id='type-id-11' id='type-id-35'/>
+    </array-type-def>
+    <union-decl name='__anonymous_union__1' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='73' column='1' id='type-id-40'>
+      <data-member access='public'>
+        <var-decl name='dad' type-id='type-id-51' visibility='default' filepath='src.d/deflate.h' line='74' column='1'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='len' type-id='type-id-51' visibility='default' filepath='src.d/deflate.h' line='75' column='1'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='__anonymous_union__' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='69' column='1' id='type-id-39'>
+      <data-member access='public'>
+        <var-decl name='freq' type-id='type-id-51' visibility='default' filepath='src.d/deflate.h' line='70' column='1'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='code' type-id='type-id-51' visibility='default' filepath='src.d/deflate.h' line='71' column='1'/>
+      </data-member>
+    </union-decl>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-71'/>
+    <array-type-def dimensions='1' type-id='type-id-51' size-in-bits='256' id='type-id-48'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-11' id='type-id-74'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-5' size-in-bits='32' id='type-id-21'/>
+    <pointer-type-def type-id='type-id-61' size-in-bits='32' id='type-id-45'/>
+    <pointer-type-def type-id='type-id-30' size-in-bits='32' id='type-id-55'/>
+    <pointer-type-def type-id='type-id-63' size-in-bits='32' id='type-id-75'/>
+    <qualified-type-def type-id='type-id-30' const='yes' id='type-id-76'/>
+    <pointer-type-def type-id='type-id-76' size-in-bits='32' id='type-id-24'/>
+    <pointer-type-def type-id='type-id-64' size-in-bits='32' id='type-id-52'/>
+    <pointer-type-def type-id='type-id-65' size-in-bits='32' id='type-id-77'/>
+    <pointer-type-def type-id='type-id-67' size-in-bits='32' id='type-id-68'/>
+    <pointer-type-def type-id='type-id-22' size-in-bits='32' id='type-id-78'/>
+    <pointer-type-def type-id='type-id-42' size-in-bits='32' id='type-id-56'/>
+    <pointer-type-def type-id='type-id-79' size-in-bits='32' id='type-id-62'/>
+    <pointer-type-def type-id='type-id-13' size-in-bits='32' id='type-id-80'/>
+    <pointer-type-def type-id='type-id-70' size-in-bits='32' id='type-id-50'/>
+    <pointer-type-def type-id='type-id-11' size-in-bits='32' id='type-id-81'/>
+    <pointer-type-def type-id='type-id-82' size-in-bits='32' id='type-id-66'/>
     <pointer-type-def type-id='type-id-72' size-in-bits='32' id='type-id-73'/>
-    <class-decl name='static_tree_desc_s' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-29'/>
+    <qualified-type-def type-id='type-id-83' const='yes' id='type-id-84'/>
+    <pointer-type-def type-id='type-id-84' size-in-bits='32' id='type-id-53'/>
+    <class-decl name='static_tree_desc_s' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-85'/>
+    <typedef-decl name='voidpf' type-id='type-id-86' filepath='./zconf.h' line='415' column='1' id='type-id-59'/>
     <function-decl name='memcpy' filepath='/usr/include/string.h' line='43' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-46'/>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-12'/>
+      <return type-id='type-id-86'/>
     </function-decl>
     <function-decl name='memset' filepath='/usr/include/string.h' line='61' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-86'/>
       <parameter type-id='type-id-22'/>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-46'/>
-    </function-decl>
-    <function-decl name='deflateInit_' mangled-name='deflateInit_' filepath='src.d/deflate.c' line='225' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateInit_'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='226' column='1'/>
-      <parameter type-id='type-id-22' name='level' filepath='src.d/deflate.c' line='227' column='1'/>
-      <parameter type-id='type-id-80' name='version' filepath='src.d/deflate.c' line='228' column='1'/>
-      <parameter type-id='type-id-22' name='stream_size' filepath='src.d/deflate.c' line='229' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-12'/>
+      <return type-id='type-id-86'/>
     </function-decl>
     <function-decl name='deflateInit2_' mangled-name='deflateInit2_' filepath='src.d/deflate.c' line='237' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateInit2_'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='239' column='1'/>
+      <parameter type-id='type-id-23' name='strm' filepath='src.d/deflate.c' line='239' column='1'/>
       <parameter type-id='type-id-22' name='level' filepath='src.d/deflate.c' line='240' column='1'/>
       <parameter type-id='type-id-22' name='method' filepath='src.d/deflate.c' line='241' column='1'/>
       <parameter type-id='type-id-22' name='windowBits' filepath='src.d/deflate.c' line='242' column='1'/>
       <parameter type-id='type-id-22' name='memLevel' filepath='src.d/deflate.c' line='243' column='1'/>
       <parameter type-id='type-id-22' name='strategy' filepath='src.d/deflate.c' line='244' column='1'/>
-      <parameter type-id='type-id-80' name='version' filepath='src.d/deflate.c' line='245' column='1'/>
+      <parameter type-id='type-id-24' name='version' filepath='src.d/deflate.c' line='245' column='1'/>
       <parameter type-id='type-id-22' name='stream_size' filepath='src.d/deflate.c' line='246' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='deflateSetDictionary' mangled-name='deflateSetDictionary' filepath='src.d/deflate.c' line='412' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateSetDictionary'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='413' column='1'/>
+      <parameter type-id='type-id-23' name='strm' filepath='src.d/deflate.c' line='413' column='1'/>
       <parameter type-id='type-id-18' name='dictionary' filepath='src.d/deflate.c' line='414' column='1'/>
-      <parameter type-id='type-id-9' name='dictLength' filepath='src.d/deflate.c' line='415' column='1'/>
+      <parameter type-id='type-id-13' name='dictLength' filepath='src.d/deflate.c' line='415' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='deflateGetDictionary' mangled-name='deflateGetDictionary' filepath='src.d/deflate.c' line='481' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateGetDictionary@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='482' column='1'/>
+      <parameter type-id='type-id-23' name='strm' filepath='src.d/deflate.c' line='482' column='1'/>
       <parameter type-id='type-id-21' name='dictionary' filepath='src.d/deflate.c' line='483' column='1'/>
-      <parameter type-id='type-id-85' name='dictLength' filepath='src.d/deflate.c' line='484' column='1'/>
+      <parameter type-id='type-id-80' name='dictLength' filepath='src.d/deflate.c' line='484' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='deflateResetKeep' mangled-name='deflateResetKeep' filepath='src.d/deflate.c' line='503' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateResetKeep@@ZLIB_1.2.5.2'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='504' column='1'/>
+      <parameter type-id='type-id-23' name='strm' filepath='src.d/deflate.c' line='504' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='deflateReset' mangled-name='deflateReset' filepath='src.d/deflate.c' line='541' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateReset'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='542' column='1'/>
+      <parameter type-id='type-id-23' name='strm' filepath='src.d/deflate.c' line='542' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='deflateSetHeader' mangled-name='deflateSetHeader' filepath='src.d/deflate.c' line='553' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateSetHeader@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='554' column='1'/>
-      <parameter type-id='type-id-61' name='head' filepath='src.d/deflate.c' line='555' column='1'/>
+      <parameter type-id='type-id-23' name='strm' filepath='src.d/deflate.c' line='554' column='1'/>
+      <parameter type-id='type-id-44' name='head' filepath='src.d/deflate.c' line='555' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='deflatePending' mangled-name='deflatePending' filepath='src.d/deflate.c' line='564' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflatePending@@ZLIB_1.2.5.1'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='567' column='1'/>
-      <parameter type-id='type-id-86' name='pending' filepath='src.d/deflate.c' line='565' column='1'/>
-      <parameter type-id='type-id-83' name='bits' filepath='src.d/deflate.c' line='566' column='1'/>
+      <parameter type-id='type-id-23' name='strm' filepath='src.d/deflate.c' line='567' column='1'/>
+      <parameter type-id='type-id-81' name='pending' filepath='src.d/deflate.c' line='565' column='1'/>
+      <parameter type-id='type-id-78' name='bits' filepath='src.d/deflate.c' line='566' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='deflatePrime' mangled-name='deflatePrime' filepath='src.d/deflate.c' line='578' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflatePrime@@ZLIB_1.2.0.8'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='579' column='1'/>
+      <parameter type-id='type-id-23' name='strm' filepath='src.d/deflate.c' line='579' column='1'/>
       <parameter type-id='type-id-22' name='bits' filepath='src.d/deflate.c' line='580' column='1'/>
       <parameter type-id='type-id-22' name='value' filepath='src.d/deflate.c' line='581' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='deflateParams' mangled-name='deflateParams' filepath='src.d/deflate.c' line='605' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateParams'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='606' column='1'/>
+      <parameter type-id='type-id-23' name='strm' filepath='src.d/deflate.c' line='606' column='1'/>
       <parameter type-id='type-id-22' name='level' filepath='src.d/deflate.c' line='607' column='1'/>
       <parameter type-id='type-id-22' name='strategy' filepath='src.d/deflate.c' line='608' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='deflateTune' mangled-name='deflateTune' filepath='src.d/deflate.c' line='654' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateTune@@ZLIB_1.2.2.3'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='655' column='1'/>
+      <parameter type-id='type-id-23' name='strm' filepath='src.d/deflate.c' line='655' column='1'/>
       <parameter type-id='type-id-22' name='good_length' filepath='src.d/deflate.c' line='656' column='1'/>
       <parameter type-id='type-id-22' name='max_lazy' filepath='src.d/deflate.c' line='657' column='1'/>
       <parameter type-id='type-id-22' name='nice_length' filepath='src.d/deflate.c' line='658' column='1'/>
@@ -651,198 +656,203 @@
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='deflateBound' mangled-name='deflateBound' filepath='src.d/deflate.c' line='696' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateBound@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='697' column='1'/>
-      <parameter type-id='type-id-10' name='sourceLen' filepath='src.d/deflate.c' line='698' column='1'/>
-      <return type-id='type-id-10'/>
-    </function-decl>
-    <function-decl name='deflate' mangled-name='deflate' filepath='src.d/deflate.c' line='815' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflate'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='816' column='1'/>
-      <parameter type-id='type-id-22' name='flush' filepath='src.d/deflate.c' line='817' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='deflateEnd' mangled-name='deflateEnd' filepath='src.d/deflate.c' line='1130' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateEnd'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/deflate.c' line='1131' column='1'/>
-      <return type-id='type-id-22'/>
+      <parameter type-id='type-id-23' name='strm' filepath='src.d/deflate.c' line='697' column='1'/>
+      <parameter type-id='type-id-15' name='sourceLen' filepath='src.d/deflate.c' line='698' column='1'/>
+      <return type-id='type-id-15'/>
     </function-decl>
     <function-decl name='deflateCopy' mangled-name='deflateCopy' filepath='src.d/deflate.c' line='1156' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='deflateCopy'>
-      <parameter type-id='type-id-59' name='dest' filepath='src.d/deflate.c' line='1157' column='1'/>
-      <parameter type-id='type-id-59' name='source' filepath='src.d/deflate.c' line='1158' column='1'/>
+      <parameter type-id='type-id-23' name='dest' filepath='src.d/deflate.c' line='1157' column='1'/>
+      <parameter type-id='type-id-23' name='source' filepath='src.d/deflate.c' line='1158' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
+    <typedef-decl name='static_tree_desc' type-id='type-id-85' filepath='src.d/deflate.h' line='84' column='1' id='type-id-83'/>
     <function-decl name='_tr_init' filepath='src.d/deflate.h' line='294' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-82'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-77'/>
+      <return type-id='type-id-87'/>
     </function-decl>
     <function-decl name='_tr_flush_block' filepath='src.d/deflate.h' line='296' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-82'/>
-      <parameter type-id='type-id-78'/>
-      <parameter type-id='type-id-60'/>
+      <parameter type-id='type-id-77'/>
+      <parameter type-id='type-id-75'/>
+      <parameter type-id='type-id-43'/>
       <parameter type-id='type-id-22'/>
-      <return type-id='type-id-44'/>
+      <return type-id='type-id-87'/>
     </function-decl>
     <function-decl name='_tr_flush_bits' filepath='src.d/deflate.h' line='298' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-82'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-77'/>
+      <return type-id='type-id-87'/>
     </function-decl>
     <function-decl name='_tr_align' filepath='src.d/deflate.h' line='299' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-82'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-77'/>
+      <return type-id='type-id-87'/>
     </function-decl>
     <function-decl name='_tr_stored_block' filepath='src.d/deflate.h' line='300' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-82'/>
-      <parameter type-id='type-id-78'/>
-      <parameter type-id='type-id-60'/>
+      <parameter type-id='type-id-77'/>
+      <parameter type-id='type-id-75'/>
+      <parameter type-id='type-id-43'/>
       <parameter type-id='type-id-22'/>
-      <return type-id='type-id-44'/>
+      <return type-id='type-id-87'/>
+    </function-decl>
+    <function-decl name='crc32' filepath='src.d/zlib.h' line='1727' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-18'/>
+      <parameter type-id='type-id-13'/>
+      <return type-id='type-id-15'/>
     </function-decl>
     <function-decl name='zcalloc' filepath='src.d/zutil.h' line='261' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-47'/>
-      <parameter type-id='type-id-4'/>
-      <parameter type-id='type-id-4'/>
-      <return type-id='type-id-47'/>
+      <parameter type-id='type-id-59'/>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-11'/>
+      <return type-id='type-id-59'/>
     </function-decl>
     <function-decl name='zcfree' filepath='src.d/zutil.h' line='263' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-47'/>
-      <parameter type-id='type-id-47'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-59'/>
+      <parameter type-id='type-id-59'/>
+      <return type-id='type-id-87'/>
     </function-decl>
-    <function-type size-in-bits='32' id='type-id-84'>
-      <parameter type-id='type-id-47'/>
-      <parameter type-id='type-id-9'/>
-      <parameter type-id='type-id-9'/>
-      <return type-id='type-id-47'/>
+    <type-decl name='void' id='type-id-87'/>
+    <pointer-type-def type-id='type-id-87' id='type-id-86'/>
+    <function-type size-in-bits='32' id='type-id-82'>
+      <parameter type-id='type-id-59'/>
+      <parameter type-id='type-id-59'/>
+      <return type-id='type-id-87'/>
     </function-type>
-    <function-type size-in-bits='32' id='type-id-87'>
-      <parameter type-id='type-id-47'/>
-      <parameter type-id='type-id-47'/>
-      <return type-id='type-id-44'/>
+    <function-type size-in-bits='32' id='type-id-79'>
+      <parameter type-id='type-id-59'/>
+      <parameter type-id='type-id-13'/>
+      <parameter type-id='type-id-13'/>
+      <return type-id='type-id-59'/>
     </function-type>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/gzclose.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <typedef-decl name='gzFile' type-id='type-id-88' filepath='src.d/zlib.h' line='1302' column='1' id='type-id-89'/>
-    <class-decl name='gzFile_s' size-in-bits='128' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='1834' column='1' id='type-id-90'>
+    <class-decl name='gzFile_s' size-in-bits='128' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='1834' column='1' id='type-id-88'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='have' type-id='type-id-4' visibility='default' filepath='src.d/zlib.h' line='1835' column='1'/>
+        <var-decl name='have' type-id='type-id-11' visibility='default' filepath='src.d/zlib.h' line='1835' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='next' type-id='type-id-91' visibility='default' filepath='src.d/zlib.h' line='1836' column='1'/>
+        <var-decl name='next' type-id='type-id-89' visibility='default' filepath='src.d/zlib.h' line='1836' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='pos' type-id='type-id-16' visibility='default' filepath='src.d/zlib.h' line='1837' column='1'/>
+        <var-decl name='pos' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='1837' column='1'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-90' size-in-bits='32' id='type-id-88'/>
+    <typedef-decl name='gzFile' type-id='type-id-90' filepath='src.d/zlib.h' line='1302' column='1' id='type-id-91'/>
+    <pointer-type-def type-id='type-id-88' size-in-bits='32' id='type-id-90'/>
     <function-decl name='gzclose' mangled-name='gzclose' filepath='src.d/gzclose.c' line='11' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzclose'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzclose.c' line='12' column='1'/>
+      <parameter type-id='type-id-91' name='file' filepath='src.d/gzclose.c' line='12' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='gzclose_r' mangled-name='gzclose_r' filepath='src.d/zlib.h' line='1644' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzclose_r@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-89'/>
+    <function-decl name='gzclose_r' filepath='src.d/zlib.h' line='1644' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-91'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='gzclose_w' mangled-name='gzclose_w' filepath='src.d/zlib.h' line='1645' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzclose_w@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-89'/>
+    <function-decl name='gzclose_w' filepath='src.d/zlib.h' line='1645' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-91'/>
       <return type-id='type-id-22'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/gzlib.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <type-decl name='variadic parameter type' id='type-id-92'/>
-    <function-decl name='open' filepath='/usr/include/fcntl.h' line='181' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-80'/>
+    <function-decl name='open' filepath='/usr/include/fcntl.h' line='209' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-24'/>
       <parameter type-id='type-id-22'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='snprintf' filepath='/usr/include/stdio.h' line='378' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-70'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-80'/>
+    <function-decl name='snprintf' filepath='/usr/include/stdio.h' line='385' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-55'/>
+      <parameter type-id='type-id-12'/>
+      <parameter type-id='type-id-24'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-22'/>
     </function-decl>
+    <function-decl name='malloc' filepath='/usr/include/stdlib.h' line='672' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-12'/>
+      <return type-id='type-id-86'/>
+    </function-decl>
+    <function-decl name='free' filepath='/usr/include/stdlib.h' line='687' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-86'/>
+      <return type-id='type-id-87'/>
+    </function-decl>
     <function-decl name='strlen' filepath='/usr/include/string.h' line='407' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-80'/>
-      <return type-id='type-id-6'/>
+      <parameter type-id='type-id-24'/>
+      <return type-id='type-id-12'/>
     </function-decl>
     <function-decl name='lseek64' filepath='/usr/include/unistd.h' line='350' column='1' visibility='default' binding='global' size-in-bits='32'>
       <parameter type-id='type-id-22'/>
-      <parameter type-id='type-id-14'/>
+      <parameter type-id='type-id-7'/>
       <parameter type-id='type-id-22'/>
-      <return type-id='type-id-14'/>
+      <return type-id='type-id-7'/>
     </function-decl>
     <function-decl name='gzopen' mangled-name='gzopen' filepath='src.d/gzlib.c' line='272' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzopen'>
-      <parameter type-id='type-id-80' name='path' filepath='src.d/gzlib.c' line='273' column='1'/>
-      <parameter type-id='type-id-80' name='mode' filepath='src.d/gzlib.c' line='274' column='1'/>
-      <return type-id='type-id-89'/>
+      <parameter type-id='type-id-24' name='path' filepath='src.d/gzlib.c' line='273' column='1'/>
+      <parameter type-id='type-id-24' name='mode' filepath='src.d/gzlib.c' line='274' column='1'/>
+      <return type-id='type-id-91'/>
     </function-decl>
     <function-decl name='gzopen64' mangled-name='gzopen64' filepath='src.d/gzlib.c' line='280' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzopen64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-80' name='path' filepath='src.d/gzlib.c' line='281' column='1'/>
-      <parameter type-id='type-id-80' name='mode' filepath='src.d/gzlib.c' line='282' column='1'/>
-      <return type-id='type-id-89'/>
+      <parameter type-id='type-id-24' name='path' filepath='src.d/gzlib.c' line='281' column='1'/>
+      <parameter type-id='type-id-24' name='mode' filepath='src.d/gzlib.c' line='282' column='1'/>
+      <return type-id='type-id-91'/>
     </function-decl>
     <function-decl name='gzdopen' mangled-name='gzdopen' filepath='src.d/gzlib.c' line='288' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzdopen'>
       <parameter type-id='type-id-22' name='fd' filepath='src.d/gzlib.c' line='289' column='1'/>
-      <parameter type-id='type-id-80' name='mode' filepath='src.d/gzlib.c' line='290' column='1'/>
-      <return type-id='type-id-89'/>
+      <parameter type-id='type-id-24' name='mode' filepath='src.d/gzlib.c' line='290' column='1'/>
+      <return type-id='type-id-91'/>
     </function-decl>
     <function-decl name='gzbuffer' mangled-name='gzbuffer' filepath='src.d/gzlib.c' line='318' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzbuffer@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='319' column='1'/>
-      <parameter type-id='type-id-4' name='size' filepath='src.d/gzlib.c' line='320' column='1'/>
+      <parameter type-id='type-id-91' name='file' filepath='src.d/gzlib.c' line='319' column='1'/>
+      <parameter type-id='type-id-11' name='size' filepath='src.d/gzlib.c' line='320' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='gzrewind' mangled-name='gzrewind' filepath='src.d/gzlib.c' line='345' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzrewind'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='346' column='1'/>
+      <parameter type-id='type-id-91' name='file' filepath='src.d/gzlib.c' line='346' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='gzseek64' mangled-name='gzseek64' filepath='src.d/gzlib.c' line='368' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzseek64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='369' column='1'/>
-      <parameter type-id='type-id-16' name='offset' filepath='src.d/gzlib.c' line='370' column='1'/>
+      <parameter type-id='type-id-91' name='file' filepath='src.d/gzlib.c' line='369' column='1'/>
+      <parameter type-id='type-id-9' name='offset' filepath='src.d/gzlib.c' line='370' column='1'/>
       <parameter type-id='type-id-22' name='whence' filepath='src.d/gzlib.c' line='371' column='1'/>
-      <return type-id='type-id-16'/>
+      <return type-id='type-id-9'/>
     </function-decl>
     <function-decl name='gzseek' mangled-name='gzseek' filepath='src.d/gzlib.c' line='445' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzseek'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='446' column='1'/>
-      <parameter type-id='type-id-15' name='offset' filepath='src.d/gzlib.c' line='447' column='1'/>
+      <parameter type-id='type-id-91' name='file' filepath='src.d/gzlib.c' line='446' column='1'/>
+      <parameter type-id='type-id-10' name='offset' filepath='src.d/gzlib.c' line='447' column='1'/>
       <parameter type-id='type-id-22' name='whence' filepath='src.d/gzlib.c' line='448' column='1'/>
-      <return type-id='type-id-15'/>
+      <return type-id='type-id-10'/>
     </function-decl>
     <function-decl name='gztell64' mangled-name='gztell64' filepath='src.d/gzlib.c' line='457' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gztell64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='458' column='1'/>
-      <return type-id='type-id-16'/>
+      <parameter type-id='type-id-91' name='file' filepath='src.d/gzlib.c' line='458' column='1'/>
+      <return type-id='type-id-9'/>
     </function-decl>
     <function-decl name='gztell' mangled-name='gztell' filepath='src.d/gzlib.c' line='474' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gztell'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='475' column='1'/>
-      <return type-id='type-id-15'/>
+      <parameter type-id='type-id-91' name='file' filepath='src.d/gzlib.c' line='475' column='1'/>
+      <return type-id='type-id-10'/>
     </function-decl>
     <function-decl name='gzoffset64' mangled-name='gzoffset64' filepath='src.d/gzlib.c' line='484' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzoffset64@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='485' column='1'/>
-      <return type-id='type-id-16'/>
+      <parameter type-id='type-id-91' name='file' filepath='src.d/gzlib.c' line='485' column='1'/>
+      <return type-id='type-id-9'/>
     </function-decl>
     <function-decl name='gzoffset' mangled-name='gzoffset' filepath='src.d/gzlib.c' line='507' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzoffset@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='508' column='1'/>
-      <return type-id='type-id-15'/>
+      <parameter type-id='type-id-91' name='file' filepath='src.d/gzlib.c' line='508' column='1'/>
+      <return type-id='type-id-10'/>
     </function-decl>
     <function-decl name='gzeof' mangled-name='gzeof' filepath='src.d/gzlib.c' line='517' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzeof'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='518' column='1'/>
+      <parameter type-id='type-id-91' name='file' filepath='src.d/gzlib.c' line='518' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='gzerror' mangled-name='gzerror' filepath='src.d/gzlib.c' line='534' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzerror'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='535' column='1'/>
-      <parameter type-id='type-id-83' name='errnum' filepath='src.d/gzlib.c' line='536' column='1'/>
-      <return type-id='type-id-80'/>
+      <parameter type-id='type-id-91' name='file' filepath='src.d/gzlib.c' line='535' column='1'/>
+      <parameter type-id='type-id-78' name='errnum' filepath='src.d/gzlib.c' line='536' column='1'/>
+      <return type-id='type-id-24'/>
     </function-decl>
     <function-decl name='gzclearerr' mangled-name='gzclearerr' filepath='src.d/gzlib.c' line='555' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzclearerr@@ZLIB_1.2.0.2'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='556' column='1'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-91' name='file' filepath='src.d/gzlib.c' line='556' column='1'/>
+      <return type-id='type-id-87'/>
     </function-decl>
+    <type-decl name='variadic parameter type' id='type-id-92'/>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/gzread.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <typedef-decl name='voidp' type-id='type-id-46' filepath='./zconf.h' line='416' column='1' id='type-id-93'/>
-    <typedef-decl name='__ssize_t' type-id='type-id-22' filepath='/usr/include/bits/types.h' line='194' column='1' id='type-id-94'/>
-    <typedef-decl name='ssize_t' type-id='type-id-94' filepath='/usr/include/sys/types.h' line='108' column='1' id='type-id-95'/>
-    <class-decl name='gz_state' size-in-bits='1248' is-struct='yes' naming-typedef-id='type-id-96' visibility='default' filepath='src.d/gzguts.h' line='170' column='1' id='type-id-97'>
+    <class-decl name='gz_state' size-in-bits='1248' is-struct='yes' naming-typedef-id='type-id-93' visibility='default' filepath='src.d/gzguts.h' line='170' column='1' id='type-id-94'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='x' type-id='type-id-90' visibility='default' filepath='src.d/gzguts.h' line='172' column='1'/>
+        <var-decl name='x' type-id='type-id-88' visibility='default' filepath='src.d/gzguts.h' line='172' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
         <var-decl name='mode' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='177' column='1'/>
@@ -851,19 +861,19 @@
         <var-decl name='fd' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='178' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='path' type-id='type-id-70' visibility='default' filepath='src.d/gzguts.h' line='179' column='1'/>
+        <var-decl name='path' type-id='type-id-55' visibility='default' filepath='src.d/gzguts.h' line='179' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='224'>
-        <var-decl name='size' type-id='type-id-4' visibility='default' filepath='src.d/gzguts.h' line='180' column='1'/>
+        <var-decl name='size' type-id='type-id-11' visibility='default' filepath='src.d/gzguts.h' line='180' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='want' type-id='type-id-4' visibility='default' filepath='src.d/gzguts.h' line='181' column='1'/>
+        <var-decl name='want' type-id='type-id-11' visibility='default' filepath='src.d/gzguts.h' line='181' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='in' type-id='type-id-91' visibility='default' filepath='src.d/gzguts.h' line='182' column='1'/>
+        <var-decl name='in' type-id='type-id-89' visibility='default' filepath='src.d/gzguts.h' line='182' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='out' type-id='type-id-91' visibility='default' filepath='src.d/gzguts.h' line='183' column='1'/>
+        <var-decl name='out' type-id='type-id-89' visibility='default' filepath='src.d/gzguts.h' line='183' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='352'>
         <var-decl name='direct' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='184' column='1'/>
@@ -872,7 +882,7 @@
         <var-decl name='how' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='186' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='416'>
-        <var-decl name='start' type-id='type-id-16' visibility='default' filepath='src.d/gzguts.h' line='187' column='1'/>
+        <var-decl name='start' type-id='type-id-9' visibility='default' filepath='src.d/gzguts.h' line='187' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='480'>
         <var-decl name='eof' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='188' column='1'/>
@@ -890,7 +900,7 @@
         <var-decl name='reset' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='193' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='skip' type-id='type-id-16' visibility='default' filepath='src.d/gzguts.h' line='195' column='1'/>
+        <var-decl name='skip' type-id='type-id-9' visibility='default' filepath='src.d/gzguts.h' line='195' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='704'>
         <var-decl name='seek' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='196' column='1'/>
@@ -899,20 +909,23 @@
         <var-decl name='err' type-id='type-id-22' visibility='default' filepath='src.d/gzguts.h' line='198' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='msg' type-id='type-id-70' visibility='default' filepath='src.d/gzguts.h' line='199' column='1'/>
+        <var-decl name='msg' type-id='type-id-55' visibility='default' filepath='src.d/gzguts.h' line='199' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='800'>
         <var-decl name='strm' type-id='type-id-72' visibility='default' filepath='src.d/gzguts.h' line='201' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='gz_state' type-id='type-id-97' filepath='src.d/gzguts.h' line='202' column='1' id='type-id-96'/>
-    <typedef-decl name='gz_statep' type-id='type-id-98' filepath='src.d/gzguts.h' line='203' column='1' id='type-id-99'/>
-    <pointer-type-def type-id='type-id-96' size-in-bits='32' id='type-id-98'/>
+    <typedef-decl name='__ssize_t' type-id='type-id-22' filepath='/usr/include/bits/types.h' line='194' column='1' id='type-id-95'/>
+    <typedef-decl name='gz_state' type-id='type-id-94' filepath='src.d/gzguts.h' line='202' column='1' id='type-id-93'/>
+    <typedef-decl name='gz_statep' type-id='type-id-96' filepath='src.d/gzguts.h' line='203' column='1' id='type-id-97'/>
+    <typedef-decl name='ssize_t' type-id='type-id-95' filepath='/usr/include/sys/types.h' line='108' column='1' id='type-id-98'/>
+    <pointer-type-def type-id='type-id-93' size-in-bits='32' id='type-id-96'/>
+    <typedef-decl name='voidp' type-id='type-id-86' filepath='./zconf.h' line='416' column='1' id='type-id-99'/>
     <function-decl name='memchr' filepath='/usr/include/string.h' line='107' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-86'/>
       <parameter type-id='type-id-22'/>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-46'/>
+      <parameter type-id='type-id-12'/>
+      <return type-id='type-id-86'/>
     </function-decl>
     <function-decl name='close' filepath='/usr/include/unistd.h' line='358' column='1' visibility='default' binding='global' size-in-bits='32'>
       <parameter type-id='type-id-22'/>
@@ -920,126 +933,151 @@
     </function-decl>
     <function-decl name='read' filepath='/usr/include/unistd.h' line='371' column='1' visibility='default' binding='global' size-in-bits='32'>
       <parameter type-id='type-id-22'/>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-95'/>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-12'/>
+      <return type-id='type-id-98'/>
     </function-decl>
     <function-decl name='gz_error' filepath='src.d/gzguts.h' line='206' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-99'/>
+      <parameter type-id='type-id-97'/>
       <parameter type-id='type-id-22'/>
-      <parameter type-id='type-id-80'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-24'/>
+      <return type-id='type-id-87'/>
     </function-decl>
     <function-decl name='gzread' mangled-name='gzread' filepath='src.d/gzread.c' line='373' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzread'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='374' column='1'/>
-      <parameter type-id='type-id-93' name='buf' filepath='src.d/gzread.c' line='375' column='1'/>
-      <parameter type-id='type-id-4' name='len' filepath='src.d/gzread.c' line='376' column='1'/>
+      <parameter type-id='type-id-91' name='file' filepath='src.d/gzread.c' line='374' column='1'/>
+      <parameter type-id='type-id-99' name='buf' filepath='src.d/gzread.c' line='375' column='1'/>
+      <parameter type-id='type-id-11' name='len' filepath='src.d/gzread.c' line='376' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='gzfread' mangled-name='gzfread' filepath='src.d/gzread.c' line='409' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzfread@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-93' name='buf' filepath='src.d/gzread.c' line='410' column='1'/>
-      <parameter type-id='type-id-7' name='size' filepath='src.d/gzread.c' line='411' column='1'/>
-      <parameter type-id='type-id-7' name='nitems' filepath='src.d/gzread.c' line='412' column='1'/>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='413' column='1'/>
-      <return type-id='type-id-7'/>
+      <parameter type-id='type-id-99' name='buf' filepath='src.d/gzread.c' line='410' column='1'/>
+      <parameter type-id='type-id-16' name='size' filepath='src.d/gzread.c' line='411' column='1'/>
+      <parameter type-id='type-id-16' name='nitems' filepath='src.d/gzread.c' line='412' column='1'/>
+      <parameter type-id='type-id-91' name='file' filepath='src.d/gzread.c' line='413' column='1'/>
+      <return type-id='type-id-16'/>
     </function-decl>
     <function-decl name='gzgetc' mangled-name='gzgetc' filepath='src.d/gzread.c' line='445' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzgetc'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='446' column='1'/>
+      <parameter type-id='type-id-91' name='file' filepath='src.d/gzread.c' line='446' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='gzgetc_' mangled-name='gzgetc_' filepath='src.d/gzread.c' line='472' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzgetc_@@ZLIB_1.2.5.2'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='473' column='1'/>
+      <parameter type-id='type-id-91' name='file' filepath='src.d/gzread.c' line='473' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='gzungetc' mangled-name='gzungetc' filepath='src.d/gzread.c' line='479' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzungetc@@ZLIB_1.2.0.2'>
       <parameter type-id='type-id-22' name='c' filepath='src.d/gzread.c' line='480' column='1'/>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='481' column='1'/>
+      <parameter type-id='type-id-91' name='file' filepath='src.d/gzread.c' line='481' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='gzgets' mangled-name='gzgets' filepath='src.d/gzread.c' line='539' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzgets'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='540' column='1'/>
-      <parameter type-id='type-id-70' name='buf' filepath='src.d/gzread.c' line='541' column='1'/>
+      <parameter type-id='type-id-91' name='file' filepath='src.d/gzread.c' line='540' column='1'/>
+      <parameter type-id='type-id-55' name='buf' filepath='src.d/gzread.c' line='541' column='1'/>
       <parameter type-id='type-id-22' name='len' filepath='src.d/gzread.c' line='542' column='1'/>
-      <return type-id='type-id-70'/>
+      <return type-id='type-id-55'/>
     </function-decl>
     <function-decl name='gzdirect' mangled-name='gzdirect' filepath='src.d/gzread.c' line='603' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzdirect@@ZLIB_1.2.2.3'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='604' column='1'/>
+      <parameter type-id='type-id-91' name='file' filepath='src.d/gzread.c' line='604' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='inflate' filepath='src.d/zlib.h' line='400' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-23'/>
+      <parameter type-id='type-id-22'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='inflateEnd' filepath='src.d/zlib.h' line='520' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-23'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='inflateReset' filepath='src.d/zlib.h' line='959' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-23'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='inflateInit2_' filepath='src.d/zlib.h' line='1789' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-23'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-24'/>
+      <parameter type-id='type-id-22'/>
       <return type-id='type-id-22'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/gzwrite.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <typedef-decl name='voidpc' type-id='type-id-46' filepath='./zconf.h' line='414' column='1' id='type-id-100'/>
-    <typedef-decl name='__gnuc_va_list' type-id='type-id-70' filepath='/usr/lib/gcc/x86_64-linux-gnu/11/include/stdarg.h' line='40' column='1' id='type-id-101'/>
-    <typedef-decl name='va_list' type-id='type-id-101' filepath='/usr/lib/gcc/x86_64-linux-gnu/11/include/stdarg.h' line='99' column='1' id='type-id-102'/>
-    <function-decl name='vsnprintf' filepath='/usr/include/stdio.h' line='382' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-70'/>
-      <parameter type-id='type-id-6'/>
-      <parameter type-id='type-id-80'/>
-      <parameter type-id='type-id-70'/>
+    <typedef-decl name='__gnuc_va_list' type-id='type-id-55' filepath='/usr/lib/gcc/x86_64-linux-gnu/13/include/stdarg.h' line='40' column='1' id='type-id-100'/>
+    <typedef-decl name='va_list' type-id='type-id-100' filepath='/usr/lib/gcc/x86_64-linux-gnu/13/include/stdarg.h' line='103' column='1' id='type-id-101'/>
+    <typedef-decl name='voidpc' type-id='type-id-86' filepath='./zconf.h' line='414' column='1' id='type-id-102'/>
+    <function-decl name='vsnprintf' filepath='/usr/include/stdio.h' line='389' column='1' visibility='default' binding='global' size-in-bits='32'>
+      <parameter type-id='type-id-55'/>
+      <parameter type-id='type-id-12'/>
+      <parameter type-id='type-id-24'/>
+      <parameter type-id='type-id-55'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='memmove' filepath='/usr/include/string.h' line='47' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-46'/>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-12'/>
+      <return type-id='type-id-86'/>
     </function-decl>
     <function-decl name='write' filepath='/usr/include/unistd.h' line='378' column='1' visibility='default' binding='global' size-in-bits='32'>
       <parameter type-id='type-id-22'/>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-95'/>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-12'/>
+      <return type-id='type-id-98'/>
     </function-decl>
     <function-decl name='gzwrite' mangled-name='gzwrite' filepath='src.d/gzwrite.c' line='255' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzwrite'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='256' column='1'/>
-      <parameter type-id='type-id-100' name='buf' filepath='src.d/gzwrite.c' line='257' column='1'/>
-      <parameter type-id='type-id-4' name='len' filepath='src.d/gzwrite.c' line='258' column='1'/>
+      <parameter type-id='type-id-91' name='file' filepath='src.d/gzwrite.c' line='256' column='1'/>
+      <parameter type-id='type-id-102' name='buf' filepath='src.d/gzwrite.c' line='257' column='1'/>
+      <parameter type-id='type-id-11' name='len' filepath='src.d/gzwrite.c' line='258' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='gzfwrite' mangled-name='gzfwrite' filepath='src.d/gzwrite.c' line='283' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzfwrite@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-100' name='buf' filepath='src.d/gzwrite.c' line='284' column='1'/>
-      <parameter type-id='type-id-7' name='size' filepath='src.d/gzwrite.c' line='285' column='1'/>
-      <parameter type-id='type-id-7' name='nitems' filepath='src.d/gzwrite.c' line='286' column='1'/>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='287' column='1'/>
-      <return type-id='type-id-7'/>
+      <parameter type-id='type-id-102' name='buf' filepath='src.d/gzwrite.c' line='284' column='1'/>
+      <parameter type-id='type-id-16' name='size' filepath='src.d/gzwrite.c' line='285' column='1'/>
+      <parameter type-id='type-id-16' name='nitems' filepath='src.d/gzwrite.c' line='286' column='1'/>
+      <parameter type-id='type-id-91' name='file' filepath='src.d/gzwrite.c' line='287' column='1'/>
+      <return type-id='type-id-16'/>
     </function-decl>
     <function-decl name='gzputc' mangled-name='gzputc' filepath='src.d/gzwrite.c' line='313' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzputc'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='314' column='1'/>
+      <parameter type-id='type-id-91' name='file' filepath='src.d/gzwrite.c' line='314' column='1'/>
       <parameter type-id='type-id-22' name='c' filepath='src.d/gzwrite.c' line='315' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='gzputs' mangled-name='gzputs' filepath='src.d/gzwrite.c' line='361' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzputs'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='362' column='1'/>
-      <parameter type-id='type-id-80' name='s' filepath='src.d/gzwrite.c' line='363' column='1'/>
+      <parameter type-id='type-id-91' name='file' filepath='src.d/gzwrite.c' line='362' column='1'/>
+      <parameter type-id='type-id-24' name='s' filepath='src.d/gzwrite.c' line='363' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='gzvprintf' mangled-name='gzvprintf' filepath='src.d/gzwrite.c' line='391' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzvprintf@@ZLIB_1.2.7.1'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='391' column='1'/>
-      <parameter type-id='type-id-80' name='format' filepath='src.d/gzwrite.c' line='391' column='1'/>
-      <parameter type-id='type-id-102' name='va' filepath='src.d/gzwrite.c' line='391' column='1'/>
+      <parameter type-id='type-id-91' name='file' filepath='src.d/gzwrite.c' line='391' column='1'/>
+      <parameter type-id='type-id-24' name='format' filepath='src.d/gzwrite.c' line='391' column='1'/>
+      <parameter type-id='type-id-101' name='va' filepath='src.d/gzwrite.c' line='391' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='gzprintf' mangled-name='gzprintf' filepath='src.d/gzwrite.c' line='463' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzprintf'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='463' column='1'/>
-      <parameter type-id='type-id-80' name='format' filepath='src.d/gzwrite.c' line='463' column='1'/>
+      <parameter type-id='type-id-91' name='file' filepath='src.d/gzwrite.c' line='463' column='1'/>
+      <parameter type-id='type-id-24' name='format' filepath='src.d/gzwrite.c' line='463' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='gzflush' mangled-name='gzflush' filepath='src.d/gzwrite.c' line='565' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzflush'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='566' column='1'/>
+      <parameter type-id='type-id-91' name='file' filepath='src.d/gzwrite.c' line='566' column='1'/>
       <parameter type-id='type-id-22' name='flush' filepath='src.d/gzwrite.c' line='567' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='gzsetparams' mangled-name='gzsetparams' filepath='src.d/gzwrite.c' line='597' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='gzsetparams'>
-      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='598' column='1'/>
+      <parameter type-id='type-id-91' name='file' filepath='src.d/gzwrite.c' line='598' column='1'/>
       <parameter type-id='type-id-22' name='level' filepath='src.d/gzwrite.c' line='599' column='1'/>
       <parameter type-id='type-id-22' name='strategy' filepath='src.d/gzwrite.c' line='600' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/infback.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-103'/>
-    <class-decl name='code' size-in-bits='32' is-struct='yes' naming-typedef-id='type-id-104' visibility='default' filepath='src.d/inftrees.h' line='24' column='1' id='type-id-105'>
+    <enum-decl name='codetype' naming-typedef-id='type-id-103' filepath='src.d/inftrees.h' line='54' column='1' id='type-id-104'>
+      <underlying-type type-id='type-id-105'/>
+      <enumerator name='CODES' value='0'/>
+      <enumerator name='LENS' value='1'/>
+      <enumerator name='DISTS' value='2'/>
+    </enum-decl>
+    <class-decl name='code' size-in-bits='32' is-struct='yes' naming-typedef-id='type-id-106' visibility='default' filepath='src.d/inftrees.h' line='24' column='1' id='type-id-107'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='op' type-id='type-id-3' visibility='default' filepath='src.d/inftrees.h' line='25' column='1'/>
       </data-member>
@@ -1047,217 +1085,186 @@
         <var-decl name='bits' type-id='type-id-3' visibility='default' filepath='src.d/inftrees.h' line='26' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='16'>
-        <var-decl name='val' type-id='type-id-40' visibility='default' filepath='src.d/inftrees.h' line='27' column='1'/>
+        <var-decl name='val' type-id='type-id-71' visibility='default' filepath='src.d/inftrees.h' line='27' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='code' type-id='type-id-105' filepath='src.d/inftrees.h' line='28' column='1' id='type-id-104'/>
-    <enum-decl name='codetype' naming-typedef-id='type-id-106' filepath='src.d/inftrees.h' line='54' column='1' id='type-id-107'>
-      <underlying-type type-id='type-id-103'/>
-      <enumerator name='CODES' value='0'/>
-      <enumerator name='LENS' value='1'/>
-      <enumerator name='DISTS' value='2'/>
-    </enum-decl>
-    <typedef-decl name='codetype' type-id='type-id-107' filepath='src.d/inftrees.h' line='58' column='1' id='type-id-106'/>
+    <typedef-decl name='code' type-id='type-id-107' filepath='src.d/inftrees.h' line='28' column='1' id='type-id-106'/>
+    <typedef-decl name='codetype' type-id='type-id-104' filepath='src.d/inftrees.h' line='58' column='1' id='type-id-103'/>
     <typedef-decl name='in_func' type-id='type-id-108' filepath='src.d/zlib.h' line='1094' column='1' id='type-id-109'/>
     <typedef-decl name='out_func' type-id='type-id-110' filepath='src.d/zlib.h' line='1096' column='1' id='type-id-111'/>
-    <pointer-type-def type-id='type-id-104' size-in-bits='32' id='type-id-112'/>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-105'/>
+    <pointer-type-def type-id='type-id-106' size-in-bits='32' id='type-id-112'/>
     <pointer-type-def type-id='type-id-112' size-in-bits='32' id='type-id-113'/>
     <pointer-type-def type-id='type-id-114' size-in-bits='32' id='type-id-110'/>
-    <pointer-type-def type-id='type-id-3' size-in-bits='32' id='type-id-91'/>
-    <pointer-type-def type-id='type-id-91' size-in-bits='32' id='type-id-115'/>
+    <pointer-type-def type-id='type-id-3' size-in-bits='32' id='type-id-89'/>
+    <pointer-type-def type-id='type-id-89' size-in-bits='32' id='type-id-115'/>
     <pointer-type-def type-id='type-id-116' size-in-bits='32' id='type-id-108'/>
-    <pointer-type-def type-id='type-id-40' size-in-bits='32' id='type-id-117'/>
+    <pointer-type-def type-id='type-id-71' size-in-bits='32' id='type-id-117'/>
+    <typedef-decl name='voidpf' type-id='type-id-86' filepath='./zconf.h' line='415' column='1' id='type-id-118'/>
     <function-decl name='inflateBackInit_' mangled-name='inflateBackInit_' filepath='src.d/infback.c' line='28' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateBackInit_@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/infback.c' line='29' column='1'/>
+      <parameter type-id='type-id-23' name='strm' filepath='src.d/infback.c' line='29' column='1'/>
       <parameter type-id='type-id-22' name='windowBits' filepath='src.d/infback.c' line='30' column='1'/>
-      <parameter type-id='type-id-91' name='window' filepath='src.d/infback.c' line='31' column='1'/>
-      <parameter type-id='type-id-80' name='version' filepath='src.d/infback.c' line='32' column='1'/>
+      <parameter type-id='type-id-89' name='window' filepath='src.d/infback.c' line='31' column='1'/>
+      <parameter type-id='type-id-24' name='version' filepath='src.d/infback.c' line='32' column='1'/>
       <parameter type-id='type-id-22' name='stream_size' filepath='src.d/infback.c' line='33' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='inflateBack' mangled-name='inflateBack' filepath='src.d/infback.c' line='251' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateBack@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/infback.c' line='252' column='1'/>
+      <parameter type-id='type-id-23' name='strm' filepath='src.d/infback.c' line='252' column='1'/>
       <parameter type-id='type-id-109' name='in' filepath='src.d/infback.c' line='253' column='1'/>
-      <parameter type-id='type-id-46' name='in_desc' filepath='src.d/infback.c' line='254' column='1'/>
+      <parameter type-id='type-id-86' name='in_desc' filepath='src.d/infback.c' line='254' column='1'/>
       <parameter type-id='type-id-111' name='out' filepath='src.d/infback.c' line='255' column='1'/>
-      <parameter type-id='type-id-46' name='out_desc' filepath='src.d/infback.c' line='256' column='1'/>
+      <parameter type-id='type-id-86' name='out_desc' filepath='src.d/infback.c' line='256' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='inflateBackEnd' mangled-name='inflateBackEnd' filepath='src.d/infback.c' line='635' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateBackEnd@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/infback.c' line='636' column='1'/>
+      <parameter type-id='type-id-23' name='strm' filepath='src.d/infback.c' line='636' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='inflate_fast' filepath='src.d/inffast.h' line='11' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-59'/>
-      <parameter type-id='type-id-4'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-23'/>
+      <parameter type-id='type-id-11'/>
+      <return type-id='type-id-87'/>
     </function-decl>
     <function-decl name='inflate_table' filepath='src.d/inftrees.h' line='60' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-106'/>
+      <parameter type-id='type-id-103'/>
       <parameter type-id='type-id-117'/>
-      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-11'/>
       <parameter type-id='type-id-113'/>
-      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-81'/>
       <parameter type-id='type-id-117'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-type size-in-bits='32' id='type-id-114'>
-      <parameter type-id='type-id-46'/>
-      <parameter type-id='type-id-91'/>
-      <parameter type-id='type-id-4'/>
+      <parameter type-id='type-id-86'/>
+      <parameter type-id='type-id-89'/>
+      <parameter type-id='type-id-11'/>
       <return type-id='type-id-22'/>
     </function-type>
     <function-type size-in-bits='32' id='type-id-116'>
-      <parameter type-id='type-id-46'/>
+      <parameter type-id='type-id-86'/>
       <parameter type-id='type-id-115'/>
-      <return type-id='type-id-4'/>
+      <return type-id='type-id-11'/>
     </function-type>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/inflate.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
+    <typedef-decl name='voidpf' type-id='type-id-86' filepath='./zconf.h' line='415' column='1' id='type-id-119'/>
     <function-decl name='inflateResetKeep' mangled-name='inflateResetKeep' filepath='src.d/inflate.c' line='119' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateResetKeep@@ZLIB_1.2.5.2'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='120' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='inflateReset' mangled-name='inflateReset' filepath='src.d/inflate.c' line='145' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateReset'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='146' column='1'/>
+      <parameter type-id='type-id-23' name='strm' filepath='src.d/inflate.c' line='120' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='inflateReset2' mangled-name='inflateReset2' filepath='src.d/inflate.c' line='158' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateReset2@@ZLIB_1.2.3.4'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='159' column='1'/>
+      <parameter type-id='type-id-23' name='strm' filepath='src.d/inflate.c' line='159' column='1'/>
       <parameter type-id='type-id-22' name='windowBits' filepath='src.d/inflate.c' line='160' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='inflateInit2_' mangled-name='inflateInit2_' filepath='src.d/inflate.c' line='198' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateInit2_'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='199' column='1'/>
-      <parameter type-id='type-id-22' name='windowBits' filepath='src.d/inflate.c' line='200' column='1'/>
-      <parameter type-id='type-id-80' name='version' filepath='src.d/inflate.c' line='201' column='1'/>
-      <parameter type-id='type-id-22' name='stream_size' filepath='src.d/inflate.c' line='202' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
     <function-decl name='inflateInit_' mangled-name='inflateInit_' filepath='src.d/inflate.c' line='242' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateInit_'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='243' column='1'/>
-      <parameter type-id='type-id-80' name='version' filepath='src.d/inflate.c' line='244' column='1'/>
+      <parameter type-id='type-id-23' name='strm' filepath='src.d/inflate.c' line='243' column='1'/>
+      <parameter type-id='type-id-24' name='version' filepath='src.d/inflate.c' line='244' column='1'/>
       <parameter type-id='type-id-22' name='stream_size' filepath='src.d/inflate.c' line='245' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='inflatePrime' mangled-name='inflatePrime' filepath='src.d/inflate.c' line='250' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflatePrime@@ZLIB_1.2.2.4'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='251' column='1'/>
+      <parameter type-id='type-id-23' name='strm' filepath='src.d/inflate.c' line='251' column='1'/>
       <parameter type-id='type-id-22' name='bits' filepath='src.d/inflate.c' line='252' column='1'/>
       <parameter type-id='type-id-22' name='value' filepath='src.d/inflate.c' line='253' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
-    <function-decl name='inflate' mangled-name='inflate' filepath='src.d/inflate.c' line='625' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflate'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='626' column='1'/>
-      <parameter type-id='type-id-22' name='flush' filepath='src.d/inflate.c' line='627' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
-    <function-decl name='inflateEnd' mangled-name='inflateEnd' filepath='src.d/inflate.c' line='1304' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateEnd'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1305' column='1'/>
-      <return type-id='type-id-22'/>
-    </function-decl>
     <function-decl name='inflateGetDictionary' mangled-name='inflateGetDictionary' filepath='src.d/inflate.c' line='1318' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateGetDictionary@@ZLIB_1.2.7.1'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1319' column='1'/>
+      <parameter type-id='type-id-23' name='strm' filepath='src.d/inflate.c' line='1319' column='1'/>
       <parameter type-id='type-id-21' name='dictionary' filepath='src.d/inflate.c' line='1320' column='1'/>
-      <parameter type-id='type-id-85' name='dictLength' filepath='src.d/inflate.c' line='1321' column='1'/>
+      <parameter type-id='type-id-80' name='dictLength' filepath='src.d/inflate.c' line='1321' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='inflateSetDictionary' mangled-name='inflateSetDictionary' filepath='src.d/inflate.c' line='1341' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateSetDictionary'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1342' column='1'/>
+      <parameter type-id='type-id-23' name='strm' filepath='src.d/inflate.c' line='1342' column='1'/>
       <parameter type-id='type-id-18' name='dictionary' filepath='src.d/inflate.c' line='1343' column='1'/>
-      <parameter type-id='type-id-9' name='dictLength' filepath='src.d/inflate.c' line='1344' column='1'/>
+      <parameter type-id='type-id-13' name='dictLength' filepath='src.d/inflate.c' line='1344' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='inflateGetHeader' mangled-name='inflateGetHeader' filepath='src.d/inflate.c' line='1376' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateGetHeader@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1377' column='1'/>
-      <parameter type-id='type-id-61' name='head' filepath='src.d/inflate.c' line='1378' column='1'/>
+      <parameter type-id='type-id-23' name='strm' filepath='src.d/inflate.c' line='1377' column='1'/>
+      <parameter type-id='type-id-44' name='head' filepath='src.d/inflate.c' line='1378' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='inflateSync' mangled-name='inflateSync' filepath='src.d/inflate.c' line='1427' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateSync'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1428' column='1'/>
+      <parameter type-id='type-id-23' name='strm' filepath='src.d/inflate.c' line='1428' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='inflateSyncPoint' mangled-name='inflateSyncPoint' filepath='src.d/inflate.c' line='1485' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateSyncPoint'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1486' column='1'/>
+      <parameter type-id='type-id-23' name='strm' filepath='src.d/inflate.c' line='1486' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='inflateCopy' mangled-name='inflateCopy' filepath='src.d/inflate.c' line='1495' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateCopy@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-59' name='dest' filepath='src.d/inflate.c' line='1496' column='1'/>
-      <parameter type-id='type-id-59' name='source' filepath='src.d/inflate.c' line='1497' column='1'/>
+      <parameter type-id='type-id-23' name='dest' filepath='src.d/inflate.c' line='1496' column='1'/>
+      <parameter type-id='type-id-23' name='source' filepath='src.d/inflate.c' line='1497' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='inflateUndermine' mangled-name='inflateUndermine' filepath='src.d/inflate.c' line='1542' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateUndermine@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1543' column='1'/>
+      <parameter type-id='type-id-23' name='strm' filepath='src.d/inflate.c' line='1543' column='1'/>
       <parameter type-id='type-id-22' name='subvert' filepath='src.d/inflate.c' line='1544' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='inflateValidate' mangled-name='inflateValidate' filepath='src.d/inflate.c' line='1560' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateValidate@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1561' column='1'/>
+      <parameter type-id='type-id-23' name='strm' filepath='src.d/inflate.c' line='1561' column='1'/>
       <parameter type-id='type-id-22' name='check' filepath='src.d/inflate.c' line='1562' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='inflateMark' mangled-name='inflateMark' filepath='src.d/inflate.c' line='1575' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateMark@@ZLIB_1.2.3.4'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1576' column='1'/>
+      <parameter type-id='type-id-23' name='strm' filepath='src.d/inflate.c' line='1576' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='inflateCodesUsed' mangled-name='inflateCodesUsed' filepath='src.d/inflate.c' line='1588' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='inflateCodesUsed@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-59' name='strm' filepath='src.d/inflate.c' line='1589' column='1'/>
-      <return type-id='type-id-5'/>
+      <parameter type-id='type-id-23' name='strm' filepath='src.d/inflate.c' line='1589' column='1'/>
+      <return type-id='type-id-14'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/trees.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <array-type-def dimensions='1' type-id='type-id-118' size-in-bits='2048' id='type-id-119'>
-      <subrange length='256' type-id='type-id-4' id='type-id-120'/>
+    <array-type-def dimensions='1' type-id='type-id-120' size-in-bits='2048' id='type-id-121'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-11' id='type-id-122'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-118' size-in-bits='4096' id='type-id-121'>
-      <subrange length='512' type-id='type-id-4' id='type-id-122'/>
+    <array-type-def dimensions='1' type-id='type-id-120' size-in-bits='4096' id='type-id-123'>
+      <subrange length='512' lower-bound='0' upper-bound='511' type-id='type-id-11' id='type-id-124'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-118' size-in-bits='infinite' id='type-id-123'>
-      <subrange length='infinite' id='type-id-124'/>
+    <array-type-def dimensions='1' type-id='type-id-120' size-in-bits='unknown' id='type-id-125'>
+      <subrange length='unknown' lower-bound='0' upper-bound='0' id='type-id-126'/>
     </array-type-def>
-    <qualified-type-def type-id='type-id-38' const='yes' id='type-id-118'/>
-    <var-decl name='_length_code' type-id='type-id-123' visibility='default' filepath='src.d/deflate.h' line='317' column='1'/>
+    <qualified-type-def type-id='type-id-69' const='yes' id='type-id-120'/>
+    <var-decl name='_length_code' type-id='type-id-121' visibility='default' filepath='src.d/deflate.h' line='317' column='1'/>
     <var-decl name='_dist_code' type-id='type-id-123' visibility='default' filepath='src.d/deflate.h' line='318' column='1'/>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/uncompr.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <pointer-type-def type-id='type-id-10' size-in-bits='32' id='type-id-125'/>
+    <pointer-type-def type-id='type-id-15' size-in-bits='32' id='type-id-127'/>
     <function-decl name='uncompress2' mangled-name='uncompress2' filepath='src.d/uncompr.c' line='27' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='uncompress2@@ZLIB_1.2.9'>
       <parameter type-id='type-id-21' name='dest' filepath='src.d/uncompr.c' line='28' column='1'/>
       <parameter type-id='type-id-20' name='destLen' filepath='src.d/uncompr.c' line='29' column='1'/>
       <parameter type-id='type-id-18' name='source' filepath='src.d/uncompr.c' line='30' column='1'/>
-      <parameter type-id='type-id-125' name='sourceLen' filepath='src.d/uncompr.c' line='31' column='1'/>
+      <parameter type-id='type-id-127' name='sourceLen' filepath='src.d/uncompr.c' line='31' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='uncompress' mangled-name='uncompress' filepath='src.d/uncompr.c' line='86' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='uncompress'>
       <parameter type-id='type-id-21' name='dest' filepath='src.d/uncompr.c' line='87' column='1'/>
       <parameter type-id='type-id-20' name='destLen' filepath='src.d/uncompr.c' line='88' column='1'/>
       <parameter type-id='type-id-18' name='source' filepath='src.d/uncompr.c' line='89' column='1'/>
-      <parameter type-id='type-id-10' name='sourceLen' filepath='src.d/uncompr.c' line='90' column='1'/>
+      <parameter type-id='type-id-15' name='sourceLen' filepath='src.d/uncompr.c' line='90' column='1'/>
       <return type-id='type-id-22'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='32' path='src.d/zutil.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <array-type-def dimensions='1' type-id='type-id-126' size-in-bits='320' id='type-id-127'>
-      <subrange length='10' type-id='type-id-4' id='type-id-128'/>
+    <array-type-def dimensions='1' type-id='type-id-128' size-in-bits='320' id='type-id-129'>
+      <subrange length='10' lower-bound='0' upper-bound='9' type-id='type-id-11' id='type-id-130'/>
     </array-type-def>
-    <qualified-type-def type-id='type-id-70' const='yes' id='type-id-126'/>
-    <function-decl name='malloc' filepath='/usr/include/stdlib.h' line='540' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-6'/>
-      <return type-id='type-id-46'/>
-    </function-decl>
-    <function-decl name='free' filepath='/usr/include/stdlib.h' line='555' column='1' visibility='default' binding='global' size-in-bits='32'>
-      <parameter type-id='type-id-46'/>
-      <return type-id='type-id-44'/>
-    </function-decl>
+    <qualified-type-def type-id='type-id-55' const='yes' id='type-id-128'/>
     <function-decl name='zlibVersion' mangled-name='zlibVersion' filepath='src.d/zutil.c' line='27' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='zlibVersion'>
-      <return type-id='type-id-80'/>
+      <return type-id='type-id-24'/>
     </function-decl>
     <function-decl name='zlibCompileFlags' mangled-name='zlibCompileFlags' filepath='src.d/zutil.c' line='32' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='zlibCompileFlags@@ZLIB_1.2.0.2'>
-      <return type-id='type-id-10'/>
+      <return type-id='type-id-15'/>
     </function-decl>
     <function-decl name='zError' mangled-name='zError' filepath='src.d/zutil.c' line='135' column='1' visibility='default' binding='global' size-in-bits='32' elf-symbol-id='zError'>
       <parameter type-id='type-id-22' name='err' filepath='src.d/zutil.c' line='136' column='1'/>
-      <return type-id='type-id-80'/>
+      <return type-id='type-id-24'/>
     </function-decl>
-    <var-decl name='z_errmsg' type-id='type-id-127' visibility='default' filepath='src.d/zutil.h' line='56' column='1'/>
+    <var-decl name='z_errmsg' type-id='type-id-129' visibility='default' filepath='src.d/zutil.h' line='56' column='1'/>
   </abi-instr>
 </abi-corpus>

--- a/test/abi/zlib-04f42ceca40f73e2978b50e93806c2a18c1281fc-x86_64-pc-linux-gnu.abi
+++ b/test/abi/zlib-04f42ceca40f73e2978b50e93806c2a18c1281fc-x86_64-pc-linux-gnu.abi
@@ -1,4 +1,4 @@
-<abi-corpus version='2.0' path='btmp1/libz.so.1.2.13' architecture='elf-amd-x86_64' soname='libz.so.1'>
+<abi-corpus version='2.2' path='btmp1/libz.so.1.2.13' architecture='elf-amd-x86_64' soname='libz.so.1'>
   <elf-needed>
     <dependency name='libc.so.6'/>
   </elf-needed>
@@ -94,54 +94,54 @@
   </elf-function-symbols>
   <abi-instr address-size='64' path='src.d/adler32.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
     <type-decl name='long int' size-in-bits='64' id='type-id-1'/>
+    <typedef-decl name='Byte' type-id='type-id-2' filepath='./zconf.h' line='397' column='1' id='type-id-3'/>
+    <typedef-decl name='Bytef' type-id='type-id-3' filepath='./zconf.h' line='406' column='1' id='type-id-4'/>
+    <typedef-decl name='__off64_t' type-id='type-id-1' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='153' column='1' id='type-id-5'/>
+    <typedef-decl name='__off_t' type-id='type-id-1' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='152' column='1' id='type-id-6'/>
+    <typedef-decl name='off64_t' type-id='type-id-5' filepath='/usr/include/x86_64-linux-gnu/sys/types.h' line='92' column='1' id='type-id-7'/>
+    <typedef-decl name='off_t' type-id='type-id-6' filepath='/usr/include/x86_64-linux-gnu/sys/types.h' line='85' column='1' id='type-id-8'/>
+    <typedef-decl name='size_t' type-id='type-id-9' filepath='/usr/lib/gcc/x86_64-linux-gnu/13/include/stddef.h' line='214' column='1' id='type-id-10'/>
+    <typedef-decl name='uInt' type-id='type-id-11' filepath='./zconf.h' line='399' column='1' id='type-id-12'/>
+    <typedef-decl name='uLong' type-id='type-id-9' filepath='./zconf.h' line='400' column='1' id='type-id-13'/>
+    <typedef-decl name='z_size_t' type-id='type-id-10' filepath='./zconf.h' line='251' column='1' id='type-id-14'/>
     <type-decl name='unsigned char' size-in-bits='8' id='type-id-2'/>
-    <type-decl name='unsigned int' size-in-bits='32' id='type-id-3'/>
-    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-4'/>
-    <typedef-decl name='z_size_t' type-id='type-id-5' filepath='./zconf.h' line='251' column='1' id='type-id-6'/>
-    <typedef-decl name='Byte' type-id='type-id-2' filepath='./zconf.h' line='397' column='1' id='type-id-7'/>
-    <typedef-decl name='uInt' type-id='type-id-3' filepath='./zconf.h' line='399' column='1' id='type-id-8'/>
-    <typedef-decl name='uLong' type-id='type-id-4' filepath='./zconf.h' line='400' column='1' id='type-id-9'/>
-    <typedef-decl name='Bytef' type-id='type-id-7' filepath='./zconf.h' line='406' column='1' id='type-id-10'/>
-    <typedef-decl name='__off_t' type-id='type-id-1' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='152' column='1' id='type-id-11'/>
-    <typedef-decl name='__off64_t' type-id='type-id-1' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='153' column='1' id='type-id-12'/>
-    <typedef-decl name='off_t' type-id='type-id-11' filepath='/usr/include/x86_64-linux-gnu/sys/types.h' line='85' column='1' id='type-id-13'/>
-    <typedef-decl name='off64_t' type-id='type-id-12' filepath='/usr/include/x86_64-linux-gnu/sys/types.h' line='92' column='1' id='type-id-14'/>
-    <typedef-decl name='size_t' type-id='type-id-4' filepath='/usr/lib/gcc/x86_64-linux-gnu/11/include/stddef.h' line='209' column='1' id='type-id-5'/>
-    <qualified-type-def type-id='type-id-10' const='yes' id='type-id-15'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-11'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-9'/>
+    <qualified-type-def type-id='type-id-4' const='yes' id='type-id-15'/>
     <pointer-type-def type-id='type-id-15' size-in-bits='64' id='type-id-16'/>
     <function-decl name='adler32_z' mangled-name='adler32_z' filepath='src.d/adler32.c' line='63' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='adler32_z@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-9' name='adler' filepath='src.d/adler32.c' line='64' column='1'/>
+      <parameter type-id='type-id-13' name='adler' filepath='src.d/adler32.c' line='64' column='1'/>
       <parameter type-id='type-id-16' name='buf' filepath='src.d/adler32.c' line='65' column='1'/>
-      <parameter type-id='type-id-6' name='len' filepath='src.d/adler32.c' line='66' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-14' name='len' filepath='src.d/adler32.c' line='66' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='adler32' mangled-name='adler32' filepath='src.d/adler32.c' line='134' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='adler32'>
-      <parameter type-id='type-id-9' name='adler' filepath='src.d/adler32.c' line='135' column='1'/>
+      <parameter type-id='type-id-13' name='adler' filepath='src.d/adler32.c' line='135' column='1'/>
       <parameter type-id='type-id-16' name='buf' filepath='src.d/adler32.c' line='136' column='1'/>
-      <parameter type-id='type-id-8' name='len' filepath='src.d/adler32.c' line='137' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-12' name='len' filepath='src.d/adler32.c' line='137' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='adler32_combine' mangled-name='adler32_combine' filepath='src.d/adler32.c' line='172' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='adler32_combine@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-9' name='adler1' filepath='src.d/adler32.c' line='173' column='1'/>
-      <parameter type-id='type-id-9' name='adler2' filepath='src.d/adler32.c' line='174' column='1'/>
-      <parameter type-id='type-id-13' name='len2' filepath='src.d/adler32.c' line='175' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-13' name='adler1' filepath='src.d/adler32.c' line='173' column='1'/>
+      <parameter type-id='type-id-13' name='adler2' filepath='src.d/adler32.c' line='174' column='1'/>
+      <parameter type-id='type-id-8' name='len2' filepath='src.d/adler32.c' line='175' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='adler32_combine64' mangled-name='adler32_combine64' filepath='src.d/adler32.c' line='180' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='adler32_combine64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-9' name='adler1' filepath='src.d/adler32.c' line='181' column='1'/>
-      <parameter type-id='type-id-9' name='adler2' filepath='src.d/adler32.c' line='182' column='1'/>
-      <parameter type-id='type-id-14' name='len2' filepath='src.d/adler32.c' line='183' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-13' name='adler1' filepath='src.d/adler32.c' line='181' column='1'/>
+      <parameter type-id='type-id-13' name='adler2' filepath='src.d/adler32.c' line='182' column='1'/>
+      <parameter type-id='type-id-7' name='len2' filepath='src.d/adler32.c' line='183' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/compress.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <typedef-decl name='uLongf' type-id='type-id-9' filepath='./zconf.h' line='411' column='1' id='type-id-17'/>
+    <typedef-decl name='uLongf' type-id='type-id-13' filepath='./zconf.h' line='411' column='1' id='type-id-17'/>
     <pointer-type-def type-id='type-id-17' size-in-bits='64' id='type-id-18'/>
     <function-decl name='compress2' mangled-name='compress2' filepath='src.d/compress.c' line='22' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='compress2'>
       <parameter type-id='type-id-19' name='dest' filepath='src.d/compress.c' line='23' column='1'/>
       <parameter type-id='type-id-18' name='destLen' filepath='src.d/compress.c' line='24' column='1'/>
       <parameter type-id='type-id-16' name='source' filepath='src.d/compress.c' line='25' column='1'/>
-      <parameter type-id='type-id-9' name='sourceLen' filepath='src.d/compress.c' line='26' column='1'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/compress.c' line='26' column='1'/>
       <parameter type-id='type-id-20' name='level' filepath='src.d/compress.c' line='27' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
@@ -149,362 +149,107 @@
       <parameter type-id='type-id-19' name='dest' filepath='src.d/compress.c' line='69' column='1'/>
       <parameter type-id='type-id-18' name='destLen' filepath='src.d/compress.c' line='70' column='1'/>
       <parameter type-id='type-id-16' name='source' filepath='src.d/compress.c' line='71' column='1'/>
-      <parameter type-id='type-id-9' name='sourceLen' filepath='src.d/compress.c' line='72' column='1'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/compress.c' line='72' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='compressBound' mangled-name='compressBound' filepath='src.d/compress.c' line='81' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='compressBound@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-9' name='sourceLen' filepath='src.d/compress.c' line='82' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/compress.c' line='82' column='1'/>
+      <return type-id='type-id-13'/>
+    </function-decl>
+    <function-decl name='deflate' filepath='src.d/zlib.h' line='250' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='deflateEnd' filepath='src.d/zlib.h' line='363' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-21'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='deflateInit_' filepath='src.d/zlib.h' line='1781' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/crc32.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <typedef-decl name='z_crc_t' type-id='type-id-3' filepath='./zconf.h' line='435' column='1' id='type-id-21'/>
-    <qualified-type-def type-id='type-id-2' const='yes' id='type-id-22'/>
-    <pointer-type-def type-id='type-id-22' size-in-bits='64' id='type-id-23'/>
-    <qualified-type-def type-id='type-id-21' const='yes' id='type-id-24'/>
+    <typedef-decl name='z_crc_t' type-id='type-id-11' filepath='./zconf.h' line='435' column='1' id='type-id-23'/>
+    <qualified-type-def type-id='type-id-2' const='yes' id='type-id-24'/>
     <pointer-type-def type-id='type-id-24' size-in-bits='64' id='type-id-25'/>
+    <qualified-type-def type-id='type-id-23' const='yes' id='type-id-26'/>
+    <pointer-type-def type-id='type-id-26' size-in-bits='64' id='type-id-27'/>
     <function-decl name='get_crc_table' mangled-name='get_crc_table' filepath='src.d/crc32.c' line='595' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='get_crc_table'>
-      <return type-id='type-id-25'/>
+      <return type-id='type-id-27'/>
     </function-decl>
     <function-decl name='crc32_z' mangled-name='crc32_z' filepath='src.d/crc32.c' line='748' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_z@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-4' name='crc' filepath='src.d/crc32.c' line='749' column='1'/>
-      <parameter type-id='type-id-23' name='buf' filepath='src.d/crc32.c' line='750' column='1'/>
-      <parameter type-id='type-id-6' name='len' filepath='src.d/crc32.c' line='751' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-9' name='crc' filepath='src.d/crc32.c' line='749' column='1'/>
+      <parameter type-id='type-id-25' name='buf' filepath='src.d/crc32.c' line='750' column='1'/>
+      <parameter type-id='type-id-14' name='len' filepath='src.d/crc32.c' line='751' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32' mangled-name='crc32' filepath='src.d/crc32.c' line='1072' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32'>
-      <parameter type-id='type-id-4' name='crc' filepath='src.d/crc32.c' line='1073' column='1'/>
-      <parameter type-id='type-id-23' name='buf' filepath='src.d/crc32.c' line='1074' column='1'/>
-      <parameter type-id='type-id-8' name='len' filepath='src.d/crc32.c' line='1075' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-9' name='crc' filepath='src.d/crc32.c' line='1073' column='1'/>
+      <parameter type-id='type-id-25' name='buf' filepath='src.d/crc32.c' line='1074' column='1'/>
+      <parameter type-id='type-id-12' name='len' filepath='src.d/crc32.c' line='1075' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine64' mangled-name='crc32_combine64' filepath='src.d/crc32.c' line='1081' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_combine64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-9' name='crc1' filepath='src.d/crc32.c' line='1082' column='1'/>
-      <parameter type-id='type-id-9' name='crc2' filepath='src.d/crc32.c' line='1083' column='1'/>
-      <parameter type-id='type-id-14' name='len2' filepath='src.d/crc32.c' line='1084' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-13' name='crc1' filepath='src.d/crc32.c' line='1082' column='1'/>
+      <parameter type-id='type-id-13' name='crc2' filepath='src.d/crc32.c' line='1083' column='1'/>
+      <parameter type-id='type-id-7' name='len2' filepath='src.d/crc32.c' line='1084' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine' mangled-name='crc32_combine' filepath='src.d/crc32.c' line='1093' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_combine@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-9' name='crc1' filepath='src.d/crc32.c' line='1094' column='1'/>
-      <parameter type-id='type-id-9' name='crc2' filepath='src.d/crc32.c' line='1095' column='1'/>
-      <parameter type-id='type-id-13' name='len2' filepath='src.d/crc32.c' line='1096' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-13' name='crc1' filepath='src.d/crc32.c' line='1094' column='1'/>
+      <parameter type-id='type-id-13' name='crc2' filepath='src.d/crc32.c' line='1095' column='1'/>
+      <parameter type-id='type-id-8' name='len2' filepath='src.d/crc32.c' line='1096' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine_gen64' mangled-name='crc32_combine_gen64' filepath='src.d/crc32.c' line='1102' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_combine_gen64@@ZLIB_1.2.12'>
-      <parameter type-id='type-id-14' name='len2' filepath='src.d/crc32.c' line='1103' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-7' name='len2' filepath='src.d/crc32.c' line='1103' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine_gen' mangled-name='crc32_combine_gen' filepath='src.d/crc32.c' line='1112' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_combine_gen@@ZLIB_1.2.12'>
-      <parameter type-id='type-id-13' name='len2' filepath='src.d/crc32.c' line='1113' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-8' name='len2' filepath='src.d/crc32.c' line='1113' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='crc32_combine_op' mangled-name='crc32_combine_op' filepath='src.d/crc32.c' line='1119' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='crc32_combine_op@@ZLIB_1.2.12'>
-      <parameter type-id='type-id-9' name='crc1' filepath='src.d/crc32.c' line='1120' column='1'/>
-      <parameter type-id='type-id-9' name='crc2' filepath='src.d/crc32.c' line='1121' column='1'/>
-      <parameter type-id='type-id-9' name='op' filepath='src.d/crc32.c' line='1122' column='1'/>
-      <return type-id='type-id-9'/>
+      <parameter type-id='type-id-13' name='crc1' filepath='src.d/crc32.c' line='1120' column='1'/>
+      <parameter type-id='type-id-13' name='crc2' filepath='src.d/crc32.c' line='1121' column='1'/>
+      <parameter type-id='type-id-13' name='op' filepath='src.d/crc32.c' line='1122' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/deflate.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <type-decl name='char' size-in-bits='8' id='type-id-26'/>
-    <class-decl name='static_tree_desc_s' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-27'/>
-    <array-type-def dimensions='1' type-id='type-id-28' size-in-bits='1248' id='type-id-29'>
-      <subrange length='39' type-id='type-id-4' id='type-id-30'/>
+    <type-decl name='char' size-in-bits='8' id='type-id-28'/>
+    <array-type-def dimensions='1' type-id='type-id-29' size-in-bits='1248' id='type-id-30'>
+      <subrange length='39' lower-bound='0' upper-bound='38' type-id='type-id-9' id='type-id-31'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-28' size-in-bits='18336' id='type-id-31'>
-      <subrange length='573' type-id='type-id-4' id='type-id-32'/>
+    <array-type-def dimensions='1' type-id='type-id-29' size-in-bits='18336' id='type-id-32'>
+      <subrange length='573' lower-bound='0' upper-bound='572' type-id='type-id-9' id='type-id-33'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-28' size-in-bits='1952' id='type-id-33'>
-      <subrange length='61' type-id='type-id-4' id='type-id-34'/>
+    <array-type-def dimensions='1' type-id='type-id-29' size-in-bits='1952' id='type-id-34'>
+      <subrange length='61' lower-bound='0' upper-bound='60' type-id='type-id-9' id='type-id-35'/>
     </array-type-def>
     <type-decl name='int' size-in-bits='32' id='type-id-20'/>
-    <array-type-def dimensions='1' type-id='type-id-20' size-in-bits='18336' id='type-id-35'>
-      <subrange length='573' type-id='type-id-4' id='type-id-32'/>
+    <array-type-def dimensions='1' type-id='type-id-20' size-in-bits='18336' id='type-id-36'>
+      <subrange length='573' lower-bound='0' upper-bound='572' type-id='type-id-9' id='type-id-33'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-36' size-in-bits='4584' id='type-id-37'>
-      <subrange length='573' type-id='type-id-4' id='type-id-32'/>
-    </array-type-def>
-    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-38'/>
-    <array-type-def dimensions='1' type-id='type-id-39' size-in-bits='256' id='type-id-40'>
-      <subrange length='16' type-id='type-id-4' id='type-id-41'/>
-    </array-type-def>
-    <type-decl name='void' id='type-id-42'/>
-    <typedef-decl name='charf' type-id='type-id-26' filepath='./zconf.h' line='408' column='1' id='type-id-43'/>
-    <typedef-decl name='voidpf' type-id='type-id-44' filepath='./zconf.h' line='415' column='1' id='type-id-45'/>
-    <class-decl name='ct_data_s' size-in-bits='32' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='68' column='1' id='type-id-28'>
+    <class-decl name='ct_data_s' size-in-bits='32' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='68' column='1' id='type-id-29'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='fc' type-id='type-id-46' visibility='default' filepath='src.d/deflate.h' line='72' column='1'/>
+        <var-decl name='fc' type-id='type-id-37' visibility='default' filepath='src.d/deflate.h' line='72' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='16'>
-        <var-decl name='dl' type-id='type-id-47' visibility='default' filepath='src.d/deflate.h' line='76' column='1'/>
+        <var-decl name='dl' type-id='type-id-38' visibility='default' filepath='src.d/deflate.h' line='76' column='1'/>
       </data-member>
     </class-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='69' column='1' id='type-id-46'>
-      <data-member access='public'>
-        <var-decl name='freq' type-id='type-id-39' visibility='default' filepath='src.d/deflate.h' line='70' column='1'/>
-      </data-member>
-      <data-member access='public'>
-        <var-decl name='code' type-id='type-id-39' visibility='default' filepath='src.d/deflate.h' line='71' column='1'/>
-      </data-member>
-    </union-decl>
-    <union-decl name='__anonymous_union__1' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='73' column='1' id='type-id-47'>
-      <data-member access='public'>
-        <var-decl name='dad' type-id='type-id-39' visibility='default' filepath='src.d/deflate.h' line='74' column='1'/>
-      </data-member>
-      <data-member access='public'>
-        <var-decl name='len' type-id='type-id-39' visibility='default' filepath='src.d/deflate.h' line='75' column='1'/>
-      </data-member>
-    </union-decl>
-    <typedef-decl name='ct_data' type-id='type-id-28' filepath='src.d/deflate.h' line='77' column='1' id='type-id-48'/>
-    <typedef-decl name='static_tree_desc' type-id='type-id-27' filepath='src.d/deflate.h' line='84' column='1' id='type-id-49'/>
-    <class-decl name='tree_desc_s' size-in-bits='192' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='86' column='1' id='type-id-50'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='dyn_tree' type-id='type-id-51' visibility='default' filepath='src.d/deflate.h' line='87' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='max_code' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='88' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='stat_desc' type-id='type-id-52' visibility='default' filepath='src.d/deflate.h' line='89' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='Pos' type-id='type-id-39' filepath='src.d/deflate.h' line='92' column='1' id='type-id-53'/>
-    <typedef-decl name='Posf' type-id='type-id-53' filepath='src.d/deflate.h' line='93' column='1' id='type-id-54'/>
-    <typedef-decl name='IPos' type-id='type-id-3' filepath='src.d/deflate.h' line='94' column='1' id='type-id-55'/>
-    <class-decl name='internal_state' size-in-bits='47616' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='100' column='1' id='type-id-56'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='strm' type-id='type-id-57' visibility='default' filepath='src.d/deflate.h' line='101' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='status' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='102' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='pending_buf' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='103' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='pending_buf_size' type-id='type-id-58' visibility='default' filepath='src.d/deflate.h' line='104' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='pending_out' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='105' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='pending' type-id='type-id-58' visibility='default' filepath='src.d/deflate.h' line='106' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='wrap' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='107' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='gzhead' type-id='type-id-59' visibility='default' filepath='src.d/deflate.h' line='108' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='gzindex' type-id='type-id-58' visibility='default' filepath='src.d/deflate.h' line='109' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='method' type-id='type-id-7' visibility='default' filepath='src.d/deflate.h' line='110' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='608'>
-        <var-decl name='last_flush' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='111' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='w_size' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='115' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='672'>
-        <var-decl name='w_bits' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='116' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='w_mask' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='117' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='window' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='119' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='window_size' type-id='type-id-58' visibility='default' filepath='src.d/deflate.h' line='129' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='prev' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='134' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='head' type-id='type-id-60' visibility='default' filepath='src.d/deflate.h' line='140' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='ins_h' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='142' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1056'>
-        <var-decl name='hash_size' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='143' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1088'>
-        <var-decl name='hash_bits' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='144' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1120'>
-        <var-decl name='hash_mask' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='145' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1152'>
-        <var-decl name='hash_shift' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='147' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='block_start' type-id='type-id-1' visibility='default' filepath='src.d/deflate.h' line='154' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='match_length' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='159' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1312'>
-        <var-decl name='prev_match' type-id='type-id-55' visibility='default' filepath='src.d/deflate.h' line='160' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1344'>
-        <var-decl name='match_available' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='161' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1376'>
-        <var-decl name='strstart' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='162' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1408'>
-        <var-decl name='match_start' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='163' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1440'>
-        <var-decl name='lookahead' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='164' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1472'>
-        <var-decl name='prev_length' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='166' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1504'>
-        <var-decl name='max_chain_length' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='171' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1536'>
-        <var-decl name='max_lazy_match' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='177' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1568'>
-        <var-decl name='level' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='188' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1600'>
-        <var-decl name='strategy' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='189' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1632'>
-        <var-decl name='good_match' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='191' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1664'>
-        <var-decl name='nice_match' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='194' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1696'>
-        <var-decl name='dyn_ltree' type-id='type-id-31' visibility='default' filepath='src.d/deflate.h' line='198' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='20032'>
-        <var-decl name='dyn_dtree' type-id='type-id-33' visibility='default' filepath='src.d/deflate.h' line='199' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='21984'>
-        <var-decl name='bl_tree' type-id='type-id-29' visibility='default' filepath='src.d/deflate.h' line='200' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='23232'>
-        <var-decl name='l_desc' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='202' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='23424'>
-        <var-decl name='d_desc' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='203' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='23616'>
-        <var-decl name='bl_desc' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='204' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='23808'>
-        <var-decl name='bl_count' type-id='type-id-40' visibility='default' filepath='src.d/deflate.h' line='206' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='24064'>
-        <var-decl name='heap' type-id='type-id-35' visibility='default' filepath='src.d/deflate.h' line='209' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='42400'>
-        <var-decl name='heap_len' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='210' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='42432'>
-        <var-decl name='heap_max' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='211' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='42464'>
-        <var-decl name='depth' type-id='type-id-37' visibility='default' filepath='src.d/deflate.h' line='216' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47104'>
-        <var-decl name='sym_buf' type-id='type-id-61' visibility='default' filepath='src.d/deflate.h' line='220' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47168'>
-        <var-decl name='lit_bufsize' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='222' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47200'>
-        <var-decl name='sym_next' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='242' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47232'>
-        <var-decl name='sym_end' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='243' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47296'>
-        <var-decl name='opt_len' type-id='type-id-58' visibility='default' filepath='src.d/deflate.h' line='245' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47360'>
-        <var-decl name='static_len' type-id='type-id-58' visibility='default' filepath='src.d/deflate.h' line='246' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47424'>
-        <var-decl name='matches' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='247' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47456'>
-        <var-decl name='insert' type-id='type-id-8' visibility='default' filepath='src.d/deflate.h' line='248' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47488'>
-        <var-decl name='bi_buf' type-id='type-id-39' visibility='default' filepath='src.d/deflate.h' line='255' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47520'>
-        <var-decl name='bi_valid' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='259' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='47552'>
-        <var-decl name='high_water' type-id='type-id-58' visibility='default' filepath='src.d/deflate.h' line='264' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='deflate_state' type-id='type-id-56' filepath='src.d/deflate.h' line='271' column='1' id='type-id-62'/>
-    <typedef-decl name='alloc_func' type-id='type-id-63' filepath='src.d/zlib.h' line='81' column='1' id='type-id-64'/>
-    <typedef-decl name='free_func' type-id='type-id-65' filepath='src.d/zlib.h' line='82' column='1' id='type-id-66'/>
-    <class-decl name='z_stream_s' size-in-bits='896' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='86' column='1' id='type-id-67'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='next_in' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='87' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='avail_in' type-id='type-id-8' visibility='default' filepath='src.d/zlib.h' line='88' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='total_in' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='89' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='next_out' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='91' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='avail_out' type-id='type-id-8' visibility='default' filepath='src.d/zlib.h' line='92' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='total_out' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='93' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='msg' type-id='type-id-68' visibility='default' filepath='src.d/zlib.h' line='95' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='state' type-id='type-id-69' visibility='default' filepath='src.d/zlib.h' line='96' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='zalloc' type-id='type-id-64' visibility='default' filepath='src.d/zlib.h' line='98' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='zfree' type-id='type-id-66' visibility='default' filepath='src.d/zlib.h' line='99' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='opaque' type-id='type-id-45' visibility='default' filepath='src.d/zlib.h' line='100' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='data_type' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='102' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='adler' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='104' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='reserved' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='105' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='z_stream' type-id='type-id-67' filepath='src.d/zlib.h' line='106' column='1' id='type-id-70'/>
-    <typedef-decl name='z_streamp' type-id='type-id-71' filepath='src.d/zlib.h' line='108' column='1' id='type-id-57'/>
-    <class-decl name='gz_header_s' size-in-bits='640' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='114' column='1' id='type-id-72'>
+    <class-decl name='gz_header_s' size-in-bits='640' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='114' column='1' id='type-id-39'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='text' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='115' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='time' type-id='type-id-9' visibility='default' filepath='src.d/zlib.h' line='116' column='1'/>
+        <var-decl name='time' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='116' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
         <var-decl name='xflags' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='117' column='1'/>
@@ -516,22 +261,22 @@
         <var-decl name='extra' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='119' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='extra_len' type-id='type-id-8' visibility='default' filepath='src.d/zlib.h' line='120' column='1'/>
+        <var-decl name='extra_len' type-id='type-id-12' visibility='default' filepath='src.d/zlib.h' line='120' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='extra_max' type-id='type-id-8' visibility='default' filepath='src.d/zlib.h' line='121' column='1'/>
+        <var-decl name='extra_max' type-id='type-id-12' visibility='default' filepath='src.d/zlib.h' line='121' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
         <var-decl name='name' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='122' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='name_max' type-id='type-id-8' visibility='default' filepath='src.d/zlib.h' line='123' column='1'/>
+        <var-decl name='name_max' type-id='type-id-12' visibility='default' filepath='src.d/zlib.h' line='123' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
         <var-decl name='comment' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='124' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='comm_max' type-id='type-id-8' visibility='default' filepath='src.d/zlib.h' line='125' column='1'/>
+        <var-decl name='comm_max' type-id='type-id-12' visibility='default' filepath='src.d/zlib.h' line='125' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='544'>
         <var-decl name='hcrc' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='126' column='1'/>
@@ -540,108 +285,368 @@
         <var-decl name='done' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='127' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='gz_header' type-id='type-id-72' filepath='src.d/zlib.h' line='129' column='1' id='type-id-73'/>
-    <typedef-decl name='gz_headerp' type-id='type-id-74' filepath='src.d/zlib.h' line='131' column='1' id='type-id-59'/>
-    <typedef-decl name='uch' type-id='type-id-2' filepath='src.d/zutil.h' line='39' column='1' id='type-id-36'/>
-    <typedef-decl name='uchf' type-id='type-id-36' filepath='src.d/zutil.h' line='40' column='1' id='type-id-75'/>
-    <typedef-decl name='ush' type-id='type-id-38' filepath='src.d/zutil.h' line='41' column='1' id='type-id-39'/>
-    <typedef-decl name='ulg' type-id='type-id-4' filepath='src.d/zutil.h' line='43' column='1' id='type-id-58'/>
-    <pointer-type-def type-id='type-id-10' size-in-bits='64' id='type-id-19'/>
-    <pointer-type-def type-id='type-id-54' size-in-bits='64' id='type-id-60'/>
-    <pointer-type-def type-id='type-id-26' size-in-bits='64' id='type-id-68'/>
-    <pointer-type-def type-id='type-id-43' size-in-bits='64' id='type-id-76'/>
-    <qualified-type-def type-id='type-id-26' const='yes' id='type-id-77'/>
-    <pointer-type-def type-id='type-id-77' size-in-bits='64' id='type-id-78'/>
-    <qualified-type-def type-id='type-id-49' const='yes' id='type-id-79'/>
-    <pointer-type-def type-id='type-id-79' size-in-bits='64' id='type-id-52'/>
-    <pointer-type-def type-id='type-id-48' size-in-bits='64' id='type-id-51'/>
-    <pointer-type-def type-id='type-id-62' size-in-bits='64' id='type-id-80'/>
-    <pointer-type-def type-id='type-id-73' size-in-bits='64' id='type-id-74'/>
-    <pointer-type-def type-id='type-id-20' size-in-bits='64' id='type-id-81'/>
-    <pointer-type-def type-id='type-id-56' size-in-bits='64' id='type-id-69'/>
-    <pointer-type-def type-id='type-id-82' size-in-bits='64' id='type-id-63'/>
-    <pointer-type-def type-id='type-id-8' size-in-bits='64' id='type-id-83'/>
-    <pointer-type-def type-id='type-id-75' size-in-bits='64' id='type-id-61'/>
-    <pointer-type-def type-id='type-id-3' size-in-bits='64' id='type-id-84'/>
-    <pointer-type-def type-id='type-id-85' size-in-bits='64' id='type-id-65'/>
-    <pointer-type-def type-id='type-id-42' size-in-bits='64' id='type-id-44'/>
+    <class-decl name='internal_state' size-in-bits='47616' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='100' column='1' id='type-id-40'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='strm' type-id='type-id-21' visibility='default' filepath='src.d/deflate.h' line='101' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='status' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='102' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='pending_buf' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='103' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='pending_buf_size' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='104' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='pending_out' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='105' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='pending' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='106' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='wrap' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='107' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='gzhead' type-id='type-id-42' visibility='default' filepath='src.d/deflate.h' line='108' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='gzindex' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='109' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='method' type-id='type-id-3' visibility='default' filepath='src.d/deflate.h' line='110' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='608'>
+        <var-decl name='last_flush' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='111' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='w_size' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='115' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='672'>
+        <var-decl name='w_bits' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='116' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='w_mask' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='117' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='window' type-id='type-id-19' visibility='default' filepath='src.d/deflate.h' line='119' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='window_size' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='129' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='prev' type-id='type-id-43' visibility='default' filepath='src.d/deflate.h' line='134' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='head' type-id='type-id-43' visibility='default' filepath='src.d/deflate.h' line='140' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='ins_h' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='142' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1056'>
+        <var-decl name='hash_size' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='143' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1088'>
+        <var-decl name='hash_bits' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='144' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1120'>
+        <var-decl name='hash_mask' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='145' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1152'>
+        <var-decl name='hash_shift' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='147' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1216'>
+        <var-decl name='block_start' type-id='type-id-1' visibility='default' filepath='src.d/deflate.h' line='154' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='match_length' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='159' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1312'>
+        <var-decl name='prev_match' type-id='type-id-44' visibility='default' filepath='src.d/deflate.h' line='160' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1344'>
+        <var-decl name='match_available' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='161' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1376'>
+        <var-decl name='strstart' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='162' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1408'>
+        <var-decl name='match_start' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='163' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1440'>
+        <var-decl name='lookahead' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='164' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1472'>
+        <var-decl name='prev_length' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='166' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1504'>
+        <var-decl name='max_chain_length' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='171' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1536'>
+        <var-decl name='max_lazy_match' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='177' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1568'>
+        <var-decl name='level' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='188' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1600'>
+        <var-decl name='strategy' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='189' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1632'>
+        <var-decl name='good_match' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='191' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1664'>
+        <var-decl name='nice_match' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='194' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1696'>
+        <var-decl name='dyn_ltree' type-id='type-id-32' visibility='default' filepath='src.d/deflate.h' line='198' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='20032'>
+        <var-decl name='dyn_dtree' type-id='type-id-34' visibility='default' filepath='src.d/deflate.h' line='199' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='21984'>
+        <var-decl name='bl_tree' type-id='type-id-30' visibility='default' filepath='src.d/deflate.h' line='200' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='23232'>
+        <var-decl name='l_desc' type-id='type-id-45' visibility='default' filepath='src.d/deflate.h' line='202' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='23424'>
+        <var-decl name='d_desc' type-id='type-id-45' visibility='default' filepath='src.d/deflate.h' line='203' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='23616'>
+        <var-decl name='bl_desc' type-id='type-id-45' visibility='default' filepath='src.d/deflate.h' line='204' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='23808'>
+        <var-decl name='bl_count' type-id='type-id-46' visibility='default' filepath='src.d/deflate.h' line='206' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='24064'>
+        <var-decl name='heap' type-id='type-id-36' visibility='default' filepath='src.d/deflate.h' line='209' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='42400'>
+        <var-decl name='heap_len' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='210' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='42432'>
+        <var-decl name='heap_max' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='211' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='42464'>
+        <var-decl name='depth' type-id='type-id-47' visibility='default' filepath='src.d/deflate.h' line='216' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47104'>
+        <var-decl name='sym_buf' type-id='type-id-48' visibility='default' filepath='src.d/deflate.h' line='220' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47168'>
+        <var-decl name='lit_bufsize' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='222' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47200'>
+        <var-decl name='sym_next' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='242' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47232'>
+        <var-decl name='sym_end' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='243' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47296'>
+        <var-decl name='opt_len' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='245' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47360'>
+        <var-decl name='static_len' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='246' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47424'>
+        <var-decl name='matches' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='247' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47456'>
+        <var-decl name='insert' type-id='type-id-12' visibility='default' filepath='src.d/deflate.h' line='248' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47488'>
+        <var-decl name='bi_buf' type-id='type-id-49' visibility='default' filepath='src.d/deflate.h' line='255' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47520'>
+        <var-decl name='bi_valid' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='259' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='47552'>
+        <var-decl name='high_water' type-id='type-id-41' visibility='default' filepath='src.d/deflate.h' line='264' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='tree_desc_s' size-in-bits='192' is-struct='yes' visibility='default' filepath='src.d/deflate.h' line='86' column='1' id='type-id-45'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='dyn_tree' type-id='type-id-50' visibility='default' filepath='src.d/deflate.h' line='87' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='max_code' type-id='type-id-20' visibility='default' filepath='src.d/deflate.h' line='88' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='stat_desc' type-id='type-id-51' visibility='default' filepath='src.d/deflate.h' line='89' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='z_stream_s' size-in-bits='896' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='86' column='1' id='type-id-52'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='next_in' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='87' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='avail_in' type-id='type-id-12' visibility='default' filepath='src.d/zlib.h' line='88' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='total_in' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='89' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='next_out' type-id='type-id-19' visibility='default' filepath='src.d/zlib.h' line='91' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='avail_out' type-id='type-id-12' visibility='default' filepath='src.d/zlib.h' line='92' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='total_out' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='93' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='msg' type-id='type-id-53' visibility='default' filepath='src.d/zlib.h' line='95' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='state' type-id='type-id-54' visibility='default' filepath='src.d/zlib.h' line='96' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='zalloc' type-id='type-id-55' visibility='default' filepath='src.d/zlib.h' line='98' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='zfree' type-id='type-id-56' visibility='default' filepath='src.d/zlib.h' line='99' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='opaque' type-id='type-id-57' visibility='default' filepath='src.d/zlib.h' line='100' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='data_type' type-id='type-id-20' visibility='default' filepath='src.d/zlib.h' line='102' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='adler' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='104' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='reserved' type-id='type-id-13' visibility='default' filepath='src.d/zlib.h' line='105' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='IPos' type-id='type-id-11' filepath='src.d/deflate.h' line='94' column='1' id='type-id-44'/>
+    <typedef-decl name='Pos' type-id='type-id-49' filepath='src.d/deflate.h' line='92' column='1' id='type-id-58'/>
+    <typedef-decl name='Posf' type-id='type-id-58' filepath='src.d/deflate.h' line='93' column='1' id='type-id-59'/>
+    <typedef-decl name='alloc_func' type-id='type-id-60' filepath='src.d/zlib.h' line='81' column='1' id='type-id-55'/>
+    <typedef-decl name='charf' type-id='type-id-28' filepath='./zconf.h' line='408' column='1' id='type-id-61'/>
+    <typedef-decl name='ct_data' type-id='type-id-29' filepath='src.d/deflate.h' line='77' column='1' id='type-id-62'/>
+    <typedef-decl name='deflate_state' type-id='type-id-40' filepath='src.d/deflate.h' line='271' column='1' id='type-id-63'/>
+    <typedef-decl name='free_func' type-id='type-id-64' filepath='src.d/zlib.h' line='82' column='1' id='type-id-56'/>
+    <typedef-decl name='gz_header' type-id='type-id-39' filepath='src.d/zlib.h' line='129' column='1' id='type-id-65'/>
+    <typedef-decl name='gz_headerp' type-id='type-id-66' filepath='src.d/zlib.h' line='131' column='1' id='type-id-42'/>
+    <typedef-decl name='uch' type-id='type-id-2' filepath='src.d/zutil.h' line='39' column='1' id='type-id-67'/>
+    <typedef-decl name='uchf' type-id='type-id-67' filepath='src.d/zutil.h' line='40' column='1' id='type-id-68'/>
+    <typedef-decl name='ulg' type-id='type-id-9' filepath='src.d/zutil.h' line='43' column='1' id='type-id-41'/>
+    <typedef-decl name='ush' type-id='type-id-69' filepath='src.d/zutil.h' line='41' column='1' id='type-id-49'/>
+    <typedef-decl name='z_stream' type-id='type-id-52' filepath='src.d/zlib.h' line='106' column='1' id='type-id-70'/>
+    <typedef-decl name='z_streamp' type-id='type-id-71' filepath='src.d/zlib.h' line='108' column='1' id='type-id-21'/>
+    <array-type-def dimensions='1' type-id='type-id-67' size-in-bits='4584' id='type-id-47'>
+      <subrange length='573' lower-bound='0' upper-bound='572' type-id='type-id-9' id='type-id-33'/>
+    </array-type-def>
+    <union-decl name='__anonymous_union__1' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='73' column='1' id='type-id-38'>
+      <data-member access='public'>
+        <var-decl name='dad' type-id='type-id-49' visibility='default' filepath='src.d/deflate.h' line='74' column='1'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='len' type-id='type-id-49' visibility='default' filepath='src.d/deflate.h' line='75' column='1'/>
+      </data-member>
+    </union-decl>
+    <union-decl name='__anonymous_union__' size-in-bits='16' is-anonymous='yes' visibility='default' filepath='src.d/deflate.h' line='69' column='1' id='type-id-37'>
+      <data-member access='public'>
+        <var-decl name='freq' type-id='type-id-49' visibility='default' filepath='src.d/deflate.h' line='70' column='1'/>
+      </data-member>
+      <data-member access='public'>
+        <var-decl name='code' type-id='type-id-49' visibility='default' filepath='src.d/deflate.h' line='71' column='1'/>
+      </data-member>
+    </union-decl>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-69'/>
+    <array-type-def dimensions='1' type-id='type-id-49' size-in-bits='256' id='type-id-46'>
+      <subrange length='16' lower-bound='0' upper-bound='15' type-id='type-id-9' id='type-id-72'/>
+    </array-type-def>
+    <pointer-type-def type-id='type-id-4' size-in-bits='64' id='type-id-19'/>
+    <pointer-type-def type-id='type-id-59' size-in-bits='64' id='type-id-43'/>
+    <pointer-type-def type-id='type-id-28' size-in-bits='64' id='type-id-53'/>
+    <pointer-type-def type-id='type-id-61' size-in-bits='64' id='type-id-73'/>
+    <qualified-type-def type-id='type-id-28' const='yes' id='type-id-74'/>
+    <pointer-type-def type-id='type-id-74' size-in-bits='64' id='type-id-22'/>
+    <pointer-type-def type-id='type-id-62' size-in-bits='64' id='type-id-50'/>
+    <pointer-type-def type-id='type-id-63' size-in-bits='64' id='type-id-75'/>
+    <pointer-type-def type-id='type-id-65' size-in-bits='64' id='type-id-66'/>
+    <pointer-type-def type-id='type-id-20' size-in-bits='64' id='type-id-76'/>
+    <pointer-type-def type-id='type-id-40' size-in-bits='64' id='type-id-54'/>
+    <pointer-type-def type-id='type-id-77' size-in-bits='64' id='type-id-60'/>
+    <pointer-type-def type-id='type-id-12' size-in-bits='64' id='type-id-78'/>
+    <pointer-type-def type-id='type-id-68' size-in-bits='64' id='type-id-48'/>
+    <pointer-type-def type-id='type-id-11' size-in-bits='64' id='type-id-79'/>
+    <pointer-type-def type-id='type-id-80' size-in-bits='64' id='type-id-64'/>
     <pointer-type-def type-id='type-id-70' size-in-bits='64' id='type-id-71'/>
-    <class-decl name='static_tree_desc_s' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-27'/>
+    <qualified-type-def type-id='type-id-81' const='yes' id='type-id-82'/>
+    <pointer-type-def type-id='type-id-82' size-in-bits='64' id='type-id-51'/>
+    <class-decl name='static_tree_desc_s' is-struct='yes' visibility='default' is-declaration-only='yes' id='type-id-83'/>
+    <typedef-decl name='voidpf' type-id='type-id-84' filepath='./zconf.h' line='415' column='1' id='type-id-57'/>
     <function-decl name='memcpy' filepath='/usr/include/string.h' line='43' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-44'/>
-      <parameter type-id='type-id-44'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-84'/>
+      <parameter type-id='type-id-84'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-84'/>
     </function-decl>
     <function-decl name='memset' filepath='/usr/include/string.h' line='61' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-84'/>
       <parameter type-id='type-id-20'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-44'/>
-    </function-decl>
-    <function-decl name='deflateInit_' mangled-name='deflateInit_' filepath='src.d/deflate.c' line='225' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateInit_'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='226' column='1'/>
-      <parameter type-id='type-id-20' name='level' filepath='src.d/deflate.c' line='227' column='1'/>
-      <parameter type-id='type-id-78' name='version' filepath='src.d/deflate.c' line='228' column='1'/>
-      <parameter type-id='type-id-20' name='stream_size' filepath='src.d/deflate.c' line='229' column='1'/>
-      <return type-id='type-id-20'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-84'/>
     </function-decl>
     <function-decl name='deflateInit2_' mangled-name='deflateInit2_' filepath='src.d/deflate.c' line='237' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateInit2_'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='239' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='239' column='1'/>
       <parameter type-id='type-id-20' name='level' filepath='src.d/deflate.c' line='240' column='1'/>
       <parameter type-id='type-id-20' name='method' filepath='src.d/deflate.c' line='241' column='1'/>
       <parameter type-id='type-id-20' name='windowBits' filepath='src.d/deflate.c' line='242' column='1'/>
       <parameter type-id='type-id-20' name='memLevel' filepath='src.d/deflate.c' line='243' column='1'/>
       <parameter type-id='type-id-20' name='strategy' filepath='src.d/deflate.c' line='244' column='1'/>
-      <parameter type-id='type-id-78' name='version' filepath='src.d/deflate.c' line='245' column='1'/>
+      <parameter type-id='type-id-22' name='version' filepath='src.d/deflate.c' line='245' column='1'/>
       <parameter type-id='type-id-20' name='stream_size' filepath='src.d/deflate.c' line='246' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateSetDictionary' mangled-name='deflateSetDictionary' filepath='src.d/deflate.c' line='412' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateSetDictionary'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='413' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='413' column='1'/>
       <parameter type-id='type-id-16' name='dictionary' filepath='src.d/deflate.c' line='414' column='1'/>
-      <parameter type-id='type-id-8' name='dictLength' filepath='src.d/deflate.c' line='415' column='1'/>
+      <parameter type-id='type-id-12' name='dictLength' filepath='src.d/deflate.c' line='415' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateGetDictionary' mangled-name='deflateGetDictionary' filepath='src.d/deflate.c' line='481' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateGetDictionary@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='482' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='482' column='1'/>
       <parameter type-id='type-id-19' name='dictionary' filepath='src.d/deflate.c' line='483' column='1'/>
-      <parameter type-id='type-id-83' name='dictLength' filepath='src.d/deflate.c' line='484' column='1'/>
+      <parameter type-id='type-id-78' name='dictLength' filepath='src.d/deflate.c' line='484' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateResetKeep' mangled-name='deflateResetKeep' filepath='src.d/deflate.c' line='503' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateResetKeep@@ZLIB_1.2.5.2'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='504' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='504' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateReset' mangled-name='deflateReset' filepath='src.d/deflate.c' line='541' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateReset'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='542' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='542' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateSetHeader' mangled-name='deflateSetHeader' filepath='src.d/deflate.c' line='553' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateSetHeader@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='554' column='1'/>
-      <parameter type-id='type-id-59' name='head' filepath='src.d/deflate.c' line='555' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='554' column='1'/>
+      <parameter type-id='type-id-42' name='head' filepath='src.d/deflate.c' line='555' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflatePending' mangled-name='deflatePending' filepath='src.d/deflate.c' line='564' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflatePending@@ZLIB_1.2.5.1'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='567' column='1'/>
-      <parameter type-id='type-id-84' name='pending' filepath='src.d/deflate.c' line='565' column='1'/>
-      <parameter type-id='type-id-81' name='bits' filepath='src.d/deflate.c' line='566' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='567' column='1'/>
+      <parameter type-id='type-id-79' name='pending' filepath='src.d/deflate.c' line='565' column='1'/>
+      <parameter type-id='type-id-76' name='bits' filepath='src.d/deflate.c' line='566' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflatePrime' mangled-name='deflatePrime' filepath='src.d/deflate.c' line='578' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflatePrime@@ZLIB_1.2.0.8'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='579' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='579' column='1'/>
       <parameter type-id='type-id-20' name='bits' filepath='src.d/deflate.c' line='580' column='1'/>
       <parameter type-id='type-id-20' name='value' filepath='src.d/deflate.c' line='581' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateParams' mangled-name='deflateParams' filepath='src.d/deflate.c' line='605' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateParams'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='606' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='606' column='1'/>
       <parameter type-id='type-id-20' name='level' filepath='src.d/deflate.c' line='607' column='1'/>
       <parameter type-id='type-id-20' name='strategy' filepath='src.d/deflate.c' line='608' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateTune' mangled-name='deflateTune' filepath='src.d/deflate.c' line='654' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateTune@@ZLIB_1.2.2.3'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='655' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='655' column='1'/>
       <parameter type-id='type-id-20' name='good_length' filepath='src.d/deflate.c' line='656' column='1'/>
       <parameter type-id='type-id-20' name='max_lazy' filepath='src.d/deflate.c' line='657' column='1'/>
       <parameter type-id='type-id-20' name='nice_length' filepath='src.d/deflate.c' line='658' column='1'/>
@@ -649,198 +654,203 @@
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='deflateBound' mangled-name='deflateBound' filepath='src.d/deflate.c' line='696' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateBound@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='697' column='1'/>
-      <parameter type-id='type-id-9' name='sourceLen' filepath='src.d/deflate.c' line='698' column='1'/>
-      <return type-id='type-id-9'/>
-    </function-decl>
-    <function-decl name='deflate' mangled-name='deflate' filepath='src.d/deflate.c' line='815' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflate'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='816' column='1'/>
-      <parameter type-id='type-id-20' name='flush' filepath='src.d/deflate.c' line='817' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
-    <function-decl name='deflateEnd' mangled-name='deflateEnd' filepath='src.d/deflate.c' line='1130' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateEnd'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/deflate.c' line='1131' column='1'/>
-      <return type-id='type-id-20'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/deflate.c' line='697' column='1'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/deflate.c' line='698' column='1'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='deflateCopy' mangled-name='deflateCopy' filepath='src.d/deflate.c' line='1156' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='deflateCopy'>
-      <parameter type-id='type-id-57' name='dest' filepath='src.d/deflate.c' line='1157' column='1'/>
-      <parameter type-id='type-id-57' name='source' filepath='src.d/deflate.c' line='1158' column='1'/>
+      <parameter type-id='type-id-21' name='dest' filepath='src.d/deflate.c' line='1157' column='1'/>
+      <parameter type-id='type-id-21' name='source' filepath='src.d/deflate.c' line='1158' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
+    <typedef-decl name='static_tree_desc' type-id='type-id-83' filepath='src.d/deflate.h' line='84' column='1' id='type-id-81'/>
     <function-decl name='_tr_init' filepath='src.d/deflate.h' line='294' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-80'/>
-      <return type-id='type-id-42'/>
+      <parameter type-id='type-id-75'/>
+      <return type-id='type-id-85'/>
     </function-decl>
     <function-decl name='_tr_flush_block' filepath='src.d/deflate.h' line='296' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-80'/>
-      <parameter type-id='type-id-76'/>
-      <parameter type-id='type-id-58'/>
+      <parameter type-id='type-id-75'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-41'/>
       <parameter type-id='type-id-20'/>
-      <return type-id='type-id-42'/>
+      <return type-id='type-id-85'/>
     </function-decl>
     <function-decl name='_tr_flush_bits' filepath='src.d/deflate.h' line='298' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-80'/>
-      <return type-id='type-id-42'/>
+      <parameter type-id='type-id-75'/>
+      <return type-id='type-id-85'/>
     </function-decl>
     <function-decl name='_tr_align' filepath='src.d/deflate.h' line='299' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-80'/>
-      <return type-id='type-id-42'/>
+      <parameter type-id='type-id-75'/>
+      <return type-id='type-id-85'/>
     </function-decl>
     <function-decl name='_tr_stored_block' filepath='src.d/deflate.h' line='300' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-80'/>
-      <parameter type-id='type-id-76'/>
-      <parameter type-id='type-id-58'/>
+      <parameter type-id='type-id-75'/>
+      <parameter type-id='type-id-73'/>
+      <parameter type-id='type-id-41'/>
       <parameter type-id='type-id-20'/>
-      <return type-id='type-id-42'/>
+      <return type-id='type-id-85'/>
+    </function-decl>
+    <function-decl name='crc32' filepath='src.d/zlib.h' line='1727' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-13'/>
+      <parameter type-id='type-id-16'/>
+      <parameter type-id='type-id-12'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='zcalloc' filepath='src.d/zutil.h' line='261' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-45'/>
-      <parameter type-id='type-id-3'/>
-      <parameter type-id='type-id-3'/>
-      <return type-id='type-id-45'/>
+      <parameter type-id='type-id-57'/>
+      <parameter type-id='type-id-11'/>
+      <parameter type-id='type-id-11'/>
+      <return type-id='type-id-57'/>
     </function-decl>
     <function-decl name='zcfree' filepath='src.d/zutil.h' line='263' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-45'/>
-      <parameter type-id='type-id-45'/>
-      <return type-id='type-id-42'/>
+      <parameter type-id='type-id-57'/>
+      <parameter type-id='type-id-57'/>
+      <return type-id='type-id-85'/>
     </function-decl>
-    <function-type size-in-bits='64' id='type-id-82'>
-      <parameter type-id='type-id-45'/>
-      <parameter type-id='type-id-8'/>
-      <parameter type-id='type-id-8'/>
-      <return type-id='type-id-45'/>
+    <type-decl name='void' id='type-id-85'/>
+    <pointer-type-def type-id='type-id-85' id='type-id-84'/>
+    <function-type size-in-bits='64' id='type-id-80'>
+      <parameter type-id='type-id-57'/>
+      <parameter type-id='type-id-57'/>
+      <return type-id='type-id-85'/>
     </function-type>
-    <function-type size-in-bits='64' id='type-id-85'>
-      <parameter type-id='type-id-45'/>
-      <parameter type-id='type-id-45'/>
-      <return type-id='type-id-42'/>
+    <function-type size-in-bits='64' id='type-id-77'>
+      <parameter type-id='type-id-57'/>
+      <parameter type-id='type-id-12'/>
+      <parameter type-id='type-id-12'/>
+      <return type-id='type-id-57'/>
     </function-type>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/gzclose.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <typedef-decl name='gzFile' type-id='type-id-86' filepath='src.d/zlib.h' line='1302' column='1' id='type-id-87'/>
-    <class-decl name='gzFile_s' size-in-bits='192' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='1834' column='1' id='type-id-88'>
+    <class-decl name='gzFile_s' size-in-bits='192' is-struct='yes' visibility='default' filepath='src.d/zlib.h' line='1834' column='1' id='type-id-86'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='have' type-id='type-id-3' visibility='default' filepath='src.d/zlib.h' line='1835' column='1'/>
+        <var-decl name='have' type-id='type-id-11' visibility='default' filepath='src.d/zlib.h' line='1835' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='next' type-id='type-id-89' visibility='default' filepath='src.d/zlib.h' line='1836' column='1'/>
+        <var-decl name='next' type-id='type-id-87' visibility='default' filepath='src.d/zlib.h' line='1836' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='pos' type-id='type-id-14' visibility='default' filepath='src.d/zlib.h' line='1837' column='1'/>
+        <var-decl name='pos' type-id='type-id-7' visibility='default' filepath='src.d/zlib.h' line='1837' column='1'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-88' size-in-bits='64' id='type-id-86'/>
+    <typedef-decl name='gzFile' type-id='type-id-88' filepath='src.d/zlib.h' line='1302' column='1' id='type-id-89'/>
+    <pointer-type-def type-id='type-id-86' size-in-bits='64' id='type-id-88'/>
     <function-decl name='gzclose' mangled-name='gzclose' filepath='src.d/gzclose.c' line='11' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzclose'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzclose.c' line='12' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzclose.c' line='12' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='gzclose_r' mangled-name='gzclose_r' filepath='src.d/zlib.h' line='1644' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzclose_r@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-87'/>
+    <function-decl name='gzclose_r' filepath='src.d/zlib.h' line='1644' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-89'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='gzclose_w' mangled-name='gzclose_w' filepath='src.d/zlib.h' line='1645' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzclose_w@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-87'/>
+    <function-decl name='gzclose_w' filepath='src.d/zlib.h' line='1645' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-89'/>
       <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/gzlib.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <type-decl name='variadic parameter type' id='type-id-90'/>
-    <function-decl name='open' filepath='/usr/include/fcntl.h' line='181' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-78'/>
+    <function-decl name='open' filepath='/usr/include/fcntl.h' line='209' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-22'/>
       <parameter type-id='type-id-20'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='snprintf' filepath='/usr/include/stdio.h' line='378' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-68'/>
-      <parameter type-id='type-id-5'/>
-      <parameter type-id='type-id-78'/>
+    <function-decl name='snprintf' filepath='/usr/include/stdio.h' line='385' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-10'/>
+      <parameter type-id='type-id-22'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-20'/>
     </function-decl>
+    <function-decl name='malloc' filepath='/usr/include/stdlib.h' line='672' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-84'/>
+    </function-decl>
+    <function-decl name='free' filepath='/usr/include/stdlib.h' line='687' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-84'/>
+      <return type-id='type-id-85'/>
+    </function-decl>
     <function-decl name='strlen' filepath='/usr/include/string.h' line='407' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-78'/>
-      <return type-id='type-id-5'/>
+      <parameter type-id='type-id-22'/>
+      <return type-id='type-id-10'/>
     </function-decl>
     <function-decl name='lseek64' filepath='/usr/include/unistd.h' line='350' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-20'/>
-      <parameter type-id='type-id-12'/>
+      <parameter type-id='type-id-5'/>
       <parameter type-id='type-id-20'/>
-      <return type-id='type-id-12'/>
+      <return type-id='type-id-5'/>
     </function-decl>
     <function-decl name='gzopen' mangled-name='gzopen' filepath='src.d/gzlib.c' line='272' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzopen'>
-      <parameter type-id='type-id-78' name='path' filepath='src.d/gzlib.c' line='273' column='1'/>
-      <parameter type-id='type-id-78' name='mode' filepath='src.d/gzlib.c' line='274' column='1'/>
-      <return type-id='type-id-87'/>
+      <parameter type-id='type-id-22' name='path' filepath='src.d/gzlib.c' line='273' column='1'/>
+      <parameter type-id='type-id-22' name='mode' filepath='src.d/gzlib.c' line='274' column='1'/>
+      <return type-id='type-id-89'/>
     </function-decl>
     <function-decl name='gzopen64' mangled-name='gzopen64' filepath='src.d/gzlib.c' line='280' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzopen64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-78' name='path' filepath='src.d/gzlib.c' line='281' column='1'/>
-      <parameter type-id='type-id-78' name='mode' filepath='src.d/gzlib.c' line='282' column='1'/>
-      <return type-id='type-id-87'/>
+      <parameter type-id='type-id-22' name='path' filepath='src.d/gzlib.c' line='281' column='1'/>
+      <parameter type-id='type-id-22' name='mode' filepath='src.d/gzlib.c' line='282' column='1'/>
+      <return type-id='type-id-89'/>
     </function-decl>
     <function-decl name='gzdopen' mangled-name='gzdopen' filepath='src.d/gzlib.c' line='288' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzdopen'>
       <parameter type-id='type-id-20' name='fd' filepath='src.d/gzlib.c' line='289' column='1'/>
-      <parameter type-id='type-id-78' name='mode' filepath='src.d/gzlib.c' line='290' column='1'/>
-      <return type-id='type-id-87'/>
+      <parameter type-id='type-id-22' name='mode' filepath='src.d/gzlib.c' line='290' column='1'/>
+      <return type-id='type-id-89'/>
     </function-decl>
     <function-decl name='gzbuffer' mangled-name='gzbuffer' filepath='src.d/gzlib.c' line='318' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzbuffer@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='319' column='1'/>
-      <parameter type-id='type-id-3' name='size' filepath='src.d/gzlib.c' line='320' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='319' column='1'/>
+      <parameter type-id='type-id-11' name='size' filepath='src.d/gzlib.c' line='320' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzrewind' mangled-name='gzrewind' filepath='src.d/gzlib.c' line='345' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzrewind'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='346' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='346' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzseek64' mangled-name='gzseek64' filepath='src.d/gzlib.c' line='368' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzseek64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='369' column='1'/>
-      <parameter type-id='type-id-14' name='offset' filepath='src.d/gzlib.c' line='370' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='369' column='1'/>
+      <parameter type-id='type-id-7' name='offset' filepath='src.d/gzlib.c' line='370' column='1'/>
       <parameter type-id='type-id-20' name='whence' filepath='src.d/gzlib.c' line='371' column='1'/>
-      <return type-id='type-id-14'/>
+      <return type-id='type-id-7'/>
     </function-decl>
     <function-decl name='gzseek' mangled-name='gzseek' filepath='src.d/gzlib.c' line='445' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzseek'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='446' column='1'/>
-      <parameter type-id='type-id-13' name='offset' filepath='src.d/gzlib.c' line='447' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='446' column='1'/>
+      <parameter type-id='type-id-8' name='offset' filepath='src.d/gzlib.c' line='447' column='1'/>
       <parameter type-id='type-id-20' name='whence' filepath='src.d/gzlib.c' line='448' column='1'/>
-      <return type-id='type-id-13'/>
+      <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='gztell64' mangled-name='gztell64' filepath='src.d/gzlib.c' line='457' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gztell64@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='458' column='1'/>
-      <return type-id='type-id-14'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='458' column='1'/>
+      <return type-id='type-id-7'/>
     </function-decl>
     <function-decl name='gztell' mangled-name='gztell' filepath='src.d/gzlib.c' line='474' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gztell'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='475' column='1'/>
-      <return type-id='type-id-13'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='475' column='1'/>
+      <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='gzoffset64' mangled-name='gzoffset64' filepath='src.d/gzlib.c' line='484' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzoffset64@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='485' column='1'/>
-      <return type-id='type-id-14'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='485' column='1'/>
+      <return type-id='type-id-7'/>
     </function-decl>
     <function-decl name='gzoffset' mangled-name='gzoffset' filepath='src.d/gzlib.c' line='507' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzoffset@@ZLIB_1.2.3.5'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='508' column='1'/>
-      <return type-id='type-id-13'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='508' column='1'/>
+      <return type-id='type-id-8'/>
     </function-decl>
     <function-decl name='gzeof' mangled-name='gzeof' filepath='src.d/gzlib.c' line='517' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzeof'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='518' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='518' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzerror' mangled-name='gzerror' filepath='src.d/gzlib.c' line='534' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzerror'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='535' column='1'/>
-      <parameter type-id='type-id-81' name='errnum' filepath='src.d/gzlib.c' line='536' column='1'/>
-      <return type-id='type-id-78'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='535' column='1'/>
+      <parameter type-id='type-id-76' name='errnum' filepath='src.d/gzlib.c' line='536' column='1'/>
+      <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='gzclearerr' mangled-name='gzclearerr' filepath='src.d/gzlib.c' line='555' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzclearerr@@ZLIB_1.2.0.2'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzlib.c' line='556' column='1'/>
-      <return type-id='type-id-42'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzlib.c' line='556' column='1'/>
+      <return type-id='type-id-85'/>
     </function-decl>
+    <type-decl name='variadic parameter type' id='type-id-90'/>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/gzread.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <typedef-decl name='voidp' type-id='type-id-44' filepath='./zconf.h' line='416' column='1' id='type-id-91'/>
-    <typedef-decl name='__ssize_t' type-id='type-id-1' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='194' column='1' id='type-id-92'/>
-    <typedef-decl name='ssize_t' type-id='type-id-92' filepath='/usr/include/x86_64-linux-gnu/sys/types.h' line='108' column='1' id='type-id-93'/>
-    <class-decl name='gz_state' size-in-bits='1920' is-struct='yes' naming-typedef-id='type-id-94' visibility='default' filepath='src.d/gzguts.h' line='170' column='1' id='type-id-95'>
+    <class-decl name='gz_state' size-in-bits='1920' is-struct='yes' naming-typedef-id='type-id-91' visibility='default' filepath='src.d/gzguts.h' line='170' column='1' id='type-id-92'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='x' type-id='type-id-88' visibility='default' filepath='src.d/gzguts.h' line='172' column='1'/>
+        <var-decl name='x' type-id='type-id-86' visibility='default' filepath='src.d/gzguts.h' line='172' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
         <var-decl name='mode' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='177' column='1'/>
@@ -849,19 +859,19 @@
         <var-decl name='fd' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='178' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='path' type-id='type-id-68' visibility='default' filepath='src.d/gzguts.h' line='179' column='1'/>
+        <var-decl name='path' type-id='type-id-53' visibility='default' filepath='src.d/gzguts.h' line='179' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='size' type-id='type-id-3' visibility='default' filepath='src.d/gzguts.h' line='180' column='1'/>
+        <var-decl name='size' type-id='type-id-11' visibility='default' filepath='src.d/gzguts.h' line='180' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='want' type-id='type-id-3' visibility='default' filepath='src.d/gzguts.h' line='181' column='1'/>
+        <var-decl name='want' type-id='type-id-11' visibility='default' filepath='src.d/gzguts.h' line='181' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='in' type-id='type-id-89' visibility='default' filepath='src.d/gzguts.h' line='182' column='1'/>
+        <var-decl name='in' type-id='type-id-87' visibility='default' filepath='src.d/gzguts.h' line='182' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='out' type-id='type-id-89' visibility='default' filepath='src.d/gzguts.h' line='183' column='1'/>
+        <var-decl name='out' type-id='type-id-87' visibility='default' filepath='src.d/gzguts.h' line='183' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='512'>
         <var-decl name='direct' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='184' column='1'/>
@@ -870,7 +880,7 @@
         <var-decl name='how' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='186' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='start' type-id='type-id-14' visibility='default' filepath='src.d/gzguts.h' line='187' column='1'/>
+        <var-decl name='start' type-id='type-id-7' visibility='default' filepath='src.d/gzguts.h' line='187' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='640'>
         <var-decl name='eof' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='188' column='1'/>
@@ -888,7 +898,7 @@
         <var-decl name='reset' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='193' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='skip' type-id='type-id-14' visibility='default' filepath='src.d/gzguts.h' line='195' column='1'/>
+        <var-decl name='skip' type-id='type-id-7' visibility='default' filepath='src.d/gzguts.h' line='195' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='896'>
         <var-decl name='seek' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='196' column='1'/>
@@ -897,27 +907,30 @@
         <var-decl name='err' type-id='type-id-20' visibility='default' filepath='src.d/gzguts.h' line='198' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='msg' type-id='type-id-68' visibility='default' filepath='src.d/gzguts.h' line='199' column='1'/>
+        <var-decl name='msg' type-id='type-id-53' visibility='default' filepath='src.d/gzguts.h' line='199' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1024'>
         <var-decl name='strm' type-id='type-id-70' visibility='default' filepath='src.d/gzguts.h' line='201' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='gz_state' type-id='type-id-95' filepath='src.d/gzguts.h' line='202' column='1' id='type-id-94'/>
-    <typedef-decl name='gz_statep' type-id='type-id-96' filepath='src.d/gzguts.h' line='203' column='1' id='type-id-97'/>
-    <pointer-type-def type-id='type-id-94' size-in-bits='64' id='type-id-96'/>
+    <typedef-decl name='__ssize_t' type-id='type-id-1' filepath='/usr/include/x86_64-linux-gnu/bits/types.h' line='194' column='1' id='type-id-93'/>
+    <typedef-decl name='gz_state' type-id='type-id-92' filepath='src.d/gzguts.h' line='202' column='1' id='type-id-91'/>
+    <typedef-decl name='gz_statep' type-id='type-id-94' filepath='src.d/gzguts.h' line='203' column='1' id='type-id-95'/>
+    <typedef-decl name='ssize_t' type-id='type-id-93' filepath='/usr/include/x86_64-linux-gnu/sys/types.h' line='108' column='1' id='type-id-96'/>
+    <pointer-type-def type-id='type-id-91' size-in-bits='64' id='type-id-94'/>
+    <typedef-decl name='voidp' type-id='type-id-84' filepath='./zconf.h' line='416' column='1' id='type-id-97'/>
     <function-decl name='__errno_location' filepath='/usr/include/errno.h' line='37' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-81'/>
+      <return type-id='type-id-76'/>
     </function-decl>
     <function-decl name='memchr' filepath='/usr/include/string.h' line='107' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-84'/>
       <parameter type-id='type-id-20'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-84'/>
     </function-decl>
     <function-decl name='strerror' filepath='/usr/include/string.h' line='419' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-20'/>
-      <return type-id='type-id-68'/>
+      <return type-id='type-id-53'/>
     </function-decl>
     <function-decl name='close' filepath='/usr/include/unistd.h' line='358' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-20'/>
@@ -925,139 +938,164 @@
     </function-decl>
     <function-decl name='read' filepath='/usr/include/unistd.h' line='371' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-20'/>
-      <parameter type-id='type-id-44'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-93'/>
+      <parameter type-id='type-id-84'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-96'/>
     </function-decl>
     <function-decl name='gz_error' filepath='src.d/gzguts.h' line='206' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-97'/>
+      <parameter type-id='type-id-95'/>
       <parameter type-id='type-id-20'/>
-      <parameter type-id='type-id-78'/>
-      <return type-id='type-id-42'/>
+      <parameter type-id='type-id-22'/>
+      <return type-id='type-id-85'/>
     </function-decl>
     <function-decl name='gzread' mangled-name='gzread' filepath='src.d/gzread.c' line='373' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzread'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzread.c' line='374' column='1'/>
-      <parameter type-id='type-id-91' name='buf' filepath='src.d/gzread.c' line='375' column='1'/>
-      <parameter type-id='type-id-3' name='len' filepath='src.d/gzread.c' line='376' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='374' column='1'/>
+      <parameter type-id='type-id-97' name='buf' filepath='src.d/gzread.c' line='375' column='1'/>
+      <parameter type-id='type-id-11' name='len' filepath='src.d/gzread.c' line='376' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzfread' mangled-name='gzfread' filepath='src.d/gzread.c' line='409' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzfread@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-91' name='buf' filepath='src.d/gzread.c' line='410' column='1'/>
-      <parameter type-id='type-id-6' name='size' filepath='src.d/gzread.c' line='411' column='1'/>
-      <parameter type-id='type-id-6' name='nitems' filepath='src.d/gzread.c' line='412' column='1'/>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzread.c' line='413' column='1'/>
-      <return type-id='type-id-6'/>
+      <parameter type-id='type-id-97' name='buf' filepath='src.d/gzread.c' line='410' column='1'/>
+      <parameter type-id='type-id-14' name='size' filepath='src.d/gzread.c' line='411' column='1'/>
+      <parameter type-id='type-id-14' name='nitems' filepath='src.d/gzread.c' line='412' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='413' column='1'/>
+      <return type-id='type-id-14'/>
     </function-decl>
     <function-decl name='gzgetc' mangled-name='gzgetc' filepath='src.d/gzread.c' line='445' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzgetc'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzread.c' line='446' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='446' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzgetc_' mangled-name='gzgetc_' filepath='src.d/gzread.c' line='472' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzgetc_@@ZLIB_1.2.5.2'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzread.c' line='473' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='473' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzungetc' mangled-name='gzungetc' filepath='src.d/gzread.c' line='479' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzungetc@@ZLIB_1.2.0.2'>
       <parameter type-id='type-id-20' name='c' filepath='src.d/gzread.c' line='480' column='1'/>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzread.c' line='481' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='481' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzgets' mangled-name='gzgets' filepath='src.d/gzread.c' line='539' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzgets'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzread.c' line='540' column='1'/>
-      <parameter type-id='type-id-68' name='buf' filepath='src.d/gzread.c' line='541' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='540' column='1'/>
+      <parameter type-id='type-id-53' name='buf' filepath='src.d/gzread.c' line='541' column='1'/>
       <parameter type-id='type-id-20' name='len' filepath='src.d/gzread.c' line='542' column='1'/>
-      <return type-id='type-id-68'/>
+      <return type-id='type-id-53'/>
     </function-decl>
     <function-decl name='gzdirect' mangled-name='gzdirect' filepath='src.d/gzread.c' line='603' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzdirect@@ZLIB_1.2.2.3'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzread.c' line='604' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzread.c' line='604' column='1'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflate' filepath='src.d/zlib.h' line='400' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-20'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateEnd' filepath='src.d/zlib.h' line='520' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-21'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateReset' filepath='src.d/zlib.h' line='959' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-21'/>
+      <return type-id='type-id-20'/>
+    </function-decl>
+    <function-decl name='inflateInit2_' filepath='src.d/zlib.h' line='1789' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-20'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-20'/>
       <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/gzwrite.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
     <class-decl name='__va_list_tag' size-in-bits='192' is-struct='yes' visibility='default' id='type-id-98'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='gp_offset' type-id='type-id-3' visibility='default'/>
+        <var-decl name='gp_offset' type-id='type-id-11' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='fp_offset' type-id='type-id-3' visibility='default'/>
+        <var-decl name='fp_offset' type-id='type-id-11' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='overflow_arg_area' type-id='type-id-44' visibility='default'/>
+        <var-decl name='overflow_arg_area' type-id='type-id-84' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='reg_save_area' type-id='type-id-44' visibility='default'/>
+        <var-decl name='reg_save_area' type-id='type-id-84' visibility='default'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='voidpc' type-id='type-id-44' filepath='./zconf.h' line='414' column='1' id='type-id-99'/>
-    <pointer-type-def type-id='type-id-98' size-in-bits='64' id='type-id-100'/>
-    <function-decl name='vsnprintf' filepath='/usr/include/stdio.h' line='382' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-68'/>
-      <parameter type-id='type-id-5'/>
-      <parameter type-id='type-id-78'/>
-      <parameter type-id='type-id-100'/>
+    <pointer-type-def type-id='type-id-98' size-in-bits='64' id='type-id-99'/>
+    <typedef-decl name='voidpc' type-id='type-id-84' filepath='./zconf.h' line='414' column='1' id='type-id-100'/>
+    <function-decl name='vsnprintf' filepath='/usr/include/stdio.h' line='389' column='1' visibility='default' binding='global' size-in-bits='64'>
+      <parameter type-id='type-id-53'/>
+      <parameter type-id='type-id-10'/>
+      <parameter type-id='type-id-22'/>
+      <parameter type-id='type-id-99'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='memmove' filepath='/usr/include/string.h' line='47' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-44'/>
-      <parameter type-id='type-id-44'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-44'/>
+      <parameter type-id='type-id-84'/>
+      <parameter type-id='type-id-84'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-84'/>
     </function-decl>
     <function-decl name='write' filepath='/usr/include/unistd.h' line='378' column='1' visibility='default' binding='global' size-in-bits='64'>
       <parameter type-id='type-id-20'/>
-      <parameter type-id='type-id-44'/>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-93'/>
+      <parameter type-id='type-id-84'/>
+      <parameter type-id='type-id-10'/>
+      <return type-id='type-id-96'/>
     </function-decl>
     <function-decl name='gzwrite' mangled-name='gzwrite' filepath='src.d/gzwrite.c' line='255' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzwrite'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='256' column='1'/>
-      <parameter type-id='type-id-99' name='buf' filepath='src.d/gzwrite.c' line='257' column='1'/>
-      <parameter type-id='type-id-3' name='len' filepath='src.d/gzwrite.c' line='258' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='256' column='1'/>
+      <parameter type-id='type-id-100' name='buf' filepath='src.d/gzwrite.c' line='257' column='1'/>
+      <parameter type-id='type-id-11' name='len' filepath='src.d/gzwrite.c' line='258' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzfwrite' mangled-name='gzfwrite' filepath='src.d/gzwrite.c' line='283' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzfwrite@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-99' name='buf' filepath='src.d/gzwrite.c' line='284' column='1'/>
-      <parameter type-id='type-id-6' name='size' filepath='src.d/gzwrite.c' line='285' column='1'/>
-      <parameter type-id='type-id-6' name='nitems' filepath='src.d/gzwrite.c' line='286' column='1'/>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='287' column='1'/>
-      <return type-id='type-id-6'/>
+      <parameter type-id='type-id-100' name='buf' filepath='src.d/gzwrite.c' line='284' column='1'/>
+      <parameter type-id='type-id-14' name='size' filepath='src.d/gzwrite.c' line='285' column='1'/>
+      <parameter type-id='type-id-14' name='nitems' filepath='src.d/gzwrite.c' line='286' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='287' column='1'/>
+      <return type-id='type-id-14'/>
     </function-decl>
     <function-decl name='gzputc' mangled-name='gzputc' filepath='src.d/gzwrite.c' line='313' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzputc'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='314' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='314' column='1'/>
       <parameter type-id='type-id-20' name='c' filepath='src.d/gzwrite.c' line='315' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzputs' mangled-name='gzputs' filepath='src.d/gzwrite.c' line='361' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzputs'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='362' column='1'/>
-      <parameter type-id='type-id-78' name='s' filepath='src.d/gzwrite.c' line='363' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='362' column='1'/>
+      <parameter type-id='type-id-22' name='s' filepath='src.d/gzwrite.c' line='363' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzvprintf' mangled-name='gzvprintf' filepath='src.d/gzwrite.c' line='391' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzvprintf@@ZLIB_1.2.7.1'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='391' column='1'/>
-      <parameter type-id='type-id-78' name='format' filepath='src.d/gzwrite.c' line='391' column='1'/>
-      <parameter type-id='type-id-100' name='va' filepath='src.d/gzwrite.c' line='391' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='391' column='1'/>
+      <parameter type-id='type-id-22' name='format' filepath='src.d/gzwrite.c' line='391' column='1'/>
+      <parameter type-id='type-id-99' name='va' filepath='src.d/gzwrite.c' line='391' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzprintf' mangled-name='gzprintf' filepath='src.d/gzwrite.c' line='463' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzprintf'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='463' column='1'/>
-      <parameter type-id='type-id-78' name='format' filepath='src.d/gzwrite.c' line='463' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='463' column='1'/>
+      <parameter type-id='type-id-22' name='format' filepath='src.d/gzwrite.c' line='463' column='1'/>
       <parameter is-variadic='yes'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzflush' mangled-name='gzflush' filepath='src.d/gzwrite.c' line='565' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzflush'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='566' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='566' column='1'/>
       <parameter type-id='type-id-20' name='flush' filepath='src.d/gzwrite.c' line='567' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='gzsetparams' mangled-name='gzsetparams' filepath='src.d/gzwrite.c' line='597' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='gzsetparams'>
-      <parameter type-id='type-id-87' name='file' filepath='src.d/gzwrite.c' line='598' column='1'/>
+      <parameter type-id='type-id-89' name='file' filepath='src.d/gzwrite.c' line='598' column='1'/>
       <parameter type-id='type-id-20' name='level' filepath='src.d/gzwrite.c' line='599' column='1'/>
       <parameter type-id='type-id-20' name='strategy' filepath='src.d/gzwrite.c' line='600' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/infback.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-101'/>
-    <class-decl name='code' size-in-bits='32' is-struct='yes' naming-typedef-id='type-id-102' visibility='default' filepath='src.d/inftrees.h' line='24' column='1' id='type-id-103'>
+    <enum-decl name='codetype' naming-typedef-id='type-id-101' filepath='src.d/inftrees.h' line='54' column='1' id='type-id-102'>
+      <underlying-type type-id='type-id-103'/>
+      <enumerator name='CODES' value='0'/>
+      <enumerator name='LENS' value='1'/>
+      <enumerator name='DISTS' value='2'/>
+    </enum-decl>
+    <class-decl name='code' size-in-bits='32' is-struct='yes' naming-typedef-id='type-id-104' visibility='default' filepath='src.d/inftrees.h' line='24' column='1' id='type-id-105'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='op' type-id='type-id-2' visibility='default' filepath='src.d/inftrees.h' line='25' column='1'/>
       </data-member>
@@ -1065,217 +1103,186 @@
         <var-decl name='bits' type-id='type-id-2' visibility='default' filepath='src.d/inftrees.h' line='26' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='16'>
-        <var-decl name='val' type-id='type-id-38' visibility='default' filepath='src.d/inftrees.h' line='27' column='1'/>
+        <var-decl name='val' type-id='type-id-69' visibility='default' filepath='src.d/inftrees.h' line='27' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='code' type-id='type-id-103' filepath='src.d/inftrees.h' line='28' column='1' id='type-id-102'/>
-    <enum-decl name='codetype' naming-typedef-id='type-id-104' filepath='src.d/inftrees.h' line='54' column='1' id='type-id-105'>
-      <underlying-type type-id='type-id-101'/>
-      <enumerator name='CODES' value='0'/>
-      <enumerator name='LENS' value='1'/>
-      <enumerator name='DISTS' value='2'/>
-    </enum-decl>
-    <typedef-decl name='codetype' type-id='type-id-105' filepath='src.d/inftrees.h' line='58' column='1' id='type-id-104'/>
+    <typedef-decl name='code' type-id='type-id-105' filepath='src.d/inftrees.h' line='28' column='1' id='type-id-104'/>
+    <typedef-decl name='codetype' type-id='type-id-102' filepath='src.d/inftrees.h' line='58' column='1' id='type-id-101'/>
     <typedef-decl name='in_func' type-id='type-id-106' filepath='src.d/zlib.h' line='1094' column='1' id='type-id-107'/>
     <typedef-decl name='out_func' type-id='type-id-108' filepath='src.d/zlib.h' line='1096' column='1' id='type-id-109'/>
-    <pointer-type-def type-id='type-id-102' size-in-bits='64' id='type-id-110'/>
+    <type-decl name='unnamed-enum-underlying-type-32' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-103'/>
+    <pointer-type-def type-id='type-id-104' size-in-bits='64' id='type-id-110'/>
     <pointer-type-def type-id='type-id-110' size-in-bits='64' id='type-id-111'/>
     <pointer-type-def type-id='type-id-112' size-in-bits='64' id='type-id-108'/>
-    <pointer-type-def type-id='type-id-2' size-in-bits='64' id='type-id-89'/>
-    <pointer-type-def type-id='type-id-89' size-in-bits='64' id='type-id-113'/>
+    <pointer-type-def type-id='type-id-2' size-in-bits='64' id='type-id-87'/>
+    <pointer-type-def type-id='type-id-87' size-in-bits='64' id='type-id-113'/>
     <pointer-type-def type-id='type-id-114' size-in-bits='64' id='type-id-106'/>
-    <pointer-type-def type-id='type-id-38' size-in-bits='64' id='type-id-115'/>
+    <pointer-type-def type-id='type-id-69' size-in-bits='64' id='type-id-115'/>
+    <typedef-decl name='voidpf' type-id='type-id-84' filepath='./zconf.h' line='415' column='1' id='type-id-116'/>
     <function-decl name='inflateBackInit_' mangled-name='inflateBackInit_' filepath='src.d/infback.c' line='28' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateBackInit_@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/infback.c' line='29' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/infback.c' line='29' column='1'/>
       <parameter type-id='type-id-20' name='windowBits' filepath='src.d/infback.c' line='30' column='1'/>
-      <parameter type-id='type-id-89' name='window' filepath='src.d/infback.c' line='31' column='1'/>
-      <parameter type-id='type-id-78' name='version' filepath='src.d/infback.c' line='32' column='1'/>
+      <parameter type-id='type-id-87' name='window' filepath='src.d/infback.c' line='31' column='1'/>
+      <parameter type-id='type-id-22' name='version' filepath='src.d/infback.c' line='32' column='1'/>
       <parameter type-id='type-id-20' name='stream_size' filepath='src.d/infback.c' line='33' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateBack' mangled-name='inflateBack' filepath='src.d/infback.c' line='251' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateBack@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/infback.c' line='252' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/infback.c' line='252' column='1'/>
       <parameter type-id='type-id-107' name='in' filepath='src.d/infback.c' line='253' column='1'/>
-      <parameter type-id='type-id-44' name='in_desc' filepath='src.d/infback.c' line='254' column='1'/>
+      <parameter type-id='type-id-84' name='in_desc' filepath='src.d/infback.c' line='254' column='1'/>
       <parameter type-id='type-id-109' name='out' filepath='src.d/infback.c' line='255' column='1'/>
-      <parameter type-id='type-id-44' name='out_desc' filepath='src.d/infback.c' line='256' column='1'/>
+      <parameter type-id='type-id-84' name='out_desc' filepath='src.d/infback.c' line='256' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateBackEnd' mangled-name='inflateBackEnd' filepath='src.d/infback.c' line='635' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateBackEnd@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/infback.c' line='636' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/infback.c' line='636' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflate_fast' filepath='src.d/inffast.h' line='11' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-57'/>
-      <parameter type-id='type-id-3'/>
-      <return type-id='type-id-42'/>
+      <parameter type-id='type-id-21'/>
+      <parameter type-id='type-id-11'/>
+      <return type-id='type-id-85'/>
     </function-decl>
     <function-decl name='inflate_table' filepath='src.d/inftrees.h' line='60' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-104'/>
+      <parameter type-id='type-id-101'/>
       <parameter type-id='type-id-115'/>
-      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-11'/>
       <parameter type-id='type-id-111'/>
-      <parameter type-id='type-id-84'/>
+      <parameter type-id='type-id-79'/>
       <parameter type-id='type-id-115'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-type size-in-bits='64' id='type-id-112'>
-      <parameter type-id='type-id-44'/>
-      <parameter type-id='type-id-89'/>
-      <parameter type-id='type-id-3'/>
+      <parameter type-id='type-id-84'/>
+      <parameter type-id='type-id-87'/>
+      <parameter type-id='type-id-11'/>
       <return type-id='type-id-20'/>
     </function-type>
     <function-type size-in-bits='64' id='type-id-114'>
-      <parameter type-id='type-id-44'/>
+      <parameter type-id='type-id-84'/>
       <parameter type-id='type-id-113'/>
-      <return type-id='type-id-3'/>
+      <return type-id='type-id-11'/>
     </function-type>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/inflate.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
+    <typedef-decl name='voidpf' type-id='type-id-84' filepath='./zconf.h' line='415' column='1' id='type-id-117'/>
     <function-decl name='inflateResetKeep' mangled-name='inflateResetKeep' filepath='src.d/inflate.c' line='119' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateResetKeep@@ZLIB_1.2.5.2'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='120' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
-    <function-decl name='inflateReset' mangled-name='inflateReset' filepath='src.d/inflate.c' line='145' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateReset'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='146' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='120' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateReset2' mangled-name='inflateReset2' filepath='src.d/inflate.c' line='158' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateReset2@@ZLIB_1.2.3.4'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='159' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='159' column='1'/>
       <parameter type-id='type-id-20' name='windowBits' filepath='src.d/inflate.c' line='160' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='inflateInit2_' mangled-name='inflateInit2_' filepath='src.d/inflate.c' line='198' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateInit2_'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='199' column='1'/>
-      <parameter type-id='type-id-20' name='windowBits' filepath='src.d/inflate.c' line='200' column='1'/>
-      <parameter type-id='type-id-78' name='version' filepath='src.d/inflate.c' line='201' column='1'/>
-      <parameter type-id='type-id-20' name='stream_size' filepath='src.d/inflate.c' line='202' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
     <function-decl name='inflateInit_' mangled-name='inflateInit_' filepath='src.d/inflate.c' line='242' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateInit_'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='243' column='1'/>
-      <parameter type-id='type-id-78' name='version' filepath='src.d/inflate.c' line='244' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='243' column='1'/>
+      <parameter type-id='type-id-22' name='version' filepath='src.d/inflate.c' line='244' column='1'/>
       <parameter type-id='type-id-20' name='stream_size' filepath='src.d/inflate.c' line='245' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflatePrime' mangled-name='inflatePrime' filepath='src.d/inflate.c' line='250' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflatePrime@@ZLIB_1.2.2.4'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='251' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='251' column='1'/>
       <parameter type-id='type-id-20' name='bits' filepath='src.d/inflate.c' line='252' column='1'/>
       <parameter type-id='type-id-20' name='value' filepath='src.d/inflate.c' line='253' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
-    <function-decl name='inflate' mangled-name='inflate' filepath='src.d/inflate.c' line='625' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflate'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='626' column='1'/>
-      <parameter type-id='type-id-20' name='flush' filepath='src.d/inflate.c' line='627' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
-    <function-decl name='inflateEnd' mangled-name='inflateEnd' filepath='src.d/inflate.c' line='1304' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateEnd'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1305' column='1'/>
-      <return type-id='type-id-20'/>
-    </function-decl>
     <function-decl name='inflateGetDictionary' mangled-name='inflateGetDictionary' filepath='src.d/inflate.c' line='1318' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateGetDictionary@@ZLIB_1.2.7.1'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1319' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1319' column='1'/>
       <parameter type-id='type-id-19' name='dictionary' filepath='src.d/inflate.c' line='1320' column='1'/>
-      <parameter type-id='type-id-83' name='dictLength' filepath='src.d/inflate.c' line='1321' column='1'/>
+      <parameter type-id='type-id-78' name='dictLength' filepath='src.d/inflate.c' line='1321' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateSetDictionary' mangled-name='inflateSetDictionary' filepath='src.d/inflate.c' line='1341' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateSetDictionary'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1342' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1342' column='1'/>
       <parameter type-id='type-id-16' name='dictionary' filepath='src.d/inflate.c' line='1343' column='1'/>
-      <parameter type-id='type-id-8' name='dictLength' filepath='src.d/inflate.c' line='1344' column='1'/>
+      <parameter type-id='type-id-12' name='dictLength' filepath='src.d/inflate.c' line='1344' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateGetHeader' mangled-name='inflateGetHeader' filepath='src.d/inflate.c' line='1376' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateGetHeader@@ZLIB_1.2.2'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1377' column='1'/>
-      <parameter type-id='type-id-59' name='head' filepath='src.d/inflate.c' line='1378' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1377' column='1'/>
+      <parameter type-id='type-id-42' name='head' filepath='src.d/inflate.c' line='1378' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateSync' mangled-name='inflateSync' filepath='src.d/inflate.c' line='1427' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateSync'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1428' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1428' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateSyncPoint' mangled-name='inflateSyncPoint' filepath='src.d/inflate.c' line='1485' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateSyncPoint'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1486' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1486' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateCopy' mangled-name='inflateCopy' filepath='src.d/inflate.c' line='1495' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateCopy@@ZLIB_1.2.0'>
-      <parameter type-id='type-id-57' name='dest' filepath='src.d/inflate.c' line='1496' column='1'/>
-      <parameter type-id='type-id-57' name='source' filepath='src.d/inflate.c' line='1497' column='1'/>
+      <parameter type-id='type-id-21' name='dest' filepath='src.d/inflate.c' line='1496' column='1'/>
+      <parameter type-id='type-id-21' name='source' filepath='src.d/inflate.c' line='1497' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateUndermine' mangled-name='inflateUndermine' filepath='src.d/inflate.c' line='1542' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateUndermine@@ZLIB_1.2.3.3'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1543' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1543' column='1'/>
       <parameter type-id='type-id-20' name='subvert' filepath='src.d/inflate.c' line='1544' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateValidate' mangled-name='inflateValidate' filepath='src.d/inflate.c' line='1560' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateValidate@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1561' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1561' column='1'/>
       <parameter type-id='type-id-20' name='check' filepath='src.d/inflate.c' line='1562' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='inflateMark' mangled-name='inflateMark' filepath='src.d/inflate.c' line='1575' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateMark@@ZLIB_1.2.3.4'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1576' column='1'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1576' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <function-decl name='inflateCodesUsed' mangled-name='inflateCodesUsed' filepath='src.d/inflate.c' line='1588' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='inflateCodesUsed@@ZLIB_1.2.9'>
-      <parameter type-id='type-id-57' name='strm' filepath='src.d/inflate.c' line='1589' column='1'/>
-      <return type-id='type-id-4'/>
+      <parameter type-id='type-id-21' name='strm' filepath='src.d/inflate.c' line='1589' column='1'/>
+      <return type-id='type-id-9'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/trees.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <array-type-def dimensions='1' type-id='type-id-116' size-in-bits='2048' id='type-id-117'>
-      <subrange length='256' type-id='type-id-4' id='type-id-118'/>
+    <array-type-def dimensions='1' type-id='type-id-118' size-in-bits='2048' id='type-id-119'>
+      <subrange length='256' lower-bound='0' upper-bound='255' type-id='type-id-9' id='type-id-120'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-116' size-in-bits='4096' id='type-id-119'>
-      <subrange length='512' type-id='type-id-4' id='type-id-120'/>
+    <array-type-def dimensions='1' type-id='type-id-118' size-in-bits='4096' id='type-id-121'>
+      <subrange length='512' lower-bound='0' upper-bound='511' type-id='type-id-9' id='type-id-122'/>
     </array-type-def>
-    <array-type-def dimensions='1' type-id='type-id-116' size-in-bits='infinite' id='type-id-121'>
-      <subrange length='infinite' id='type-id-122'/>
+    <array-type-def dimensions='1' type-id='type-id-118' size-in-bits='unknown' id='type-id-123'>
+      <subrange length='unknown' lower-bound='0' upper-bound='0' id='type-id-124'/>
     </array-type-def>
-    <qualified-type-def type-id='type-id-36' const='yes' id='type-id-116'/>
-    <var-decl name='_length_code' type-id='type-id-121' visibility='default' filepath='src.d/deflate.h' line='317' column='1'/>
+    <qualified-type-def type-id='type-id-67' const='yes' id='type-id-118'/>
+    <var-decl name='_length_code' type-id='type-id-119' visibility='default' filepath='src.d/deflate.h' line='317' column='1'/>
     <var-decl name='_dist_code' type-id='type-id-121' visibility='default' filepath='src.d/deflate.h' line='318' column='1'/>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/uncompr.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <pointer-type-def type-id='type-id-9' size-in-bits='64' id='type-id-123'/>
+    <pointer-type-def type-id='type-id-13' size-in-bits='64' id='type-id-125'/>
     <function-decl name='uncompress2' mangled-name='uncompress2' filepath='src.d/uncompr.c' line='27' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uncompress2@@ZLIB_1.2.9'>
       <parameter type-id='type-id-19' name='dest' filepath='src.d/uncompr.c' line='28' column='1'/>
       <parameter type-id='type-id-18' name='destLen' filepath='src.d/uncompr.c' line='29' column='1'/>
       <parameter type-id='type-id-16' name='source' filepath='src.d/uncompr.c' line='30' column='1'/>
-      <parameter type-id='type-id-123' name='sourceLen' filepath='src.d/uncompr.c' line='31' column='1'/>
+      <parameter type-id='type-id-125' name='sourceLen' filepath='src.d/uncompr.c' line='31' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
     <function-decl name='uncompress' mangled-name='uncompress' filepath='src.d/uncompr.c' line='86' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='uncompress'>
       <parameter type-id='type-id-19' name='dest' filepath='src.d/uncompr.c' line='87' column='1'/>
       <parameter type-id='type-id-18' name='destLen' filepath='src.d/uncompr.c' line='88' column='1'/>
       <parameter type-id='type-id-16' name='source' filepath='src.d/uncompr.c' line='89' column='1'/>
-      <parameter type-id='type-id-9' name='sourceLen' filepath='src.d/uncompr.c' line='90' column='1'/>
+      <parameter type-id='type-id-13' name='sourceLen' filepath='src.d/uncompr.c' line='90' column='1'/>
       <return type-id='type-id-20'/>
     </function-decl>
   </abi-instr>
   <abi-instr address-size='64' path='src.d/zutil.c' comp-dir-path='/mnt/c/build/git/zlib-ng/btmp1' language='LANG_C11'>
-    <array-type-def dimensions='1' type-id='type-id-124' size-in-bits='640' id='type-id-125'>
-      <subrange length='10' type-id='type-id-4' id='type-id-126'/>
+    <array-type-def dimensions='1' type-id='type-id-126' size-in-bits='640' id='type-id-127'>
+      <subrange length='10' lower-bound='0' upper-bound='9' type-id='type-id-9' id='type-id-128'/>
     </array-type-def>
-    <qualified-type-def type-id='type-id-68' const='yes' id='type-id-124'/>
-    <function-decl name='malloc' filepath='/usr/include/stdlib.h' line='540' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-5'/>
-      <return type-id='type-id-44'/>
-    </function-decl>
-    <function-decl name='free' filepath='/usr/include/stdlib.h' line='555' column='1' visibility='default' binding='global' size-in-bits='64'>
-      <parameter type-id='type-id-44'/>
-      <return type-id='type-id-42'/>
-    </function-decl>
+    <qualified-type-def type-id='type-id-53' const='yes' id='type-id-126'/>
     <function-decl name='zlibVersion' mangled-name='zlibVersion' filepath='src.d/zutil.c' line='27' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zlibVersion'>
-      <return type-id='type-id-78'/>
+      <return type-id='type-id-22'/>
     </function-decl>
     <function-decl name='zlibCompileFlags' mangled-name='zlibCompileFlags' filepath='src.d/zutil.c' line='32' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zlibCompileFlags@@ZLIB_1.2.0.2'>
-      <return type-id='type-id-9'/>
+      <return type-id='type-id-13'/>
     </function-decl>
     <function-decl name='zError' mangled-name='zError' filepath='src.d/zutil.c' line='135' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='zError'>
       <parameter type-id='type-id-20' name='err' filepath='src.d/zutil.c' line='136' column='1'/>
-      <return type-id='type-id-78'/>
+      <return type-id='type-id-22'/>
     </function-decl>
-    <var-decl name='z_errmsg' type-id='type-id-125' visibility='default' filepath='src.d/zutil.h' line='56' column='1'/>
+    <var-decl name='z_errmsg' type-id='type-id-127' visibility='default' filepath='src.d/zutil.h' line='56' column='1'/>
   </abi-instr>
 </abi-corpus>


### PR DESCRIPTION
* Generate using Ubuntu 24.04.1 LTS to fix mismatch in function signatures of gzseek() and gztell()

See #1840.