### PR TITLE
Inline bi_reverse

### DIFF
--- a/arch/s390/dfltcc_deflate.c
+++ b/arch/s390/dfltcc_deflate.c
@@ -15,6 +15,7 @@
 
 #include "zbuild.h"
 #include "deflate.h"
+#include "deflate_p.h"
 #include "trees_emit.h"
 #include "dfltcc_deflate.h"
 #include "dfltcc_detail.h"
@@ -90,7 +91,7 @@ static inline dfltcc_cc dfltcc_cmpr(PREFIX3(streamp) strm) {
 static inline void send_eobs(PREFIX3(streamp) strm, const struct dfltcc_param_v0 *param) {
     deflate_state *state = (deflate_state *)strm->state;
 
-    send_bits(state, PREFIX(bi_reverse)(param->eobs >> (15 - param->eobl), param->eobl), param->eobl, state->bi_buf, state->bi_valid);
+    send_bits(state, bi_reverse(param->eobs >> (15 - param->eobl), param->eobl), param->eobl, state->bi_buf, state->bi_valid);
     PREFIX(flush_pending)(strm);
     if (state->pending != 0) {
         /* The remaining data is located in pending_out[0:pending]. If someone

--- a/deflate.h
+++ b/deflate.h
@@ -432,7 +432,6 @@ void Z_INTERNAL zng_tr_flush_block(deflate_state *s, char *buf, uint32_t stored_
 void Z_INTERNAL zng_tr_flush_bits(deflate_state *s);
 void Z_INTERNAL zng_tr_align(deflate_state *s);
 void Z_INTERNAL zng_tr_stored_block(deflate_state *s, char *buf, uint32_t stored_len, int last);
-uint16_t Z_INTERNAL PREFIX(bi_reverse)(unsigned code, int len);
 void Z_INTERNAL PREFIX(flush_pending)(PREFIX3(streamp) strm);
 #define d_code(dist) ((dist) < 256 ? zng_dist_code[dist] : zng_dist_code[256+((dist)>>7)])
 /* Mapping from a distance to a distance code. dist is the distance - 1 and

--- a/deflate_p.h
+++ b/deflate_p.h
@@ -98,6 +98,18 @@ static inline int zng_tr_tally_dist(deflate_state* s, uint32_t dist, uint32_t le
 }
 
 /* ===========================================================================
+ * Reverse the first len bits of a code using bit manipulation
+ */
+static inline uint16_t bi_reverse(unsigned code, int len) {
+    /* code: the value to invert */
+    /* len: its bit length */
+    Assert(len >= 1 && len <= 15, "code length must be 1-15");
+#define bitrev8(b) \
+    (uint8_t)((((uint8_t)(b) * 0x80200802ULL) & 0x0884422110ULL) * 0x0101010101ULL >> 32)
+    return (bitrev8(code >> 8) | (uint16_t)bitrev8(code) << 8) >> (16 - len);
+}
+
+/* ===========================================================================
  * Flush the current block, with given end-of-file flag.
  * IN assertion: strstart is set to the end of the current match.
  */

--- a/tools/maketrees.c
+++ b/tools/maketrees.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include "zbuild.h"
 #include "deflate.h"
+#include "deflate_p.h"
 #include "trees.h"
 
 static ct_data static_ltree[L_CODES+2];
@@ -90,7 +91,7 @@ static void tr_static_init(void) {
     /* The static distance tree is trivial: */
     for (n = 0; n < D_CODES; n++) {
         static_dtree[n].Len = 5;
-        static_dtree[n].Code = PREFIX(bi_reverse)((unsigned)n, 5);
+        static_dtree[n].Code = bi_reverse((unsigned)n, 5);
     }
 }
 

--- a/trees.c
+++ b/trees.c
@@ -32,6 +32,7 @@
 
 #include "zbuild.h"
 #include "deflate.h"
+#include "deflate_p.h"
 #include "trees.h"
 #include "trees_emit.h"
 #include "trees_tbl.h"
@@ -399,7 +400,7 @@ Z_INTERNAL void gen_codes(ct_data *tree, int max_code, uint16_t *bl_count) {
         if (len == 0)
             continue;
         /* Now reverse the bits */
-        tree[n].Code = PREFIX(bi_reverse)(next_code[len]++, len);
+        tree[n].Code = bi_reverse(next_code[len]++, len);
 
         Tracecv(tree != static_ltree, (stderr, "\nn %3d %c l %2d c %4x (%x) ",
              n, (isgraph(n & 0xff) ? n : ' '), len, tree[n].Code, next_code[len]-1));
@@ -814,16 +815,4 @@ void Z_INTERNAL zng_tr_flush_bits(deflate_state *s) {
         s->bi_buf >>= 8;
         s->bi_valid -= 8;
     }
-}
-
-/* ===========================================================================
- * Reverse the first len bits of a code using bit manipulation
- */
-Z_INTERNAL uint16_t PREFIX(bi_reverse)(unsigned code, int len) {
-    /* code: the value to invert */
-    /* len: its bit length */
-    Assert(len >= 1 && len <= 15, "code length must be 1-15");
-#define bitrev8(b) \
-    (uint8_t)((((uint8_t)(b) * 0x80200802ULL) & 0x0884422110ULL) * 0x0101010101ULL >> 32)
-    return (bitrev8(code >> 8) | (uint16_t)bitrev8(code) << 8) >> (16 - len);
 }


### PR DESCRIPTION
It surprised me to find that this was not already being inlines, seeing how small and simple the function is.
Inlining it reduces the size of the library by ~160 bytes on x86-64.
Performance difference is very minimal, can't really tell for certain from the benchmarks, but logic says it should be a bit faster.

### Develop
```
 Level   Comp   Comptime min/avg/max/stddev  Decomptime min/avg/max/stddev  Compressed size
 1     54.185%  0.0773/0.0776/0.0777/0.0001    0.0300/0.0308/0.0308/0.0001        8,526,745
 2     43.871%  0.1254/0.1257/0.1260/0.0002    0.0301/0.0302/0.0302/0.0000        6,903,702
 3     42.388%  0.1504/0.1508/0.1510/0.0002    0.0290/0.0290/0.0290/0.0000        6,670,239
 4     41.647%  0.1746/0.1751/0.1754/0.0002    0.0282/0.0283/0.0283/0.0000        6,553,746
 5     41.216%  0.1910/0.1913/0.1916/0.0002    0.0281/0.0281/0.0282/0.0000        6,485,936
 6     41.038%  0.2365/0.2369/0.2372/0.0002    0.0277/0.0278/0.0278/0.0000        6,457,827
 7     40.778%  0.3328/0.3334/0.3338/0.0003    0.0280/0.0281/0.0281/0.0000        6,416,941
 8     40.704%  0.4404/0.4409/0.4413/0.0003    0.0281/0.0281/0.0281/0.0000        6,405,249
 9     40.409%  0.5238/0.5244/0.5248/0.0003    0.0273/0.0273/0.0273/0.0000        6,358,951

 avg1  42.915%                       0.2507                         0.0286
 tot                                67.6793                         7.7268       60,779,336

   text    data     bss     dec     hex filename
 147782    1344       8  149134   2468e libz-ng.so.2
 
compress_bench/compress_bench/1                 3706 ns         3706 ns       755372
compress_bench/compress_bench/8                 4011 ns         4011 ns       697152
compress_bench/compress_bench/16                4167 ns         4167 ns       672118
compress_bench/compress_bench/32                4472 ns         4472 ns       626409
compress_bench/compress_bench/64                4759 ns         4759 ns       588360
compress_bench/compress_bench/512               4824 ns         4824 ns       581876
compress_bench/compress_bench/4096              5321 ns         5321 ns       526197
compress_bench/compress_bench/32768             9500 ns         9501 ns       294534
```

## PR
```
 Level   Comp   Comptime min/avg/max/stddev  Decomptime min/avg/max/stddev  Compressed size
 1     54.185%  0.0773/0.0775/0.0776/0.0001    0.0299/0.0308/0.0308/0.0002        8,526,745
 2     43.871%  0.1254/0.1258/0.1261/0.0002    0.0302/0.0302/0.0302/0.0000        6,903,702
 3     42.388%  0.1504/0.1508/0.1509/0.0001    0.0290/0.0291/0.0291/0.0000        6,670,239
 4     41.647%  0.1747/0.1751/0.1754/0.0002    0.0283/0.0283/0.0284/0.0000        6,553,746
 5     41.216%  0.1908/0.1912/0.1915/0.0002    0.0282/0.0282/0.0282/0.0000        6,485,936
 6     41.038%  0.2362/0.2366/0.2369/0.0002    0.0278/0.0278/0.0279/0.0000        6,457,827
 7     40.778%  0.3326/0.3333/0.3336/0.0002    0.0281/0.0281/0.0281/0.0000        6,416,941
 8     40.704%  0.4404/0.4408/0.4410/0.0002    0.0281/0.0282/0.0282/0.0000        6,405,249
 9     40.409%  0.5241/0.5245/0.5249/0.0002    0.0273/0.0273/0.0274/0.0000        6,358,951

 avg1  42.915%                       0.2506                         0.0287
 tot                                67.6674                         7.7416       60,779,336

   text    data     bss     dec     hex filename
 147622    1344       8  148974   245ee libz-ng.so.2

compress_bench/compress_bench/1                 3738 ns         3738 ns       749251
compress_bench/compress_bench/8                 4000 ns         4000 ns       700073
compress_bench/compress_bench/16                4152 ns         4152 ns       674635
compress_bench/compress_bench/32                4454 ns         4454 ns       627244
compress_bench/compress_bench/64                4735 ns         4735 ns       591568
compress_bench/compress_bench/512               4820 ns         4820 ns       581146
compress_bench/compress_bench/4096              5308 ns         5308 ns       528096
compress_bench/compress_bench/32768             9484 ns         9484 ns       295214
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Consolidated low-level bit handling into a shared helper, removing duplicate implementations and simplifying internal calls.
  - Streamlined compression internals for improved maintainability without changing behavior.

- Chores
  - Updated internal includes to align with the new shared helper.

- Notes
  - No user-facing changes or API impacts; functionality and results remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->