### PR TITLE
Add large 1mb buffer test for crc32 hashing.

### DIFF
--- a/test/test_crc32.cc
+++ b/test/test_crc32.cc
@@ -227,6 +227,29 @@ public:
     }
 };
 
+/* Test large 1MB buffer with known CRC32 */
+class crc32_large_buf : public ::testing::Test {
+protected:
+    static uint8_t *buffer;
+    static const size_t buffer_size = 1024 * 1024;
+
+    static void SetUpTestSuite() {
+        buffer = (uint8_t*)zng_alloc(buffer_size);
+        memset(buffer, 0x55, buffer_size);
+    }
+
+    static void TearDownTestSuite() {
+        zng_free(buffer);
+    }
+
+public:
+    void hash(crc32_func crc32) {
+        EXPECT_EQ(crc32(0, buffer, buffer_size), 0x0026D5FB);
+    }
+};
+
+uint8_t *crc32_large_buf::buffer = nullptr;
+
 INSTANTIATE_TEST_SUITE_P(crc32, crc32_variant, testing::ValuesIn(tests));
 
 #define TEST_CRC32(name, func, support_flag) \
@@ -236,6 +259,13 @@ INSTANTIATE_TEST_SUITE_P(crc32, crc32_variant, testing::ValuesIn(tests));
             return; \
         } \
         hash(GetParam(), func); \
+    } \
+    TEST_F(crc32_large_buf, name) { \
+        if (!(support_flag)) { \
+            GTEST_SKIP(); \
+            return; \
+        } \
+        hash(func); \
     }
 
 #ifndef WITHOUT_CHORBA


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added new tests to verify CRC32 implementations on large 512KB buffers for improved coverage.
  - Extended existing test macros to include large buffer test cases for each CRC32 variant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->