### PR TITLE
Check the proper bit for BMI2

### DIFF
--- a/arch/x86/x86_features.c
+++ b/arch/x86/x86_features.c
@@ -101,7 +101,7 @@ void Z_INTERNAL x86_check_features(struct x86_cpu_features *features) {
         cpuidex(7, 0, &eax, &ebx, &ecx, &edx);
 
         // check BMI2 bit
-        features->has_bmi2 = ebx & 0x8;
+        features->has_bmi2 = ebx & 0x100;
 
         // check AVX2 bit if the OS supports saving YMM registers
         if (features->has_os_save_ymm) {


### PR DESCRIPTION
We were actually checking for BMI1 support here. This is unlikely to have caused any issues because to date there have not been any x86 CPUs with AVX2 support but no BMI2 support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected CPU capability detection on x86 systems to accurately recognize BMI2 and AVX-512 support. This ensures features are enabled only when supported, reducing potential illegal-instruction errors and improving stability.
  - Users on affected CPUs may see more reliable startup, fewer compatibility issues, and performance improvements where advanced instructions are now correctly utilized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->