### PR TITLE
Fix broken actions-runner

### DIFF
--- a/arch/s390/self-hosted-builder/actions-runner
+++ b/arch/s390/self-hosted-builder/actions-runner
@@ -21,15 +21,18 @@ fi
 TOKEN_FILE=registration-token.json
 if [ -f $TOKEN_FILE ]; then
     set +e
-    EXPIRES=$(jq --raw-output .EXPIRES "$TOKEN_FILE" 2>/dev/null)
+    EXPIRES=$(jq --raw-output .expires_at "$TOKEN_FILE" 2>/dev/null)
     STATUS=$?
     set -e
 else
     STATUS=1
+    EXPIRES=""
 fi
-if [[ $STATUS -ne 0 || $(date +%s) -ge $(date -d "$EXPIRES" +%s) ]]; then
+
+if [[ $STATUS -ne 0 || -z "$EXPIRES" || "$EXPIRES" == "null" || $(date +%s) -ge $(date -d "$EXPIRES" +%s) ]]; then
     # Refresh the cached registration token.
     curl \
+        -sS \
         -X POST \
         -H "Accept: application/vnd.github+json" \
         -H "Authorization: Bearer $PAT_TOKEN" \

--- a/arch/s390/self-hosted-builder/actions-runner-rebuild.sh
+++ b/arch/s390/self-hosted-builder/actions-runner-rebuild.sh
@@ -33,7 +33,7 @@ podman build --squash -f actions-runner.Dockerfile --tag zlib-ng/actions-runner 
 
 # Create new container
 podman create --replace --name=gaplib-actions-runner --env-file=/etc/actions-runner --init \
-       --volume=actions-runner-temp:/home/actions-runner zlib-ng/actions-runner 2>&1 | tee -a /var/log/actions-runner-build.log
+       zlib-ng/actions-runner 2>&1 | tee -a /var/log/actions-runner-build.log
 
 # Start service
 systemctl start actions-runner || true

--- a/arch/s390/self-hosted-builder/actions-runner.Dockerfile
+++ b/arch/s390/self-hosted-builder/actions-runner.Dockerfile
@@ -4,7 +4,8 @@ FROM    almalinux:9
 
 RUN     dnf update -y -q && \
         dnf install -y -q --enablerepo=crb wget git which sudo jq sed \
-            cmake make automake autoconf m4 libtool ninja-build python3-pip \
+            cmake make automake autoconf m4 libtool ninja-build \
+            python3-pip python3-devel python3-lxml \
             gcc gcc-c++ clang llvm-toolset glibc-all-langpacks langpacks-en \
             glibc-static libstdc++-static libstdc++-devel libxslt-devel libxml2-devel
 
@@ -14,9 +15,10 @@ RUN     dnf install -y -q dotnet-sdk-8.0 && \
 RUN     cd /tmp && \
         git clone -q https://github.com/actions/runner && \
         cd runner && \
-        git checkout $(git tag | grep "^v[0-9]\+\.[0-9]\+\.[0-9]\+$" | sort -V | tail -1) -b build && \
+        git checkout $(git tag --sort=-v:refname | grep '^v[0-9]' | head -n1) && \
+        git log -n 1 && \
         wget https://github.com/anup-kodlekere/gaplib/raw/refs/heads/main/patches/runner-main-sdk8-s390x.patch -O runner-sdk-8.patch && \
-        git apply runner-sdk-8.patch && \
+        git apply --whitespace=nowarn runner-sdk-8.patch && \
         sed -i'' -e /version/s/8......\"$/$8.0.100\"/ src/global.json
 
 RUN     cd /tmp/runner/src && \
@@ -29,16 +31,6 @@ RUN     useradd -c "Action Runner" -m actions-runner && \
 
 RUN     tar -xf /tmp/runner/_package/*.tar.gz -C /home/actions-runner && \
         chown -R actions-runner:actions-runner /home/actions-runner
-
-#VOLUME  /home/actions-runner
-
-# Workaround: Install custom clang version to avoid compiler bug, ref #1852
-RUN     mkdir /tmp/clang
-
-COPY    clang/*.rpm /tmp/clang
-
-RUN     dnf -y upgrade /tmp/clang/*.rpm && \
-        rm -rf /tmp/clang
 
 # Cleanup
 RUN     rm -rf /tmp/runner /var/cache/dnf/* /tmp/runner.patch /tmp/global.json && \


### PR DESCRIPTION
Fixed 3 problems, removed clang workaround now that clang packages have been updated, and made some improvements to robustness and logging.

Hopefully it keeps working now 😄 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of token expiration and refresh logic for self-hosted builder scripts, ensuring more robust operation when tokens are missing or invalid.

* **Refactor**
  * Updated the method for checking out the latest GitHub Actions runner version to enhance reliability.
  * Suppressed whitespace warnings during patch application for a cleaner build process.

* **Chores**
  * Removed unnecessary volume mounting in container creation.
  * Eliminated obsolete compiler workaround steps from the build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->