### PR TITLE
[WebAssembly] Fix stack overflow in crc32_chorba_118960_nondestructive.

### DIFF
--- a/arch/generic/crc32_chorba_c.c
+++ b/arch/generic/crc32_chorba_c.c
@@ -1,4 +1,7 @@
 #include "zbuild.h"
+#if defined(__EMSCRIPTEN__)
+#  include "zutil_p.h"
+#endif
 #include "crc32_braid_p.h"
 #include "crc32_braid_tbl.h"
 #include "generic_functions.h"
@@ -25,7 +28,11 @@
  * @note Uses 128KB temporary buffer
  */
 Z_INTERNAL uint32_t crc32_chorba_118960_nondestructive (uint32_t crc, const z_word_t* input, size_t len) {
+#if defined(__EMSCRIPTEN__)
+    z_word_t* bitbuffer = (z_word_t*)zng_alloc(bitbuffersizebytes);
+#else
     ALIGNED_(16) z_word_t bitbuffer[bitbuffersizezwords];
+#endif
     const uint8_t* bitbufferbytes = (const uint8_t*) bitbuffer;
 
     size_t i = 0;
@@ -480,6 +487,9 @@ Z_INTERNAL uint32_t crc32_chorba_118960_nondestructive (uint32_t crc, const z_wo
         crc = crc_table[(crc ^ final_bytes[j] ^ bitbufferbytes[(j+i) % bitbuffersizebytes]) & 0xff] ^ (crc >> 8);
     }
 
+#if defined(__EMSCRIPTEN__)
+    zng_free(bitbuffer);
+#endif
     return crc;
 }
 


### PR DESCRIPTION
* Currently default stack size on emscripten is 64 kB, which is too small for Chorba.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with Emscripten by updating memory allocation for temporary buffers, ensuring stable operation in web environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->