### PR TITLE
Replace usage of aligned alloc implementations with malloc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -457,49 +457,6 @@ endif()
 set(CMAKE_REQUIRED_FLAGS)
 
 #
-# Check for aligned memory allocation support: POSIX
-#
-set(CMAKE_REQUIRED_DEFINITIONS -D_POSIX_C_SOURCE=200112L -D_ISOC11_SOURCE=1)
-set(CMAKE_REQUIRED_FLAGS "${ADDITIONAL_CHECK_FLAGS}")
-check_symbol_exists(posix_memalign stdlib.h HAVE_POSIX_MEMALIGN)
-if(HAVE_POSIX_MEMALIGN)
-    add_definitions(-DHAVE_POSIX_MEMALIGN)
-endif()
-set(CMAKE_REQUIRED_FLAGS)
-set(CMAKE_REQUIRED_DEFINITIONS)
-
-#
-# Check for aligned memory allocation support: C11
-#
-set(CMAKE_REQUIRED_DEFINITIONS -D_POSIX_C_SOURCE=200112L -D_ISOC11_SOURCE=1)
-set(CMAKE_REQUIRED_FLAGS "${ADDITIONAL_CHECK_FLAGS}")
-check_symbol_exists(aligned_alloc stdlib.h HAVE_ALIGNED_ALLOC)
-if(HAVE_ALIGNED_ALLOC)
-    add_definitions(-DHAVE_ALIGNED_ALLOC)
-endif()
-set(CMAKE_REQUIRED_FLAGS)
-set(CMAKE_REQUIRED_DEFINITIONS)
-
-#
-# Check for aligned memory allocation support: GNU extension
-# Note: memalign() is deprecated in glibc
-#
-check_symbol_exists(memalign malloc.h HAVE_MEMALIGN)
-if(HAVE_MEMALIGN)
-    add_definitions(-DHAVE_MEMALIGN)
-endif()
-set(CMAKE_REQUIRED_DEFINITIONS)
-
-#
-# Check for aligned memory allocation support: MSVC extensions
-#
-check_symbol_exists(_aligned_malloc malloc.h HAVE__ALIGNED_MALLOC)
-if(HAVE__ALIGNED_MALLOC)
-    add_definitions(-DHAVE__ALIGNED_MALLOC)
-endif()
-set(CMAKE_REQUIRED_DEFINITIONS)
-
-#
 # Check for x86 __cpuid / __cpuid_count support: GNU extensions
 # gcc/clang and MSVC have __cpuid, so check __cpuid_count instead
 check_symbol_exists(__cpuid_count cpuid.h HAVE_CPUID_GNU)

--- a/configure
+++ b/configure
@@ -739,91 +739,6 @@ EOF
 fi
 echo >> configure.log
 
-
-# check for aligned memory allocation support: POSIX
-cat > $test.c <<EOF
-#define _POSIX_C_SOURCE 200112L
-#define _ISOC11_SOURCE 1
-#include <stdlib.h>
-int main(void) {
-  void *ptr = 0;
-  int ret = posix_memalign(&ptr, 64, 10);
-  if (ptr)
-    free(ptr);
-  return ret;
-}
-EOF
-if try $CC $CFLAGS $ADDITIONAL_CHECK_FLAGS -o $test $test.c $LDSHAREDLIBC; then
-  echo "Checking for posix_memalign... Yes." | tee -a configure.log
-  CFLAGS="${CFLAGS} -DHAVE_POSIX_MEMALIGN"
-  SFLAGS="${SFLAGS} -DHAVE_POSIX_MEMALIGN"
-else
-  echo "Checking for posix_memalign... No." | tee -a configure.log
-fi
-echo >> configure.log
-
-# check for aligned memory allocation support: C11
-cat > $test.c <<EOF
-#define _POSIX_C_SOURCE 200112L
-#define _ISOC11_SOURCE 1
-#include <stdlib.h>
-int main(void) {
-  void *ptr = aligned_alloc(64, 10);
-  if (ptr)
-    free(ptr);
-  return 0;
-}
-EOF
-if try $CC $CFLAGS $ADDITIONAL_CHECK_FLAGS -o $test $test.c $LDSHAREDLIBC; then
-  echo "Checking for aligned_alloc... Yes." | tee -a configure.log
-  CFLAGS="${CFLAGS} -DHAVE_ALIGNED_ALLOC"
-  SFLAGS="${SFLAGS} -DHAVE_ALIGNED_ALLOC"
-else
-  echo "Checking for aligned_alloc... No." | tee -a configure.log
-fi
-echo >> configure.log
-
-
-# check for aligned memory allocation support: GNU extension
-# Note: memalign() is deprecated in glibc
-cat > $test.c <<EOF
-#include <malloc.h>
-int main(void) {
-  void *ptr = memalign(64, 10);
-  if (ptr)
-    free(ptr);
-  return 0;
-}
-EOF
-if try $CC $CFLAGS -o $test $test.c $LDSHAREDLIBC; then
-  echo "Checking for memalign... Yes." | tee -a configure.log
-  CFLAGS="${CFLAGS} -DHAVE_MEMALIGN"
-  SFLAGS="${SFLAGS} -DHAVE_MEMALIGN"
-else
-  echo "Checking for memalign... No." | tee -a configure.log
-fi
-echo >> configure.log
-
-# check for aligned memory allocation support: MSVC extensions
-cat > $test.c <<EOF
-#include <malloc.h>
-int main(void) {
-  void *ptr = _aligned_malloc(10, 64);
-  if (ptr)
-    _aligned_free(ptr);
-  return 0;
-}
-EOF
-if try $CC $CFLAGS -o $test $test.c $LDSHAREDLIBC; then
-  echo "Checking for _aligned_malloc... Yes." | tee -a configure.log
-  CFLAGS="${CFLAGS} -DHAVE__ALIGNED_MALLOC"
-  SFLAGS="${SFLAGS} -DHAVE__ALIGNED_MALLOC"
-else
-  echo "Checking for _aligned_malloc... No." | tee -a configure.log
-fi
-echo >> configure.log
-
-
 # check for cpuid support: GNU extensions
 cat > $test.c <<EOF
 #include <cpuid.h>
