### PR TITLE
Fix shift overflow in inflate and send_code.

### DIFF
--- a/infback.c
+++ b/infback.c
@@ -102,7 +102,7 @@ int32_t Z_EXPORT PREFIX(inflateBackInit_)(PREFIX3(stream) *strm, int32_t windowB
     do { \
         PULL(); \
         have--; \
-        hold += ((unsigned)(*next++) << bits); \
+        hold += ((uint64_t)(*next++) << bits); \
         bits += 8; \
     } while (0)
 
@@ -154,7 +154,7 @@ int32_t Z_EXPORT PREFIX(inflateBack)(PREFIX3(stream) *strm, in_func in, void *in
     z_const unsigned char *next; /* next input */
     unsigned char *put;          /* next output */
     unsigned have, left;         /* available input and output */
-    uint32_t hold;               /* bit buffer */
+    uint64_t hold;               /* bit buffer */
     unsigned bits;               /* bits in bit buffer */
     unsigned copy;               /* number of stored or match bytes to copy */
     unsigned char *from;         /* where to copy match bytes from */

--- a/inflate.c
+++ b/inflate.c
@@ -291,7 +291,7 @@ int32_t Z_EXPORT PREFIX(inflatePrime)(PREFIX3(stream) *strm, int32_t bits, int32
     if (bits > 16 || state->bits + (unsigned int)bits > 32)
         return Z_STREAM_ERROR;
     value &= (1L << bits) - 1;
-    state->hold += (unsigned)value << state->bits;
+    state->hold += (uint64_t)value << state->bits;
     state->bits += (unsigned int)bits;
     return Z_OK;
 }
@@ -387,7 +387,7 @@ static void updatewindow(PREFIX3(stream) *strm, const uint8_t *end, uint32_t len
     do { \
         if (have == 0) goto inf_leave; \
         have--; \
-        hold += ((unsigned)(*next++) << bits); \
+        hold += ((uint64_t)(*next++) << bits); \
         bits += 8; \
     } while (0)
 
@@ -479,7 +479,7 @@ int32_t Z_EXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int32_t flush) {
     unsigned char *put;         /* next output */
     unsigned char *from;        /* where to copy match bytes from */
     unsigned have, left;        /* available input and output */
-    uint32_t hold;              /* bit buffer */
+    uint64_t hold;              /* bit buffer */
     unsigned bits;              /* bits in bit buffer */
     uint32_t in, out;           /* save starting available input and output */
     unsigned copy;              /* number of stored or match bytes to copy */
@@ -577,7 +577,7 @@ int32_t Z_EXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int32_t flush) {
         case TIME:
             NEEDBITS(32);
             if (state->head != NULL)
-                state->head->time = hold;
+                state->head->time = (unsigned)(hold);
             if ((state->flags & 0x0200) && (state->wrap & 4))
                 CRC4(state->check, hold);
             INITBITS();
@@ -704,7 +704,7 @@ int32_t Z_EXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int32_t flush) {
 #endif
         case DICTID:
             NEEDBITS(32);
-            strm->adler = state->check = ZSWAP32(hold);
+            strm->adler = state->check = ZSWAP32((unsigned)hold);
             INITBITS();
             state->mode = DICT;
             Z_FALLTHROUGH;
@@ -1128,7 +1128,7 @@ int32_t Z_EXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int32_t flush) {
 #ifdef GUNZIP
                      state->flags ? hold :
 #endif
-                     ZSWAP32(hold)) != state->check) {
+                     ZSWAP32((unsigned)hold)) != state->check) {
                     SET_BAD("incorrect data check");
                     break;
                 }

--- a/inflate.h
+++ b/inflate.h
@@ -121,7 +121,7 @@ struct ALIGNED_(64) inflate_state {
     uint32_t chunksize;         /* size of memory copying chunk */
 
         /* bit accumulator */
-    uint32_t hold;              /* input bit accumulator */
+    uint64_t hold;              /* input bit accumulator */
     unsigned bits;              /* number of bits in "in" */
         /* fixed and dynamic code tables */
     unsigned lenbits;           /* index bits for lencode */
@@ -141,7 +141,7 @@ struct ALIGNED_(64) inflate_state {
     code *next;                 /* next available space in codes[] */
 
 #if defined(_M_IX86) || defined(_M_ARM)
-    uint32_t padding[2];
+    uint32_t padding[1];
 #endif
     struct crc32_fold_s ALIGNED_(16) crc_fold;
 


### PR DESCRIPTION
Size of `hold` was inconsistent between different inflate versions. Make all use 64-bit variable.
In `send_bits` there was no guard against shifting by variable bit width, which will overflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Performance Improvements**
  - Enhanced bit buffer handling by expanding variable types to support larger data values.
  - Improved data processing capacity in compression and decompression functions.

- **Bug Fixes**
  - Added safety checks to prevent potential buffer overflow in bit manipulation operations.

- **Technical Updates**
  - Updated internal data type representations to increase range and precision of bit-level operations.
  - Reduced memory footprint in the `inflate_state` structure by modifying the `padding` array size.
  - Refined control flow for bit processing, ensuring proper handling of buffer states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->