### PR TITLE
Added --installnamedir

### DIFF
--- a/configure
+++ b/configure
@@ -83,6 +83,7 @@ bindir=${bindir-'${exec_prefix}/bin'}
 libdir=${libdir-'${exec_prefix}/lib'}
 sharedlibdir=${sharedlibdir-'${libdir}'}
 includedir=${includedir-'${prefix}/include'}
+installnamedir=${installnamedir-'@rpath'}
 mandir=${mandir-'${prefix}/share/man'}
 shared_ext='.so'
 shared=1
@@ -158,7 +159,7 @@ case "$1" in
       echo 'usage:' | tee -a configure.log
       echo '  configure [--prefix=PREFIX]  [--eprefix=EXPREFIX]' | tee -a configure.log
       echo '    [--static] [--32] [--64] [--libdir=LIBDIR] [--sharedlibdir=LIBDIR]' | tee -a configure.log
-      echo '    [--includedir=INCLUDEDIR] [--mandir=MANDIR] [--archs="-arch i386 -arch x86_64"]' | tee -a configure.log
+      echo '    [--includedir=INCLUDEDIR] [--installnamedir="@rpath"] [--mandir=MANDIR] [--archs="-arch i386 -arch x86_64"]' | tee -a configure.log
       echo '    [--sprefix=SYMBOL_PREFIX]   Adds a prefix to all exported symbols' | tee -a configure.log
       echo '    [--warn]                    Enables extra compiler warnings' | tee -a configure.log
       echo '    [--debug]                   Enables extra debug prints during operation' | tee -a configure.log
@@ -183,6 +184,7 @@ case "$1" in
     -l*=* | --libdir=*) libdir=$(echo $1 | sed 's/.*=//'); shift ;;
     --sharedlibdir=*) sharedlibdir=$(echo $1 | sed 's/.*=//'); shift ;;
     -i*=* | --includedir=*) includedir=$(echo $1 | sed 's/.*=//');shift ;;
+    --installnamedir=*) installnamedir=$(echo $1 | sed 's/.*=//'); shift ;;
     --mandir=*) mandir=$(echo $1 | sed 's/.*=//');shift ;;
     -u*=* | --uname=*) uname=$(echo $1 | sed 's/.*=//');shift ;;
     -p* | --prefix) prefix="$2"; shift; shift ;;
@@ -470,7 +472,7 @@ if test "$gcc" -eq 1 && ($cc $CFLAGS -c $test.c) >> configure.log 2>&1; then
              SHAREDLIBM=${LIBNAME}.$VER1$shared_ext
              SHAREDTARGET=$SHAREDLIBV
              LDSHARED=${LDSHARED-"$cc"}
-             LDSHAREDFLAGS="-dynamiclib -install_name @rpath/${SHAREDLIBM} -compatibility_version ${VER1} -current_version ${VER3}"
+             LDSHAREDFLAGS="-dynamiclib -install_name ${installnamedir}/${SHAREDLIBM} -compatibility_version ${VER1} -current_version ${VER3}"
              if "${CROSS_PREFIX}libtool" -V 2>&1 | grep Apple > /dev/null; then
                  AR="${CROSS_PREFIX}libtool"
              elif libtool -V 2>&1 | grep Apple > /dev/null; then
@@ -1936,6 +1938,7 @@ echo TEST = $TEST >> configure.log
 echo VER = $VER >> configure.log
 echo exec_prefix = $exec_prefix >> configure.log
 echo includedir = $includedir >> configure.log
+echo installnamedir = $installnamedir >> configure.log
 echo bindir = $bindir >> configure.log
 echo libdir = $libdir >> configure.log
 echo mandir = $mandir >> configure.log
@@ -2007,6 +2010,7 @@ sed < $SRCDIR/Makefile.in "
 /^libdir *=/s#=.*#= $libdir#
 /^sharedlibdir *=/s#=.*#= $sharedlibdir#
 /^includedir *=/s#=.*#= $includedir#
+/^installnamedir *=/s#=.*#= $installnamedir#
 /^mandir *=/s#=.*#= $mandir#
 /^SRCDIR *=/s#=.*#=$SRCDIR#
 /^INCLUDES *=/s#=.*#=$INCLUDES#
@@ -2206,6 +2210,7 @@ sed < $SRCDIR/zlib.pc.in "
 /^libdir *=/s#=.*#=$libdir#
 /^sharedlibdir *=/s#=.*#=$sharedlibdir#
 /^includedir *=/s#=.*#=$includedir#
+/^installnamedir *=/s#=.*#=$installnamedir#
 /^mandir *=/s#=.*#=$mandir#
 /^LDFLAGS *=/s#=.*#=$LDFLAGS#
 " | sed -e "


### PR DESCRIPTION
Rather than having the `install_name` always set to `@rpath/${SHAREDLIBM}` on macOS

https://github.com/zlib-ng/zlib-ng/blob/43b27034358d657a2ef6926009d3b5553ad3799c/configure#L473

this PR suggests making it possible to replace `@rpath` via `--installnamedir`.

This is helpful as setting it can remove a need for `DYLD_LIBRARY_PATH` - recent versions of macOS have System Integrity Protection (SIP) which prevents `DYLD_LIBRARY_PATH` from being passed into subshells.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new command-line option that allows users to specify a custom installation directory during build.
	- Updated help messaging to clearly present this configurable option.
	- Enhanced logging to record the selected installation directory for future reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->