### PR TITLE
[CI] Use MacOS 14 for GCC UBSAN.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -621,7 +621,7 @@ jobs:
             codecov: macos_gcc
 
           - name: macOS GCC UBSAN (ARM64)
-            os: macos-latest
+            os: macos-14
             compiler: gcc-13
             cxx-compiler: g++-13
             cmake-args: -DWITH_SANITIZER=Undefined


### PR DESCRIPTION
* macOS 15 runners have broken g++ support causing errors when trying to use `std::at_quick_exit()` and `std::quick_exit()` as is done in GoogleTest framework.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated the macOS ARM64 continuous integration runner to macOS 14 for the GCC UBSAN build.
  - Build artifacts for macOS ARM64 will now be produced on the newer runner image, with no changes to build configuration.
  - No impact on product features; end-user functionality remains unchanged.
  - This change may slightly affect build timing and environment consistency for future macOS ARM64 releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->