### PR TITLE
Retemplatize the elided copy with the adler checksum

### DIFF
--- a/arch/x86/adler32_avx2.c
+++ b/arch/x86/adler32_avx2.c
@@ -10,136 +10,18 @@
 #ifdef X86_AVX2
 
 #include "zbuild.h"
-#include <immintrin.h>
-#include "adler32_p.h"
-#include "adler32_avx2_p.h"
-#include "x86_intrins.h"
 
-extern uint32_t adler32_fold_copy_sse42(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len);
-extern uint32_t adler32_ssse3(uint32_t adler, const uint8_t *src, size_t len);
-
-static inline uint32_t adler32_fold_copy_impl(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len, const int COPY) {
-    if (src == NULL) return 1L;
-    if (len == 0) return adler;
-
-    uint32_t adler0, adler1;
-    adler1 = (adler >> 16) & 0xffff;
-    adler0 = adler & 0xffff;
-
-rem_peel:
-    if (len < 16) {
-        if (COPY) {
-            return adler32_copy_len_16(adler0, src, dst, len, adler1);
-        } else {
-            return adler32_len_16(adler0, src, len, adler1);
-        }
-    } else if (len < 32) {
-        if (COPY) {
-            return adler32_fold_copy_sse42(adler, dst, src, len);
-        } else {
-            return adler32_ssse3(adler, src, len);
-        }
-    }
-
-    __m256i vs1, vs2;
-
-    const __m256i dot2v = _mm256_setr_epi8(32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15,
-                                           14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1);
-    const __m256i dot3v = _mm256_set1_epi16(1);
-    const __m256i zero = _mm256_setzero_si256();
-
-    while (len >= 32) {
-        vs1 = _mm256_zextsi128_si256(_mm_cvtsi32_si128(adler0));
-        vs2 = _mm256_zextsi128_si256(_mm_cvtsi32_si128(adler1));
-        __m256i vs1_0 = vs1;
-        __m256i vs3 = _mm256_setzero_si256();
-
-        size_t k = MIN(len, NMAX);
-        k -= k % 32;
-        len -= k;
-
-        while (k >= 32) {
-            /*
-               vs1 = adler + sum(c[i])
-               vs2 = sum2 + 32 vs1 + sum( (32-i+1) c[i] )
-            */
-            __m256i vbuf = _mm256_loadu_si256((__m256i*)src);
-            src += 32;
-            k -= 32;
-
-            __m256i vs1_sad = _mm256_sad_epu8(vbuf, zero); // Sum of abs diff, resulting in 2 x int32's
-
-            if (COPY) {
-                _mm256_storeu_si256((__m256i*)dst, vbuf);
-                dst += 32;
-            }
- 
-            vs1 = _mm256_add_epi32(vs1, vs1_sad);
-            vs3 = _mm256_add_epi32(vs3, vs1_0);
-            __m256i v_short_sum2 = _mm256_maddubs_epi16(vbuf, dot2v); // sum 32 uint8s to 16 shorts
-            __m256i vsum2 = _mm256_madd_epi16(v_short_sum2, dot3v); // sum 16 shorts to 8 uint32s
-            vs2 = _mm256_add_epi32(vsum2, vs2);
-            vs1_0 = vs1;
-        }
-
-        /* Defer the multiplication with 32 to outside of the loop */
-        vs3 = _mm256_slli_epi32(vs3, 5);
-        vs2 = _mm256_add_epi32(vs2, vs3);
-
-        /* The compiler is generating the following sequence for this integer modulus
-         * when done the scalar way, in GPRs:
-
-         adler = (s1_unpack[0] % BASE) + (s1_unpack[1] % BASE) + (s1_unpack[2] % BASE) + (s1_unpack[3] % BASE) +
-                 (s1_unpack[4] % BASE) + (s1_unpack[5] % BASE) + (s1_unpack[6] % BASE) + (s1_unpack[7] % BASE);
-
-         mov    $0x80078071,%edi // move magic constant into 32 bit register %edi
-         ...
-         vmovd  %xmm1,%esi // move vector lane 0 to 32 bit register %esi
-         mov    %rsi,%rax  // zero-extend this value to 64 bit precision in %rax
-         imul   %rdi,%rsi // do a signed multiplication with magic constant and vector element
-         shr    $0x2f,%rsi // shift right by 47
-         imul   $0xfff1,%esi,%esi // do a signed multiplication with value truncated to 32 bits with 0xfff1
-         sub    %esi,%eax // subtract lower 32 bits of original vector value from modified one above
-         ...
-         // repeats for each element with vpextract instructions
-
-         This is tricky with AVX2 for a number of reasons:
-             1.) There's no 64 bit multiplication instruction, but there is a sequence to get there
-             2.) There's ways to extend vectors to 64 bit precision, but no simple way to truncate
-                 back down to 32 bit precision later (there is in AVX512)
-             3.) Full width integer multiplications aren't cheap
-
-         We can, however, do a relatively cheap sequence for horizontal sums.
-         Then, we simply do the integer modulus on the resulting 64 bit GPR, on a scalar value. It was
-         previously thought that casting to 64 bit precision was needed prior to the horizontal sum, but
-         that is simply not the case, as NMAX is defined as the maximum number of scalar sums that can be
-         performed on the maximum possible inputs before overflow
-         */
-
-
-         /* In AVX2-land, this trip through GPRs will probably be unavoidable, as there's no cheap and easy
-          * conversion from 64 bit integer to 32 bit (needed for the inexpensive modulus with a constant).
-          * This casting to 32 bit is cheap through GPRs (just register aliasing). See above for exactly
-          * what the compiler is doing to avoid integer divisions. */
-         adler0 = partial_hsum256(vs1) % BASE;
-         adler1 = hsum256(vs2) % BASE;
-    }
-
-    adler = adler0 | (adler1 << 16);
-
-    if (len) {
-        goto rem_peel;
-    }
-
-    return adler;
-}
+#include "adler32_avx2_tpl.h"
 
 Z_INTERNAL uint32_t adler32_avx2(uint32_t adler, const uint8_t *src, size_t len) {
-    return adler32_fold_copy_impl(adler, NULL, src, len, 0);
+    return adler32_fold_impl(adler, NULL, src, len);
 }
 
