### PR TITLE
Fix cyclic sharedlibdir variable in zlib.pc.in for autotools builds.

### DIFF
--- a/zlib.pc.in
+++ b/zlib.pc.in
@@ -2,7 +2,7 @@ prefix=@prefix@
 exec_prefix=@exec_prefix@
 symbol_prefix=@symbol_prefix@
 libdir=@libdir@
-sharedlibdir=@sharedlibdir@
+sharedlibdir=@libdir@
 includedir=@includedir@
 
 Name: zlib@SUFFIX@


### PR DESCRIPTION
Fixes #1918
Syncs with value in https://github.com/zlib-ng/zlib-ng/blob/stable/zlib.pc.cmakein :
https://github.com/zlib-ng/zlib-ng/blob/860e4cff7917d93f54f5d7f0bc1d0e8b1a3cb988/zlib.pc.cmakein#L5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the directory path used for shared libraries in the configuration template to improve consistency with standard library locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->