### PR TITLE
Verify pointers during functable init

### DIFF
--- a/functable.h
+++ b/functable.h
@@ -24,7 +24,7 @@
 #else
 
 struct functable_s {
-    void     (* force_init)         (void);
+    int      (* force_init)         (void);
     uint32_t (* adler32)            (uint32_t adler, const uint8_t *buf, size_t len);
     uint32_t (* adler32_fold_copy)  (uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len);
     uint8_t* (* chunkmemset_safe)   (uint8_t *out, uint8_t *from, unsigned len, unsigned left);
@@ -45,7 +45,7 @@ Z_INTERNAL extern struct functable_s functable;
 
 /* Explicitly indicate functions are conditionally dispatched.
  */
-#  define FUNCTABLE_INIT functable.force_init()
+#  define FUNCTABLE_INIT if (functable.force_init()) {return Z_VERSION_ERROR;}
 #  define FUNCTABLE_CALL(name) functable.name
 #  define FUNCTABLE_FPTR(name) functable.name
 

--- a/zbuild.h
+++ b/zbuild.h
@@ -16,6 +16,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <stdio.h>
 
 /* Determine compiler version of C Standard */
 #ifdef __STDC_VERSION__
@@ -235,7 +236,6 @@
 
 /* Diagnostic functions */
 #ifdef ZLIB_DEBUG
-#  include <stdio.h>
    extern int Z_INTERNAL z_verbose;
    extern void Z_INTERNAL z_error(const char *m);
 #  define Assert(cond, msg) {int _cond = (cond); if (!_cond) z_error(msg);}


### PR DESCRIPTION
During init, make sure none of the functable entries are nullpointers.
This will cause zlib-ng to abort during init if it is run on a cpu that is missing both optimized and generic fallback functions, instead of running fine until such a missing function is called and potentially being missed during testing.