### PR TITLE
s390x: Update CI clang version

### DIFF
--- a/arch/s390/self-hosted-builder/actions-runner
+++ b/arch/s390/self-hosted-builder/actions-runner
@@ -44,6 +44,7 @@ if [ $REG_TOKEN = "null" ]; then
 fi
 
 # (Re-)register the runner.
+./config.sh remove --token "$REG_TOKEN" || true
 set -x
 ./config.sh \
     --url "https://github.com/$REPO" \

--- a/arch/s390/self-hosted-builder/actions-runner.Dockerfile
+++ b/arch/s390/self-hosted-builder/actions-runner.Dockerfile
@@ -32,6 +32,15 @@ RUN     tar -xf /tmp/runner/_package/*.tar.gz -C /home/actions-runner && \
 
 #VOLUME  /home/actions-runner
 
+# Workaround: Install custom clang version to avoid compiler bug, ref #1852
+RUN     mkdir /tmp/clang
+
+COPY    clang/*.rpm /tmp/clang
+
+RUN     dnf -y upgrade /tmp/clang/*.rpm && \
+        rm -rf /tmp/clang
+
+# Cleanup
 RUN     rm -rf /tmp/runner /var/cache/dnf/* /tmp/runner.patch /tmp/global.json && \
         dnf clean all
 


### PR DESCRIPTION
Add workaround to install custom Clang 19.1.5 rpms to actions-runner
image in order to avoid the VX compiler bug in older clang versions.

I sourced the updated packages from Centos Stream 9, but to avoid downloading them each time and risking 404 due to Centos Stream having removed older packages I downloaded them manually to a local folder. We could instead add the CS9 repo and install from there using dnf, but that would be messier and could risk pulling in/updating a lot of other packages as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced self-hosted GitHub Actions runner configuration for IBM Z architecture
	- Added custom Clang compiler installation process
	- Improved runner registration and rebuild scripts

- **Bug Fixes**
	- Implemented more robust runner configuration removal
	- Added error handling for image removal and temporary directory management

- **Chores**
	- Updated scripts to handle temporary directory creation and cleanup more effectively

<!-- end of auto-generated comment: release notes by coderabbit.ai -->