### PR TITLE
Remove here pointer in inflate_fast.

### DIFF
--- a/inffast_tpl.h
+++ b/inffast_tpl.h
@@ -163,15 +163,14 @@ void Z_INTERNAL INFLATE_FAST(PREFIX3(stream) *strm, uint32_t start) {
         }
       dolen:
         DROPBITS(here.bits);
-        op = here.op;
-        if (op == 0) {                          /* literal */
+        if (here.op == 0) {                     /* literal */
             Tracevv((stderr, here.val >= 0x20 && here.val < 0x7f ?
                     "inflate:         literal '%c'\n" :
                     "inflate:         literal 0x%02x\n", here.val));
             *out++ = (unsigned char)(here.val);
-        } else if (op & 16) {                     /* length base */
+        } else if (here.op & 16) {              /* length base */
             len = here.val;
-            op &= MAX_BITS;                       /* number of extra bits */
+            op = here.op & MAX_BITS;            /* number of extra bits */
             len += BITS(op);
             DROPBITS(op);
             Tracevv((stderr, "inflate:         length %u\n", len));
@@ -181,10 +180,9 @@ void Z_INTERNAL INFLATE_FAST(PREFIX3(stream) *strm, uint32_t start) {
             }
           dodist:
             DROPBITS(here.bits);
-            op = here.op;
-            if (op & 16) {                      /* distance base */
+            if (here.op & 16) {                 /* distance base */
                 dist = here.val;
-                op &= MAX_BITS;                 /* number of extra bits */
+                op = here.op & MAX_BITS;        /* number of extra bits */
                 dist += BITS(op);
 #ifdef INFLATE_STRICT
                 if (dist > state->dmax) {
@@ -277,17 +275,17 @@ void Z_INTERNAL INFLATE_FAST(PREFIX3(stream) *strm, uint32_t start) {
                     else
                         out = CHUNKMEMSET(out, out - dist, len);
                 }
-            } else if ((op & 64) == 0) {          /* 2nd level distance code */
-                memcpy(&here, &dcode[here.val + BITS(op)], 4);
+            } else if ((here.op & 64) == 0) {      /* 2nd level distance code */
+                memcpy(&here, &dcode[here.val + BITS(here.op)], 4);
                 goto dodist;
             } else {
                 SET_BAD("invalid distance code");
                 break;
             }
-        } else if ((op & 64) == 0) {              /* 2nd level length code */
-            memcpy(&here, &lcode[here.val + BITS(op)], 4);
+        } else if ((here.op & 64) == 0) {       /* 2nd level length code */
+            memcpy(&here, &lcode[here.val + BITS(here.op)], 4);
             goto dolen;
-        } else if (op & 32) {                     /* end-of-block */
+        } else if (here.op & 32) {              /* end-of-block */
             Tracevv((stderr, "inflate:         end of block\n"));
             state->mode = TYPE;
             break;

--- a/inffast_tpl.h
+++ b/inffast_tpl.h
@@ -151,11 +151,18 @@ void Z_INTERNAL INFLATE_FAST(PREFIX3(stream) *strm, uint32_t start) {
     do {
         REFILL();
         memcpy(&here, &lcode[hold & lmask], 4);
+        /* unroll literal */
         if (here.op == 0) {
+            Tracevv((stderr, here.val >= 0x20 && here.val < 0x7f ?
+                    "inflate:         literal '%c'\n" :
+                    "inflate:         literal 0x%02x\n", here.val));
             *out++ = (unsigned char)(here.val);
             DROPBITS(here.bits);
             memcpy(&here, &lcode[hold & lmask], 4);
             if (here.op == 0) {
+                Tracevv((stderr, here.val >= 0x20 && here.val < 0x7f ?
+                        "inflate:         literal '%c'\n" :
+                        "inflate:         literal 0x%02x\n", here.val));
                 *out++ = (unsigned char)(here.val);
                 DROPBITS(here.bits);
                 memcpy(&here, &lcode[hold & lmask], 4);

--- a/inffast_tpl.h
+++ b/inffast_tpl.h
@@ -150,7 +150,7 @@ void Z_INTERNAL INFLATE_FAST(PREFIX3(stream) *strm, uint32_t start) {
        input data or output space */
     do {
         REFILL();
-        memcpy(&here, &lcode[hold & lmask], 4);
+        memcpy(&here, &lcode[hold & lmask], sizeof(code));
         /* unroll literal */
         if (here.op == 0) {
             Tracevv((stderr, here.val >= 0x20 && here.val < 0x7f ?
@@ -158,14 +158,14 @@ void Z_INTERNAL INFLATE_FAST(PREFIX3(stream) *strm, uint32_t start) {
                     "inflate:         literal 0x%02x\n", here.val));
             *out++ = (unsigned char)(here.val);
             DROPBITS(here.bits);
-            memcpy(&here, &lcode[hold & lmask], 4);
+            memcpy(&here, &lcode[hold & lmask], sizeof(code));
             if (here.op == 0) {
                 Tracevv((stderr, here.val >= 0x20 && here.val < 0x7f ?
                         "inflate:         literal '%c'\n" :
                         "inflate:         literal 0x%02x\n", here.val));
                 *out++ = (unsigned char)(here.val);
                 DROPBITS(here.bits);
-                memcpy(&here, &lcode[hold & lmask], 4);
+                memcpy(&here, &lcode[hold & lmask], sizeof(code));
             }
         }
       dolen:
@@ -181,7 +181,7 @@ void Z_INTERNAL INFLATE_FAST(PREFIX3(stream) *strm, uint32_t start) {
             len += BITS(op);
             DROPBITS(op);
             Tracevv((stderr, "inflate:         length %u\n", len));
-            memcpy(&here, &dcode[hold & dmask], 4);
+            memcpy(&here, &dcode[hold & dmask], sizeof(code));
             if (bits < MAX_BITS + MAX_DIST_EXTRA_BITS) {
                 REFILL();
             }
@@ -283,14 +283,14 @@ void Z_INTERNAL INFLATE_FAST(PREFIX3(stream) *strm, uint32_t start) {
                         out = CHUNKMEMSET(out, out - dist, len);
                 }
             } else if ((here.op & 64) == 0) {      /* 2nd level distance code */
-                memcpy(&here, &dcode[here.val + BITS(here.op)], 4);
+                memcpy(&here, &dcode[here.val + BITS(here.op)], sizeof(code));
                 goto dodist;
             } else {
                 SET_BAD("invalid distance code");
                 break;
             }
         } else if ((here.op & 64) == 0) {       /* 2nd level length code */
-            memcpy(&here, &lcode[here.val + BITS(here.op)], 4);
+            memcpy(&here, &lcode[here.val + BITS(here.op)], sizeof(code));
             goto dolen;
         } else if (here.op & 32) {              /* end-of-block */
             Tracevv((stderr, "inflate:         end of block\n"));

--- a/inffast_tpl.h
+++ b/inffast_tpl.h
@@ -107,7 +107,7 @@ void Z_INTERNAL INFLATE_FAST(PREFIX3(stream) *strm, uint32_t start) {
     unsigned dmask;             /* mask for first level of distance codes */
     code const *lcode;          /* local strm->lencode */
     code const *dcode;          /* local strm->distcode */
-    const code *here;           /* retrieved table entry */
+    code here;                  /* retrieved table entry */
     unsigned op;                /* code bits, operation, extra bits, or */
                                 /*  window position, window bytes to copy */
     unsigned len;               /* match length, unused bytes */
@@ -150,40 +150,40 @@ void Z_INTERNAL INFLATE_FAST(PREFIX3(stream) *strm, uint32_t start) {
        input data or output space */
     do {
         REFILL();
-        here = lcode + (hold & lmask);
-        if (here->op == 0) {
-            *out++ = (unsigned char)(here->val);
-            DROPBITS(here->bits);
-            here = lcode + (hold & lmask);
-            if (here->op == 0) {
-                *out++ = (unsigned char)(here->val);
-                DROPBITS(here->bits);
-                here = lcode + (hold & lmask);
+        memcpy(&here, &lcode[hold & lmask], 4);
+        if (here.op == 0) {
+            *out++ = (unsigned char)(here.val);
+            DROPBITS(here.bits);
+            memcpy(&here, &lcode[hold & lmask], 4);
+            if (here.op == 0) {
+                *out++ = (unsigned char)(here.val);
+                DROPBITS(here.bits);
+                memcpy(&here, &lcode[hold & lmask], 4);
             }
         }
       dolen:
-        DROPBITS(here->bits);
-        op = here->op;
+        DROPBITS(here.bits);
+        op = here.op;
         if (op == 0) {                          /* literal */
-            Tracevv((stderr, here->val >= 0x20 && here->val < 0x7f ?
+            Tracevv((stderr, here.val >= 0x20 && here.val < 0x7f ?
                     "inflate:         literal '%c'\n" :
-                    "inflate:         literal 0x%02x\n", here->val));
-            *out++ = (unsigned char)(here->val);
+                    "inflate:         literal 0x%02x\n", here.val));
+            *out++ = (unsigned char)(here.val);
         } else if (op & 16) {                     /* length base */
-            len = here->val;
+            len = here.val;
             op &= MAX_BITS;                       /* number of extra bits */
             len += BITS(op);
             DROPBITS(op);
             Tracevv((stderr, "inflate:         length %u\n", len));
-            here = dcode + (hold & dmask);
+            memcpy(&here, &dcode[hold & dmask], 4);
             if (bits < MAX_BITS + MAX_DIST_EXTRA_BITS) {
                 REFILL();
             }
           dodist:
-            DROPBITS(here->bits);
-            op = here->op;
+            DROPBITS(here.bits);
+            op = here.op;
             if (op & 16) {                      /* distance base */
-                dist = here->val;
+                dist = here.val;
                 op &= MAX_BITS;                 /* number of extra bits */
                 dist += BITS(op);
 #ifdef INFLATE_STRICT
@@ -278,14 +278,14 @@ void Z_INTERNAL INFLATE_FAST(PREFIX3(stream) *strm, uint32_t start) {
                         out = CHUNKMEMSET(out, out - dist, len);
                 }
             } else if ((op & 64) == 0) {          /* 2nd level distance code */
-                here = dcode + here->val + BITS(op);
+                memcpy(&here, &dcode[here.val + BITS(op)], 4);
                 goto dodist;
             } else {
                 SET_BAD("invalid distance code");
                 break;
             }
         } else if ((op & 64) == 0) {              /* 2nd level length code */
-            here = lcode + here->val + BITS(op);
+            memcpy(&here, &lcode[here.val + BITS(op)], 4);
             goto dolen;
         } else if (op & 32) {                     /* end-of-block */
             Tracevv((stderr, "inflate:         end of block\n"));


### PR DESCRIPTION
`struct code here` is only 4 bytes and can easily be replaced by a single integer copy which may be faster than pointer indirection.

### DEVELOP
```
OS: Darwin 24.6.0 Darwin Kernel Version 24.6.0: Mon Jul 14 11:29:54 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T8122 arm64
CPU: arm
Tool: /Users/nathan/Source/deflatebench/minigzip-develop Size: 159,736 B
Timing: GNU time (gtime)
Levels: 0-9       
Runs: 60         Trim worst: 30        

 Level   Comp   Comptime min/avg/max/stddev  Decomptime min/avg/max/stddev  Compressed size
 0    100.008%      0.030/0.030/0.030/0.000        0.030/0.030/0.030/0.000      211,973,953
 1     44.409%      0.640/0.640/0.640/0.000        0.320/0.320/0.320/0.000       94,127,497
 2     35.519%      1.000/1.008/1.010/0.004        0.310/0.310/0.310/0.000       75,286,322
 3     33.882%      1.260/1.266/1.270/0.005        0.290/0.292/0.300/0.004       71,815,206
 4     33.175%      1.430/1.439/1.440/0.003        0.290/0.290/0.290/0.000       70,317,229
 5     32.661%      1.510/1.518/1.530/0.006        0.280/0.280/0.280/0.000       69,228,146
 6     32.507%      1.780/1.797/1.800/0.005        0.280/0.280/0.280/0.000       68,902,143
 7     32.255%      2.580/2.593/2.600/0.007        0.280/0.280/0.280/0.000       68,366,759
 8     32.167%      4.030/4.042/4.050/0.007        0.280/0.280/0.280/0.000       68,180,762
 9     31.887%      4.430/4.446/4.450/0.006        0.270/0.270/0.270/0.000       67,586,442

 avg1  40.847%                        1.878                          0.263
 avg2  45.386%                        2.087                          0.292
 tot                                563.380                         78.950      865,784,459
```

### PR
```
OS: Darwin 24.6.0 Darwin Kernel Version 24.6.0: Mon Jul 14 11:29:54 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T8122 arm64
CPU: arm
Tool: /Users/nathan/Source/zlib-ng/build/minigzip Size: 159,736 B
Timing: GNU time (gtime)
Levels: 0-9       
Runs: 60         Trim worst: 30        

 Level   Comp   Comptime min/avg/max/stddev  Decomptime min/avg/max/stddev  Compressed size
 0    100.008%      0.030/0.030/0.030/0.000        0.030/0.030/0.030/0.000      211,973,953
 1     44.409%      0.640/0.640/0.640/0.000        0.310/0.310/0.310/0.000       94,127,497
 2     35.519%      1.000/1.008/1.010/0.004        0.300/0.300/0.300/0.000       75,286,322
 3     33.882%      1.240/1.246/1.250/0.005        0.290/0.290/0.290/0.000       71,815,206
 4     33.175%      1.410/1.417/1.420/0.005        0.280/0.280/0.280/0.000       70,317,229
 5     32.661%      1.500/1.508/1.510/0.004        0.280/0.280/0.280/0.000       69,228,146
 6     32.507%      1.780/1.787/1.790/0.005        0.280/0.280/0.280/0.000       68,902,143
 7     32.255%      2.570/2.583/2.590/0.007        0.280/0.280/0.280/0.000       68,366,759
 8     32.167%      4.020/4.033/4.040/0.007        0.280/0.280/0.280/0.000       68,180,762
 9     31.887%      4.430/4.440/4.450/0.006        0.270/0.270/0.270/0.000       67,586,442

 avg1  40.847%                        1.869                          0.260
 avg2  45.386%                        2.077                          0.289
 tot                                560.740                         78.000      865,784,459
```
Measured decompression performance improvement of about ~1.2%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Internal decoding table access was reworked to use value-based reads for more consistent and robust handling.
  - Control flow for literal/length/distance processing was streamlined while preserving behavior.
  - No user-facing feature changes; targeted at maintainability with potential minor stability and performance improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->