### PR TITLE
DONT MERGE Chorba large 32bit fix unit test

### DIFF
--- a/arch/generic/crc32_chorba_c.c
+++ b/arch/generic/crc32_chorba_c.c
@@ -27,13 +27,15 @@
 Z_INTERNAL uint32_t crc32_chorba_118960_nondestructive (uint32_t crc, const z_word_t* input, size_t len) {
     ALIGNED_(16) z_word_t bitbuffer[bitbuffersizezwords];
     const uint8_t* bitbufferbytes = (const uint8_t*) bitbuffer;
+    uint64_t* bitbufferqwords = (uint64_t*) bitbuffer;
+    uint64_t* inputqwords = (uint64_t*) input;
 
     size_t i = 0;
 
 #if BYTE_ORDER == LITTLE_ENDIAN
     z_word_t next1 = crc;
 #else
-    z_word_t next1 = ZSWAP64(crc);
+    z_word_t next1 = ZSWAPWORD(crc);
 #endif
 
     z_word_t next2 = 0;
@@ -407,8 +409,8 @@ Z_INTERNAL uint32_t crc32_chorba_118960_nondestructive (uint32_t crc, const z_wo
         uint64_t out4;
         uint64_t out5;
 
-        in1 = input[i / sizeof(z_word_t)] ^ bitbuffer[(i / sizeof(uint64_t)) % bitbuffersizeqwords];
-        in2 = input[(i + 8) / sizeof(z_word_t)] ^ bitbuffer[(i / sizeof(uint64_t) + 1) % bitbuffersizeqwords];
+        in1 = inputqwords[i / sizeof(uint64_t)] ^ bitbufferqwords[(i / sizeof(uint64_t)) % bitbuffersizeqwords];
+        in2 = inputqwords[i / sizeof(uint64_t) + 1] ^ bitbufferqwords[(i / sizeof(uint64_t) + 1) % bitbuffersizeqwords];
 #if BYTE_ORDER == BIG_ENDIAN
         in1 = ZSWAP64(in1);
         in2 = ZSWAP64(in2);
@@ -426,8 +428,8 @@ Z_INTERNAL uint32_t crc32_chorba_118960_nondestructive (uint32_t crc, const z_wo
         b3 = (in2 >> 45) ^ (in2 << 44);
         b4 = (in2 >> 20);
 
-        in3 = input[(i + 16) / sizeof(z_word_t)] ^ bitbuffer[(i / sizeof(uint64_t) + 2) % bitbuffersizeqwords];
-        in4 = input[(i + 24) / sizeof(z_word_t)] ^ bitbuffer[(i / sizeof(uint64_t) + 3) % bitbuffersizeqwords];
+        in3 = inputqwords[i / sizeof(uint64_t) + 2] ^ bitbufferqwords[(i / sizeof(uint64_t) + 2) % bitbuffersizeqwords];
+        in4 = inputqwords[i / sizeof(uint64_t) + 3] ^ bitbufferqwords[(i / sizeof(uint64_t) + 3) % bitbuffersizeqwords];
 #if BYTE_ORDER == BIG_ENDIAN
         in3 = ZSWAP64(in3);
         in4 = ZSWAP64(in4);
@@ -467,7 +469,7 @@ Z_INTERNAL uint32_t crc32_chorba_118960_nondestructive (uint32_t crc, const z_wo
     next5_64 = ZSWAP64(next5_64);
 #endif
 
-    memcpy(final, input+(i / sizeof(uint64_t)), len-i);
+    memcpy(final, inputqwords + (i / sizeof(uint64_t)), len-i);
     final[0] ^= next1_64;
     final[1] ^= next2_64;
     final[2] ^= next3_64;

--- a/test/test_crc32.cc
+++ b/test/test_crc32.cc
@@ -228,6 +228,32 @@ public:
     }
 };
 
+/* Test large 1MB buffer with known CRC32 */
+class crc32_large_buf : public ::testing::Test {
+protected:
+    static uint8_t *buffer;
+    static const size_t buffer_size = 1024 * 1024;
+    static const uint32_t expected_hash = 0x0026D5FB;
+
+    static void SetUpTestSuite() {
+        buffer = (uint8_t*)zng_alloc(buffer_size);
+        memset(buffer, 0x55, buffer_size);
+    }
+
+    static void TearDownTestSuite() {
+        zng_free(buffer);
+    }
+
+public:
+    void hash(crc32_func crc32) {
+        const uint32_t actual_hash = crc32(0, buffer, buffer_size);
+        EXPECT_EQ(actual_hash, expected_hash);
+    }
+};
+
+const uint32_t crc32_large_buf::expected_hash;
+uint8_t *crc32_large_buf::buffer = nullptr;
+
 INSTANTIATE_TEST_SUITE_P(crc32, crc32_variant, testing::ValuesIn(tests));
 
 #define TEST_CRC32(name, func, support_flag) \
@@ -237,6 +263,13 @@ INSTANTIATE_TEST_SUITE_P(crc32, crc32_variant, testing::ValuesIn(tests));
             return; \
         } \
         hash(GetParam(), func); \
+    } \
+    TEST_F(crc32_large_buf, name) { \
+        if (!(support_flag)) { \
+            GTEST_SKIP(); \
+            return; \
+        } \
+        hash(func); \
     }
 
 #ifndef WITHOUT_CHORBA


### PR DESCRIPTION
Adding 1913 on top of 1912 so we can see CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved internal data handling for CRC32 calculations to ensure consistent and accurate processing across different platforms.

- **Tests**
  - Added new tests to verify CRC32 correctness on large 1MB buffers, increasing confidence in handling large data inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->