### PR TITLE
Clean up crc32_braid.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -97,6 +97,13 @@ jobs:
             packages: gcc-multilib g++-multilib
             codecov: ubuntu_gcc_m32
 
+          - name: Ubuntu GCC No Chorba
+            os: ubuntu-latest
+            compiler: gcc
+            cxx-compiler: g++
+            cmake-args: -DWITH_CHORBA=OFF
+            codecov: ubuntu_gcc_no_chorba
+
           - name: Ubuntu GCC No CTZLL
             os: ubuntu-latest
             compiler: gcc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,7 @@ option(WITH_BENCHMARK_APPS "Build application benchmarks" OFF)
 option(WITH_OPTIM "Build with optimisation" ON)
 option(WITH_REDUCED_MEM "Reduced memory usage for special cases (reduces performance)" OFF)
 option(WITH_NEW_STRATEGIES "Use new strategies" ON)
+option(WITH_CRC32_CHORBA "Enable optimized CRC32 algorithm Chorba" ON)
 option(WITH_NATIVE_INSTRUCTIONS
     "Instruct the compiler to use the full instruction set on this host (gcc/clang -march=native)" OFF)
 option(WITH_RUNTIME_CPU_DETECTION "Build with runtime detection of CPU architecture" ON)
@@ -137,6 +138,7 @@ option(INSTALL_UTILS "Copy minigzip and minideflate during install" OFF)
 mark_as_advanced(FORCE
     ZLIB_SYMBOL_PREFIX
     WITH_REDUCED_MEM
+    WITH_CRC32_CHORBA
     WITH_ARMV8 WITH_NEON
     WITH_ARMV6
     WITH_DFLTCC_DEFLATE
@@ -168,6 +170,10 @@ endif()
 
 if(WITH_GZFILEOP)
     add_definitions(-DWITH_GZFILEOP)
+endif()
+
+if(NOT WITH_CRC32_CHORBA)
+    add_definitions(-DWITHOUT_CHORBA)
 endif()
 
 if(CMAKE_C_COMPILER_ID MATCHES "^Intel")
@@ -1092,14 +1098,16 @@ set(ZLIB_PRIVATE_HDRS
     arch/generic/compare256_p.h
     arch/generic/generic_functions.h
     adler32_p.h
+    arch_functions.h
     chunkset_tpl.h
     compare256_rle.h
-    arch_functions.h
+    crc32.h
     crc32_braid_p.h
     crc32_braid_comb_p.h
     crc32_braid_tbl.h
     deflate.h
     deflate_p.h
+    fallback_builtins.h
     functable.h
     inffast_tpl.h
     inffixed_tbl.h
@@ -1113,7 +1121,9 @@ set(ZLIB_PRIVATE_HDRS
     trees_tbl.h
     zbuild.h
     zendian.h
+    zmemory.h
     zutil.h
+    zutil_p.h
 )
 set(ZLIB_SRCS
     arch/generic/adler32_c.c
@@ -1122,7 +1132,6 @@ set(ZLIB_SRCS
     arch/generic/compare256_c.c
     arch/generic/crc32_braid_c.c
     arch/generic/crc32_c.c
-    arch/generic/crc32_chorba_c.c
     arch/generic/crc32_fold_c.c
     arch/generic/slide_hash_c.c
     adler32.c
@@ -1147,6 +1156,10 @@ set(ZLIB_SRCS
     uncompr.c
     zutil.c
 )
+
+if(WITH_CRC32_CHORBA)
+    list(APPEND ZLIB_SRCS arch/generic/crc32_chorba_c.c)
+endif()
 
 if(WITH_RUNTIME_CPU_DETECTION)
     list(APPEND ZLIB_PRIVATE_HDRS cpu_features.h)
@@ -1390,6 +1403,7 @@ add_feature_info(WITH_BENCHMARKS WITH_BENCHMARKS "Build test/benchmarks")
 add_feature_info(WITH_BENCHMARK_APPS WITH_BENCHMARK_APPS "Build application benchmarks")
 add_feature_info(WITH_OPTIM WITH_OPTIM "Build with optimisation")
 add_feature_info(WITH_NEW_STRATEGIES WITH_NEW_STRATEGIES "Use new strategies")
+add_feature_info(WITH_CRC32_CHORBA WITH_CRC32_CHORBA "Use optimized CRC32 algorithm Chorba")
 add_feature_info(WITH_NATIVE_INSTRUCTIONS WITH_NATIVE_INSTRUCTIONS
     "Instruct the compiler to use the full instruction set on this host (gcc/clang -march=native)")
 add_feature_info(WITH_RUNTIME_CPU_DETECTION WITH_RUNTIME_CPU_DETECTION "Build with runtime CPU detection")

--- a/Makefile.in
+++ b/Makefile.in
@@ -81,7 +81,6 @@ OBJZ = \
 	arch/generic/compare256_c.o \
 	arch/generic/crc32_braid_c.o \
 	arch/generic/crc32_c.o \
-	arch/generic/crc32_chorba_c.o \
 	arch/generic/crc32_fold_c.o \
 	arch/generic/slide_hash_c.o \
 	adler32.o \
@@ -105,6 +104,7 @@ OBJZ = \
 	trees.o \
 	uncompr.o \
 	zutil.o \
+	arch/generic/crc32_chorba_c.o \
 	cpu_features.o \
 	$(ARCH_STATIC_OBJS)
 
@@ -123,7 +123,6 @@ PIC_OBJZ = \
 	arch/generic/compare256_c.lo \
 	arch/generic/crc32_braid_c.lo \
 	arch/generic/crc32_c.lo \
-	arch/generic/crc32_chorba_c.lo \
 	arch/generic/crc32_fold_c.lo \
 	arch/generic/slide_hash_c.lo \
 	adler32.lo \
@@ -147,6 +146,7 @@ PIC_OBJZ = \
 	trees.lo \
 	uncompr.lo \
 	zutil.lo \
+	arch/generic/crc32_chorba_c.lo \
 	cpu_features.lo \
 	$(ARCH_SHARED_OBJS)
 

--- a/adler32_p.h
+++ b/adler32_p.h
@@ -12,11 +12,11 @@
 #define NMAX 5552
 /* NMAX is the largest n such that 255n(n+1)/2 + (n+1)(BASE-1) <= 2^32-1 */
 
-#define DO1(sum1, sum2, buf, i)  {(sum1) += buf[(i)]; (sum2) += (sum1);}
-#define DO2(sum1, sum2, buf, i)  {DO1(sum1, sum2, buf, i); DO1(sum1, sum2, buf, i+1);}
-#define DO4(sum1, sum2, buf, i)  {DO2(sum1, sum2, buf, i); DO2(sum1, sum2, buf, i+2);}
-#define DO8(sum1, sum2, buf, i)  {DO4(sum1, sum2, buf, i); DO4(sum1, sum2, buf, i+4);}
-#define DO16(sum1, sum2, buf)    {DO8(sum1, sum2, buf, 0); DO8(sum1, sum2, buf, 8);}
+#define ADLER_DO1(sum1, sum2, buf, i)  {(sum1) += buf[(i)]; (sum2) += (sum1);}
+#define ADLER_DO2(sum1, sum2, buf, i)  {ADLER_DO1(sum1, sum2, buf, i); ADLER_DO1(sum1, sum2, buf, i+1);}
+#define ADLER_DO4(sum1, sum2, buf, i)  {ADLER_DO2(sum1, sum2, buf, i); ADLER_DO2(sum1, sum2, buf, i+2);}
+#define ADLER_DO8(sum1, sum2, buf, i)  {ADLER_DO4(sum1, sum2, buf, i); ADLER_DO4(sum1, sum2, buf, i+4);}
+#define ADLER_DO16(sum1, sum2, buf)    {ADLER_DO8(sum1, sum2, buf, 0); ADLER_DO8(sum1, sum2, buf, 8);}
 
 static inline uint32_t adler32_len_1(uint32_t adler, const uint8_t *buf, uint32_t sum2) {
     adler += buf[0];
@@ -54,12 +54,12 @@ static inline uint32_t adler32_len_64(uint32_t adler, const uint8_t *buf, size_t
 #ifdef UNROLL_MORE
     while (len >= 16) {
         len -= 16;
-        DO16(adler, sum2, buf);
+        ADLER_DO16(adler, sum2, buf);
         buf += 16;
 #else
     while (len >= 8) {
         len -= 8;
-        DO8(adler, sum2, buf, 0);
+        ADLER_DO8(adler, sum2, buf, 0);
         buf += 8;
 #endif
     }

--- a/arch/generic/adler32_c.c
+++ b/arch/generic/adler32_c.c
@@ -38,10 +38,10 @@ Z_INTERNAL uint32_t adler32_c(uint32_t adler, const uint8_t *buf, size_t len) {
 #endif
         do {
 #ifdef UNROLL_MORE
-            DO16(adler, sum2, buf);          /* 16 sums unrolled */
+            ADLER_DO16(adler, sum2, buf);          /* 16 sums unrolled */
             buf += 16;
 #else
-            DO8(adler, sum2, buf, 0);         /* 8 sums unrolled */
+            ADLER_DO8(adler, sum2, buf, 0);         /* 8 sums unrolled */
             buf += 8;
 #endif
         } while (--n);

--- a/arch/generic/crc32_braid_c.c
+++ b/arch/generic/crc32_braid_c.c
@@ -12,83 +12,84 @@
 #include "crc32_braid_tbl.h"
 
 /*
-  A CRC of a message is computed on N braids of words in the message, where
-  each word consists of W bytes (4 or 8). If N is 3, for example, then three
-  running sparse CRCs are calculated respectively on each braid, at these
+  A CRC of a message is computed on BRAID_N braids of words in the message, where
+  each word consists of BRAID_W bytes (4 or 8). If BRAID_N is 3, for example, then
+  three running sparse CRCs are calculated respectively on each braid, at these
   indices in the array of words: 0, 3, 6, ..., 1, 4, 7, ..., and 2, 5, 8, ...
-  This is done starting at a word boundary, and continues until as many blocks
-  of N * W bytes as are available have been processed. The results are combined
-  into a single CRC at the end. For this code, N must be in the range 1..6 and
-  W must be 4 or 8. The upper limit on N can be increased if desired by adding
-  more #if blocks, extending the patterns apparent in the code. In addition,
-  crc32 tables would need to be regenerated, if the maximum N value is increased.
+  This is done starting at a word boundary, and continues until as many blocks of
+  BRAID_N * BRAID_W bytes as are available have been processed. The results are
+  combined into a single CRC at the end. For this code, BRAID_N must be in the
+  range 1..6 and BRAID_W must be 4 or 8. The upper limit on BRAID_N can be increased
+  if desired by adding more #if blocks, extending the patterns apparent in the code.
+  In addition, crc32 tables would need to be regenerated, if the maximum BRAID_N
+  value is increased.
 
-  N and W are chosen empirically by benchmarking the execution time on a given
-  processor. The choices for N and W below were based on testing on Intel Kaby
-  Lake i7, AMD Ryzen 7, ARM Cortex-A57, Sparc64-VII, PowerPC POWER9, and MIPS64
-  Octeon II processors. The Intel, AMD, and ARM processors were all fastest
-  with N=5, W=8. The Sparc, PowerPC, and MIPS64 were all fastest at N=5, W=4.
+  BRAID_N and BRAID_W are chosen empirically by benchmarking the execution time
+  on a given processor. The choices for BRAID_N and BRAID_W below were based on
+  testing on Intel Kaby Lake i7, AMD Ryzen 7, ARM Cortex-A57, Sparc64-VII, PowerPC
+  POWER9, and MIPS64 Octeon II processors.
+  The Intel, AMD, and ARM processors were all fastest with BRAID_N=5, BRAID_W=8.
+  The Sparc, PowerPC, and MIPS64 were all fastest at BRAID_N=5, BRAID_W=4.
   They were all tested with either gcc or clang, all using the -O3 optimization
   level. Your mileage may vary.
 */
 
 /* ========================================================================= */
-#ifdef W
+#ifdef BRAID_W
 /*
-  Return the CRC of the W bytes in the word_t data, taking the
+  Return the CRC of the BRAID_W bytes in the word_t data, taking the
   least-significant byte of the word as the first byte of data, without any pre
   or post conditioning. This is used to combine the CRCs of each braid.
  */
-#if BYTE_ORDER == LITTLE_ENDIAN
+#  if BYTE_ORDER == LITTLE_ENDIAN
 static uint32_t crc_word(z_word_t data) {
     int k;
-    for (k = 0; k < W; k++)
+    for (k = 0; k < BRAID_W; k++)
         data = (data >> 8) ^ crc_table[data & 0xff];
     return (uint32_t)data;
 }
-#elif BYTE_ORDER == BIG_ENDIAN
+#  elif BYTE_ORDER == BIG_ENDIAN
 static z_word_t crc_word(z_word_t data) {
     int k;
-    for (k = 0; k < W; k++)
+    for (k = 0; k < BRAID_W; k++)
         data = (data << 8) ^
-            crc_big_table[(data >> ((W - 1) << 3)) & 0xff];
+            crc_big_table[(data >> ((BRAID_W - 1) << 3)) & 0xff];
     return data;
 }
-#endif /* BYTE_ORDER */
-
-#endif /* W */
+#  endif /* BYTE_ORDER */
+#endif /* BRAID_W */
 
 /* ========================================================================= */
 Z_INTERNAL uint32_t crc32_braid_internal(uint32_t c, const uint8_t *buf, size_t len) {
 
-#ifdef W
+#ifdef BRAID_W
     /* If provided enough bytes, do a braided CRC calculation. */
-    if (len >= N * W + W - 1) {
+    if (len >= BRAID_N * BRAID_W + BRAID_W - 1) {
         size_t blks;
         z_word_t const *words;
         int k;
 
         /* Compute the CRC up to a z_word_t boundary. */
-        while (len && ((uintptr_t)buf & (W - 1)) != 0) {
+        while (len && ((uintptr_t)buf & (BRAID_W - 1)) != 0) {
             len--;
             DO1;
         }
 
-        /* Compute the CRC on as many N z_word_t blocks as are available. */
-        blks = len / (N * W);
-        len -= blks * N * W;
+        /* Compute the CRC on as many BRAID_N z_word_t blocks as are available. */
+        blks = len / (BRAID_N * BRAID_W);
+        len -= blks * BRAID_N * BRAID_W;
         words = (z_word_t const *)buf;
 
         z_word_t crc0, word0, comb;
-#if N > 1
+#if BRAID_N > 1
         z_word_t crc1, word1;
-#if N > 2
+#if BRAID_N > 2
         z_word_t crc2, word2;
-#if N > 3
+#if BRAID_N > 3
         z_word_t crc3, word3;
-#if N > 4
+#if BRAID_N > 4
         z_word_t crc4, word4;
-#if N > 5
+#if BRAID_N > 5
         z_word_t crc5, word5;
 #endif
 #endif
@@ -97,15 +98,15 @@ Z_INTERNAL uint32_t crc32_braid_internal(uint32_t c, const uint8_t *buf, size_t 
 #endif
         /* Initialize the CRC for each braid. */
         crc0 = ZSWAPWORD(c);
-#if N > 1
+#if BRAID_N > 1
         crc1 = 0;
-#if N > 2
+#if BRAID_N > 2
         crc2 = 0;
-#if N > 3
+#if BRAID_N > 3
         crc3 = 0;
-#if N > 4
+#if BRAID_N > 4
         crc4 = 0;
-#if N > 5
+#if BRAID_N > 5
         crc5 = 0;
 #endif
 #endif
@@ -116,51 +117,51 @@ Z_INTERNAL uint32_t crc32_braid_internal(uint32_t c, const uint8_t *buf, size_t 
         while (--blks) {
             /* Load the word for each braid into registers. */
             word0 = crc0 ^ words[0];
-#if N > 1
+#if BRAID_N > 1
             word1 = crc1 ^ words[1];
-#if N > 2
+#if BRAID_N > 2
             word2 = crc2 ^ words[2];
-#if N > 3
+#if BRAID_N > 3
             word3 = crc3 ^ words[3];
-#if N > 4
+#if BRAID_N > 4
             word4 = crc4 ^ words[4];
-#if N > 5
+#if BRAID_N > 5
             word5 = crc5 ^ words[5];
 #endif
 #endif
 #endif
 #endif
 #endif
-            words += N;
+            words += BRAID_N;
 
             /* Compute and update the CRC for each word. The loop should get unrolled. */
             crc0 = BRAID_TABLE[0][word0 & 0xff];
-#if N > 1
+#if BRAID_N > 1
             crc1 = BRAID_TABLE[0][word1 & 0xff];
-#if N > 2
+#if BRAID_N > 2
             crc2 = BRAID_TABLE[0][word2 & 0xff];
-#if N > 3
+#if BRAID_N > 3
             crc3 = BRAID_TABLE[0][word3 & 0xff];
-#if N > 4
+#if BRAID_N > 4
             crc4 = BRAID_TABLE[0][word4 & 0xff];
-#if N > 5
+#if BRAID_N > 5
             crc5 = BRAID_TABLE[0][word5 & 0xff];
 #endif
 #endif
 #endif
 #endif
 #endif
-            for (k = 1; k < W; k++) {
+            for (k = 1; k < BRAID_W; k++) {
                 crc0 ^= BRAID_TABLE[k][(word0 >> (k << 3)) & 0xff];
-#if N > 1
+#if BRAID_N > 1
                 crc1 ^= BRAID_TABLE[k][(word1 >> (k << 3)) & 0xff];
-#if N > 2
+#if BRAID_N > 2
                 crc2 ^= BRAID_TABLE[k][(word2 >> (k << 3)) & 0xff];
-#if N > 3
+#if BRAID_N > 3
                 crc3 ^= BRAID_TABLE[k][(word3 >> (k << 3)) & 0xff];
-#if N > 4
+#if BRAID_N > 4
                 crc4 ^= BRAID_TABLE[k][(word4 >> (k << 3)) & 0xff];
-#if N > 5
+#if BRAID_N > 5
                 crc5 ^= BRAID_TABLE[k][(word5 >> (k << 3)) & 0xff];
 #endif
 #endif
@@ -170,24 +171,24 @@ Z_INTERNAL uint32_t crc32_braid_internal(uint32_t c, const uint8_t *buf, size_t 
             }
         }
 
-        /* Process the last block, combining the CRCs of the N braids at the same time. */
+        /* Process the last block, combining the CRCs of the BRAID_N braids at the same time. */
         comb = crc_word(crc0 ^ words[0]);
-#if N > 1
+#if BRAID_N > 1
         comb = crc_word(crc1 ^ words[1] ^ comb);
-#if N > 2
+#if BRAID_N > 2
         comb = crc_word(crc2 ^ words[2] ^ comb);
-#if N > 3
+#if BRAID_N > 3
         comb = crc_word(crc3 ^ words[3] ^ comb);
-#if N > 4
+#if BRAID_N > 4
         comb = crc_word(crc4 ^ words[4] ^ comb);
-#if N > 5
+#if BRAID_N > 5
         comb = crc_word(crc5 ^ words[5] ^ comb);
 #endif
 #endif
 #endif
 #endif
 #endif
-        words += N;
+        words += BRAID_N;
         Assert(comb <= UINT32_MAX, "comb should fit in uint32_t");
         c = (uint32_t)ZSWAPWORD(comb);
 
@@ -195,7 +196,7 @@ Z_INTERNAL uint32_t crc32_braid_internal(uint32_t c, const uint8_t *buf, size_t 
         buf = (const unsigned char *)words;
     }
 
-#endif /* W */
+#endif /* BRAID_W */
 
     /* Complete the computation of the CRC on any remaining bytes. */
     while (len >= 8) {
@@ -211,7 +212,7 @@ Z_INTERNAL uint32_t crc32_braid_internal(uint32_t c, const uint8_t *buf, size_t 
     return c;
 }
 
-uint32_t PREFIX(crc32_braid)(uint32_t c, const uint8_t *buf, size_t len) {
+Z_INTERNAL uint32_t crc32_braid(uint32_t c, const uint8_t *buf, size_t len) {
     c = (~c) & 0xffffffff;
 
     c = crc32_braid_internal(c, buf, len);

--- a/arch/generic/crc32_braid_c.c
+++ b/arch/generic/crc32_braid_c.c
@@ -72,7 +72,7 @@ Z_INTERNAL uint32_t crc32_braid_internal(uint32_t c, const uint8_t *buf, size_t 
         /* Compute the CRC up to a z_word_t boundary. */
         while (len && ((uintptr_t)buf & (BRAID_W - 1)) != 0) {
             len--;
-            DO1;
+            CRC_DO1;
         }
 
         /* Compute the CRC on as many BRAID_N z_word_t blocks as are available. */
@@ -201,11 +201,11 @@ Z_INTERNAL uint32_t crc32_braid_internal(uint32_t c, const uint8_t *buf, size_t 
     /* Complete the computation of the CRC on any remaining bytes. */
     while (len >= 8) {
         len -= 8;
-        DO8;
+        CRC_DO8;
     }
     while (len) {
         len--;
-        DO1;
+        CRC_DO1;
     }
 
     /* Return the CRC, post-conditioned. */

--- a/arch/generic/crc32_c.c
+++ b/arch/generic/crc32_c.c
@@ -1,9 +1,9 @@
 #include "zbuild.h"
 #include "crc32.h"
 #include "crc32_braid_p.h"
-#include "crc32_c.h"
+#include "generic_functions.h"
 
-uint32_t PREFIX(crc32_c)(uint32_t crc, const uint8_t *buf, size_t len) {
+Z_INTERNAL uint32_t crc32_c(uint32_t crc, const uint8_t *buf, size_t len) {
     uint32_t c;
     uint64_t* aligned_buf;
     size_t aligned_len;

--- a/arch/generic/crc32_c.c
+++ b/arch/generic/crc32_c.c
@@ -4,12 +4,11 @@
 #include "generic_functions.h"
 
 Z_INTERNAL uint32_t crc32_c(uint32_t crc, const uint8_t *buf, size_t len) {
-    uint32_t c;
+    uint32_t c = (~crc) & 0xffffffff;
+
+#ifndef WITHOUT_CHORBA
     uint64_t* aligned_buf;
     size_t aligned_len;
-
-    c = (~crc) & 0xffffffff;
-#ifndef WITHOUT_CHORBA
     unsigned long algn_diff = ((uintptr_t)8 - ((uintptr_t)buf & 0xF)) & 0xF;
     if (algn_diff < len) {
         if (algn_diff) {

--- a/arch/generic/crc32_c.c
+++ b/arch/generic/crc32_c.c
@@ -1,13 +1,7 @@
 #include "zbuild.h"
+#include "crc32.h"
 #include "crc32_braid_p.h"
 #include "crc32_c.h"
-
-/* Size thresholds for Chorba algorithm variants */
-#define CHORBA_LARGE_THRESHOLD (sizeof(z_word_t) * 64 * 1024)
-#define CHORBA_MEDIUM_UPPER_THRESHOLD 32768
-#define CHORBA_MEDIUM_LOWER_THRESHOLD 8192
-#define CHORBA_SMALL_THRESHOLD_64BIT 72
-#define CHORBA_SMALL_THRESHOLD_32BIT 80
 
 uint32_t PREFIX(crc32_c)(uint32_t crc, const uint8_t *buf, size_t len) {
     uint32_t c;

--- a/arch/generic/crc32_c.c
+++ b/arch/generic/crc32_c.c
@@ -25,7 +25,7 @@ uint32_t PREFIX(crc32_c)(uint32_t crc, const uint8_t *buf, size_t len) {
         aligned_len = len - algn_diff;
         if(aligned_len > CHORBA_LARGE_THRESHOLD)
             c = crc32_chorba_118960_nondestructive(c, (z_word_t*) aligned_buf, aligned_len);
-#  if W == 8
+#  if BRAID_W == 8
         else if (aligned_len > CHORBA_MEDIUM_LOWER_THRESHOLD && aligned_len <= CHORBA_MEDIUM_UPPER_THRESHOLD)
             c = crc32_chorba_32768_nondestructive(c, (uint64_t*) aligned_buf, aligned_len);
         else if (aligned_len > CHORBA_SMALL_THRESHOLD_64BIT)

--- a/arch/generic/crc32_c.c
+++ b/arch/generic/crc32_c.c
@@ -19,7 +19,7 @@ Z_INTERNAL uint32_t crc32_c(uint32_t crc, const uint8_t *buf, size_t len) {
         aligned_len = len - algn_diff;
         if(aligned_len > CHORBA_LARGE_THRESHOLD)
             c = crc32_chorba_118960_nondestructive(c, (z_word_t*) aligned_buf, aligned_len);
-#  if BRAID_W == 8
+#  if OPTIMAL_CMP == 64
         else if (aligned_len > CHORBA_MEDIUM_LOWER_THRESHOLD && aligned_len <= CHORBA_MEDIUM_UPPER_THRESHOLD)
             c = crc32_chorba_32768_nondestructive(c, (uint64_t*) aligned_buf, aligned_len);
         else if (aligned_len > CHORBA_SMALL_THRESHOLD_64BIT)

--- a/arch/generic/crc32_chorba_c.c
+++ b/arch/generic/crc32_chorba_c.c
@@ -1,7 +1,7 @@
 #include "zbuild.h"
 #include "crc32_braid_p.h"
 #include "crc32_braid_tbl.h"
-#include "crc32_c.h"
+#include "generic_functions.h"
 
 /* Implement Chorba algorithm from https://arxiv.org/abs/2412.16398 */
 #define bitbuffersizebytes (16 * 1024 * sizeof(z_word_t))

--- a/arch/generic/generic_functions.h
+++ b/arch/generic/generic_functions.h
@@ -6,37 +6,45 @@
 #define GENERIC_FUNCTIONS_H_
 
 #include "zendian.h"
-
-Z_INTERNAL uint32_t crc32_fold_reset_c(crc32_fold *crc);
-Z_INTERNAL void     crc32_fold_copy_c(crc32_fold *crc, uint8_t *dst, const uint8_t *src, size_t len);
-Z_INTERNAL void     crc32_fold_c(crc32_fold *crc, const uint8_t *src, size_t len, uint32_t init_crc);
-Z_INTERNAL uint32_t crc32_fold_final_c(crc32_fold *crc);
-
-Z_INTERNAL uint32_t adler32_fold_copy_c(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len);
-
+#include "deflate.h"
+#include "crc32_braid_p.h"
 
 typedef uint32_t (*adler32_func)(uint32_t adler, const uint8_t *buf, size_t len);
 typedef uint32_t (*compare256_func)(const uint8_t *src0, const uint8_t *src1);
 typedef uint32_t (*crc32_func)(uint32_t crc32, const uint8_t *buf, size_t len);
+typedef void     (*slide_hash_func)(deflate_state *s);
+
 
 uint32_t adler32_c(uint32_t adler, const uint8_t *buf, size_t len);
+uint32_t adler32_fold_copy_c(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len);
 
-uint32_t chunksize_c(void);
 uint8_t* chunkmemset_safe_c(uint8_t *out, uint8_t *from, unsigned len, unsigned left);
-void     inflate_fast_c(PREFIX3(stream) *strm, uint32_t start);
-
-uint32_t PREFIX(crc32_c)(uint32_t crc, const uint8_t *buf, size_t len);
-uint32_t PREFIX(crc32_braid)(uint32_t c, const uint8_t *buf, size_t len);
-Z_INTERNAL uint32_t crc32_braid_internal(uint32_t c, const uint8_t *buf, size_t len);
+uint32_t chunksize_c(void);
 
 uint32_t compare256_c(const uint8_t *src0, const uint8_t *src1);
 
-typedef void (*slide_hash_func)(deflate_state *s);
+uint32_t crc32_c(uint32_t crc, const uint8_t *buf, size_t len);
+uint32_t crc32_braid(uint32_t c, const uint8_t *buf, size_t len);
+uint32_t crc32_braid_internal(uint32_t c, const uint8_t *buf, size_t len);
 
-void     slide_hash_c(deflate_state *s);
+#ifndef WITHOUT_CHORBA
+  uint32_t crc32_chorba_118960_nondestructive (uint32_t crc, const z_word_t* input, size_t len);
+  uint32_t crc32_chorba_32768_nondestructive (uint32_t crc, const uint64_t* buf, size_t len);
+  uint32_t crc32_chorba_small_nondestructive (uint32_t crc, const uint64_t* buf, size_t len);
+  uint32_t crc32_chorba_small_nondestructive_32bit (uint32_t crc, const uint32_t* buf, size_t len);
+#endif
+
+uint32_t crc32_fold_reset_c(crc32_fold *crc);
+void     crc32_fold_copy_c(crc32_fold *crc, uint8_t *dst, const uint8_t *src, size_t len);
+void     crc32_fold_c(crc32_fold *crc, const uint8_t *src, size_t len, uint32_t init_crc);
+uint32_t crc32_fold_final_c(crc32_fold *crc);
+
+void     inflate_fast_c(PREFIX3(stream) *strm, uint32_t start);
 
 uint32_t longest_match_c(deflate_state *const s, Pos cur_match);
 uint32_t longest_match_slow_c(deflate_state *const s, Pos cur_match);
+
+void     slide_hash_c(deflate_state *s);
 
 #ifdef DISABLE_RUNTIME_CPU_DETECTION
 // Generic code

--- a/arch/s390/crc32-vx.c
+++ b/arch/s390/crc32-vx.c
@@ -202,12 +202,12 @@ uint32_t Z_INTERNAL crc32_s390_vx(uint32_t crc, const unsigned char *buf, size_t
     size_t prealign, aligned, remaining;
 
     if (len < VX_MIN_LEN + VX_ALIGN_MASK)
-        return PREFIX(crc32_c)(crc, buf, len);
+        return crc32_c(crc, buf, len);
 
     if ((uintptr_t)buf & VX_ALIGN_MASK) {
         prealign = VX_ALIGNMENT - ((uintptr_t)buf & VX_ALIGN_MASK);
         len -= prealign;
-        crc = PREFIX(crc32_c)(crc, buf, prealign);
+        crc = crc32_c(crc, buf, prealign);
         buf += prealign;
     }
     aligned = len & ~VX_ALIGN_MASK;
@@ -216,7 +216,7 @@ uint32_t Z_INTERNAL crc32_s390_vx(uint32_t crc, const unsigned char *buf, size_t
     crc = crc32_le_vgfm_16(crc ^ 0xffffffff, buf, aligned) ^ 0xffffffff;
 
     if (remaining)
-        crc = PREFIX(crc32_c)(crc, buf + aligned, remaining);
+        crc = crc32_c(crc, buf + aligned, remaining);
 
     return crc;
 }

--- a/arch/x86/crc32_pclmulqdq_tpl.h
+++ b/arch/x86/crc32_pclmulqdq_tpl.h
@@ -168,6 +168,7 @@ static void fold_4(__m128i *xmm_crc0, __m128i *xmm_crc1, __m128i *xmm_crc2, __m1
     *xmm_crc3 = _mm_castps_si128(ps_res3);
 }
 
+#ifndef WITHOUT_CHORBA
 static void fold_12(__m128i *xmm_crc0, __m128i *xmm_crc1, __m128i *xmm_crc2, __m128i *xmm_crc3) {
     const __m128i xmm_fold12 = _mm_set_epi64x(0x596C8D81, 0xF5E48C85);
     __m128i x_tmp0, x_tmp1, x_tmp2, x_tmp3;
@@ -209,6 +210,7 @@ static void fold_12(__m128i *xmm_crc0, __m128i *xmm_crc1, __m128i *xmm_crc2, __m
     *xmm_crc2 = _mm_castps_si128(ps_res2);
     *xmm_crc3 = _mm_castps_si128(ps_res3);
 }
+#endif
 
 static const unsigned ALIGNED_(32) pshufb_shf_table[60] = {
     0x84838281, 0x88878685, 0x8c8b8a89, 0x008f8e8d, /* shl 15 (16 - 1)/shr1 */

--- a/arch/x86/crc32_pclmulqdq_tpl.h
+++ b/arch/x86/crc32_pclmulqdq_tpl.h
@@ -398,7 +398,7 @@ static inline uint32_t crc32_small(uint32_t crc, const uint8_t *buf, size_t len)
 
     while (len) {
         len--;
-        DO1;
+        CRC_DO1;
     }
 
     return c ^ 0xffffffff;

--- a/crc32.h
+++ b/crc32.h
@@ -5,8 +5,15 @@
 #ifndef CRC32_H_
 #define CRC32_H_
 
-#define CRC32_FOLD_BUFFER_SIZE (16 * 4)
 /* sizeof(__m128i) * (4 folds) */
+#define CRC32_FOLD_BUFFER_SIZE (16 * 4)
+
+/* Size thresholds for Chorba algorithm variants */
+#define CHORBA_LARGE_THRESHOLD (sizeof(z_word_t) * 64 * 1024)
+#define CHORBA_MEDIUM_UPPER_THRESHOLD 32768
+#define CHORBA_MEDIUM_LOWER_THRESHOLD 8192
+#define CHORBA_SMALL_THRESHOLD_64BIT 72
+#define CHORBA_SMALL_THRESHOLD_32BIT 80
 
 typedef struct crc32_fold_s {
     uint8_t fold[CRC32_FOLD_BUFFER_SIZE];

--- a/crc32_braid_p.h
+++ b/crc32_braid_p.h
@@ -3,51 +3,27 @@
 
 #include "zendian.h"
 
-/* Define N */
-#ifdef Z_TESTN
-#  define N Z_TESTN
-#else
-#  define N 5
-#endif
-#if N < 1 || N > 6
-#  error N must be in 1..6
-#endif
+/* Define BRAID_N, valid range is 1..6 */
+#define BRAID_N 5
 
-/*
-  Define W and the associated z_word_t type. If W is not defined, then a
-  braided calculation is not used, and the associated tables and code are not
-  compiled.
+/* Define BRAID_W and the associated z_word_t type. If BRAID_W is not defined, then a braided
+   calculation is not used, and the associated tables and code are not compiled.
  */
-#ifdef Z_TESTW
-#  if Z_TESTW-1 != -1
-#    define W Z_TESTW
-#  endif
+#if defined(__x86_64__) || defined(_M_AMD64) || defined(__aarch64__) || defined(_M_ARM64) || defined(__powerpc64__)
+#  define BRAID_W 8
+    typedef uint64_t z_word_t;
 #else
-#  ifndef W
-#    if defined(__x86_64__) || defined(_M_AMD64) || defined(__aarch64__) || defined(_M_ARM64) || defined(__powerpc64__)
-#      define W 8
-#    else
-#      define W 4
-#    endif
-#  endif
-#endif
-#ifdef W
-#  if W == 8
-     typedef uint64_t z_word_t;
-#  else
-#    undef W
-#    define W 4
-     typedef uint32_t z_word_t;
-#  endif
+#  define BRAID_W 4
+    typedef uint32_t z_word_t;
 #endif
 
 #if BYTE_ORDER == LITTLE_ENDIAN
 #  define ZSWAPWORD(word) (word)
 #  define BRAID_TABLE crc_braid_table
 #elif BYTE_ORDER == BIG_ENDIAN
-#  if W == 8
+#  if BRAID_W == 8
 #    define ZSWAPWORD(word) ZSWAP64(word)
-#  elif W == 4
+#  elif BRAID_W == 4
 #    define ZSWAPWORD(word) ZSWAP32(word)
 #  endif
 #  define BRAID_TABLE crc_braid_big_table

--- a/crc32_braid_p.h
+++ b/crc32_braid_p.h
@@ -31,8 +31,8 @@
 #  error "No endian defined"
 #endif
 
-#define DO1 c = crc_table[(c ^ *buf++) & 0xff] ^ (c >> 8)
-#define DO8 DO1; DO1; DO1; DO1; DO1; DO1; DO1; DO1
+#define CRC_DO1 c = crc_table[(c ^ *buf++) & 0xff] ^ (c >> 8)
+#define CRC_DO8 CRC_DO1; CRC_DO1; CRC_DO1; CRC_DO1; CRC_DO1; CRC_DO1; CRC_DO1; CRC_DO1
 
 /* CRC polynomial. */
 #define POLY 0xedb88320         /* p(x) reflected, with x^32 implied */

--- a/crc32_braid_tbl.h
+++ b/crc32_braid_tbl.h
@@ -59,9 +59,8 @@ static const uint32_t crc_table[] = {
     0x5d681b02, 0x2a6f2b94, 0xb40bbe37, 0xc30c8ea1, 0x5a05df1b,
     0x2d02ef8d};
 
-#ifdef W
-
-#if W == 8
+#ifdef BRAID_W
+#  if BRAID_W == 8
 
 static const z_word_t crc_big_table[] = {
     0x0000000000000000, 0x9630077700000000, 0x2c610eee00000000,
@@ -151,7 +150,7 @@ static const z_word_t crc_big_table[] = {
     0x37be0bb400000000, 0xa18e0cc300000000, 0x1bdf055a00000000,
     0x8def022d00000000};
 
-#else /* W == 4 */
+#  else /* BRAID_W == 4 */
 
 static const z_word_t crc_big_table[] = {
     0x00000000, 0x96300777, 0x2c610eee, 0xba510999, 0x19c46d07,
@@ -207,13 +206,11 @@ static const z_word_t crc_big_table[] = {
     0x021b685d, 0x942b6f2a, 0x37be0bb4, 0xa18e0cc3, 0x1bdf055a,
     0x8def022d};
 
-#endif
+#  endif
+#endif /* BRAID_W */
 
-#endif /* W */
-
-#if N == 1
-
-#if W == 8
+#if BRAID_N == 1
+#  if BRAID_W == 8
 
 static const uint32_t crc_braid_table[][256] = {
    {0x00000000, 0xccaa009e, 0x4225077d, 0x8e8f07e3, 0x844a0efa,
@@ -1323,7 +1320,7 @@ static const z_word_t crc_braid_big_table[][256] = {
     0x0501c4a800000000, 0x9b016e6400000000, 0x7806e1ea00000000,
     0xe6064b2600000000}};
 
-#else /* W == 4 */
+#  else /* BRAID_W == 4 */
 
 static const uint32_t crc_braid_table[][256] = {
    {0x00000000, 0xb8bc6765, 0xaa09c88b, 0x12b5afee, 0x8f629757,
@@ -1745,12 +1742,10 @@ static const z_word_t crc_braid_big_table[][256] = {
     0xc3f6dbe9, 0xa6916751, 0x1fa9b0cc, 0x7ace0c74, 0x9461b966,
     0xf10605de}};
 
-#endif /* W */
-
-#endif /* N == 1 */
-#if N == 2
-
-#if W == 8
+#  endif /* BRAID_W */
+#endif /* BRAID_N == 1 */
+#if BRAID_N == 2
+#  if BRAID_W == 8
 
 static const uint32_t crc_braid_table[][256] = {
    {0x00000000, 0xae689191, 0x87a02563, 0x29c8b4f2, 0xd4314c87,
@@ -2860,7 +2855,7 @@ static const z_word_t crc_braid_big_table[][256] = {
     0x258db92400000000, 0xb41cd18a00000000, 0x46a819a300000000,
     0xd739710d00000000}};
 
-#else /* W == 4 */
+#  else /* BRAID_W == 4 */
 
 static const uint32_t crc_braid_table[][256] = {
    {0x00000000, 0xccaa009e, 0x4225077d, 0x8e8f07e3, 0x844a0efa,
@@ -3282,12 +3277,10 @@ static const z_word_t crc_braid_big_table[][256] = {
     0x8208ab6e, 0x1c0801a2, 0x0501c4a8, 0x9b016e64, 0x7806e1ea,
     0xe6064b26}};
 
-#endif /* W */
-
-#endif /* N == 2 */
-#if N == 3
-
-#if W == 8
+#  endif /* BRAID_W */
+#endif /* BRAID_N == 2 */
+#if BRAID_N == 3
+#  if BRAID_W == 8
 
 static const uint32_t crc_braid_table[][256] = {
    {0x00000000, 0x81256527, 0xd93bcc0f, 0x581ea928, 0x69069e5f,
@@ -4397,7 +4390,7 @@ static const z_word_t crc_braid_big_table[][256] = {
     0x792cd35100000000, 0x5e49f6d000000000, 0x76e0e88800000000,
     0x5185cd0900000000}};
 
-#else /* W == 4 */
+#  else /* BRAID_W == 4 */
 
 static const uint32_t crc_braid_table[][256] = {
    {0x00000000, 0x9ba54c6f, 0xec3b9e9f, 0x779ed2f0, 0x03063b7f,
@@ -4819,12 +4812,10 @@ static const z_word_t crc_braid_big_table[][256] = {
     0x7506baae, 0x1a4a1f35, 0x95a38741, 0xfaef22da, 0x0a3dbcad,
     0x65711936}};
 
-#endif /* W */
-
-#endif /* N == 3 */
-#if N == 4
-
-#if W == 8
+#  endif /* BRAID_W */
+#endif /* BRAID_N == 3 */
+#if BRAID_N == 4
+#  if BRAID_W == 8
 
 static const uint32_t crc_braid_table[][256] = {
    {0x00000000, 0xf1da05aa, 0x38c50d15, 0xc91f08bf, 0x718a1a2a,
@@ -5934,7 +5925,7 @@ static const z_word_t crc_braid_big_table[][256] = {
     0xa951db2a00000000, 0x035401db00000000, 0xbc5c1e1200000000,
     0x1659c4e300000000}};
 
-#else /* W == 4 */
+#  else /* BRAID_W == 4 */
 
 static const uint32_t crc_braid_table[][256] = {
    {0x00000000, 0xae689191, 0x87a02563, 0x29c8b4f2, 0xd4314c87,
@@ -6356,12 +6347,10 @@ static const z_word_t crc_braid_big_table[][256] = {
     0xc1e42877, 0x507540d9, 0x258db924, 0xb41cd18a, 0x46a819a3,
     0xd739710d}};
 
-#endif /* W */
-
-#endif /* N == 4 */
-#if N == 5
-
-#if W == 8
+#  endif /* BRAID_W */
+#endif /* BRAID_N == 4 */
+#if BRAID_N == 5
+#  if BRAID_W == 8
 
 static const uint32_t crc_braid_table[][256] = {
    {0x00000000, 0xaf449247, 0x85f822cf, 0x2abcb088, 0xd08143df,
@@ -7471,7 +7460,7 @@ static const z_word_t crc_braid_big_table[][256] = {
     0xedc528c300000000, 0xaa576c6c00000000, 0x22e7d04600000000,
     0x657594e900000000}};
 
-#else /* W == 4 */
+#  else /* BRAID_W == 4 */
 
 static const uint32_t crc_braid_table[][256] = {
    {0x00000000, 0x65673b46, 0xcace768c, 0xafa94dca, 0x4eedeb59,
@@ -7893,12 +7882,10 @@ static const z_word_t crc_braid_big_table[][256] = {
     0x2abb26f3, 0x6c804196, 0xff260577, 0xb91d6212, 0x7350cbbd,
     0x356bacd8}};
 
-#endif /* W */
-
-#endif /* N == 5 */
-#if N == 6
-
-#if W == 8
+#  endif /* BRAID_W */
+#endif /* BRAID_N == 5 */
+#if BRAID_N == 6
+#  if BRAID_W == 8
 
 static const uint32_t crc_braid_table[][256] = {
    {0x00000000, 0x3db1ecdc, 0x7b63d9b8, 0x46d23564, 0xf6c7b370,
@@ -9008,7 +8995,7 @@ static const z_word_t crc_braid_big_table[][256] = {
     0xcc95bac300000000, 0x10790bfe00000000, 0x744cd9b800000000,
     0xa8a0688500000000}};
 
-#else /* W == 4 */
+#  else /* BRAID_W == 4 */
 
 static const uint32_t crc_braid_table[][256] = {
    {0x00000000, 0x81256527, 0xd93bcc0f, 0x581ea928, 0x69069e5f,
@@ -9430,9 +9417,8 @@ static const z_word_t crc_braid_big_table[][256] = {
     0x297eeee1, 0x0e1bcb60, 0x792cd351, 0x5e49f6d0, 0x76e0e888,
     0x5185cd09}};
 
-#endif /* W */
-
-#endif /* N == 6 */
+#  endif /* BRAID_W */
+#endif /* BRAID_N == 6 */
 
 static const uint32_t x2n_table[] = {
     0x40000000, 0x20000000, 0x08000000, 0x00800000, 0x00008000,

--- a/crc32_c.h
+++ b/crc32_c.h
@@ -1,4 +1,0 @@
-Z_INTERNAL uint32_t crc32_chorba_118960_nondestructive (uint32_t crc, const z_word_t* input, size_t len);
-Z_INTERNAL uint32_t crc32_chorba_32768_nondestructive (uint32_t crc, const uint64_t* buf, size_t len);
-Z_INTERNAL uint32_t crc32_chorba_small_nondestructive (uint32_t crc, const uint64_t* buf, size_t len);
-Z_INTERNAL uint32_t crc32_chorba_small_nondestructive_32bit (uint32_t crc, const uint32_t* buf, size_t len);

--- a/crc32_c.h
+++ b/crc32_c.h
@@ -2,4 +2,3 @@ Z_INTERNAL uint32_t crc32_chorba_118960_nondestructive (uint32_t crc, const z_wo
 Z_INTERNAL uint32_t crc32_chorba_32768_nondestructive (uint32_t crc, const uint64_t* buf, size_t len);
 Z_INTERNAL uint32_t crc32_chorba_small_nondestructive (uint32_t crc, const uint64_t* buf, size_t len);
 Z_INTERNAL uint32_t crc32_chorba_small_nondestructive_32bit (uint32_t crc, const uint32_t* buf, size_t len);
-Z_INTERNAL uint32_t crc32_braid_internal(uint32_t c, const uint8_t *buf, size_t len);

--- a/functable.c
+++ b/functable.c
@@ -54,7 +54,7 @@ static void init_functable(void) {
     ft.adler32_fold_copy = &adler32_fold_copy_c;
     ft.chunkmemset_safe = &chunkmemset_safe_c;
     ft.chunksize = &chunksize_c;
-    ft.crc32 = &PREFIX(crc32_c);
+    ft.crc32 = &crc32_c;
     ft.crc32_fold = &crc32_fold_c;
     ft.crc32_fold_copy = &crc32_fold_copy_c;
     ft.crc32_fold_final = &crc32_fold_final_c;

--- a/test/benchmarks/benchmark_crc32.cc
+++ b/test/benchmarks/benchmark_crc32.cc
@@ -56,8 +56,13 @@ public:
     } \
     BENCHMARK_REGISTER_F(crc32, name)->Arg(1)->Arg(8)->Arg(12)->Arg(16)->Arg(32)->Arg(64)->Arg(512)->Arg(4<<10)->Arg(32<<10)->Arg(256<<10)->Arg(4096<<10);
 
-BENCHMARK_CRC32(braid, PREFIX(crc32_braid), 1);
-BENCHMARK_CRC32(generic, PREFIX(crc32_c), 1);
+#ifndef WITHOUT_CHORBA
+BENCHMARK_CRC32(generic_chorba, crc32_c, 1);
+#else
+BENCHMARK_CRC32(generic, crc32_c, 1);
+#endif
+
+BENCHMARK_CRC32(braid, crc32_braid, 1);
 
 #ifdef DISABLE_RUNTIME_CPU_DETECTION
 BENCHMARK_CRC32(native, native_crc32, 1);

--- a/test/test_crc32.cc
+++ b/test/test_crc32.cc
@@ -224,8 +224,13 @@ INSTANTIATE_TEST_SUITE_P(crc32, crc32_variant, testing::ValuesIn(tests));
         hash(GetParam(), func); \
     }
 
-TEST_CRC32(generic, PREFIX(crc32_c), 1)
-TEST_CRC32(braid, PREFIX(crc32_braid), 1)
+#ifndef WITHOUT_CHORBA
+TEST_CRC32(generic_chorba, crc32_c, 1)
+#else
+TEST_CRC32(generic, crc32_c, 1)
+#endif
+
+TEST_CRC32(braid, crc32_braid, 1)
 
 #ifdef DISABLE_RUNTIME_CPU_DETECTION
 TEST_CRC32(native, native_crc32, 1)

--- a/tools/makecrct.c
+++ b/tools/makecrct.c
@@ -15,9 +15,9 @@
     and writes out the tables for the case that z_word_t is 32 bits.
 */
 
-#define W 8 /* Need a 64-bit integer type in order to generate crc32 tables. */
-
-#include "crc32_braid_p.h"
+#define POLY 0xedb88320         /* p(x) reflected, with x^32 implied */
+#define BRAID_W 8 /* Need a 64-bit integer type in order to generate crc32 tables. */
+typedef uint64_t z_word_t;
 
 static uint32_t crc_table[256];
 static z_word_t crc_big_table[256];
@@ -156,32 +156,31 @@ static void print_crc_table(void) {
     printf("};\n\n");
 
     /* print big-endian CRC table for 64-bit z_word_t */
-    printf("#ifdef W\n\n");
-    printf("#if W == 8\n\n");
+    printf("#ifdef BRAID_W\n");
+    printf("#  if BRAID_W == 8\n\n");
     printf("static const z_word_t crc_big_table[] = {\n");
     printf("    ");
     write_table64(crc_big_table, 256);
     printf("};\n\n");
 
     /* print big-endian CRC table for 32-bit z_word_t */
-    printf("#else /* W == 4 */\n\n");
+    printf("#  else /* BRAID_W == 4 */\n\n");
     printf("static const z_word_t crc_big_table[] = {\n");
     printf("    ");
     write_table32hi(crc_big_table, 256);
     printf("};\n\n");
-    printf("#endif\n\n");
-    printf("#endif /* W */\n\n");
+    printf("#  endif\n");
+    printf("#endif /* BRAID_W */\n\n");
 
     /* write out braid tables for each value of N */
     for (n = 1; n <= 6; n++) {
-        printf("#if N == %d\n", n);
+        printf("#if BRAID_N == %d\n", n);
 
         /* compute braid tables for this N and 64-bit word_t */
         braid(ltl, big, n, 8);
 
         /* write out braid tables for 64-bit z_word_t */
-        printf("\n");
-        printf("#if W == 8\n\n");
+        printf("#  if BRAID_W == 8\n\n");
         printf("static const uint32_t crc_braid_table[][256] = {\n");
         for (k = 0; k < 8; k++) {
             printf("   {");
@@ -202,7 +201,7 @@ static void print_crc_table(void) {
 
         /* write out braid tables for 32-bit z_word_t */
         printf("\n");
-        printf("#else /* W == 4 */\n\n");
+        printf("#  else /* BRAID_W == 4 */\n\n");
         printf("static const uint32_t crc_braid_table[][256] = {\n");
         for (k = 0; k < 4; k++) {
             printf("   {");
@@ -217,9 +216,8 @@ static void print_crc_table(void) {
             printf("}%s", k < 3 ? ",\n" : "");
         }
         printf("};\n\n");
-        printf("#endif /* W */\n\n");
-
-        printf("#endif /* N == %d */\n", n);
+        printf("#  endif /* BRAID_W */\n");
+        printf("#endif /* BRAID_N == %d */\n", n);
     }
     printf("\n");
 


### PR DESCRIPTION
- Rename N and W to BRAID_N and BRAID_W
- Remove override capabilities for BRAID_N and BRAID_W
- Fix formatting in crc32_braid_tbl.h
- Make makecrct not rely on crc32_braid_p.h
- Move Chorba defines
- Rename DO1/DO8 macros
- Mark crc32_c and crc32_braid functions as internal, and remove prefix
- Reorder contents of generic_functions, and remove Z_INTERNAL hints from declarations
- Add test/benchmark output to indicate whether Chorba is used
- Use OPTIMAL_CMP instead of BRAID_W to test for optimal size for Chorba
- Make Chorba configurable,and add a few missing header files to CMake config.
- Add CI run without chorba enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration option for an optimized CRC32 algorithm—enabled by default—to enhance checksum performance and provide improved flexibility in build configurations.
  - Added a new benchmark for `generic_chorba` CRC32 processing.
  - Added several new preprocessor definitions related to the Chorba algorithm thresholds, enhancing configuration options.

- **Tests**
  - Expanded the testing and benchmarking suite to rigorously validate enhanced CRC32 processing under various build setups, including conditional test cases based on compilation flags.

- **Chores**
  - Streamlined build configurations and improved continuous integration workflows, contributing to higher overall stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->