### PR TITLE
CI: Preinstall packages needed for testing and benchmark.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -653,7 +653,7 @@ jobs:
       run: sudo dpkg --add-architecture i386
 
     - name: Add ubuntu mirrors
-      if: runner.os == 'Linux' && matrix.packages && !contains(matrix.os, 'z15')
+      if: runner.os == 'Linux' && !contains(matrix.os, 'z15')
       # Github Actions caching proxy is at times unreliable
       run: |
         echo -e 'http://azure.archive.ubuntu.com/ubuntu\tpriority:1\n' | sudo tee /etc/apt/mirrors.txt
@@ -661,10 +661,11 @@ jobs:
         sudo sed -i 's#http://azure.archive.ubuntu.com/ubuntu/#mirror+file:/etc/apt/mirrors.txt#' /etc/apt/sources.list
 
     - name: Install packages (Ubuntu)
-      if: runner.os == 'Linux' && matrix.packages && !contains(matrix.os, 'z15')
+      if: runner.os == 'Linux' && !contains(matrix.os, 'z15')
       run: |
         sudo apt-get update
-        sudo apt-get install -y --allow-downgrades --no-install-recommends ${{ matrix.packages }}
+        sudo apt-get install -y --allow-downgrades --no-install-recommends \
+            ${{ matrix.packages || 'libgtest-dev libbenchmark-dev' }}
 
     - name: Install packages (Windows)
       if: runner.os == 'Windows'


### PR DESCRIPTION
Avoids having to compile gtest and google benchmark in every CI job. To make sure we also test downloading and building ourself, don't install for jobs that specify any matrix.packages.

In my spotchecks, it typically spends ~7-8sec extra to run apt install, while the compile is ~22-40sec faster.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Refined the continuous integration conditions to streamline the setup process.
  - Added a default package installation fallback to ensure essential dependencies are reliably installed during automated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->