### PR TITLE
X86_AVX512VNNI: test _mm256_dpbusd_epi32 too

### DIFF
--- a/cmake/detect-intrinsics.cmake
+++ b/cmake/detect-intrinsics.cmake
@@ -164,18 +164,17 @@ macro(check_avx512vnni_intrinsics)
     endif()
     # Check whether compiler supports AVX512vnni intrinsics
     set(CMAKE_REQUIRED_FLAGS "${AVX512VNNIFLAG} ${NATIVEFLAG} ${ZNOLTOFLAG}")
-    check_c_source_compiles([=[
-#include <immintrin.h>
-int main(void) {
-    const __m512i z512 = _mm512_setzero_si512();
-    const __m256i z256 = _mm256_setzero_si256();
-    volatile __m512i r512 = _mm512_dpbusd_epi32(z512, z512, z512);
-    volatile __m256i r256 = _mm256_dpbusd_epi32(z256, z256, z256);
-    (void)r512;
-    (void)r256;
-    return 0;
-}
-]=]
+    check_c_source_compiles(
+        "#include <immintrin.h>
+        int main(void) {
+            const __m512i z512 = _mm512_setzero_si512();
+            const __m256i z256 = _mm256_setzero_si256();
+            volatile __m512i r512 = _mm512_dpbusd_epi32(z512, z512, z512);
+            volatile __m256i r256 = _mm256_dpbusd_epi32(z256, z256, z256);
+            (void)r512;
+            (void)r256;
+            return 0;
+        }"
         HAVE_AVX512VNNI_INTRIN
     )
     set(CMAKE_REQUIRED_FLAGS)

--- a/cmake/detect-intrinsics.cmake
+++ b/cmake/detect-intrinsics.cmake
@@ -164,13 +164,18 @@ macro(check_avx512vnni_intrinsics)
     endif()
     # Check whether compiler supports AVX512vnni intrinsics
     set(CMAKE_REQUIRED_FLAGS "${AVX512VNNIFLAG} ${NATIVEFLAG} ${ZNOLTOFLAG}")
-    check_c_source_compiles(
-        "#include <immintrin.h>
-        __m512i f(__m512i x, __m512i y) {
-            __m512i z = _mm512_setzero_epi32();
-            return _mm512_dpbusd_epi32(z, x, y);
-        }
-        int main(void) { return 0; }"
+    check_c_source_compiles([=[
+#include <immintrin.h>
+int main(void) {
+    const __m512i z512 = _mm512_setzero_si512();
+    const __m256i z256 = _mm256_setzero_si256();
+    volatile __m512i r512 = _mm512_dpbusd_epi32(z512, z512, z512);
+    volatile __m256i r256 = _mm256_dpbusd_epi32(z256, z256, z256);
+    (void)r512;
+    (void)r256;
+    return 0;
+}
+]=]
         HAVE_AVX512VNNI_INTRIN
     )
     set(CMAKE_REQUIRED_FLAGS)

--- a/configure
+++ b/configure
@@ -1188,11 +1188,15 @@ check_avx512vnni_intrinsics() {
     # Check whether compiler supports AVX512-VNNI intrinsics
     cat > $test.c << EOF
 #include <immintrin.h>
-__m512i f(__m512i x, __m512i y) {
-    __m512i z = _mm512_setzero_epi32();
-    return _mm512_dpbusd_epi32(z, x, y);
+int main(void) {
+    const __m512i z512 = _mm512_setzero_si512();
+    const __m256i z256 = _mm256_setzero_si256();
+    volatile __m512i r512 = _mm512_dpbusd_epi32(z512, z512, z512);
+    volatile __m256i r256 = _mm256_dpbusd_epi32(z256, z256, z256);
+    (void)r512;
+    (void)r256;
+    return 0;
 }
-int main(void) { return 0; }
 EOF
     if try ${CC} ${CFLAGS} ${avx512vnniflag} $test.c; then
         echo "Checking for AVX512VNNI intrinsics ... Yes." | tee -a configure.log


### PR DESCRIPTION
On RHEL9 the GCC is new enough to support AVX512-VNNI, but its assembler
(binutils) is not and errors with

```
Error: unsupported instruction vpdpbusd
```

This was already addressed earlier in #1562 to some extent, except that
a check for `_mm256_dpbusd_epi32` was not added, which is what the
assembler errors over. So, check the 256 bit version as well.

After some more digging, seems that the difference is that when just
`-mavx512vl -mavx512vnni` flags are given, the following assembly is
generated, which is not problematic for the assembler:

```assembly
      vpdpbusd        %ymm0, %ymm0, %ymm0
```

whereas with `-march=sapphirerapids` the following is, which is apparently
problematic for the assembler:

```assembly
      {vex} vpdpbusd  %ymm0, %ymm0, %ymm0
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated the system check for AVX512-VNNI support to test both 512-bit and 256-bit variants during configuration. This enhances compatibility detection on different hardware platforms. No changes to user-facing features or public interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->