+#define COPY
+#include "adler32_avx2_tpl.h"
+
 Z_INTERNAL uint32_t adler32_fold_copy_avx2(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len) {
-    return adler32_fold_copy_impl(adler, dst, src, len, 1);
+    return adler32_fold_copy_impl(adler, dst, src, len);
 }
 
 #endif

--- a/arch/x86/adler32_avx2_tpl.h
+++ b/arch/x86/adler32_avx2_tpl.h
@@ -1,0 +1,127 @@
+#include <immintrin.h>
+#include "adler32_p.h"
+#include "adler32_avx2_p.h"
+#include "x86_intrins.h"
+
+extern uint32_t adler32_fold_copy_sse42(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len);
+extern uint32_t adler32_ssse3(uint32_t adler, const uint8_t *src, size_t len);
+
+#ifdef COPY
+static inline uint32_t adler32_fold_copy_impl(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len) {
+#else
+static inline uint32_t adler32_fold_impl(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len) {
+#endif
+    if (src == NULL) return 1L;
+    if (len == 0) return adler;
+
+    uint32_t adler0, adler1;
+    adler1 = (adler >> 16) & 0xffff;
+    adler0 = adler & 0xffff;
+
+rem_peel:
+    if (len < 16) {
+#ifdef COPY
+            return adler32_copy_len_16(adler0, src, dst, len, adler1);
+#else
+            return adler32_len_16(adler0, src, len, adler1);
+#endif
+    } else if (len < 32) {
+#ifdef COPY
+            return adler32_fold_copy_sse42(adler, dst, src, len);
+#else
+            return adler32_ssse3(adler, src, len);
+#endif
+    }
+
+    __m256i vs1, vs2;
+
+    const __m256i dot2v = _mm256_setr_epi8(32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15,
+                                           14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1);
+    const __m256i dot3v = _mm256_set1_epi16(1);
+    const __m256i zero = _mm256_setzero_si256();
+
+    while (len >= 32) {
+        vs1 = _mm256_zextsi128_si256(_mm_cvtsi32_si128(adler0));
+        vs2 = _mm256_zextsi128_si256(_mm_cvtsi32_si128(adler1));
+        __m256i vs1_0 = vs1;
+        __m256i vs3 = _mm256_setzero_si256();
+
+        size_t k = MIN(len, NMAX);
+        k -= k % 32;
+        len -= k;
+
+        while (k >= 32) {
+            /*
+               vs1 = adler + sum(c[i])
+               vs2 = sum2 + 32 vs1 + sum( (32-i+1) c[i] )
+            */
+            __m256i vbuf = _mm256_loadu_si256((__m256i*)src);
+            src += 32;
+            k -= 32;
+
+            __m256i vs1_sad = _mm256_sad_epu8(vbuf, zero); // Sum of abs diff, resulting in 2 x int32's
+
+#ifdef COPY
+                _mm256_storeu_si256((__m256i*)dst, vbuf);
+                dst += 32;
+#endif
+ 
+            vs1 = _mm256_add_epi32(vs1, vs1_sad);
+            vs3 = _mm256_add_epi32(vs3, vs1_0);
+            __m256i v_short_sum2 = _mm256_maddubs_epi16(vbuf, dot2v); // sum 32 uint8s to 16 shorts
+            __m256i vsum2 = _mm256_madd_epi16(v_short_sum2, dot3v); // sum 16 shorts to 8 uint32s
+            vs2 = _mm256_add_epi32(vsum2, vs2);
+            vs1_0 = vs1;
+        }
+
+        /* Defer the multiplication with 32 to outside of the loop */
+        vs3 = _mm256_slli_epi32(vs3, 5);
+        vs2 = _mm256_add_epi32(vs2, vs3);
+
+        /* The compiler is generating the following sequence for this integer modulus
+         * when done the scalar way, in GPRs:
+
+         adler = (s1_unpack[0] % BASE) + (s1_unpack[1] % BASE) + (s1_unpack[2] % BASE) + (s1_unpack[3] % BASE) +
+                 (s1_unpack[4] % BASE) + (s1_unpack[5] % BASE) + (s1_unpack[6] % BASE) + (s1_unpack[7] % BASE);
+
+         mov    $0x80078071,%edi // move magic constant into 32 bit register %edi
+         ...
+         vmovd  %xmm1,%esi // move vector lane 0 to 32 bit register %esi
+         mov    %rsi,%rax  // zero-extend this value to 64 bit precision in %rax
+         imul   %rdi,%rsi // do a signed multiplication with magic constant and vector element
+         shr    $0x2f,%rsi // shift right by 47
+         imul   $0xfff1,%esi,%esi // do a signed multiplication with value truncated to 32 bits with 0xfff1
+         sub    %esi,%eax // subtract lower 32 bits of original vector value from modified one above
+         ...
+         // repeats for each element with vpextract instructions
+
+         This is tricky with AVX2 for a number of reasons:
+             1.) There's no 64 bit multiplication instruction, but there is a sequence to get there
+             2.) There's ways to extend vectors to 64 bit precision, but no simple way to truncate
+                 back down to 32 bit precision later (there is in AVX512)
+             3.) Full width integer multiplications aren't cheap
+
+         We can, however, do a relatively cheap sequence for horizontal sums.
+         Then, we simply do the integer modulus on the resulting 64 bit GPR, on a scalar value. It was
+         previously thought that casting to 64 bit precision was needed prior to the horizontal sum, but
+         that is simply not the case, as NMAX is defined as the maximum number of scalar sums that can be
+         performed on the maximum possible inputs before overflow
+         */
+
+
+         /* In AVX2-land, this trip through GPRs will probably be unavoidable, as there's no cheap and easy
+          * conversion from 64 bit integer to 32 bit (needed for the inexpensive modulus with a constant).
+          * This casting to 32 bit is cheap through GPRs (just register aliasing). See above for exactly
+          * what the compiler is doing to avoid integer divisions. */
+         adler0 = partial_hsum256(vs1) % BASE;
+         adler1 = hsum256(vs2) % BASE;
+    }
+
+    adler = adler0 | (adler1 << 16);
+
+    if (len) {
+        goto rem_peel;
+    }
+
+    return adler;
+}

--- a/arch/x86/adler32_avx512.c
+++ b/arch/x86/adler32_avx512.c
@@ -9,99 +9,18 @@
 #ifdef X86_AVX512
 
 #include "zbuild.h"
-#include "adler32_p.h"
-#include "arch_functions.h"
-#include <immintrin.h>
-#include "x86_intrins.h"
-#include "adler32_avx512_p.h"
-
-static inline uint32_t adler32_fold_copy_impl(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len, const int COPY) {
-    if (src == NULL) return 1L;
-    if (len == 0) return adler;
-
-    uint32_t adler0, adler1;
-    adler1 = (adler >> 16) & 0xffff;
-    adler0 = adler & 0xffff;
-
-rem_peel:
-    if (len < 64) {
-        /* This handles the remaining copies, just call normal adler checksum after this */
-        if (COPY) {
-            __mmask64 storemask = (0xFFFFFFFFFFFFFFFFUL >> (64 - len));
-            __m512i copy_vec = _mm512_maskz_loadu_epi8(storemask, src);
-            _mm512_mask_storeu_epi8(dst, storemask, copy_vec);
-        }
-
-        return adler32_avx2(adler, src, len);
-    }
-
-    __m512i vbuf, vs1_0, vs3;
-
-    const __m512i dot2v = _mm512_set_epi8(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
-                                          20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37,
-                                          38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55,
-                                          56, 57, 58, 59, 60, 61, 62, 63, 64);
-    const __m512i dot3v = _mm512_set1_epi16(1);
-    const __m512i zero = _mm512_setzero_si512();
-    size_t k;
-
-    while (len >= 64) {
-        __m512i vs1 = _mm512_zextsi128_si512(_mm_cvtsi32_si128(adler0));
-        __m512i vs2 = _mm512_zextsi128_si512(_mm_cvtsi32_si128(adler1));
-        vs1_0 = vs1;
-        vs3 = _mm512_setzero_si512();
-
-        k = MIN(len, NMAX);
-        k -= k % 64;
-        len -= k;
-
-        while (k >= 64) {
-            /*
-               vs1 = adler + sum(c[i])
-               vs2 = sum2 + 64 vs1 + sum( (64-i+1) c[i] )
-            */
-            vbuf = _mm512_loadu_si512(src);
-
-            if (COPY) {
-                _mm512_storeu_si512(dst, vbuf);
-                dst += 64;
-            }
-
-            src += 64;
-            k -= 64;
-
-            __m512i vs1_sad = _mm512_sad_epu8(vbuf, zero);
-            __m512i v_short_sum2 = _mm512_maddubs_epi16(vbuf, dot2v);
-            vs1 = _mm512_add_epi32(vs1_sad, vs1);
-            vs3 = _mm512_add_epi32(vs3, vs1_0);
-            __m512i vsum2 = _mm512_madd_epi16(v_short_sum2, dot3v);
-            vs2 = _mm512_add_epi32(vsum2, vs2);
-            vs1_0 = vs1;
-        }
-
-        vs3 = _mm512_slli_epi32(vs3, 6);
-        vs2 = _mm512_add_epi32(vs2, vs3);
-
-        adler0 = partial_hsum(vs1) % BASE;
-        adler1 = _mm512_reduce_add_epu32(vs2) % BASE;
-    }
-
-    adler = adler0 | (adler1 << 16);
-
-    /* Process tail (len < 64). */
-    if (len) {
-        goto rem_peel;
-    }
-
-    return adler;
-}
-
-Z_INTERNAL uint32_t adler32_fold_copy_avx512(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len) {
-    return adler32_fold_copy_impl(adler, dst, src, len, 1);
-}
+#include "adler32_avx512_tpl.h"
 
 Z_INTERNAL uint32_t adler32_avx512(uint32_t adler, const uint8_t *src, size_t len) {
-    return adler32_fold_copy_impl(adler, NULL, src, len, 0);
+    return adler32_fold_impl(adler, NULL, src, len);
+}
+
+
+#define COPY
+#include "adler32_avx512_tpl.h"
+
+Z_INTERNAL uint32_t adler32_fold_copy_avx512(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len) {
+    return adler32_fold_copy_impl(adler, dst, src, len);
 }
 
 #endif

--- a/arch/x86/adler32_avx512_tpl.h
+++ b/arch/x86/adler32_avx512_tpl.h
@@ -1,0 +1,90 @@
+#include "adler32_p.h"
+#include "arch_functions.h"
+#include <immintrin.h>
+#include "x86_intrins.h"
+#include "adler32_avx512_p.h"
+
+#ifdef COPY
+static inline uint32_t adler32_fold_copy_impl(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len) {
+#else
+static inline uint32_t adler32_fold_impl(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len) {
+#endif
+    if (src == NULL) return 1L;
+    if (len == 0) return adler;
+
+    uint32_t adler0, adler1;
+    adler1 = (adler >> 16) & 0xffff;
+    adler0 = adler & 0xffff;
+
+rem_peel:
+    if (len < 64) {
+        /* This handles the remaining copies, just call normal adler checksum after this */
+#ifdef COPY
+        __mmask64 storemask = (0xFFFFFFFFFFFFFFFFUL >> (64 - len));
+        __m512i copy_vec = _mm512_maskz_loadu_epi8(storemask, src);
+        _mm512_mask_storeu_epi8(dst, storemask, copy_vec);
+#endif
+
+        return adler32_avx2(adler, src, len);
+    }
+
+    __m512i vbuf, vs1_0, vs3;
+
+    const __m512i dot2v = _mm512_set_epi8(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+                                          20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37,
+                                          38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55,
+                                          56, 57, 58, 59, 60, 61, 62, 63, 64);
+    const __m512i dot3v = _mm512_set1_epi16(1);
+    const __m512i zero = _mm512_setzero_si512();
+    size_t k;
+
+    while (len >= 64) {
+        __m512i vs1 = _mm512_zextsi128_si512(_mm_cvtsi32_si128(adler0));
+        __m512i vs2 = _mm512_zextsi128_si512(_mm_cvtsi32_si128(adler1));
+        vs1_0 = vs1;
+        vs3 = _mm512_setzero_si512();
+
+        k = MIN(len, NMAX);
+        k -= k % 64;
+        len -= k;
+
+        while (k >= 64) {
+            /*
+               vs1 = adler + sum(c[i])
+               vs2 = sum2 + 64 vs1 + sum( (64-i+1) c[i] )
+            */
+            vbuf = _mm512_loadu_si512(src);
+
+#ifdef COPY
+                _mm512_storeu_si512(dst, vbuf);
+                dst += 64;
+#endif
+
+            src += 64;
+            k -= 64;
+
+            __m512i vs1_sad = _mm512_sad_epu8(vbuf, zero);
+            __m512i v_short_sum2 = _mm512_maddubs_epi16(vbuf, dot2v);
+            vs1 = _mm512_add_epi32(vs1_sad, vs1);
+            vs3 = _mm512_add_epi32(vs3, vs1_0);
+            __m512i vsum2 = _mm512_madd_epi16(v_short_sum2, dot3v);
+            vs2 = _mm512_add_epi32(vsum2, vs2);
+            vs1_0 = vs1;
+        }
+
+        vs3 = _mm512_slli_epi32(vs3, 6);
+        vs2 = _mm512_add_epi32(vs2, vs3);
+
+        adler0 = partial_hsum(vs1) % BASE;
+        adler1 = _mm512_reduce_add_epu32(vs2) % BASE;
+    }
+
+    adler = adler0 | (adler1 << 16);
+
+    /* Process tail (len < 64). */
+    if (len) {
+        goto rem_peel;
+    }
+
+    return adler;
+}


### PR DESCRIPTION
At some point, GCC became too clever and stopped compiling this compile time constant input as a separately inlined function. What this meant was both implementations suffered a branch when compiled, resulting in slower performance for both our internal usage and well as external callers who simply want to checksum a buffer.

This change effectively reverts that behavior so now the compiler can compile out this branch again, making the loop just a tad bit faster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Performance Improvements
  - Faster Adler-32 checksum throughput on modern x86 CPUs with AVX2/AVX-512, especially for large buffers and combined copy+checksum paths.
  - Reduced latency and more consistent performance across varying input sizes.

- Refactor
  - Consolidated vectorized logic into shared templates, simplifying the codebase while preserving existing behavior and compatibility.

- Stability
  - Streamlined code paths reduce divergence across CPU feature levels, improving reliability without changing public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->