### PR TITLE
Update macOS CI images

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -618,15 +618,15 @@ jobs:
             cmake-args: -G Ninja -DZLIB_COMPAT=ON -DWITH_NEW_STRATEGIES=OFF -DWITH_OPTIM=OFF
             codecov: win64_gcc_compat_no_opt
 
-          - name: macOS Clang (Target 10.10)
-            os: macos-13
+          - name: macOS Clang (Intel, Target 10.10)
+            os: macos-15-intel
             compiler: clang
             cxx-compiler: clang++
             cmake-args: -DCMAKE_OSX_DEPLOYMENT_TARGET=10.10 -DWITH_BENCHMARKS=ON
             ldflags: -ld_classic
 
-          - name: macOS Clang ASAN
-            os: macos-13
+          - name: macOS Clang ASAN (Intel)
+            os: macos-15-intel
             compiler: clang
             cxx-compiler: clang++
             cmake-args: -DWITH_SANITIZER=Address
@@ -639,16 +639,13 @@ jobs:
             cmake-args: -DWITH_SANITIZER=Address
             codecov: macos_clang_arm64
 
-          - name: macOS GCC UBSAN
-            os: macos-13
-            compiler: gcc-10
-            cxx-compiler: g++-10
-            # Xcode 15 uses a new linker that is not compatible with GCC. Switch to the old linker.
-            # Homebrew gcc@11 and later have a built-in workaround for it.
-            ldflags: -ld_classic
+          - name: macOS GCC UBSAN (Intel)
+            os: macos-15-intel
+            compiler: gcc-13
+            cxx-compiler: g++-13
             cmake-args: -DWITH_SANITIZER=Undefined
-            packages: gcc@10
-            gcov-exec: gcov-10
+            packages: gcc@13
+            gcov-exec: gcov-13
             codecov: macos_gcc
 
           - name: macOS GCC UBSAN (ARM64)
@@ -660,8 +657,14 @@ jobs:
             gcov-exec: gcov-13
             codecov: macos_gcc_arm64
 
+          - name: macOS Clang Native Instructions (Intel)
+            os: macos-15-intel
+            compiler: clang
+            cxx-compiler: clang++
+            cmake-args: -DWITH_NATIVE_INSTRUCTIONS=ON
+
           - name: macOS Clang Native Instructions (ARM64)
-            os: macos-14
+            os: macos-latest
             compiler: clang
             cxx-compiler: clang++
             cmake-args: -DWITH_NATIVE_INSTRUCTIONS=ON

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -189,8 +189,8 @@ jobs:
             ldflags: -static
             emu-run: node
 
-          - name: macOS GCC Symbol Prefix
-            os: macos-13
+          - name: macOS GCC Symbol Prefix (Intel)
+            os: macos-15-intel
             compiler: gcc-11
             configure-args: --sprefix=zTest_
             packages: gcc@11
@@ -202,8 +202,8 @@ jobs:
             configure-args: --sprefix=zTest_
             packages: gcc@11
 
-          - name: macOS GCC Symbol Prefix & Compat
-            os: macos-13
+          - name: macOS GCC Symbol Prefix & Compat (Intel)
+            os: macos-15-intel
             compiler: gcc-11
             configure-args: --zlib-compat --sprefix=zTest_
             packages: gcc@11
@@ -215,8 +215,8 @@ jobs:
             configure-args: --zlib-compat --sprefix=zTest_
             packages: gcc@11
 
-          - name: macOS GCC
-            os: macos-13
+          - name: macOS GCC (Intel)
+            os: macos-15-intel
             compiler: gcc-11
             configure-args: --warn
             packages: gcc@11


### PR DESCRIPTION
The `macos-13` images are currently deprecated and will be removed in December, with `macos-15-intel` being the replacement for Intel builds.

More information: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated macOS CI matrix to explicitly cover Intel runners and align ARM64 labels.
  - Added native-instruction builds for macOS Intel to validate performance-related flags.
  - Refreshed macOS runner versions and toolchains to improve compatibility and stability.

- Tests
  - Expanded sanitizer coverage (ASAN/UBSAN) on macOS Intel.
  - Improved cross-platform CI consistency, increasing confidence in macOS (Intel and ARM64) builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->