### PR TITLE
Reorganize initialization and buffer allocation for gz* code

### DIFF
--- a/gzguts.h
+++ b/gzguts.h
@@ -112,6 +112,7 @@ typedef struct {
     unsigned want;          /* requested buffer size, default is GZBUFSIZE */
     unsigned char *in;      /* input buffer (double-sized when writing) */
     unsigned char *out;     /* output buffer (double-sized when reading) */
+    unsigned char *buffers; /* Pointer to the real input/output buffer allocation */
     int direct;             /* 0 if processing gzip, 1 if transparent */
         /* just for reading */
     int how;                /* 0: get header, 1: copy, 2: decompress */
@@ -135,6 +136,10 @@ typedef gz_state *gz_statep;
 
 /* shared functions */
 void Z_INTERNAL gz_error(gz_state *, int, const char *);
+int  Z_INTERNAL gz_buffer_alloc(gz_state *state);
+void Z_INTERNAL gz_buffer_free(gz_state *state);
+void Z_INTERNAL gz_state_free(gz_state *state);
+
 #ifdef ZLIB_COMPAT
 unsigned Z_INTERNAL gz_intmax(void);
 #endif

--- a/gzread.c.in
+++ b/gzread.c.in
@@ -25,9 +25,14 @@ static int gz_read_init(gz_state *state) {
     }
 
     /* Initialize inflate state */
-    if (PREFIX(inflateInit2)(&(state->strm), MAX_WBITS + 16) != Z_OK) {
+    int ret = PREFIX(inflateInit2)(&(state->strm), MAX_WBITS + 16);
+    if (ret != Z_OK) {
         gz_buffer_free(state);
-        gz_error(state, Z_MEM_ERROR, "out of memory");
+        if (ret == Z_MEM_ERROR) {
+            gz_error(state, Z_MEM_ERROR, "out of memory");
+        } else {
+            gz_error(state, Z_STREAM_ERROR, "invalid compression parameters");
+        }
         return -1;
     }
     return 0;

--- a/gzread.c.in
+++ b/gzread.c.in
@@ -8,6 +8,7 @@
 #include "gzguts.h"
 
 /* Local functions */
+static int gz_read_init(gz_state *state);
 static int gz_load(gz_state *, unsigned char *, unsigned, unsigned *);
 static int gz_avail(gz_state *);
 static int gz_look(gz_state *);
@@ -15,6 +16,22 @@ static int gz_decomp(gz_state *);
 static int gz_fetch(gz_state *);
 static int gz_skip(gz_state *, z_off64_t);
 static size_t gz_read(gz_state *, void *, size_t);
+
+static int gz_read_init(gz_state *state) {
+    /* Allocate gz buffers */
+    if (gz_buffer_alloc(state) != 0) {
+        gz_error(state, Z_MEM_ERROR, "out of memory");
+        return -1;
+    }
+
+    /* Initialize inflate state */
+    if (PREFIX(inflateInit2)(&(state->strm), MAX_WBITS + 16) != Z_OK) {
+        gz_buffer_free(state);
+        gz_error(state, Z_MEM_ERROR, "out of memory");
+        return -1;
+    }
+    return 0;
+}
 
 /* Use read() to load a buffer -- return -1 on error, otherwise 0.  Read from
    state->fd, and update state->eof, state->err, and state->msg as appropriate.
@@ -81,19 +98,9 @@ static int gz_avail(gz_state *state) {
 static int gz_look(gz_state *state) {
     PREFIX3(stream) *strm = &(state->strm);
 
-    if (state->size == 0) {
-        /* Allocate gz buffers */
-        if (gz_buffer_alloc(state) != 0) {
-            return -1;
-        }
-
-        /* Initialize inflate state */
-        if (PREFIX(inflateInit2)(&(state->strm), MAX_WBITS + 16) != Z_OK) {    /* gunzip */
-            gz_buffer_free(state);
-            gz_error(state, Z_MEM_ERROR, "out of memory");
-            return -1;
-        }
-    }
+    /* allocate memory if this is the first time through */
+    if (state->size == 0 && gz_read_init(state) == -1)
+        return -1;
 
     /* get at least the magic bytes in the input buffer */
     if (strm->avail_in < 2) {

--- a/gzread.c.in
+++ b/gzread.c.in
@@ -81,29 +81,15 @@ static int gz_avail(gz_state *state) {
 static int gz_look(gz_state *state) {
     PREFIX3(stream) *strm = &(state->strm);
 
-    /* allocate read buffers and inflate memory */
     if (state->size == 0) {
-        /* allocate buffers */
-        state->in = (unsigned char *)zng_alloc(state->want);
-        state->out = (unsigned char *)zng_alloc(state->want << 1);
-        if (state->in == NULL || state->out == NULL) {
-            zng_free(state->out);
-            zng_free(state->in);
-            gz_error(state, Z_MEM_ERROR, "out of memory");
+        /* Allocate gz buffers */
+        if (gz_buffer_alloc(state) != 0) {
             return -1;
         }
-        state->size = state->want;
 
-        /* allocate inflate memory */
-        state->strm.zalloc = NULL;
-        state->strm.zfree = NULL;
-        state->strm.opaque = NULL;
-        state->strm.avail_in = 0;
-        state->strm.next_in = NULL;
+        /* Initialize inflate state */
         if (PREFIX(inflateInit2)(&(state->strm), MAX_WBITS + 16) != Z_OK) {    /* gunzip */
-            zng_free(state->out);
-            zng_free(state->in);
-            state->size = 0;
+            gz_buffer_free(state);
             gz_error(state, Z_MEM_ERROR, "out of memory");
             return -1;
         }
@@ -594,8 +580,7 @@ int Z_EXPORT PREFIX(gzclose_r)(gzFile file) {
     /* free memory and close file */
     if (state->size) {
         PREFIX(inflateEnd)(&(state->strm));
-        zng_free(state->out);
-        zng_free(state->in);
+        gz_buffer_free(state);
     }
     err = state->err == Z_BUF_ERROR ? Z_BUF_ERROR : Z_OK;
     gz_error(state, Z_OK, NULL);

--- a/gzwrite.c
+++ b/gzwrite.c
@@ -29,10 +29,14 @@ static int gz_write_init(gz_state *state) {
     /* only need deflate state if compressing */
     if (!state->direct) {
         /* allocate deflate memory, set up for gzip compression */
-        ret = PREFIX(deflateInit2)(strm, state->level, Z_DEFLATED, MAX_WBITS + 16, DEF_MEM_LEVEL, state->strategy);
+        int ret = PREFIX(deflateInit2)(strm, state->level, Z_DEFLATED, MAX_WBITS + 16, DEF_MEM_LEVEL, state->strategy);
         if (ret != Z_OK) {
             gz_buffer_free(state);
-            gz_error(state, Z_MEM_ERROR, "out of memory");
+            if (ret == Z_MEM_ERROR) {
+                gz_error(state, Z_MEM_ERROR, "out of memory");
+            } else {
+                gz_error(state, Z_STREAM_ERROR, "invalid compression parameters");
+            }
             return -1;
         }
         strm->next_in = NULL;

--- a/zutil.c
+++ b/zutil.c
@@ -111,3 +111,41 @@ void Z_INTERNAL PREFIX(zcfree)(void *opaque, void *ptr) {
     Z_UNUSED(opaque);
     zng_free(ptr);
 }
+
+/* Provide aligned allocations, only used by gz* code */
+void Z_INTERNAL *zng_alloc_aligned(unsigned size, unsigned align) {
+    uintptr_t return_ptr, original_ptr;
+    uint32_t alloc_size, align_diff;
+    void *ptr;
+
+    /* Allocate enough memory for proper alignment and to store the original memory pointer */
+    alloc_size = sizeof(void *) + size + align;
+    ptr = zng_alloc(alloc_size);
+    if (!ptr)
+        return NULL;
+
+    /* Calculate return pointer address with space enough to store original pointer */
+    align_diff = align - ((uintptr_t)ptr % align);
+    return_ptr = (uintptr_t)ptr + align_diff;
+    if (align_diff < sizeof(void *))
+        return_ptr += align;
+
+    /* Store the original pointer for free() */
+    original_ptr = return_ptr - sizeof(void *);
+    memcpy((void *)original_ptr, &ptr, sizeof(void *));
+
+    /* Return properly aligned pointer in allocation */
+    return (void *)return_ptr;
+}
+
+void Z_INTERNAL zng_free_aligned(void *ptr) {
+    if (!ptr)
+        return;
+
+    /* Calculate offset to original memory allocation pointer */
+    void *original_ptr = (void *)((uintptr_t)ptr - sizeof(void *));
+    void *free_ptr = *(void **)original_ptr;
+
+    /* Free original memory allocation */
+    zng_free(free_ptr);
+}

--- a/zutil.h
+++ b/zutil.h
@@ -133,6 +133,8 @@ extern z_const char * const PREFIX(z_errmsg)[10]; /* indexed by 2-zlib_error */
 
 void Z_INTERNAL *PREFIX(zcalloc)(void *opaque, unsigned items, unsigned size);
 void Z_INTERNAL  PREFIX(zcfree)(void *opaque, void *ptr);
+void Z_INTERNAL *zng_alloc_aligned(unsigned size, unsigned align);
+void Z_INTERNAL zng_free_aligned(void *ptr);
 
 typedef void *zng_calloc_func(void *opaque, unsigned items, unsigned size);
 typedef void  zng_cfree_func(void *opaque, void *ptr);


### PR DESCRIPTION
- Reorganize initialization and buffer allocation for gzopen/gzread/gzwrite
  Unify initialization code into `gz_state_init()` and `gz_buffer_alloc()`.
- Reintroduce a simplified version of @nmoinvaz's `zng_alloc_aligned()` function that was removed in 5b208676f8db6aa169bf7a355226034404a4f503, and start using that for gz*
- Use a single malloc call for both in and out buffers in gzopen/gzread/gzwrite.
- Remove a malloc call from `gzdopen()`.
- Split out gz_read_init() from gzlook(), and rename gz_init() to gz_write_init().
   This makes gzread.c more like gzwrite.c, and fits in with the new code in gzlib.c.
   
In total, these changes should make the gz* code become a little easier to read and behave more like the rest of the zlib code.
This reduces the amount of malloc calls in gz* code from 7 places to 4.
The only `malloc()` calls I have not touched is the one in `gz_open()` that allocates `state->path`, and as far as I can tell there is no good way to define a good size for it, since the path can be short, or 32k long, or possibly even longer. And also the one that allocates `state->msg` ing in `gz_error()`

`gz_state_init()` initializes a few more state variables than either gzread or gzwrite code did previously, as an effect of unifying the code. `gz_buffer_free()` also makes sure to set pointers to NULL after freeing them, something the old code did not do.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized initialization, buffer lifecycle, and cleanup for gzip read/write, reducing duplicated setup/teardown.

* **New Features**
  * Added aligned memory allocation for I/O buffers and explicit buffer management to improve alignment and performance.

* **Bug Fixes**
  * Hardening of allocation/error paths and consolidated frees reduces memory-leak risk and makes open/read/write/close error handling more consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->