### PR TITLE
Disable MSVC optimizations for AVX512 GET_CHUNK_MAG

### DIFF
--- a/arch/x86/chunkset_avx512.c
+++ b/arch/x86/chunkset_avx512.c
@@ -98,6 +98,10 @@ static inline uint8_t* CHUNKCOPY(uint8_t *out, uint8_t const *from, unsigned len
     return out;
 }
 
+/* MSVC compiler decompression bug when optimizing for size */
+#if defined(_MSC_VER) && _MSC_VER < 1943
+#  pragma optimize("", off)
+#endif
 static inline chunk_t GET_CHUNK_MAG(uint8_t *buf, uint32_t *chunk_rem, uint32_t dist) {
     lut_rem_pair lut_rem = perm_idx_lut[dist - 3];
     __m256i ret_vec;
@@ -128,6 +132,9 @@ static inline chunk_t GET_CHUNK_MAG(uint8_t *buf, uint32_t *chunk_rem, uint32_t 
 
     return ret_vec;
 }
+#if defined(_MSC_VER) && _MSC_VER < 1943
+#  pragma optimize("", on)
+#endif
 
 static inline void storehalfchunk(uint8_t *out, halfchunk_t *chunk) {
     _mm_storeu_si128((__m128i *)out, *chunk);


### PR DESCRIPTION
MSVC compiler (VS 17.11.x) incorrectly optimizes the GET_CHUNK_MAG code on older versions. Appears to be resolved in VS 17.13.2. The compiler would optimize the code in such a way that it would cause a decompression failure. It only happens when /Os flag is set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Addressed a compiler optimization issue affecting builds with older versions of Microsoft Visual Studio, ensuring a more reliable and stable build process without changing the application's functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->