### PR TITLE
riscv: chunkset_rvv: fix SIGSEGV in CHUNKCOPY

### DIFF
--- a/arch/riscv/chunkset_rvv.c
+++ b/arch/riscv/chunkset_rvv.c
@@ -92,7 +92,7 @@ static inline uint8_t* CHUNKCOPY(uint8_t *out, uint8_t const *from, unsigned len
     from += align;
     len -= align;
     ptrdiff_t dist = out - from;
-    if (dist >= len) {
+    if (dist < 0 || dist >= len) {
         memcpy(out, from, len);
         out += len;
         from += len;


### PR DESCRIPTION
The chunkset_tpl comment allows negative dist (out - from) as long as the length is smaller than the absolute value of dist (i.e. memory does not overlap). However this case is currently broken in the RVV override of CHUNKCOPY -- it compares dist (which is a ptrdiff_t, a value that should be of the same size with size_t but signed) with the result of sizeof (which is a size_t), and this triggers the implicit conversion from signed to unsigned (thus losing negative values).

As it's promised to be not overlapping when dist is negative, just use a gaint memcpy() call to copy everything.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced error handling for memory copy operations, allowing better management of pointer overlap scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->