### PR TITLE
[CI] Install Windows 11 SDK 10.0.22621 for 32-bit ARM.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -712,6 +712,15 @@ jobs:
         $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
         $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
 
+    - name: Install Windows 11 SDK (ARM)
+      if: contains(matrix.name, 'MSVC ARM ')
+      run: |
+        # Windows 11 SDK (10.0.22621.2428)
+        # https://developer.microsoft.com/en-us/windows/downloads/sdk-archive/index-legacy
+        Invoke-WebRequest -Method Get -Uri https://go.microsoft.com/fwlink/p/?LinkId=2250105 -OutFile sdksetup.exe -UseBasicParsing
+        Unblock-File sdksetup.exe
+        Start-Process -Wait sdksetup.exe -ArgumentList "/q", "/norestart", "/ceip off"
+
     - name: Install packages (macOS)
       if: runner.os == 'macOS'
       run: brew install ninja ${{ matrix.packages }}


### PR DESCRIPTION
* Windows Server 2025 runner doesn't support targeting 32-bit ARM anymore, so install older SDK manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CI step to install the Windows 11 SDK for MSVC ARM jobs, gated to ARM-specific runs to improve ARM Windows build readiness and reliability.
  * Ensures required SDK components are present during ARM CI, reducing build failures and setup friction.
  * No changes to app features or user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->