### PR TITLE
Remove late enable_language calls.

### DIFF
--- a/cmake/detect-arch.cmake
+++ b/cmake/detect-arch.cmake
@@ -22,7 +22,6 @@ elseif(CMAKE_CROSSCOMPILING)
     set(ARCH ${CMAKE_C_COMPILER_TARGET})
 else()
     # Let preprocessor parse archdetect.c and raise an error containing the arch identifier
-    enable_language(C)
     try_run(
         run_result_unused
         compile_result_unused

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -96,7 +96,6 @@ if(WITH_GTEST OR WITH_BENCHMARKS)
         set(WITH_BENCHMARKS OFF)
         set(WITH_BENCHMARKS OFF PARENT_SCOPE)
     endif()
-    enable_language(CXX)
 endif()
 
 if(WITH_BENCHMARKS)

--- a/test/benchmarks/CMakeLists.txt
+++ b/test/benchmarks/CMakeLists.txt
@@ -12,8 +12,6 @@ if(NOT DEFINED CMAKE_CXX_EXTENSIONS)
     set(CMAKE_CXX_EXTENSIONS ON)
 endif()
 
-enable_language(CXX)
-
 # Search for Google benchmark package
 find_package(benchmark QUIET)
 if(NOT benchmark_FOUND)

--- a/test/fuzz/CMakeLists.txt
+++ b/test/fuzz/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.5.1...3.29.0)
 
 if(CMAKE_C_COMPILER_ID MATCHES "Clang")
-    enable_language(CXX)
-
     if(DEFINED ENV{LIB_FUZZING_ENGINE})
         set(FUZZING_ENGINE $ENV{LIB_FUZZING_ENGINE})
         set(FUZZING_ENGINE_FOUND ON)


### PR DESCRIPTION
Cleanup after #1902

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Revised the build configuration by removing explicit language activation commands for C and C++. This update affects how language-specific code is processed in scenarios like tests, benchmarks, and fuzzing, so users may need to verify that their build environments meet the necessary compilation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->