### PR TITLE
Fix pointer type mismatch.

### DIFF
--- a/test/benchmarks/benchmark_uncompress.cc
+++ b/test/benchmarks/benchmark_uncompress.cc
@@ -51,7 +51,7 @@ public:
             compressed_buff[i] = (uint8_t *)zng_alloc(MAX_SIZE + 1);
             assert(compressed_buff[i] != NULL);
 
-            uLong compressed_size = maxlen;
+            z_uintmax_t compressed_size = maxlen;
             int err = PREFIX(compress)(compressed_buff[i], &compressed_size, inbuff, sizes[i]);
             if (err != Z_OK) {
                 fprintf(stderr, "Compression failed with error %d\n", err);
@@ -68,7 +68,7 @@ public:
             int index = 0;
             while (sizes[index] != state.range(0)) ++index;
 
-            uLong out_size = maxlen;
+            z_uintmax_t out_size = maxlen;
             err = PREFIX(uncompress)(outbuff, &out_size, compressed_buff[index], compressed_sizes[index]);
         }
 


### PR DESCRIPTION
* When passing pointer as function parameter, we need to make sure the underlying type is exact match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced internal handling of compression and decompression operations to support larger data sizes, which helps ensure robustness and scalability for demanding use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->