### PR TITLE
port: Use __cpuid only, when available.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -497,6 +497,44 @@ endif()
 set(CMAKE_REQUIRED_DEFINITIONS)
 
 #
+# Check for x86 __cpuid / __cpuid_count support: GNU extensions
+# gcc/clang and MSVC have __cpuid, so check __cpuid_count instead
+check_symbol_exists(__cpuid_count cpuid.h HAVE_CPUID_GNU)
+if(HAVE_CPUID_GNU)
+    add_definitions(-DHAVE_CPUID_GNU)
+endif()
+set(CMAKE_REQUIRED_DEFINITIONS)
+
+#
+# Check for x86 __cpuid / __cpuidex support: MSVC extensions
+# gcc/clang and MSVC have __cpuid, so check __cpuidex instead
+# check_symbol_exists() does not work for intrinsics
+
+check_c_source_compiles(
+"
+#include <intrin.h>
+static inline void cpuid_ms(int info, unsigned int *eax, unsigned int *ebx, unsigned int *ecx, unsigned int *edx) {
+    unsigned int registers[4];
+    __cpuid((int *)registers, info);
+    *eax = registers[0];
+    *ebx = registers[1];
+    *ecx = registers[2];
+    *edx = registers[3];
+}
+
+int main(void) {
+  unsigned int eax, ebx, ecx, edx;
+  cpuid_ms(0, &eax, &ebx, &ecx, &edx);
+  return eax;
+}"
+HAVE_CPUID_MS)
+
+if(HAVE_CPUID_MS)
+    add_definitions(-DHAVE_CPUID_MS)
+endif()
+set(CMAKE_REQUIRED_DEFINITIONS)
+
+#
 # Check whether a sanitizer was requested
 #
 if(WITH_SANITIZER STREQUAL "Address")

--- a/configure
+++ b/configure
@@ -809,6 +809,61 @@ fi
 echo >> configure.log
 
 
+# check for cpuid support: GNU extensions
+cat > $test.c <<EOF
+#include <cpuid.h>
+#include <stdio.h>
+static inline void cpuid_gnu(int info, unsigned int *eax, unsigned int *ebx, unsigned int *ecx, unsigned int *edx) {
+    *eax = *ebx = *ecx = *edx = 0;
+    __cpuid(info, *eax, *ebx, *ecx, *edx);
+}
+
+int main(void) {
+  unsigned int eax, ebx, ecx, edx;
+  cpuid_gnu(0, &eax, &ebx, &ecx, &edx);
+  printf("%d\n", eax);
+  return eax;
+}
+EOF
+if try $CC $CFLAGS -o $test $test.c $LDSHAREDLIBC; then
+  echo "Checking for GNU style __cpuid... Yes." | tee -a configure.log
+  CFLAGS="${CFLAGS} -DHAVE_CPUID_GNU"
+  SFLAGS="${SFLAGS} -DHAVE_CPUID_GNU"
+else
+  echo "Checking for GNU style __cpuid... No." | tee -a configure.log
+fi
+echo >> configure.log
+
+# check for cpuid support: MSVC extensions
+cat > $test.c <<EOF
+#include <intrin.h>
+#include <stdio.h>
+static inline void cpuid_ms(int info, unsigned int *eax, unsigned int *ebx, unsigned int *ecx, unsigned int *edx) {
+    unsigned int registers[4];
+    __cpuid((int *)registers, info);
+    *eax = registers[0];
+    *ebx = registers[1];
+    *ecx = registers[2];
+    *edx = registers[3];
+}
+
+int main(void) {
+  unsigned int eax, ebx, ecx, edx;
+  cpuid_ms(0, &eax, &ebx, &ecx, &edx);
+  printf("%d\n", eax);
+  return 0;
+}
+EOF
+if try $CC $CFLAGS -o $test $test.c $LDSHAREDLIBC; then
+  echo "Checking for MS style __cpuid... Yes." | tee -a configure.log
+  CFLAGS="${CFLAGS} -DHAVE_CPUID_MS"
+  SFLAGS="${SFLAGS} -DHAVE_CPUID_MS"
+else
+  echo "Checking for MS style __cpuid... No." | tee -a configure.log
+fi
+echo >> configure.log
+
+
 # check for strerror() for use by gz* functions
 cat > $test.c <<EOF
 #include <string.h>


### PR DESCRIPTION
Add a fallback, when __cpuid is not available.

This allows other compiler to build zlib-ng.
tcc as example
(compiling zlib-ng with OpenWatcom needs a C99 feature, which has issues in OW)

Regards ... Detlef


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved detection of CPU instruction support for different compilers, enhancing compatibility on x86 systems.
- **Bug Fixes**
  - More robust handling of CPU feature detection to ensure correct functionality across various compiler environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->