### PR TITLE
port: Use memalign or _aligned_malloc only, when available, fallback to malloc.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -447,6 +447,9 @@ if(NOT HAVE_STRERROR)
 endif()
 set(CMAKE_REQUIRED_FLAGS)
 
+#
+# Check for aligned memory allocation support: POSIX
+#
 set(CMAKE_REQUIRED_DEFINITIONS -D_POSIX_C_SOURCE=200112L)
 set(CMAKE_REQUIRED_FLAGS "${ADDITIONAL_CHECK_FLAGS}")
 check_symbol_exists(posix_memalign stdlib.h HAVE_POSIX_MEMALIGN)
@@ -456,6 +459,9 @@ endif()
 set(CMAKE_REQUIRED_FLAGS)
 set(CMAKE_REQUIRED_DEFINITIONS)
 
+#
+# Check for aligned memory allocation support: C11
+#
 set(CMAKE_REQUIRED_DEFINITIONS -D_ISOC11_SOURCE=1)
 set(CMAKE_REQUIRED_FLAGS "${ADDITIONAL_CHECK_FLAGS}")
 check_symbol_exists(aligned_alloc stdlib.h HAVE_ALIGNED_ALLOC)
@@ -465,6 +471,28 @@ endif()
 set(CMAKE_REQUIRED_FLAGS)
 set(CMAKE_REQUIRED_DEFINITIONS)
 
+#
+# Check for aligned memory allocation support: GNU extension
+# Note: memalign() is deprecated in glibc
+#
+check_symbol_exists(memalign malloc.h HAVE_MEMALIGN)
+if(HAVE_MEMALIGN)
+    add_definitions(-DHAVE_MEMALIGN)
+endif()
+set(CMAKE_REQUIRED_DEFINITIONS)
+
+#
+# Check for aligned memory allocation support: MSVC extensions
+#
+check_symbol_exists(_aligned_malloc malloc.h HAVE__ALIGNED_MALLOC)
+if(HAVE__ALIGNED_MALLOC)
+    add_definitions(-DHAVE__ALIGNED_MALLOC)
+endif()
+set(CMAKE_REQUIRED_DEFINITIONS)
+
+#
+# Check whether a sanitizer was requested
+#
 if(WITH_SANITIZER STREQUAL "Address")
     add_address_sanitizer()
 elseif(WITH_SANITIZER STREQUAL "Memory")

--- a/configure
+++ b/configure
@@ -724,6 +724,8 @@ EOF
 fi
 echo >> configure.log
 
+
+# check for aligned memory allocation support: POSIX
 cat > $test.c <<EOF
 #define _POSIX_C_SOURCE 200112L
 #include <stdlib.h>
@@ -744,6 +746,7 @@ else
 fi
 echo >> configure.log
 
+# check for aligned memory allocation support: C11
 cat > $test.c <<EOF
 #define _ISOC11_SOURCE 1
 #include <stdlib.h>
@@ -762,6 +765,47 @@ else
   echo "Checking for aligned_alloc... No." | tee -a configure.log
 fi
 echo >> configure.log
+
+
+# check for aligned memory allocation support: GNU extension
+# Note: memalign() is deprecated in glibc
+cat > $test.c <<EOF
+#include <malloc.h>
+int main(void) {
+  void *ptr = memalign(64, 10);
+  if (ptr)
+    free(ptr);
+  return 0;
+}
+EOF
+if try $CC $CFLAGS -o $test $test.c $LDSHAREDLIBC; then
+  echo "Checking for memalign... Yes." | tee -a configure.log
+  CFLAGS="${CFLAGS} -DHAVE_MEMALIGN"
+  SFLAGS="${SFLAGS} -DHAVE_MEMALIGN"
+else
+  echo "Checking for memalign... No." | tee -a configure.log
+fi
+echo >> configure.log
+
+# check for aligned memory allocation support: MSVC extensions
+cat > $test.c <<EOF
+#include <malloc.h>
+int main(void) {
+  void *ptr = _aligned_malloc(10, 64);
+  if (ptr)
+    _aligned_free(ptr);
+  return 0;
+}
+EOF
+if try $CC $CFLAGS -o $test $test.c $LDSHAREDLIBC; then
+  echo "Checking for _aligned_malloc... Yes." | tee -a configure.log
+  CFLAGS="${CFLAGS} -DHAVE__ALIGNED_MALLOC"
+  SFLAGS="${SFLAGS} -DHAVE__ALIGNED_MALLOC"
+else
+  echo "Checking for _aligned_malloc... No." | tee -a configure.log
+fi
+echo >> configure.log
+
 
 # check for strerror() for use by gz* functions
 cat > $test.c <<EOF


### PR DESCRIPTION

This fixes also the usage of "_WIN32" to decide, 
if the MSVC extensions _aligned_malloc / _aligned_free are available

That bug breaks other Compiler on Windows. (OpenWatcom as Example).

-- 
Regards ... Detlef

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced build configuration to automatically detect and enable advanced aligned memory allocation methods.
  - Introduced support for optional sanitizers to improve error detection during builds.

- **Refactor**
  - Refined the logic for memory allocation and deallocation, ensuring more robust cross-platform behavior.
  - Improved header inclusion logic for aligned memory allocation methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->