### PR TITLE
Remove deprecated ubuntu-20.04 image from CI.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -306,7 +306,7 @@ jobs:
           - name: Ubuntu GCC SPARC64
             os: ubuntu-latest
             cmake-args: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-sparc64.cmake
-            packages: qemu qemu-user gcc-sparc64-linux-gnu g++-sparc64-linux-gnu libc-dev-sparc64-cross
+            packages: qemu-user gcc-sparc64-linux-gnu g++-sparc64-linux-gnu libc-dev-sparc64-cross
             ldflags: -static
             gcov-exec: sparc64-linux-gnu-gcov
             codecov: ubuntu_gcc_sparc64

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -15,11 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Ubuntu 20.04 GCC
-            os: ubuntu-20.04
-            compiler: gcc
-            cxx-compiler: g++
-
           - name: Ubuntu GCC ASAN
             os: ubuntu-latest
             compiler: gcc
@@ -280,7 +275,7 @@ jobs:
 
           - name: Ubuntu GCC PPC64LE
             # qemu appears to be broken in newer versions of Ubuntu (see issue 1378)
-            os: ubuntu-20.04
+            os: ubuntu-latest
             cmake-args: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-powerpc64le.cmake
             packages: qemu qemu-user gcc-powerpc64le-linux-gnu g++-powerpc64le-linux-gnu libc-dev-ppc64el-cross
             gcov-exec: powerpc64le-linux-gnu-gcov
@@ -307,7 +302,7 @@ jobs:
 
           - name: Ubuntu GCC SPARC64
             # qemu appears to be broken in newer versions of Ubuntu (see issue 1378)
-            os: ubuntu-20.04
+            os: ubuntu-latest
             cmake-args: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-sparc64.cmake
             packages: qemu qemu-user gcc-sparc64-linux-gnu g++-sparc64-linux-gnu libc-dev-sparc64-cross
             ldflags: -static
@@ -392,12 +387,6 @@ jobs:
             codecov: ubuntu_gcc_mingw_x86_64
              # Limit parallel test jobs to prevent wine errors
             parallels-jobs: 1
-
-          - name: Ubuntu 20.04 Clang 6
-            os: ubuntu-20.04
-            compiler: clang-6.0
-            cxx-compiler: clang++-6.0
-            packages: clang-6.0
 
           - name: Ubuntu Clang
             os: ubuntu-latest

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -274,11 +274,14 @@ jobs:
             packages: qemu-user clang binutils-powerpc64-linux-gnu libgcc-11-dev-ppc64-cross libc-dev-ppc64-cross libstdc++-11-dev-ppc64-cross
 
           - name: Ubuntu GCC PPC64LE
-            # qemu appears to be broken in newer versions of Ubuntu (see issue 1378)
             os: ubuntu-latest
-            cmake-args: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-powerpc64le.cmake
-            packages: qemu qemu-user gcc-powerpc64le-linux-gnu g++-powerpc64le-linux-gnu libc-dev-ppc64el-cross
+            # gtest illegal instruction (related? https://bugs.launchpad.net/qemu/+bug/1781281)
+            cmake-args: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-powerpc64le.cmake -DWITH_GTEST=OFF
+            packages: qemu-user crossbuild-essential-ppc64el
             gcov-exec: powerpc64le-linux-gnu-gcov
+            # mcpu required to test power8 with qemu-ppc64le -cpu power8 (see issue 1378)
+            cflags: -mcpu=power8
+            cxxflags: -mcpu=power8
             codecov: ubuntu_gcc_ppc64le
 
           - name: Ubuntu GCC PPC64LE No VSX
@@ -301,7 +304,6 @@ jobs:
             packages: qemu-user crossbuild-essential-ppc64el
 
           - name: Ubuntu GCC SPARC64
-            # qemu appears to be broken in newer versions of Ubuntu (see issue 1378)
             os: ubuntu-latest
             cmake-args: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-sparc64.cmake
             packages: qemu qemu-user gcc-sparc64-linux-gnu g++-sparc64-linux-gnu libc-dev-sparc64-cross
@@ -716,6 +718,7 @@ jobs:
         CC: ${{ matrix.compiler }}
         CXX: ${{ matrix.cxx-compiler }}
         CFLAGS: ${{ matrix.cflags }}
+        CXXFLAGS: ${{ matrix.cxxflags }}
         LDFLAGS: ${{ matrix.ldflags }}
         CI: true
 

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -16,11 +16,6 @@ jobs:
             compiler: gcc
             configure-args: --warn
 
-          - name: Ubuntu 20.04 GCC
-            os: ubuntu-20.04
-            compiler: gcc
-            configure-args: --warn
-
           - name: Ubuntu GCC OSB
             os: ubuntu-latest
             compiler: gcc


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Revised our continuous integration pipeline by retiring outdated configurations and employing the latest Ubuntu environment for better consistency.
	- Streamlined job settings and adjusted environment parameters to enhance the performance and reliability of our build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->