### PR TITLE
Optimize compress_block() and build_tree()

### DIFF
--- a/trees.c
+++ b/trees.c
@@ -66,7 +66,7 @@ static const static_tree_desc  static_bl_desc =
  */
 
 static void init_block       (deflate_state *s);
-static void pqdownheap       (unsigned char *depth, int *heap, const int heap_len, ct_data *tree, int k);
+static inline void pqdownheap       (unsigned char *depth, int *heap, const int heap_len, ct_data *tree, int k);
 static void build_tree       (deflate_state *s, tree_desc *desc);
 static void gen_bitlen       (deflate_state *s, tree_desc *desc);
 static void scan_tree        (deflate_state *s, ct_data *tree, int max_code);
@@ -147,7 +147,7 @@ static void init_block(deflate_state *s) {
  * when the heap property is re-established (each father smaller than its
  * two sons). Used by build_tree().
  */
-static void pqdownheap(unsigned char *depth, int *heap, const int heap_len, ct_data *tree, int k) {
+static inline void pqdownheap(unsigned char *depth, int *heap, const int heap_len, ct_data *tree, int k) {
     /* tree: the tree to restore */
     /* k: node to move down */
     int j = k << 1;  /* left son of k */


### PR DESCRIPTION
- Use local pointers to avoid indirection penalty in compress_block
- Use local pointers to avoid indirection penalty in pqdownheap and build_tree
- Reorder functions related to build_tree
- Inline pqdownheap

Tested on Intel i7-11700K, AMD E450 and Rpi-5, all showing good speed results in multiple builds of different configs.
Deflatebench shows compression is 0.25 - 0.75% faster
compress_bench shows compression is 0.95% - 2.65% faster

## i7-11700K:
### Develop
```
 Level   Comp   Comptime min/avg/max/stddev  Decomptime min/avg/max/stddev  Compressed size
 1     54.185%  0.0783/0.0786/0.0787/0.0001    0.0302/0.0310/0.0310/0.0002        8,526,745
 2     43.871%  0.1284/0.1291/0.1293/0.0002    0.0304/0.0305/0.0305/0.0000        6,903,702
 3     42.388%  0.1561/0.1562/0.1564/0.0001    0.0292/0.0293/0.0293/0.0000        6,670,239
 4     41.647%  0.1795/0.1799/0.1801/0.0002    0.0285/0.0286/0.0286/0.0000        6,553,746
 5     41.216%  0.1945/0.1949/0.1953/0.0002    0.0283/0.0284/0.0285/0.0000        6,485,936
 6     41.038%  0.2402/0.2407/0.2411/0.0002    0.0280/0.0281/0.0281/0.0000        6,457,827
 7     40.778%  0.3374/0.3378/0.3381/0.0002    0.0283/0.0283/0.0284/0.0000        6,416,941
 8     40.704%  0.4448/0.4453/0.4457/0.0002    0.0283/0.0284/0.0284/0.0000        6,405,249
 9     40.409%  0.5249/0.5256/0.5260/0.0002    0.0276/0.0276/0.0276/0.0000        6,358,951

 avg1  42.915%                       0.2542                         0.0289
 tot                                68.6448                         7.8051       60,779,336

   text    data     bss     dec     hex filename
 159302    1344       8  160654   2738e libz-ng.so.2

slide_hash/avx2/1024        2469 ns         2469 ns       850225
slide_hash/avx2/2048        2493 ns         2493 ns       841372
slide_hash/avx2/4096        2551 ns         2551 ns       823830
slide_hash/avx2/8192        2669 ns         2669 ns       786739
slide_hash/avx2/16384       2905 ns         2905 ns       723014
slide_hash/avx2/32768       3379 ns         3379 ns       621056

compress_bench/compress_bench/1                 3759 ns         3759 ns       745247
compress_bench/compress_bench/8                 4012 ns         4012 ns       698459
compress_bench/compress_bench/16                4204 ns         4204 ns       668137
compress_bench/compress_bench/32                4527 ns         4527 ns       619999
compress_bench/compress_bench/64                4863 ns         4863 ns       575942
compress_bench/compress_bench/512               4898 ns         4898 ns       572839
compress_bench/compress_bench/4096              5445 ns         5445 ns       512955
compress_bench/compress_bench/32768            10006 ns        10006 ns       280370
```

### PR
```
 Level   Comp   Comptime min/avg/max/stddev  Decomptime min/avg/max/stddev  Compressed size
 1     54.185%  0.0783/0.0785/0.0786/0.0001    0.0301/0.0310/0.0310/0.0002        8,526,745
 2     43.871%  0.1268/0.1271/0.1273/0.0002    0.0303/0.0304/0.0305/0.0000        6,903,702
 3     42.388%  0.1527/0.1531/0.1533/0.0001    0.0292/0.0293/0.0293/0.0000        6,670,239
 4     41.647%  0.1767/0.1769/0.1771/0.0001    0.0285/0.0285/0.0286/0.0000        6,553,746
 5     41.216%  0.1928/0.1932/0.1936/0.0002    0.0283/0.0284/0.0284/0.0000        6,485,936
 6     41.038%  0.2389/0.2393/0.2395/0.0002    0.0280/0.0281/0.0281/0.0000        6,457,827
 7     40.778%  0.3354/0.3359/0.3363/0.0003    0.0283/0.0283/0.0284/0.0000        6,416,941
 8     40.704%  0.4428/0.4435/0.4439/0.0003    0.0283/0.0284/0.0284/0.0000        6,405,249
 9     40.409%  0.5234/0.5242/0.5246/0.0003    0.0276/0.0276/0.0276/0.0000        6,358,951

 avg1  42.915%                       0.2524                         0.0289
 tot                                68.1497                         7.7984       60,779,336

   text    data     bss     dec     hex filename
 159862    1344       8  161214   275be libz-ng.so.2

compress_bench/compress_bench/1                 3730 ns         3730 ns       750349
compress_bench/compress_bench/8                 4002 ns         4002 ns       700884
compress_bench/compress_bench/16                4147 ns         4147 ns       675454
compress_bench/compress_bench/32                4469 ns         4469 ns       627385
compress_bench/compress_bench/64                4734 ns         4734 ns       589830
compress_bench/compress_bench/512               4807 ns         4807 ns       582401
compress_bench/compress_bench/4096              5306 ns         5306 ns       528373
compress_bench/compress_bench/32768             9741 ns         9741 ns       287033
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Reworked internal Huffman tree construction and heap management to streamline processing and reduce overhead.
  - Simplified compression loop to reduce indirection and improve data access patterns.

- Performance
  - Faster compression with improved CPU efficiency and higher throughput, especially on varied data.
  - No changes to output format or compatibility; results remain identical.

- Documentation
  - Updated inline comments to reflect the new compression pipeline flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->