### PR TITLE
riscv: add  bash configure script support for riscv

### DIFF
--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -228,6 +228,27 @@ jobs:
             configure-args: --warn
             packages: gcc@11
 
+          - name: Ubuntu GCC RISCV64
+            os: ubuntu-latest
+            compiler: riscv64-linux-gnu-gcc
+            configure-args: --warn
+            chost: riscv64-linux-gnu
+            packages: qemu-user crossbuild-essential-riscv64
+
+          - name: Ubuntu GCC RISCV64 No RVV
+            os: ubuntu-latest
+            compiler: riscv64-linux-gnu-gcc
+            configure-args: --warn --without-rvv
+            chost: riscv64-linux-gnu
+            packages: qemu-user crossbuild-essential-riscv64
+
+          - name: Ubuntu GCC RISCV64 Compat No Opt
+            os: ubuntu-latest
+            compiler: riscv64-linux-gnu-gcc
+            configure-args: --warn --zlib-compat --without-optimizations --without-new-strategies
+            chost: riscv64-linux-gnu
+            packages: qemu-user crossbuild-essential-riscv64
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/pkgcheck.yml
+++ b/.github/workflows/pkgcheck.yml
@@ -74,6 +74,14 @@ jobs:
             cmake-args: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-powerpc64le.cmake
             packages: qemu-user gcc-powerpc64le-linux-gnu g++-powerpc64le-linux-gnu libc6-dev-ppc64el-cross
 
+          - name: Ubuntu GCC RISC-V
+            os: ubuntu-latest
+            chost: riscv64-linux-gnu
+            compiler: riscv64-linux-gnu-gcc
+            cxx-compiler: riscv64-linux-gnu-g++
+            cmake-args: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-riscv.cmake
+            packages: qemu-user gcc-riscv64-linux-gnu g++-riscv64-linux-gnu libc6-dev-riscv64-cross
+
           - name: macOS Clang
             os: macOS-latest
             compiler: clang

--- a/arch/riscv/Makefile.in
+++ b/arch/riscv/Makefile.in
@@ -1,0 +1,63 @@
+# Makefile for zlib-ng
+# Copyright (C) 1995-2013 Jean-loup Gailly, Mark Adler
+# Copyright (C) 2024 Hans Kristian Rosbach
+# Copyright (C) 2025 Yin Tong <yintong.ustc@bytedance.com>, ByteDance
+# For conditions of distribution and use, see copyright notice in zlib.h
+
+CC=
+CFLAGS=
+SFLAGS=
+INCLUDES=
+SUFFIX=
+
+SRCDIR=.
+SRCTOP=../..
+TOPDIR=$(SRCTOP)
+
+RVVFLAG=
+
+all: \
+	riscv_features.o riscv_features.lo \
+	adler32_rvv.o adler32_rvv.lo \
+	chunkset_rvv.o chunkset_rvv.lo \
+	compare256_rvv.o compare256_rvv.lo \
+	slide_hash_rvv.o slide_hash_rvv.lo
+
+riscv_features.o: $(SRCDIR)/riscv_features.c
+	$(CC) $(CFLAGS) $(RVVFLAG) $(INCLUDES) -c -o $@ $(SRCDIR)/riscv_features.c
+
+riscv_features.lo: $(SRCDIR)/riscv_features.c
+	$(CC) $(SFLAGS) $(RVVFLAG) -DPIC $(INCLUDES) -c -o $@ $(SRCDIR)/riscv_features.c
+
+adler32_rvv.o: $(SRCDIR)/adler32_rvv.c
+	$(CC) $(CFLAGS) $(RVVFLAG) $(INCLUDES) -c -o $@ $(SRCDIR)/adler32_rvv.c
+
+adler32_rvv.lo: $(SRCDIR)/adler32_rvv.c
+	$(CC) $(SFLAGS) $(RVVFLAG) -DPIC $(INCLUDES) -c -o $@ $(SRCDIR)/adler32_rvv.c
+
+chunkset_rvv.o: $(SRCDIR)/chunkset_rvv.c
+	$(CC) $(CFLAGS) $(RVVFLAG) $(INCLUDES) -c -o $@ $(SRCDIR)/chunkset_rvv.c
+
+chunkset_rvv.lo: $(SRCDIR)/chunkset_rvv.c
+	$(CC) $(SFLAGS) $(RVVFLAG) -DPIC $(INCLUDES) -c -o $@ $(SRCDIR)/chunkset_rvv.c
+
+compare256_rvv.o: $(SRCDIR)/compare256_rvv.c
+	$(CC) $(CFLAGS) $(RVVFLAG) $(INCLUDES) -c -o $@ $(SRCDIR)/compare256_rvv.c
+
+compare256_rvv.lo: $(SRCDIR)/compare256_rvv.c
+	$(CC) $(SFLAGS) $(RVVFLAG) -DPIC $(INCLUDES) -c -o $@ $(SRCDIR)/compare256_rvv.c
+
+slide_hash_rvv.o: $(SRCDIR)/slide_hash_rvv.c
+	$(CC) $(CFLAGS) $(RVVFLAG) $(INCLUDES) -c -o $@ $(SRCDIR)/slide_hash_rvv.c
+
+slide_hash_rvv.lo: $(SRCDIR)/slide_hash_rvv.c
+	$(CC) $(SFLAGS) $(RVVFLAG) -DPIC $(INCLUDES) -c -o $@ $(SRCDIR)/slide_hash_rvv.c
+
+mostlyclean: clean
+clean:
+	rm -f *.o *.lo *~
+	rm -rf objs
+	rm -f *.gcda *.gcno *.gcov
+
+distclean: clean
+	rm -f Makefile

