### PR TITLE
Fix -Wunused-command-line-argument warnings on Mac OS X

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -405,6 +405,10 @@ if(APPLE)
     if(HAVE_W_ERROR_UNGUARDED_AVAILABILITY_NEW)
         set(ADDITIONAL_CHECK_FLAGS "${ADDITIONAL_CHECK_FLAGS} -Werror=unguarded-availability-new")
     endif()
+    check_c_compiler_flag(-Werror=unused-command-line-argument HAVE_W_ERROR_UNUSED_COMMAND_LINE_ARGUMENT)
+    if(HAVE_W_ERROR_UNUSED_COMMAND_LINE_ARGUMENT)
+        set(ADDITIONAL_CHECK_FLAGS "${ADDITIONAL_CHECK_FLAGS} -Werror=unused-command-line-argument")
+    endif()
 endif()
 
 #
@@ -520,7 +524,9 @@ endif()
 #
 # Check whether compiler supports -fno-semantic-interposition parameter
 #
+set(CMAKE_REQUIRED_FLAGS "${ADDITIONAL_CHECK_FLAGS}")
 check_c_compiler_flag(-fno-semantic-interposition HAVE_NO_INTERPOSITION)
+set(CMAKE_REQUIRED_FLAGS)
 
 #
 # Check if we can hide zlib internal symbols that are linked between separate source files using hidden

--- a/configure
+++ b/configure
@@ -679,6 +679,18 @@ else
   echo "Checking for -Werror=unguarded-availability-new... No." | tee -a configure.log
 fi
 
+# Check for -Werror=unused-command-line-argument compiler support
+echo "" > test.c
+  cat > $test.c <<EOF
+int main() { return 0; }
+EOF
+if $cc $CFLAGS -Werror=unused-command-line-argument -c $test.c >> configure.log 2>&1; then
+  echo "Checking for -Werror=unused-command-line-argument... Yes." | tee -a configure.log
+  ADDITIONAL_CHECK_FLAGS="$ADDITIONAL_CHECK_FLAGS -Werror=unused-command-line-argument"
+else
+  echo "Checking for -Werror=unused-command-line-argument... No." | tee -a configure.log
+fi
+
 # check for version script support
 cat > $test.c <<EOF
 int foo(void) { return 0; }
@@ -999,7 +1011,7 @@ echo "" > test.c
   cat > $test.c <<EOF
 int main() { return 0; }
 EOF
-if test "$gcc" -eq 1 && ($cc $CFLAGS -fno-semantic-interposition -c $test.c) >> configure.log 2>&1; then
+if test "$gcc" -eq 1 && ($cc $CFLAGS $ADDITIONAL_CHECK_FLAGS -fno-semantic-interposition -c $test.c) >> configure.log 2>&1; then
   echo "Checking for -fno-semantic-interposition... Yes." | tee -a configure.log
   SFLAGS="$SFLAGS -fno-semantic-interposition"
 else


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Improved build reliability on macOS by handling additional compiler warnings as errors when supported.
  - Enhanced configure-time detection of compiler features, ensuring consistent application of previously discovered flags across subsequent checks.
  - Stabilized feature checks related to specific compiler optimizations to reduce false negatives during configuration.
  - No changes to runtime behavior or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->