### PR TITLE
Add .gitignore to allow run tests with zlib-ng/corpora and local dataset from working copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,7 @@ gzread.c
 MinSizeRel
 RelWithDebInfo
 /_deps/googletest*
+
+# Test datasets
+test/data/corpora/
+test/data/local/


### PR DESCRIPTION
Add `.gitignore` to allow run tests with zlib-ng/corpora and local dataset from working copy

Without `.gitignore`, the local test dataset will make it difficult working with git.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the ignore list to exclude additional test data directories from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->