### PR TITLE
Add uncompress benchmark

### DIFF
--- a/test/benchmarks/CMakeLists.txt
+++ b/test/benchmarks/CMakeLists.txt
@@ -48,6 +48,7 @@ add_executable(benchmark_zlib
     benchmark_crc32.cc
     benchmark_main.cc
     benchmark_slidehash.cc
+    benchmark_uncompress.cc
     )
 
 target_compile_definitions(benchmark_zlib PRIVATE -DBENCHMARK_STATIC_DEFINE)

--- a/test/benchmarks/benchmark_compare256_rle.cc
+++ b/test/benchmarks/benchmark_compare256_rle.cc
@@ -33,7 +33,7 @@ public:
 
     void Bench(benchmark::State& state, compare256_rle_func compare256_rle) {
         int32_t match_len = (int32_t)state.range(0) - 1;
-        uint32_t len;
+        uint32_t len = 0;
 
         str2[match_len] = 0;
         for (auto _ : state) {

--- a/test/benchmarks/benchmark_compress.cc
+++ b/test/benchmarks/benchmark_compress.cc
@@ -43,7 +43,7 @@ public:
     }
 
     void Bench(benchmark::State& state) {
-        int err;
+        int err = 0;
 
         for (auto _ : state) {
             err = PREFIX(compress)(outbuff, &maxlen, inbuff, (size_t)state.range(0));

--- a/test/benchmarks/benchmark_uncompress.cc
+++ b/test/benchmarks/benchmark_uncompress.cc
@@ -1,0 +1,94 @@
+/* benchmark_uncompress.cc -- benchmark uncompress()
+ * Copyright (C) 2024 Hans Kristian Rosbach
+ * For conditions of distribution and use, see copyright notice in zlib.h
+ */
+
+#include <stdio.h>
+#include <assert.h>
+#include <benchmark/benchmark.h>
+
+extern "C" {
+#  include "zbuild.h"
+#  include "zutil_p.h"
+#  if defined(ZLIB_COMPAT)
+#    include "zlib.h"
+#  else
+#    include "zlib-ng.h"
+#  endif
+}
+
+#define MAX_SIZE (1024 * 1024)
+#define NUM_TESTS 6
+
+class uncompress_bench: public benchmark::Fixture {
+private:
+    size_t maxlen;
+    uint8_t *inbuff;
+    uint8_t *outbuff;
+    uint8_t *compressed_buff[NUM_TESTS];
+    uLong compressed_sizes[NUM_TESTS];
+    int64_t sizes[NUM_TESTS] = {1, 64, 1024, 16384, 128*1024, 1024*1024};
+
+public:
+    void SetUp(const ::benchmark::State& state) {
+        const char teststr[42] = "Hello hello World broken Test tast mello.";
+        maxlen = MAX_SIZE;
+
+        inbuff = (uint8_t *)zng_alloc(MAX_SIZE + 1);
+        assert(inbuff != NULL);
+
+        outbuff = (uint8_t *)zng_alloc(MAX_SIZE + 1);
+        assert(outbuff != NULL);
+
+        // Initialize input buffer
+        int pos = 0;
+        for (int32_t i = 0; i < MAX_SIZE - 42 ; i+=42){
+           pos += sprintf((char *)inbuff+pos, "%s", teststr);
+        }
+
+        // Compress data into different buffers
+        for (size_t i = 0; i < NUM_TESTS; ++i) {
+            compressed_buff[i] = (uint8_t *)zng_alloc(MAX_SIZE + 1);
+            assert(compressed_buff[i] != NULL);
+
+            uLong compressed_size = maxlen;
+            int err = PREFIX(compress)(compressed_buff[i], &compressed_size, inbuff, sizes[i]);
+            if (err != Z_OK) {
+                fprintf(stderr, "Compression failed with error %d\n", err);
+                abort();
+            }
+            compressed_sizes[i] = compressed_size;
+        }
+    }
+
+    void Bench(benchmark::State& state) {
+        int err = 0;
+
+        for (auto _ : state) {
+            int index = 0;
+            while (sizes[index] != state.range(0)) ++index;
+
+            uLong out_size = maxlen;
+            err = PREFIX(uncompress)(outbuff, &out_size, compressed_buff[index], compressed_sizes[index]);
+        }
+
+        benchmark::DoNotOptimize(err);
+    }
+
+    void TearDown(const ::benchmark::State& state) {
+        zng_free(inbuff);
+        zng_free(outbuff);
+
+        for (size_t i = 0; i < NUM_TESTS; ++i) {
+            zng_free(compressed_buff[i]);
+        }
+    }
+};
+
+#define BENCHMARK_UNCOMPRESS(name) \
+    BENCHMARK_DEFINE_F(uncompress_bench, name)(benchmark::State& state) { \
+        Bench(state); \
+    } \
+    BENCHMARK_REGISTER_F(uncompress_bench, name)->Arg(1)->Arg(64)->Arg(1024)->Arg(16<<10)->Arg(128<<10)->Arg(1024<<10);
+
+BENCHMARK_UNCOMPRESS(uncompress_bench);


### PR DESCRIPTION
Adds uncompress benchmark.
Also fix two minor warnings in other benchmarks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added new benchmarking capabilities for uncompression performance testing
  - Introduced comprehensive performance measurement for `uncompress()` function

- **Bug Fixes**
  - Initialized previously uninitialized variables in benchmark tests to improve reliability

- **Tests**
  - Enhanced benchmark test suite with more robust performance measurement methods
  - Added detailed benchmarking for compression and uncompression operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->