### PR TITLE
Minor fix for s390x CI runner

### DIFF
--- a/arch/s390/self-hosted-builder/actions-runner.Dockerfile
+++ b/arch/s390/self-hosted-builder/actions-runner.Dockerfile
@@ -14,7 +14,7 @@ RUN     dnf install -y -q dotnet-sdk-8.0 && \
 RUN     cd /tmp && \
         git clone -q https://github.com/actions/runner && \
         cd runner && \
-        git checkout $(git describe --tags $(git rev-list --tags --max-count=1)) -b build && \
+        git checkout $(git tag | grep "^v[0-9]\+\.[0-9]\+\.[0-9]\+$" | sort -V | tail -1) -b build && \
         wget https://github.com/anup-kodlekere/gaplib/raw/refs/heads/main/patches/runner-main-sdk8-s390x.patch -O runner-sdk-8.patch && \
         git apply runner-sdk-8.patch && \
         sed -i'' -e /version/s/8......\"$/$8.0.100\"/ src/global.json


### PR DESCRIPTION
Instead of selecting the most recent tag when downloading the actions runner, select the highest version number.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Refined the version selection process in the deployment workflow to ensure that only properly formatted, semantic version tags are used for version checkout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->