--- a/configure
+++ b/configure
@@ -99,6 +99,7 @@ buildaltivec=1
 buildpower8=1
 buildpower9=1
 buildneon=1
+buildrvv=1
 builddfltccdeflate=0
 builddfltccinflate=0
 buildcrc32vx=1
@@ -117,6 +118,7 @@ vpclmulflag="-mvpclmulqdq -mavx512f"
 xsaveflag="-mxsave"
 armv8flag=
 neonflag=
+rvvflag=
 armv6flag=
 noltoflag="-fno-lto"
 vgfmaflag="-march=z13"
@@ -170,6 +172,7 @@ case "$1" in
       echo '    [--without-armv8]           Compiles without ARMv8 CRC32 instruction set' | tee -a configure.log
       echo '    [--without-neon]            Compiles without ARM Neon SIMD instruction set' | tee -a configure.log
       echo '    [--without-armv6]           Compiles without ARMv6 SIMD instruction set' | tee -a configure.log
+      echo '    [--without-rvv]             Compiles without RVV instruction set' | tee -a configure.log
       echo '    [--without-altivec]         Compiles without PPC AltiVec support' | tee -a configure.log
       echo '    [--without-power8]          Compiles without Power8 instruction set' | tee -a configure.log
       echo '    [--with-dfltcc-deflate]     Use DEFLATE CONVERSION CALL instruction for compression on IBM Z' | tee -a configure.log
@@ -206,6 +209,7 @@ case "$1" in
     --without-neon) buildneon=0; shift ;;
     --without-armv6) buildarmv6=0; shift ;;
     --without-altivec) buildaltivec=0 ; shift ;;
+    --without-rvv) buildrvv=0 ; shift ;;
     --without-power8) buildpower8=0 ; shift ;;
     --without-power9) buildpower9=0 ; shift ;;
     --with-dfltcc-deflate) builddfltccdeflate=1; shift ;;
@@ -343,6 +347,8 @@ if test "$gcc" -eq 1 && ($cc $CFLAGS -c $test.c) >> configure.log 2>&1; then
       ARCH=powerpc64 ;;
     powerpc64le | ppc64le)
       ARCH=powerpc64le ;;
+    riscv64)
+      ARCH=riscv64 ;;
   esac
   CFLAGS="-O2 ${CFLAGS}"
   if test -n "${ARCHS}"; then
@@ -1606,6 +1612,40 @@ EOF
     fi
 }
 
