### PR TITLE
Fix a big endian bug on the 32k and larger specializations of chorba

### DIFF
--- a/arch/generic/crc32_chorba_c.c
+++ b/arch/generic/crc32_chorba_c.c
@@ -30,7 +30,12 @@ Z_INTERNAL uint32_t crc32_chorba_118960_nondestructive (uint32_t crc, const z_wo
 
     size_t i = 0;
 
+#if BYTE_ORDER == LITTLE_ENDIAN
     z_word_t next1 = crc;
+#else
+    z_word_t next1 = ZSWAP64(crc);
+#endif
+
     z_word_t next2 = 0;
     z_word_t next3 = 0;
     z_word_t next4 = 0;
@@ -484,7 +489,12 @@ Z_INTERNAL uint32_t crc32_chorba_32768_nondestructive (uint32_t crc, const uint6
     uint64_t bitbuffer[32768 / sizeof(uint64_t)];
     const uint8_t* bitbufferbytes = (const uint8_t*) bitbuffer;
     memset(bitbuffer, 0, 32768);
-    bitbuffer[0] ^= crc;
+#if BYTE_ORDER == LITTLE_ENDIAN
+    bitbuffer[0] = crc;
+#else
+    bitbuffer[0] = ZSWAP64(crc);
+#endif
+
     crc = 0;
 
     size_t i = 0;
@@ -634,9 +644,10 @@ Z_INTERNAL uint32_t crc32_chorba_32768_nondestructive (uint32_t crc, const uint6
 
     uint8_t* final_bytes = (uint8_t*) final;
 
-    for(size_t j = 0; j < (len-i); j++) {
+    for (size_t j = 0; j < (len-i); j++) {
         crc = crc_table[(crc ^ final_bytes[j] ^ bitbufferbytes[(j+i)]) & 0xff] ^ (crc >> 8);
     }
+
     return crc;
 }
 

--- a/test/test_crc32.cc
+++ b/test/test_crc32.cc
@@ -26,6 +26,19 @@ typedef struct {
     unsigned long expect;
 } crc32_test;
 
+ALIGNED_(16) uint8_t fullwin_buf[32768];
+
+uint8_t* setup_buf() {
+    for (int i = 0; i < 32768; ++i) {
+        unsigned char ic = (unsigned char)(i % 256);
+        fullwin_buf[i] = ic;
+    }
+
+    return fullwin_buf;
+}
+
+static uint8_t *buf32k = setup_buf();
+
 static const crc32_test tests[] = {
   {0x0, (const uint8_t *)0x0, 0, 0x0},
   {0xffffffff, (const uint8_t *)0x0, 0, 0x0},
@@ -179,7 +192,8 @@ static const crc32_test tests[] = {
     "h{bcmdC+a;t+Cf{6Y_dFq-{X4Yu&7uNfVDh?q&_u.UWJU],-GiH7ADzb7-V.Q%4=+v!$L9W+T=bP]$_:]Vyg}A.ygD.r;h-D]m%&"
     "h{bcmdC+a;t+Cf{6Y_dFq-{X4Yu&7uNfVDh?q&_u.UWJU],-GiH7ADzb7-V.Q%4=+v!$L9W+T=bP]$_:]Vyg}A.ygD.r;h-D]m%&"
     "h{bcmdC+a;t+Cf{6Y_dFq-{X4Yu&7uNfVDh?q&_u.UWJU],-GiH7ADzb7-V.Q%4=+v!$L9W+T=bP]$_:]Vyg}A.ygD.r;h-D]m%&"
-    "h{bcmdC+a;t+Cf{6Y_dFq-{X4Yu&7uNfVDh?q&_u.UWJU],-GiH7ADzb7-V.Q%4=+v!$L9W+T=bP]$_:]Vyg}A.ygD.r;h-D]m%&", 600, 0x888AFA5B}
+    "h{bcmdC+a;t+Cf{6Y_dFq-{X4Yu&7uNfVDh?q&_u.UWJU],-GiH7ADzb7-V.Q%4=+v!$L9W+T=bP]$_:]Vyg}A.ygD.r;h-D]m%&", 600, 0x888AFA5B},
+  {0x0, buf32k, 32768, 0x217726B2}
 };
 
 class crc32_variant : public ::testing::TestWithParam<crc32_test> {


### PR DESCRIPTION
It turns out there's something in there preventing them from being endian independent. @samrussell found the issue in this PR, it's simply the fact that we weren't byteswapping the crc before folding it into the multiplications.  While the value was 0xFFFFFFFF - it still gets widened to a 64 bit variable, which means the 4 bytes ended up falling on the wrong half of the word.

I've also added a test case which enabled me to spot this issue while testing another SIMD acceleration of chorba.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved internal data handling to ensure consistent performance across systems with varied architecture settings.

- **Tests**
  - Added a new test case featuring an aligned 32768-byte buffer with cyclic value initialization to validate data integrity during processing.
  - Introduced a setup function to initialize the test buffer before execution.
  - Updated CRC32 test case with an expected value of `0x217726B2`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->