### PR TITLE
Use `static` for threes instead of `Z_INTERNAL`

### DIFF
--- a/tools/maketrees.c
+++ b/tools/maketrees.c
@@ -107,32 +107,32 @@ static void gen_trees_header(void) {
 
     printf("/* header created automatically with maketrees.c */\n\n");
 
-    printf("Z_INTERNAL const ct_data static_ltree[L_CODES+2] = {\n");
+    printf("static const ct_data static_ltree[L_CODES+2] = {\n");
     for (i = 0; i < L_CODES+2; i++) {
         printf("{{%3u},{%u}}%s", static_ltree[i].Code, static_ltree[i].Len, SEPARATOR(i, L_CODES+1, 5));
     }
 
-    printf("Z_INTERNAL const ct_data static_dtree[D_CODES] = {\n");
+    printf("static const ct_data static_dtree[D_CODES] = {\n");
     for (i = 0; i < D_CODES; i++) {
         printf("{{%2u},{%u}}%s", static_dtree[i].Code, static_dtree[i].Len, SEPARATOR(i, D_CODES-1, 5));
     }
 
-    printf("const unsigned char Z_INTERNAL zng_dist_code[DIST_CODE_LEN] = {\n");
+    printf("static const unsigned char zng_dist_code[DIST_CODE_LEN] = {\n");
     for (i = 0; i < DIST_CODE_LEN; i++) {
         printf("%2u%s", dist_code[i], SEPARATOR(i, DIST_CODE_LEN-1, 20));
     }
 
-    printf("const unsigned char Z_INTERNAL zng_length_code[STD_MAX_MATCH-STD_MIN_MATCH+1] = {\n");
+    printf("static const unsigned char zng_length_code[STD_MAX_MATCH-STD_MIN_MATCH+1] = {\n");
     for (i = 0; i < STD_MAX_MATCH-STD_MIN_MATCH+1; i++) {
         printf("%2u%s", length_code[i], SEPARATOR(i, STD_MAX_MATCH-STD_MIN_MATCH, 20));
     }
 
-    printf("Z_INTERNAL const int base_length[LENGTH_CODES] = {\n");
+    printf("static const int base_length[LENGTH_CODES] = {\n");
     for (i = 0; i < LENGTH_CODES; i++) {
         printf("%d%s", base_length[i], SEPARATOR(i, LENGTH_CODES-1, 20));
     }
 
-    printf("Z_INTERNAL const int base_dist[D_CODES] = {\n");
+    printf("static const int base_dist[D_CODES] = {\n");
     for (i = 0; i < D_CODES; i++) {
         printf("%5d%s", base_dist[i], SEPARATOR(i, D_CODES-1, 10));
     }

--- a/trees_tbl.h
+++ b/trees_tbl.h
@@ -3,7 +3,7 @@
 
 /* header created automatically with maketrees.c */
 
-Z_INTERNAL const ct_data static_ltree[L_CODES+2] = {
+static const ct_data static_ltree[L_CODES+2] = {
 {{ 12},{8}}, {{140},{8}}, {{ 76},{8}}, {{204},{8}}, {{ 44},{8}},
 {{172},{8}}, {{108},{8}}, {{236},{8}}, {{ 28},{8}}, {{156},{8}},
 {{ 92},{8}}, {{220},{8}}, {{ 60},{8}}, {{188},{8}}, {{124},{8}},
@@ -64,7 +64,7 @@ Z_INTERNAL const ct_data static_ltree[L_CODES+2] = {
 {{163},{8}}, {{ 99},{8}}, {{227},{8}}
 };
 
-Z_INTERNAL const ct_data static_dtree[D_CODES] = {
+static const ct_data static_dtree[D_CODES] = {
 {{ 0},{5}}, {{16},{5}}, {{ 8},{5}}, {{24},{5}}, {{ 4},{5}},
 {{20},{5}}, {{12},{5}}, {{28},{5}}, {{ 2},{5}}, {{18},{5}},
 {{10},{5}}, {{26},{5}}, {{ 6},{5}}, {{22},{5}}, {{14},{5}},
@@ -73,7 +73,7 @@ Z_INTERNAL const ct_data static_dtree[D_CODES] = {
 {{19},{5}}, {{11},{5}}, {{27},{5}}, {{ 7},{5}}, {{23},{5}}
 };
 
-const unsigned char Z_INTERNAL zng_dist_code[DIST_CODE_LEN] = {
+static const unsigned char zng_dist_code[DIST_CODE_LEN] = {
  0,  1,  2,  3,  4,  4,  5,  5,  6,  6,  6,  6,  7,  7,  7,  7,  8,  8,  8,  8,
  8,  8,  8,  8,  9,  9,  9,  9,  9,  9,  9,  9, 10, 10, 10, 10, 10, 10, 10, 10,
 10, 10, 10, 10, 10, 10, 10, 10, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
@@ -102,7 +102,7 @@ const unsigned char Z_INTERNAL zng_dist_code[DIST_CODE_LEN] = {
 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29
 };
 
-const unsigned char Z_INTERNAL zng_length_code[STD_MAX_MATCH-STD_MIN_MATCH+1] = {
+static const unsigned char zng_length_code[STD_MAX_MATCH-STD_MIN_MATCH+1] = {
  0,  1,  2,  3,  4,  5,  6,  7,  8,  8,  9,  9, 10, 10, 11, 11, 12, 12, 12, 12,
 13, 13, 13, 13, 14, 14, 14, 14, 15, 15, 15, 15, 16, 16, 16, 16, 16, 16, 16, 16,
 17, 17, 17, 17, 17, 17, 17, 17, 18, 18, 18, 18, 18, 18, 18, 18, 19, 19, 19, 19,
@@ -118,12 +118,12 @@ const unsigned char Z_INTERNAL zng_length_code[STD_MAX_MATCH-STD_MIN_MATCH+1] = 
 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 28
 };
 
-Z_INTERNAL const int base_length[LENGTH_CODES] = {
+static const int base_length[LENGTH_CODES] = {
 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12, 14, 16, 20, 24, 28, 32, 40, 48, 56,
 64, 80, 96, 112, 128, 160, 192, 224, 0
 };
 
-Z_INTERNAL const int base_dist[D_CODES] = {
+static const int base_dist[D_CODES] = {
     0,     1,     2,     3,     4,     6,     8,    12,    16,    24,
    32,    48,    64,    96,   128,   192,   256,   384,   512,   768,
  1024,  1536,  2048,  3072,  4096,  6144,  8192, 12288, 16384, 24576


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Tightened internal linkage for compression data tables to use static definitions, improving encapsulation and reducing symbol visibility without changing behavior.

* **Chores**
  * Regenerated internal headers to reflect linkage updates.

* **Notes**
  * No functional, API, or algorithm changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->