### PR TITLE
[FreeBSD] Define _XOPEN_SOURCE for gtest_zlib

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -205,6 +205,10 @@ if(WITH_GTEST)
             target_compile_options(gtest_zlib PRIVATE /wd4389 /EHsc)
         endif()
 
+        if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+            target_compile_options(gtest_zlib PRIVATE -D_XOPEN_SOURCE=700)
+        endif()
+
         if(WITH_SANITIZER STREQUAL "Memory")
             target_link_directories(gtest_zlib PRIVATE $ENV{LLVM_BUILD_DIR}/lib)
             target_link_options(gtest_zlib PRIVATE


### PR DESCRIPTION
* Without defining _XOPEN_SOURCE as 700, isascii() is not available on FreeBSD 14.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved system compatibility on FreeBSD by refining internal configuration settings to ensure smoother builds on that platform. No visible functionality changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->