### PR TITLE
Use aligned load/store in AVX2 Slide Hash.

### DIFF
--- a/arch/x86/slide_hash_avx2.c
+++ b/arch/x86/slide_hash_avx2.c
@@ -21,9 +21,9 @@ static inline void slide_hash_chain(Pos *table, uint32_t entries, const __m256i 
     do {
         __m256i value, result;
 
-        value = _mm256_loadu_si256((__m256i *)table);
+        value = _mm256_load_si256((__m256i *)table);
         result = _mm256_subs_epu16(value, wsize);
-        _mm256_storeu_si256((__m256i *)table, result);
+        _mm256_store_si256((__m256i *)table, result);
 
         table -= 16;
         entries -= 16;

--- a/test/benchmarks/benchmark_slidehash.cc
+++ b/test/benchmarks/benchmark_slidehash.cc
@@ -25,13 +25,13 @@ private:
 
 public:
     void SetUp(const ::benchmark::State& state) {
-        l0 = (uint16_t *)zng_alloc(HASH_SIZE * sizeof(uint16_t));
+        l0 = (uint16_t *)zng_alloc_aligned(HASH_SIZE * sizeof(uint16_t), 64);
 
         for (uint32_t i = 0; i < HASH_SIZE; i++) {
             l0[i] = rand();
         }
 
-        l1 = (uint16_t *)zng_alloc(MAX_RANDOM_INTS * sizeof(uint16_t));
+        l1 = (uint16_t *)zng_alloc_aligned(MAX_RANDOM_INTS * sizeof(uint16_t), 64);
 
         for (int32_t i = 0; i < MAX_RANDOM_INTS; i++) {
             l1[i] = rand();
@@ -53,8 +53,8 @@ public:
     }
 
     void TearDown(const ::benchmark::State& state) {
-        zng_free(l0);
-        zng_free(l1);
+        zng_free_aligned(l0);
+        zng_free_aligned(l1);
         free(s_g);
     }
 };
@@ -66,7 +66,7 @@ public:
         } \
         Bench(state, fptr); \
     } \
-    BENCHMARK_REGISTER_F(slide_hash, name)->RangeMultiplier(2)->Range(1024, MAX_RANDOM_INTS);
+    BENCHMARK_REGISTER_F(slide_hash, name)->RangeMultiplier(2)->Range(512, MAX_RANDOM_INTS);
 
 BENCHMARK_SLIDEHASH(c, slide_hash_c, 1);
 


### PR DESCRIPTION
Change to use aligned load/store in AVX2 Slide Hash, we already ensure that the buffers are aligned during any deflate run.
Also change slidehash benchmark to also test 512 bytes window size, the minimum window size we use.

PS: Fails CI until #1928 is merged because the CI does not currently enforce aligned buffers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized the AVX2 slide-hash path to use aligned memory operations, improving performance on supported x86 systems; requires aligned buffers but preserves observable behavior.

* **Tests**
  * Updated slide-hash benchmarks to allocate aligned buffers and to include smaller input sizes (starting at 512) for more comprehensive performance profiling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->