### PR TITLE
fix the url of the s390x actions worker patch

### DIFF
--- a/arch/s390/self-hosted-builder/actions-runner.Dockerfile
+++ b/arch/s390/self-hosted-builder/actions-runner.Dockerfile
@@ -15,7 +15,7 @@ RUN     cd /tmp && \
         git clone -q https://github.com/actions/runner && \
         cd runner && \
         git checkout $(git describe --tags $(git rev-list --tags --max-count=1)) -b build && \
-        wget https://github.com/anup-kodlekere/gaplib/raw/refs/heads/main/build-files/runner-sdk-8.patch && \
+        wget https://github.com/anup-kodlekere/gaplib/raw/refs/heads/main/patches/runner-main-sdk8-s390x.patch -O runner-sdk-8.patch && \
         git apply runner-sdk-8.patch && \
         sed -i'' -e /version/s/8......\"$/$8.0.100\"/ src/global.json
 


### PR DESCRIPTION
gaplib changed their patch names. This fixes the path and pins the patch to a specific git hash instead of the main branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the source URL for a key patch, which may enhance build stability and improve actions runner functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->