+check_rvv_compiler_flag() {
+    cat > $test.c << EOF
+int main() { return 0; }
+EOF
+    if try $CC -c $CFLAGS -march=rv64gcv $test.c; then
+        echo "Check whether -march=rv64gcv works ... Yes." | tee -a configure.log
+        rvvflag="-march=rv64gcv"
+    else
+        echo "Check whether -march=rv64gcv works ... No." | tee -a configure.log
+        if try $CC -c $CFLAGS -march=rv64gc_zve64x $test.c; then
+            echo "Check whether -march=rv64gc_zve64x works ... Yes." | tee -a configure.log
+            rvvflag="-march=rv64gc_zve64x"
+        else
+            echo "Check whether -march=rv64gc_zve64x works ... No." | tee -a configure.log
+            rvvflag=""
+        fi
+    fi
+
+    cat > $test.c << EOF
+#include <riscv_vector.h>
+int main(void) {
+    size_t vl = __riscv_vsetvlmax_e8m1();
+    return vl;
+}
+EOF
+    if [ -n "$rvvflag" ] && try ${CC} ${CFLAGS} ${rvvflag} $test.c; then
+        echo "Checking for RISC-V Vector intrinsics ... Yes." | tee -a configure.log
+        HAVE_RVV_INTRIN=1
+    else
+        echo "Checking for RISC-V Vector intrinsics ... No." | tee -a configure.log
+        HAVE_RVV_INTRIN=0
+    fi
+}
+
 # Check whether to disable deflate_medium and deflate_quick
 if test $without_new_strategies -eq 1; then
     CFLAGS="${CFLAGS} -DNO_QUICK_STRATEGY -DNO_MEDIUM_STRATEGY"
@@ -1967,6 +2007,29 @@ EOF
             fi
         fi
     ;;
+    riscv64)
+        [ ! -z $CROSS_PREFIX ] && QEMU_ARCH=riscv64
+        ARCHDIR=arch/riscv
+
+        if test $without_optimizations -eq 0; then
+            if test $buildrvv -eq 1; then
+            check_rvv_compiler_flag
+
+                if test $HAVE_RVV_INTRIN -eq 1; then
+                    CFLAGS="${CFLAGS} -DRISCV_FEATURES -DRISCV_RVV"
+                    SFLAGS="${SFLAGS} -DRISCV_FEATURES -DRISCV_RVV"
+
+                    ARCH_STATIC_OBJS="${ARCH_STATIC_OBJS} riscv_features.o"
+                    ARCH_SHARED_OBJS="${ARCH_SHARED_OBJS} riscv_features.lo"
+
+                    ARCH_STATIC_OBJS="${ARCH_STATIC_OBJS} adler32_rvv.o chunkset_rvv.o compare256_rvv.o slide_hash_rvv.o"
+                    ARCH_SHARED_OBJS="${ARCH_SHARED_OBJS} adler32_rvv.lo chunkset_rvv.lo compare256_rvv.lo slide_hash_rvv.lo"
+
+                    ARCH="${ARCH}+rvv"
+                fi
+            fi
+        fi
+    ;;
     s390x)
         [ ! -z $CROSS_PREFIX ] && QEMU_ARCH=s390x
         ARCHDIR=arch/s390
@@ -2218,6 +2281,7 @@ sed < $SRCDIR/$ARCHDIR/Makefile.in "
 /^NOLTOFLAG *=/s#=.*#=$noltoflag#
 /^VGFMAFLAG *=/s#=.*#=$vgfmaflag#
 /^PPCFLAGS *=/s#=.*#=$vmxflag#
+/^RVVFLAG *=/s#=.*#=$rvvflag#
 " > $ARCHDIR/Makefile
 
 # Append header files dependencies.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added build and configuration support for the RISC-V 64-bit architecture, including detection and enabling of RISC-V Vector Extension (RVV) optimizations.

- **Chores**
  - Introduced a new Makefile to manage RISC-V vector extension source files and build targets.
  - Updated the configuration process to automatically detect and enable RVV support when available, with an option to disable it.
  - Extended continuous integration workflows to include RISC-V 64-bit cross-compilation and testing with and without RVV support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->