### PR TITLE
Disable NEON workaround on Clang 20 and above, and enable it for non-mobile platforms

### DIFF
--- a/arch/arm/neon_intrins.h
+++ b/arch/arm/neon_intrins.h
@@ -27,8 +27,8 @@
 
 #  if defined(__arm__) && defined(__clang__) && \
     (!defined(__clang_major__) || __clang_major__ < 20)
-/* Clang versions before 20 have too strict of an alignment
- * requirement (:256) for x4 NEON intrinsics */
+/* Clang versions before 20 have too strict of an
+ * alignment requirement (:256) for x4 NEON intrinsics */
 #    undef ARM_NEON_HASLD4
 #    undef vld1q_u16_x4
 #    undef vld1q_u8_x4

--- a/arch/arm/neon_intrins.h
+++ b/arch/arm/neon_intrins.h
@@ -26,9 +26,9 @@
 } while (0)
 
 #  if defined(__arm__) && defined(__clang__) && \
-    (!defined(__clang_major__) || __clang_major__ < 20) && \
-    (defined(__ANDROID__) || defined(__APPLE__))
-/* Android & iOS have too strict alignment requirement (:256) for x4 NEON intrinsics */
+    (!defined(__clang_major__) || __clang_major__ < 20)
+/* Clang versions before 20 have too strict of an alignment
+ * requirement (:256) for x4 NEON intrinsics */
 #    undef ARM_NEON_HASLD4
 #    undef vld1q_u16_x4
 #    undef vld1q_u8_x4

--- a/arch/arm/neon_intrins.h
+++ b/arch/arm/neon_intrins.h
@@ -25,11 +25,9 @@
     out.val[3] = vqsubq_u16(a.val[3], b); \
 } while (0)
 
-#if defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE == 1
-#   define IS_IOS
-#endif
-
-#  if defined(__arm__) && (defined(__ANDROID__) || defined(IS_IOS))
+#  if defined(__arm__) && defined(__clang__) && \
+    (!defined(__clang_major__) || __clang_major__ < 20) && \
+    (defined(__ANDROID__) || defined(__APPLE__))
 /* Android & iOS have too strict alignment requirement (:256) for x4 NEON intrinsics */
 #    undef ARM_NEON_HASLD4
 #    undef vld1q_u16_x4


### PR DESCRIPTION
This seems like it reduces performance, (if not, maybe it should be always applied?), and it isn't needed after Clang 20 so disable it if Clang is new enough.

Also enable the workaround when building with older Clang versions targeting non-mobile platforms like normal Linux.  The original issue had discussion of Alpine Linux breaking and testing with qemu-user emulation confirms that builds with Clang 19 are broken without the workaround on Alpine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal logic to improve compatibility of NEON intrinsics with older Clang versions on 32-bit ARM devices. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->