@@ -877,7 +792,6 @@ else
   echo "Checking for MS style __cpuid... No." | tee -a configure.log
 fi
 echo >> configure.log
-
 
 # check for strerror() for use by gz* functions
 cat > $test.c <<EOF

--- a/zutil.c
+++ b/zutil.c
@@ -100,6 +100,8 @@ const char * Z_EXPORT PREFIX(zError)(int err) {
     return ERR_MSG(err);
 }
 
+// Zlib-ng's default alloc/free implementation, used unless
+// application supplies its own alloc/free functions.
 void Z_INTERNAL *PREFIX(zcalloc)(void *opaque, unsigned items, unsigned size) {
     Z_UNUSED(opaque);
     return zng_alloc((size_t)items * (size_t)size);

--- a/zutil_p.h
+++ b/zutil_p.h
@@ -5,47 +5,16 @@
 #ifndef ZUTIL_P_H
 #define ZUTIL_P_H
 
-#if defined(HAVE_POSIX_MEMALIGN) || defined(HAVE_ALIGNED_ALLOC)
-#  include <stdlib.h>
-#elif defined(__FreeBSD__)
-#  include <stdlib.h>
-#  include <malloc_np.h>
-#elif defined(HAVE_MEMALIGN) || defined(HAVE__ALIGNED_MALLOC)
-#  include <malloc.h>
-#else
-/* Fallback, when no other aligned allocation function was found */
-#  include <stdlib.h>
-#endif
+#include <stdlib.h>
 
-/* Function to allocate 16 or 64-byte aligned memory */
+// Zlib-ng's default alloc/free implementation, used unless
+// application supplies its own alloc/free functions.
 static inline void *zng_alloc(size_t size) {
-#ifdef HAVE_ALIGNED_ALLOC
-    /* Size must be a multiple of alignment */
-    size = (size + (64 - 1)) & ~(64 - 1);
-    return (void *)aligned_alloc(64, size);  /* Defined in C11 */
-#elif defined(HAVE_POSIX_MEMALIGN)
-    void *ptr;
-    return posix_memalign(&ptr, 64, size) ? NULL : ptr;
-#elif defined(HAVE__ALIGNED_MALLOC)
-    /* Fallback: Use MSVC extensions: _aligned_malloc() / _aligned_free() */
-    return (void *)_aligned_malloc(size, 64);
-#elif defined(HAVE_MEMALIGN)
-    /* Fallback: Use deprecated GNU extension: memalign() */
-    return (void *)memalign(64, size);
-#else
-    /* Fallback: Use a normal allocation (On macOS, alignment is 16 bytes) */
-    /* zlib-ng adjust allocations for [de]compression to be properly aligned */
     return (void *)malloc(size);
-#endif
 }
 
-/* Function that can free aligned memory */
 static inline void zng_free(void *ptr) {
-#if defined(HAVE__ALIGNED_MALLOC) && !defined(HAVE_POSIX_MEMALIGN) && !defined(HAVE_ALIGNED_ALLOC)
-    _aligned_free(ptr);
-#else
     free(ptr);
-#endif
 }
 
 #endif


### PR DESCRIPTION
Removes detection and usage of aligned alloc implementations and instead use malloc and handle alignment internally.

Since we already always have to do the alignment checks (because we have to support external alloc implementations), this does not cost us anything but does simplify maintenance, especially compatibility across various operating systems, C libraries and compilers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified memory allocation logic to always use standard allocation functions, removing all platform-specific aligned memory allocation checks and implementations.
  * Updated related documentation and comments for clarity.

* **Style**
  * Improved comments to clarify default memory allocation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->