### PR TITLE
Fix type mismatch on platforms where int32_t and uint32_t use long instead of int

### DIFF
--- a/compress.c
+++ b/compress.c
@@ -28,8 +28,8 @@
    memory, Z_BUF_ERROR if there was not enough room in the output buffer,
    Z_STREAM_ERROR if the level parameter is invalid.
 */
-int Z_EXPORT PREFIX(compress2)(unsigned char *dest, z_uintmax_t *destLen, const unsigned char *source,
-                        z_uintmax_t sourceLen, int level) {
+z_int32_t Z_EXPORT PREFIX(compress2)(unsigned char *dest, z_uintmax_t *destLen, const unsigned char *source,
+                        z_uintmax_t sourceLen, z_int32_t level) {
     PREFIX3(stream) stream;
     int err;
     const unsigned int max = (unsigned int)-1;
@@ -70,7 +70,7 @@ int Z_EXPORT PREFIX(compress2)(unsigned char *dest, z_uintmax_t *destLen, const 
 
 /* ===========================================================================
  */
-int Z_EXPORT PREFIX(compress)(unsigned char *dest, z_uintmax_t *destLen, const unsigned char *source, z_uintmax_t sourceLen) {
+z_int32_t Z_EXPORT PREFIX(compress)(unsigned char *dest, z_uintmax_t *destLen, const unsigned char *source, z_uintmax_t sourceLen) {
     return PREFIX(compress2)(dest, destLen, source, sourceLen, Z_DEFAULT_COMPRESSION);
 }
 

--- a/gzlib.c
+++ b/gzlib.c
@@ -302,7 +302,7 @@ gzFile Z_EXPORT PREFIX(gzopen_w)(const wchar_t *path, const char *mode) {
 }
 #endif
 
-int Z_EXPORT PREFIX(gzclose)(gzFile file) {
+z_int32_t Z_EXPORT PREFIX(gzclose)(gzFile file) {
 #ifndef NO_GZCOMPRESS
     gz_state *state;
 
@@ -317,7 +317,7 @@ int Z_EXPORT PREFIX(gzclose)(gzFile file) {
 }
 
 /* -- see zlib.h -- */
-int Z_EXPORT PREFIX(gzbuffer)(gzFile file, unsigned size) {
+z_int32_t Z_EXPORT PREFIX(gzbuffer)(gzFile file, z_uint32_t size) {
     gz_state *state;
 
     /* get internal structure and check integrity */
@@ -341,7 +341,7 @@ int Z_EXPORT PREFIX(gzbuffer)(gzFile file, unsigned size) {
 }
 
 /* -- see zlib.h -- */
-int Z_EXPORT PREFIX(gzrewind)(gzFile file) {
+z_int32_t Z_EXPORT PREFIX(gzrewind)(gzFile file) {
     gz_state *state;
 
     /* get internal structure */
@@ -499,7 +499,7 @@ z_off_t Z_EXPORT PREFIX(gzoffset)(gzFile file) {
 #endif
 
 /* -- see zlib.h -- */
-int Z_EXPORT PREFIX(gzeof)(gzFile file) {
+z_int32_t Z_EXPORT PREFIX(gzeof)(gzFile file) {
     gz_state *state;
 
     /* get internal structure and check integrity */
@@ -514,7 +514,7 @@ int Z_EXPORT PREFIX(gzeof)(gzFile file) {
 }
 
 /* -- see zlib.h -- */
-const char * Z_EXPORT PREFIX(gzerror)(gzFile file, int *errnum) {
+const char * Z_EXPORT PREFIX(gzerror)(gzFile file, z_int32_t *errnum) {
     gz_state *state;
 
     /* get internal structure and check integrity */

--- a/gzread.c.in
+++ b/gzread.c.in
@@ -340,7 +340,7 @@ static size_t gz_read(gz_state *state, void *buf, size_t len) {
 }
 
 /* -- see zlib.h -- */
-int Z_EXPORT PREFIX(gzread)(gzFile file, void *buf, unsigned len) {
+z_int32_t Z_EXPORT PREFIX(gzread)(gzFile file, void *buf, z_uint32_t len) {
     gz_state *state;
 
     /* get internal structure */
@@ -355,7 +355,7 @@ int Z_EXPORT PREFIX(gzread)(gzFile file, void *buf, unsigned len) {
 
     /* since an int is returned, make sure len fits in one, otherwise return
        with an error (this avoids a flaw in the interface) */
-    if ((int)len < 0) {
+    if ((z_int32_t)len < 0) {
         gz_error(state, Z_STREAM_ERROR, "request does not fit in an int");
         return -1;
     }
@@ -368,7 +368,7 @@ int Z_EXPORT PREFIX(gzread)(gzFile file, void *buf, unsigned len) {
         return -1;
 
     /* return the number of bytes read (this is assured to fit in an int) */
-    return (int)len;
+    return (z_int32_t)len;
 }
 
 /* -- see zlib.h -- */
@@ -404,7 +404,7 @@ size_t Z_EXPORT PREFIX(gzfread)(void *buf, size_t size, size_t nitems, gzFile fi
 /* -- see zlib.h -- */
 #undef @ZLIB_SYMBOL_PREFIX@gzgetc
 #undef @ZLIB_SYMBOL_PREFIX@zng_gzgetc
-int Z_EXPORT PREFIX(gzgetc)(gzFile file) {
+z_int32_t Z_EXPORT PREFIX(gzgetc)(gzFile file) {
     unsigned char buf[1];
     gz_state *state;
 
@@ -435,7 +435,7 @@ int Z_EXPORT PREFIX(gzgetc_)(gzFile file) {
 #endif
 
 /* -- see zlib.h -- */
-int Z_EXPORT PREFIX(gzungetc)(int c, gzFile file) {
+z_int32_t Z_EXPORT PREFIX(gzungetc)(z_int32_t c, gzFile file) {
     gz_state *state;
 
     /* get internal structure */
@@ -495,7 +495,7 @@ int Z_EXPORT PREFIX(gzungetc)(int c, gzFile file) {
 }
 
 /* -- see zlib.h -- */
-char * Z_EXPORT PREFIX(gzgets)(gzFile file, char *buf, int len) {
+char * Z_EXPORT PREFIX(gzgets)(gzFile file, char *buf, z_int32_t len) {
     unsigned left, n;
     char *str;
     unsigned char *eol;
@@ -556,7 +556,7 @@ char * Z_EXPORT PREFIX(gzgets)(gzFile file, char *buf, int len) {
 }
 
 /* -- see zlib.h -- */
-int Z_EXPORT PREFIX(gzdirect)(gzFile file) {
+z_int32_t Z_EXPORT PREFIX(gzdirect)(gzFile file) {
     gz_state *state;
 
     /* get internal structure */
@@ -575,7 +575,7 @@ int Z_EXPORT PREFIX(gzdirect)(gzFile file) {
 }
 
 /* -- see zlib.h -- */
-int Z_EXPORT PREFIX(gzclose_r)(gzFile file) {
+z_int32_t Z_EXPORT PREFIX(gzclose_r)(gzFile file) {
     int ret, err;
     gz_state *state;
 

--- a/gzwrite.c
+++ b/gzwrite.c
@@ -215,7 +215,7 @@ static size_t gz_write(gz_state *state, void const *buf, size_t len) {
 }
 
 /* -- see zlib.h -- */
-int Z_EXPORT PREFIX(gzwrite)(gzFile file, void const *buf, unsigned len) {
+z_int32_t Z_EXPORT PREFIX(gzwrite)(gzFile file, void const *buf, z_uint32_t len) {
     gz_state *state;
 
     /* get internal structure */
@@ -229,13 +229,13 @@ int Z_EXPORT PREFIX(gzwrite)(gzFile file, void const *buf, unsigned len) {
 
     /* since an int is returned, make sure len fits in one, otherwise return
        with an error (this avoids a flaw in the interface) */
-    if ((int)len < 0) {
+    if ((z_int32_t)len < 0) {
         gz_error(state, Z_DATA_ERROR, "requested length does not fit in int");
         return 0;
     }
 
     /* write len bytes from buf (the return value will fit in an int) */
-    return (int)gz_write(state, buf, len);
+    return (z_int32_t)gz_write(state, buf, len);
 }
 
 /* -- see zlib.h -- */
@@ -268,7 +268,7 @@ size_t Z_EXPORT PREFIX(gzfwrite)(void const *buf, size_t size, size_t nitems, gz
 }
 
 /* -- see zlib.h -- */
-int Z_EXPORT PREFIX(gzputc)(gzFile file, int c) {
+z_int32_t Z_EXPORT PREFIX(gzputc)(gzFile file, z_int32_t c) {
     unsigned have;
     unsigned char buf[1];
     gz_state *state;
@@ -313,7 +313,7 @@ int Z_EXPORT PREFIX(gzputc)(gzFile file, int c) {
 }
 
 /* -- see zlib.h -- */
-int Z_EXPORT PREFIX(gzputs)(gzFile file, const char *s) {
+z_int32_t Z_EXPORT PREFIX(gzputs)(gzFile file, const char *s) {
     size_t len, put;
     gz_state *state;
 
@@ -337,7 +337,7 @@ int Z_EXPORT PREFIX(gzputs)(gzFile file, const char *s) {
 }
 
 /* -- see zlib.h -- */
-int Z_EXPORTVA PREFIX(gzvprintf)(gzFile file, const char *format, va_list va) {
+z_int32_t Z_EXPORTVA PREFIX(gzvprintf)(gzFile file, const char *format, va_list va) {
     int len;
     unsigned left;
     char *next;
@@ -393,7 +393,7 @@ int Z_EXPORTVA PREFIX(gzvprintf)(gzFile file, const char *format, va_list va) {
     return len;
 }
 
-int Z_EXPORTVA PREFIX(gzprintf)(gzFile file, const char *format, ...) {
+z_int32_t Z_EXPORTVA PREFIX(gzprintf)(gzFile file, const char *format, ...) {
     va_list va;
     int ret;
 
@@ -404,7 +404,7 @@ int Z_EXPORTVA PREFIX(gzprintf)(gzFile file, const char *format, ...) {
 }
 
 /* -- see zlib.h -- */
-int Z_EXPORT PREFIX(gzflush)(gzFile file, int flush) {
+z_int32_t Z_EXPORT PREFIX(gzflush)(gzFile file, z_int32_t flush) {
     gz_state *state;
 
     /* get internal structure */
@@ -433,7 +433,7 @@ int Z_EXPORT PREFIX(gzflush)(gzFile file, int flush) {
 }
 
 /* -- see zlib.h -- */
-int Z_EXPORT PREFIX(gzsetparams)(gzFile file, int level, int strategy) {
+z_int32_t Z_EXPORT PREFIX(gzsetparams)(gzFile file, z_int32_t level, z_int32_t strategy) {
     gz_state *state;
     PREFIX3(stream) *strm;
 
@@ -471,7 +471,7 @@ int Z_EXPORT PREFIX(gzsetparams)(gzFile file, int level, int strategy) {
 }
 
 /* -- see zlib.h -- */
-int Z_EXPORT PREFIX(gzclose_w)(gzFile file) {
+z_int32_t Z_EXPORT PREFIX(gzclose_w)(gzFile file) {
     int ret = Z_OK;
     gz_state *state;
 

--- a/test/example.c
+++ b/test/example.c
@@ -74,7 +74,7 @@ static void test_gzio(const char *fname, unsigned char *uncompr, z_size_t uncomp
 #ifdef NO_GZCOMPRESS
     fprintf(stderr, "NO_GZCOMPRESS -- gz* functions cannot compress\n");
 #else
-    int err;
+    z_int32_t err;
     size_t read;
     size_t len = strlen(hello)+1;
     gzFile file;
@@ -653,7 +653,7 @@ static void test_deflate_get_dict(unsigned char *compr, size_t comprLen) {
     PREFIX3(stream) c_stream; /* compression stream */
     int err;
     unsigned char *dictNew = NULL;
-    unsigned int *dictLen;
+    z_uint32_t *dictLen;
 
     c_stream.zalloc = zalloc;
     c_stream.zfree = zfree;
@@ -674,7 +674,7 @@ static void test_deflate_get_dict(unsigned char *compr, size_t comprLen) {
         error("deflate should report Z_STREAM_END\n");
 
     dictNew = calloc(256, 1);
-    dictLen = (unsigned int *)calloc(4, 1);
+    dictLen = (z_uint32_t *)calloc(4, 1);
     err = PREFIX(deflateGetDictionary)(&c_stream, dictNew, dictLen);
 
     CHECK_ERR(err, "deflateGetDictionary");
@@ -695,8 +695,8 @@ static void test_deflate_get_dict(unsigned char *compr, size_t comprLen) {
 static void test_deflate_pending(unsigned char *compr, size_t comprLen) {
     PREFIX3(stream) c_stream; /* compression stream */
     int err;
-    int *bits = calloc(256, 1);
-    unsigned *ped = calloc(256, 1);
+    z_int32_t *bits = calloc(256, 1);
+    z_uint32_t *ped = calloc(256, 1);
     size_t len = strlen(hello)+1;
 
 

--- a/test/infcover.c
+++ b/test/infcover.c
@@ -442,7 +442,7 @@ static void cover_wrap(void) {
 }
 
 /* input and output functions for inflateBack() */
-static unsigned pull(void *desc, z_const unsigned char **buf) {
+static z_uint32_t pull(void *desc, z_const unsigned char **buf) {
     static unsigned int next = 0;
     static unsigned char dat[] = {0x63, 0, 2, 0};
     struct inflate_state *state;
@@ -457,7 +457,7 @@ static unsigned pull(void *desc, z_const unsigned char **buf) {
     return next < sizeof(dat) ? (*buf = dat + next++, 1) : 0;
 }
 
-static int push(void *desc, unsigned char *buf, unsigned len) {
+static z_int32_t push(void *desc, unsigned char *buf, z_uint32_t len) {
     buf += len;
     Z_UNUSED(buf);
     return desc != NULL;        /* force error if desc not null */

--- a/test/minideflate.c
+++ b/test/minideflate.c
@@ -5,6 +5,7 @@
 
 #include "zbuild.h"
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <assert.h>
 
@@ -48,12 +49,12 @@ static void deflate_params(FILE *fin, FILE *fout, int32_t read_buf_size, int32_t
 
     read_buf = (uint8_t *)malloc(read_buf_size);
     if (read_buf == NULL) {
-        fprintf(stderr, "failed to create read buffer (%d)\n", read_buf_size);
+        fprintf(stderr, "failed to create read buffer (%" PRId32 ")\n", read_buf_size);
         return;
     }
     write_buf = (uint8_t *)malloc(write_buf_size);
     if (write_buf == NULL) {
-        fprintf(stderr, "failed to create write buffer (%d)\n", write_buf_size);
+        fprintf(stderr, "failed to create write buffer (%" PRId32 ")\n", write_buf_size);
         free(read_buf);
         return;
     }
@@ -134,12 +135,12 @@ static void inflate_params(FILE *fin, FILE *fout, int32_t read_buf_size, int32_t
 
     read_buf = (uint8_t *)malloc(read_buf_size);
     if (read_buf == NULL) {
-        fprintf(stderr, "failed to create read buffer (%d)\n", read_buf_size);
+        fprintf(stderr, "failed to create read buffer (%" PRId32 ")\n", read_buf_size);
         return;
     }
     write_buf = (uint8_t *)malloc(write_buf_size);
     if (write_buf == NULL) {
-        fprintf(stderr, "failed to create write buffer (%d)\n", write_buf_size);
+        fprintf(stderr, "failed to create write buffer (%" PRId32 ")\n", write_buf_size);
         free(read_buf);
         return;
     }

--- a/test/minigzip.c
+++ b/test/minigzip.c
@@ -73,7 +73,7 @@ static void error(const char *msg) {
  */
 
 static void gz_fatal(gzFile file) {
-    int err;
+    z_int32_t err;
     fprintf(stderr, "%s: %s\n", prog, PREFIX(gzerror)(file, &err));
     PREFIX(gzclose)(file);
     exit(1);

--- a/test/switchlevels.c
+++ b/test/switchlevels.c
@@ -9,6 +9,7 @@
 #  include "zlib-ng.h"
 #endif
 
+#include <inttypes.h>
 #include <stdio.h>
 
 #if defined(_WIN32) || defined(__CYGWIN__)
@@ -95,7 +96,7 @@ static int compress_chunk(PREFIX3(stream) *strm, int level, int size, int last) 
         goto free_buf;
     }
     if (strm->avail_in != 0) {
-        fprintf(stderr, "deflate() did not consume %d bytes of input\n", strm->avail_in);
+        fprintf(stderr, "deflate() did not consume %" PRIu32 " bytes of input\n", strm->avail_in);
         goto free_buf;
     }
     if (write_all(buf + size, compsize - strm->avail_out) != 0) {

--- a/uncompr.c
+++ b/uncompr.c
@@ -22,7 +22,7 @@
    Z_DATA_ERROR if the input data was corrupted, including if the input data is
    an incomplete zlib stream.
 */
-int Z_EXPORT PREFIX(uncompress2)(unsigned char *dest, z_uintmax_t *destLen, const unsigned char *source, z_uintmax_t *sourceLen) {
+z_int32_t Z_EXPORT PREFIX(uncompress2)(unsigned char *dest, z_uintmax_t *destLen, const unsigned char *source, z_uintmax_t *sourceLen) {
     PREFIX3(stream) stream;
     int err;
     const unsigned int max = (unsigned int)-1;
@@ -75,6 +75,6 @@ int Z_EXPORT PREFIX(uncompress2)(unsigned char *dest, z_uintmax_t *destLen, cons
            err;
 }
 
-int Z_EXPORT PREFIX(uncompress)(unsigned char *dest, z_uintmax_t *destLen, const unsigned char *source, z_uintmax_t sourceLen) {
+z_int32_t Z_EXPORT PREFIX(uncompress)(unsigned char *dest, z_uintmax_t *destLen, const unsigned char *source, z_uintmax_t sourceLen) {
     return PREFIX(uncompress2)(dest, destLen, source, &sourceLen);
 }

--- a/zbuild.h
+++ b/zbuild.h
@@ -108,6 +108,17 @@
 #  define z_uintmax_t size_t
 #endif
 
+/* In zlib-compat headers some function return values and parameter types use int or unsigned, but zlib-ng headers use
+   int32_t and uint32_t, which will cause type mismatch when compiling zlib-ng if int32_t is long and uint32_t is
+   unsigned long */
+#if defined(ZLIB_COMPAT)
+#  define z_int32_t int
+#  define z_uint32_t unsigned int
+#else
+#  define z_int32_t int32_t
+#  define z_uint32_t uint32_t
+#endif
+
 /* Minimum of a and b. */
 #define MIN(a, b) ((a) > (b) ? (b) : (a))
 /* Maximum of a and b. */

--- a/zutil.c
+++ b/zutil.c
@@ -96,7 +96,7 @@ void Z_INTERNAL z_error(const char *m) {
 /* exported to allow conversion of error code to string for compress() and
  * uncompress()
  */
-const char * Z_EXPORT PREFIX(zError)(int err) {
+const char * Z_EXPORT PREFIX(zError)(z_int32_t err) {
     return ERR_MSG(err);
 }
 


### PR DESCRIPTION
Introduce two new private types, `z_int32_t`and `z_uint32_t` in `zbuild.h` to be used in C source files during compiling zlib-ng when the API differs between zlib-compat and zlib-ng, and toolchain use `long` instead of `int` for `int32_t`; and `unsigned long` instead of `unsigned int` for `uint32_t`.

* Based on PR #1934