### PR TITLE
Upgrade to GCC 14 for macOS UBSAN ci.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -622,11 +622,12 @@ jobs:
 
           - name: macOS GCC UBSAN (ARM64)
             os: macos-latest
-            compiler: gcc-13
-            cxx-compiler: g++-13
+            # GCC 13.4 throws _bounds.h include error on newer versions of macOS SDK
+            compiler: gcc-14
+            cxx-compiler: g++-14
             cmake-args: -DWITH_SANITIZER=Undefined
-            packages: gcc@13
-            gcov-exec: gcov-13
+            packages: gcc@14
+            gcov-exec: gcov-14
             codecov: macos_gcc_arm64
 
           - name: macOS Clang Native Instructions (ARM64)


### PR DESCRIPTION
Newer versions of macOS SDK throw _bounds.h error with GCC 13.4 when installed from homebrew.
```sh
/opt/homebrew/Cellar/gcc@13/13.4.0/lib/gcc/13/gcc/aarch64-apple-darwin24/13/include-fixed/_stdio.h:78:10: fatal error: _bounds.h: No such file or directory
   78 | #include <_bounds.h>
```