### PR TITLE
Inline read_buf and flush_pending

### DIFF
--- a/arch/s390/dfltcc_deflate.c
+++ b/arch/s390/dfltcc_deflate.c
@@ -92,7 +92,7 @@ static inline void send_eobs(PREFIX3(streamp) strm, const struct dfltcc_param_v0
     deflate_state *state = (deflate_state *)strm->state;
 
     send_bits(state, bi_reverse(param->eobs >> (15 - param->eobl), param->eobl), param->eobl, state->bi_buf, state->bi_valid);
-    PREFIX(flush_pending)(strm);
+    flush_pending_inline(strm);
     if (state->pending != 0) {
         /* The remaining data is located in pending_out[0:pending]. If someone
          * calls put_byte() - this might happen in deflate() - the byte will be

--- a/deflate.c
+++ b/deflate.c
@@ -67,45 +67,6 @@ const char PREFIX(deflate_copyright)[] = " deflate 1.3.1 Copyright 1995-2024 Jea
  */
 
 /* ===========================================================================
- *  Architecture-specific hooks.
- */
-#ifdef S390_DFLTCC_DEFLATE
-#  include "arch/s390/dfltcc_deflate.h"
-/* DFLTCC instructions require window to be page-aligned */
-#  define PAD_WINDOW            PAD_4096
-#  define WINDOW_PAD_SIZE       4096
-#  define HINT_ALIGNED_WINDOW   HINT_ALIGNED_4096
-#else
-#  define PAD_WINDOW            PAD_64
-#  define WINDOW_PAD_SIZE       64
-#  define HINT_ALIGNED_WINDOW   HINT_ALIGNED_64
-/* Adjust the window size for the arch-specific deflate code. */
-#  define DEFLATE_ADJUST_WINDOW_SIZE(n) (n)
-/* Invoked at the beginning of deflateSetDictionary(). Useful for checking arch-specific window data. */
-#  define DEFLATE_SET_DICTIONARY_HOOK(strm, dict, dict_len) do {} while (0)
-/* Invoked at the beginning of deflateGetDictionary(). Useful for adjusting arch-specific window data. */
-#  define DEFLATE_GET_DICTIONARY_HOOK(strm, dict, dict_len) do {} while (0)
-/* Invoked at the end of deflateResetKeep(). Useful for initializing arch-specific extension blocks. */
-#  define DEFLATE_RESET_KEEP_HOOK(strm) do {} while (0)
-/* Invoked at the beginning of deflateParams(). Useful for updating arch-specific compression parameters. */
-#  define DEFLATE_PARAMS_HOOK(strm, level, strategy, hook_flush) do {} while (0)
-/* Returns whether the last deflate(flush) operation did everything it's supposed to do. */
-#  define DEFLATE_DONE(strm, flush) 1
-/* Adjusts the upper bound on compressed data length based on compression parameters and uncompressed data length.
- * Useful when arch-specific deflation code behaves differently than regular zlib-ng algorithms. */
-#  define DEFLATE_BOUND_ADJUST_COMPLEN(strm, complen, sourceLen) do {} while (0)
-/* Returns whether an optimistic upper bound on compressed data length should *not* be used.
- * Useful when arch-specific deflation code behaves differently than regular zlib-ng algorithms. */
-#  define DEFLATE_NEED_CONSERVATIVE_BOUND(strm) 0
-/* Invoked for each deflate() call. Useful for plugging arch-specific deflation code. */
-#  define DEFLATE_HOOK(strm, flush, bstate) 0
-/* Returns whether zlib-ng should compute a checksum. Set to 0 if arch-specific deflation code already does that. */
-#  define DEFLATE_NEED_CHECKSUM(strm) 1
-/* Returns whether reproducibility parameter can be set to a given value. */
-#  define DEFLATE_CAN_SET_REPRODUCIBLE(strm, reproducible) 1
-#endif
-
-/* ===========================================================================
  *  Function prototypes.
  */
 static int deflateStateCheck      (PREFIX3(stream) *strm);

--- a/deflate.h
+++ b/deflate.h
@@ -452,4 +452,43 @@ void Z_INTERNAL PREFIX(flush_pending)(PREFIX3(streamp) strm);
 #  define sent_bits_align(s)
 #endif
 
+/* ===========================================================================
+ *  Architecture-specific hooks.
+ */
+#ifdef S390_DFLTCC_DEFLATE
+#  include "arch/s390/dfltcc_deflate.h"
+/* DFLTCC instructions require window to be page-aligned */
+#  define PAD_WINDOW            PAD_4096
+#  define WINDOW_PAD_SIZE       4096
+#  define HINT_ALIGNED_WINDOW   HINT_ALIGNED_4096
+#else
+#  define PAD_WINDOW            PAD_64
+#  define WINDOW_PAD_SIZE       64
+#  define HINT_ALIGNED_WINDOW   HINT_ALIGNED_64
+/* Adjust the window size for the arch-specific deflate code. */
+#  define DEFLATE_ADJUST_WINDOW_SIZE(n) (n)
+/* Invoked at the beginning of deflateSetDictionary(). Useful for checking arch-specific window data. */
+#  define DEFLATE_SET_DICTIONARY_HOOK(strm, dict, dict_len) do {} while (0)
+/* Invoked at the beginning of deflateGetDictionary(). Useful for adjusting arch-specific window data. */
+#  define DEFLATE_GET_DICTIONARY_HOOK(strm, dict, dict_len) do {} while (0)
+/* Invoked at the end of deflateResetKeep(). Useful for initializing arch-specific extension blocks. */
+#  define DEFLATE_RESET_KEEP_HOOK(strm) do {} while (0)
+/* Invoked at the beginning of deflateParams(). Useful for updating arch-specific compression parameters. */
+#  define DEFLATE_PARAMS_HOOK(strm, level, strategy, hook_flush) do {} while (0)
+/* Returns whether the last deflate(flush) operation did everything it's supposed to do. */
+#  define DEFLATE_DONE(strm, flush) 1
+/* Adjusts the upper bound on compressed data length based on compression parameters and uncompressed data length.
+ * Useful when arch-specific deflation code behaves differently than regular zlib-ng algorithms. */
+#  define DEFLATE_BOUND_ADJUST_COMPLEN(strm, complen, sourceLen) do {} while (0)
+/* Returns whether an optimistic upper bound on compressed data length should *not* be used.
+ * Useful when arch-specific deflation code behaves differently than regular zlib-ng algorithms. */
+#  define DEFLATE_NEED_CONSERVATIVE_BOUND(strm) 0
+/* Invoked for each deflate() call. Useful for plugging arch-specific deflation code. */
+#  define DEFLATE_HOOK(strm, flush, bstate) 0
+/* Returns whether zlib-ng should compute a checksum. Set to 0 if arch-specific deflation code already does that. */
+#  define DEFLATE_NEED_CHECKSUM(strm) 1
+/* Returns whether reproducibility parameter can be set to a given value. */
+#  define DEFLATE_CAN_SET_REPRODUCIBLE(strm, reproducible) 1
+#endif
+
 #endif /* DEFLATE_H_ */

--- a/deflate_p.h
+++ b/deflate_p.h
@@ -117,6 +117,7 @@ static inline uint16_t bi_reverse(unsigned code, int len) {
  * See also flush_pending_inline().
  */
 Z_FORCEINLINE static unsigned read_buf(PREFIX3(stream) *strm, unsigned char *buf, unsigned size) {
+    deflate_state *s = strm->state;
     uint32_t len = MIN(strm->avail_in, size);
 
     if (len == 0)
@@ -125,10 +126,10 @@ Z_FORCEINLINE static unsigned read_buf(PREFIX3(stream) *strm, unsigned char *buf
     if (!DEFLATE_NEED_CHECKSUM(strm)) {
         memcpy(buf, strm->next_in, len);
 #ifdef GZIP
-    } else if (strm->state->wrap == 2) {
-        FUNCTABLE_CALL(crc32_fold_copy)(&strm->state->crc_fold, buf, strm->next_in, len);
+    } else if (s->wrap == 2) {
+        FUNCTABLE_CALL(crc32_fold_copy)(&s->crc_fold, buf, strm->next_in, len);
 #endif
-    } else if (strm->state->wrap == 1) {
+    } else if (s->wrap == 1) {
         strm->adler = FUNCTABLE_CALL(adler32_fold_copy)(strm->adler, buf, strm->next_in, len);
     } else {
         memcpy(buf, strm->next_in, len);

--- a/deflate_stored.c
+++ b/deflate_stored.c
@@ -94,7 +94,7 @@ Z_INTERNAL block_state deflate_stored(deflate_state *s, int flush) {
          * the check value.
          */
         if (len) {
-            PREFIX(read_buf)(s->strm, s->strm->next_out, len);
+            read_buf(s->strm, s->strm->next_out, len);
             s->strm->next_out += len;
             s->strm->avail_out -= len;
             s->strm->total_out += len;
@@ -157,7 +157,7 @@ Z_INTERNAL block_state deflate_stored(deflate_state *s, int flush) {
 
     have = MIN(have, s->strm->avail_in);
     if (have) {
-        PREFIX(read_buf)(s->strm, s->window + s->strstart, have);
+        read_buf(s->strm, s->window + s->strstart, have);
         s->strstart += have;
         s->insert += MIN(have, s->w_size - s->insert);
     }


### PR DESCRIPTION
- Move "Architecture-specific hooks" from deflate.c to the more appropriate deflate.h
- Inline read_buf and partially inline flush_pending

This results in a small performance improvement for compression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Refactor
  * Streamlined input reading and output flushing into inlined helpers for lower overhead and simpler call paths.

* New Features
  * Introduced an architecture hook layer to support platform-specific deflate optimizations.

* Chores
  * Reorganized internal includes and updated call sites to use the new helpers; no public APIs or signatures changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->