### PR TITLE
Revert "Clean up insert_match() in deflate_medium"

### DIFF
--- a/deflate.h
+++ b/deflate.h
@@ -227,7 +227,7 @@ struct ALIGNED_(64) internal_state {
 #   define max_insert_length  max_lazy_match
     /* Insert new strings in the hash table only if the match length is not
      * greater than this length. This saves time but degrades compression.
-     * max_insert_length is used only for compression levels <= 3.
+     * max_insert_length is used only for compression levels <= 6.
      */
 
     update_hash_cb          update_hash;

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -63,8 +63,10 @@ static void insert_match(deflate_state *s, struct match match) {
         return;
     }
 
-    /* Insert new strings in the hash table. */
-    if (s->lookahead >= WANT_MIN_MATCH) {
+    /* Insert new strings in the hash table only if the match length
+     * is not too large. This saves time but degrades compression.
+     */
+    if (match.match_length <= 16 * s->max_insert_length && s->lookahead >= WANT_MIN_MATCH) {
         match.match_length--; /* string at strstart already in table */
         match.strstart++;
 

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -45,12 +45,10 @@ static void insert_match(deflate_state *s, struct match match) {
     if (UNLIKELY(s->lookahead <= (unsigned int)(match.match_length + WANT_MIN_MATCH)))
         return;
 
-    /* string at strstart already in table */
-    match.strstart++;
-    match.match_length--;
-
     /* matches that are not long enough we need to emit as literals */
-    if (LIKELY(match.match_length < WANT_MIN_MATCH - 1)) {
+    if (LIKELY(match.match_length < WANT_MIN_MATCH)) {
+        match.strstart++;
+        match.match_length--;
         if (UNLIKELY(match.match_length > 0)) {
             if (match.strstart >= match.orgstart) {
                 if (match.strstart + match.match_length - 1 >= match.orgstart) {
@@ -65,18 +63,33 @@ static void insert_match(deflate_state *s, struct match match) {
         return;
     }
 
-    /* Insert into hash table. */
-    if (LIKELY(match.strstart >= match.orgstart)) {
-        if (LIKELY(match.strstart + match.match_length - 1 >= match.orgstart)) {
-            insert_string(s, match.strstart, match.match_length);
-        } else {
-            insert_string(s, match.strstart, match.orgstart - match.strstart + 1);
+    /* Insert new strings in the hash table. */
+    if (s->lookahead >= WANT_MIN_MATCH) {
+        match.match_length--; /* string at strstart already in table */
+        match.strstart++;
+
+        if (LIKELY(match.strstart >= match.orgstart)) {
+            if (LIKELY(match.strstart + match.match_length - 1 >= match.orgstart)) {
+                insert_string(s, match.strstart, match.match_length);
+            } else {
+                insert_string(s, match.strstart, match.orgstart - match.strstart + 1);
+            }
+        } else if (match.orgstart < match.strstart + match.match_length) {
+            insert_string(s, match.orgstart, match.strstart + match.match_length - match.orgstart);
         }
-    } else if (match.orgstart < match.strstart + match.match_length) {
-        insert_string(s, match.orgstart, match.strstart + match.match_length - match.orgstart);
+        match.strstart += match.match_length;
+        match.match_length = 0;
+    } else {
+        match.strstart += match.match_length;
+        match.match_length = 0;
+
+        if (match.strstart >= (STD_MIN_MATCH - 2))
+            quick_insert_string(s, match.strstart + 2 - STD_MIN_MATCH);
+
+        /* If lookahead < WANT_MIN_MATCH, ins_h is garbage, but it does not
+         * matter since it will be recomputed at next deflate call.
+         */
     }
-    match.strstart += match.match_length;
-    match.match_length = 0;
 }
 
 static void fizzle_matches(deflate_state *s, struct match *current, struct match *next) {


### PR DESCRIPTION
This reverts commits 56d3d9851a824aeb921c9853042776866aa195a3 and 322753f36e833343ae030e499564691da15eef32 after reports of performance regressions, seemingly mostly affecting highly compressible data with a lot of very long matches (257+ bytes).

Fixes #1935 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logic for string insertion during compression to ensure more accurate handling based on match length and lookahead, potentially enhancing compression efficiency and reliability.

* **Documentation**
  * Updated a comment to clarify the usage scope of the `max_insert_length` parameter for different compression levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->