### PR TITLE
Tests: Fix cast and truncation warnings.

### DIFF
--- a/test/benchmarks/benchmark_slidehash.cc
+++ b/test/benchmarks/benchmark_slidehash.cc
@@ -28,13 +28,13 @@ public:
         l0 = (uint16_t *)zng_alloc_aligned(HASH_SIZE * sizeof(uint16_t), 64);
 
         for (uint32_t i = 0; i < HASH_SIZE; i++) {
-            l0[i] = rand();
+            l0[i] = (uint16_t)rand();
         }
 
         l1 = (uint16_t *)zng_alloc_aligned(MAX_RANDOM_INTS * sizeof(uint16_t), 64);
 
         for (int32_t i = 0; i < MAX_RANDOM_INTS; i++) {
-            l1[i] = rand();
+            l1[i] = (uint16_t)rand();
         }
 
         deflate_state *s = (deflate_state*)malloc(sizeof(deflate_state));

--- a/test/benchmarks/benchmark_uncompress.cc
+++ b/test/benchmarks/benchmark_uncompress.cc
@@ -26,7 +26,7 @@ private:
     uint8_t *inbuff;
     uint8_t *outbuff;
     uint8_t *compressed_buff[NUM_TESTS];
-    uLong compressed_sizes[NUM_TESTS];
+    z_uintmax_t compressed_sizes[NUM_TESTS];
     int64_t sizes[NUM_TESTS] = {1, 64, 1024, 16384, 128*1024, 1024*1024};
 
 public:


### PR DESCRIPTION
* `compressed_sizes` was unsigned long, but it was assigned `size_t` which is larger on MSVC
* `l0` and `l1` are both `uint16_t` but `rand()` returns `int` which is 32-bit type

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Made random data initialization explicit to avoid implicit casts in a benchmark, improving consistency.
  * Switched compressed size tracking to a larger integer type in another benchmark to prevent overflow and improve accuracy.
  * Enhances reliability and consistency of benchmark results across platforms.
  * No changes to runtime features; this affects only internal testing and does not impact end-user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->