### PR TITLE
riscv: chunkset_rvv: remove CHUNKCOPY override

### DIFF
--- a/arch/riscv/chunkset_rvv.c
+++ b/arch/riscv/chunkset_rvv.c
@@ -60,60 +60,6 @@ static inline void storechunk(uint8_t *out, chunk_t *chunk) {
 #define CHUNKMEMSET      chunkmemset_rvv
 #define CHUNKMEMSET_SAFE chunkmemset_safe_rvv
 
-#define HAVE_CHUNKCOPY
-
-/*
- * Assuming that the length is non-zero, and that `from` lags `out` by at least
- * sizeof chunk_t bytes, please see the comments in chunkset_tpl.h.
- *
- * We load/store a single chunk once in the `CHUNKCOPY`.
- * However, RISC-V glibc would enable RVV optimized memcpy at runtime by IFUNC,
- * such that, we prefer copy large memory size once to make good use of the the RVV advance.
- * 
- * To be aligned to the other platforms, we didn't modify `CHUNKCOPY` method a lot,
- * but we still copy as much memory as possible for some conditions.
- * 
- * case 1: out - from >= len (no overlap)
- *         We can use memcpy to copy `len` size once
- *         because the memory layout would be the same.
- *
- * case 2: overlap
- *         We copy N chunks using memcpy at once, aiming to achieve our goal: 
- *         to copy as much memory as possible.
- * 
- *         After using a single memcpy to copy N chunks, we have to use series of
- *         loadchunk and storechunk to ensure the result is correct.
- */
-static inline uint8_t* CHUNKCOPY(uint8_t *out, uint8_t const *from, unsigned len) {
-    Assert(len > 0, "chunkcopy should never have a length 0");
-    int32_t align = ((len - 1) % sizeof(chunk_t)) + 1;
-    memcpy(out, from, sizeof(chunk_t));
-    out += align;
-    from += align;
-    len -= align;
-    ptrdiff_t dist = out - from;
-    if (dist >= len) {
-        memcpy(out, from, len);
-        out += len;
-        from += len;
-        return out;
-    }
-    if (dist >= sizeof(chunk_t)) {
-        dist = (dist / sizeof(chunk_t)) * sizeof(chunk_t);
-        memcpy(out, from, dist);
-        out += dist;
-        from += dist;
-        len -= dist;
-    }
-    while (len > 0) {
-        memcpy(out, from, sizeof(chunk_t));
-        out += sizeof(chunk_t);
-        from += sizeof(chunk_t);
-        len -= sizeof(chunk_t);
-    }
-    return out;
-}
-
 #include "chunkset_tpl.h"
 
 #define INFLATE_FAST     inflate_fast_rvv


### PR DESCRIPTION
The override CHUNKCOPY implementation is broken, and leads to SIGSEGV now.

In addition, in my environment, these memset's are unrolled by GCC 14 and no call to memset remains in the resulting chunkset_rvv.o (eith w/ or w/o the CHUNKCOPY override), which makes the override implementation not necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed an internal mechanism for copying memory chunks, eliminating legacy code that handled specific alignment and overlap conditions. This change streamlines memory handling, ensuring more straightforward and maintainable operations. End users benefit from a refined system architecture that paves the way for future performance optimizations and improvements, as part of ongoing efforts to simplify internal logic while preserving overall reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->