### PR TITLE
Don't build C-fallback functions that never get used on x86_64

### DIFF
--- a/.github/workflows/pkgcheck.yml
+++ b/.github/workflows/pkgcheck.yml
@@ -137,7 +137,7 @@ jobs:
         CFLAGS: ${{ matrix.cflags }}
         CXXFLAGS: ${{ matrix.cxxflags }}
         CHOST: ${{ matrix.chost }}
-        CMAKE_ARGS: ${{ matrix.cmake-args }}
+        CMAKE_ARGS: ${{ matrix.cmake-args }} -DWITH_ALL_FALLBACKS=ON
         CONFIGURE_ARGS: ${{ matrix.configure-args }}
         LDFLAGS: ${{ matrix.ldflags }}
 
@@ -147,7 +147,7 @@ jobs:
         CC: ${{ matrix.compiler }}
         CFLAGS: ${{ matrix.cflags }}
         CHOST: ${{ matrix.chost }}
-        CMAKE_ARGS: ${{ matrix.cmake-args }}
+        CMAKE_ARGS: ${{ matrix.cmake-args }} -DWITH_ALL_FALLBACKS=ON
         CONFIGURE_ARGS: ${{ matrix.configure-args }}
         LDFLAGS: ${{ matrix.ldflags }}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ endif()
 option(WITH_GZFILEOP "Compile with support for gzFile related functions" ON)
 option(ZLIB_COMPAT "Compile with zlib compatible API" OFF)
 option(WITH_OPTIM "Build with optimisation" ON)
+option(WITH_ALL_FALLBACKS "Build all generic fallback functions (Useful for Gbench)" OFF)
 option(WITH_REDUCED_MEM "Reduced memory usage for special cases (reduces performance)" OFF)
 option(WITH_NEW_STRATEGIES "Use new strategies" ON)
 option(WITH_CRC32_CHORBA "Enable optimized CRC32 algorithm Chorba" ON)
@@ -151,6 +152,7 @@ mark_as_advanced(FORCE
     ZLIB_SYMBOL_PREFIX
     WITH_REDUCED_MEM
     WITH_CRC32_CHORBA
+    WITH_ALL_FALLBACKS
     WITH_ARMV8 WITH_NEON
     WITH_ARMV6
     WITH_DFLTCC_DEFLATE
@@ -713,6 +715,7 @@ else()
 endif()
 
 if(WITH_OPTIM)
+    add_definitions(-DWITH_OPTIM)
     if(BASEARCH_ARM_FOUND)
         add_definitions(-DARM_FEATURES)
         if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
@@ -1168,6 +1171,9 @@ if(WITH_OPTIM)
             endif()
         endif()
     endif()
+else()
+    # If WITH_OPTIM is disabled, we need all the fallbacks.
+    set(WITH_ALL_FALLBACKS ON)
 endif()
 
 message(STATUS "Architecture-specific source files: ${ZLIB_ARCH_SRCS}")
@@ -1275,14 +1281,6 @@ set(ZLIB_PRIVATE_HDRS
     zutil_p.h
 )
 set(ZLIB_SRCS
-    arch/generic/adler32_c.c
-    arch/generic/adler32_fold_c.c
-    arch/generic/chunkset_c.c
-    arch/generic/compare256_c.c
-    arch/generic/crc32_braid_c.c
-    arch/generic/crc32_c.c
-    arch/generic/crc32_fold_c.c
-    arch/generic/slide_hash_c.c
     adler32.c
     compress.c
     crc32.c
@@ -1306,6 +1304,39 @@ set(ZLIB_SRCS
     zutil.c
 )
 
+set(ZLIB_ALL_FALLBACK_SRCS
+    arch/generic/adler32_c.c
+    arch/generic/adler32_fold_c.c
+    arch/generic/chunkset_c.c
+    arch/generic/compare256_c.c
+    arch/generic/crc32_braid_c.c
+    arch/generic/crc32_c.c
+    arch/generic/crc32_fold_c.c
+    arch/generic/slide_hash_c.c
+)
+
+if(WITH_ALL_FALLBACKS)
+    list(APPEND ZLIB_GENERIC_SRCS ${ZLIB_ALL_FALLBACK_SRCS})
+    add_definitions(-DWITH_ALL_FALLBACKS)
+elseif(${ARCH} STREQUAL "x86_64" AND WITH_SSE2)
+    # x86_64 always has SSE2, so let the SSE2 functions act as fallbacks.
+    list(APPEND ZLIB_GENERIC_SRCS
+        arch/generic/adler32_c.c
+        arch/generic/adler32_fold_c.c
+        arch/generic/crc32_braid_c.c
+        arch/generic/crc32_c.c
+        arch/generic/crc32_fold_c.c
+    )
+
+    # x86_64 does not need compare256 fallback if we have BUILTIN_CTZ
+    if(NOT HAVE_BUILTIN_CTZ)
+        list(APPEND ZLIB_GENERIC_SRCS arch/generic/compare256_c.c)
+    endif()
+else()
+    list(APPEND ZLIB_GENERIC_SRCS ${ZLIB_ALL_FALLBACK_SRCS})
+    add_definitions(-DWITH_ALL_FALLBACKS)
+endif()
+
 if(WITH_CRC32_CHORBA)
     list(APPEND ZLIB_SRCS arch/generic/crc32_chorba_c.c)
 endif()
@@ -1324,7 +1355,7 @@ set(ZLIB_GZFILE_SRCS
     gzwrite.c
 )
 
-set(ZLIB_ALL_SRCS ${ZLIB_SRCS} ${ZLIB_ARCH_HDRS} ${ZLIB_ARCH_SRCS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
+set(ZLIB_ALL_SRCS ${ZLIB_GENERIC_SRCS} ${ZLIB_SRCS} ${ZLIB_ARCH_HDRS} ${ZLIB_ARCH_SRCS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
 if(WITH_GZFILEOP)
     list(APPEND ZLIB_ALL_SRCS ${ZLIB_GZFILE_PRIVATE_HDRS} ${ZLIB_GZFILE_SRCS})
 endif()
@@ -1550,6 +1581,7 @@ add_feature_info(WITH_GTEST WITH_GTEST "Build gtest_zlib")
 add_feature_info(WITH_FUZZERS WITH_FUZZERS "Build test/fuzz")
 add_feature_info(WITH_BENCHMARKS WITH_BENCHMARKS "Build test/benchmarks")
 add_feature_info(WITH_BENCHMARK_APPS WITH_BENCHMARK_APPS "Build application benchmarks")
+add_feature_info(WITH_ALL_FALLBACKS WITH_ALL_FALLBACKS "Build all generic fallback functions")
 add_feature_info(WITH_OPTIM WITH_OPTIM "Build with optimisation")
 add_feature_info(WITH_NEW_STRATEGIES WITH_NEW_STRATEGIES "Use new strategies")
 add_feature_info(WITH_CRC32_CHORBA WITH_CRC32_CHORBA "Use optimized CRC32 algorithm Chorba")

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Advanced Build Options
 | WITH_SSE42                      |                       | Build with SSE42 intrinsics                                         | ON                     |
 | WITH_PCLMULQDQ                  |                       | Build with PCLMULQDQ intrinsics                                     | ON                     |
 | WITH_VPCLMULQDQ                 | --without-vpclmulqdq  | Build with VPCLMULQDQ intrinsics                                    | ON                     |
-| WITH_ARMV8                      | --without-armv8       | Build with ARMv8 intrinsics                                          | ON                     |
+| WITH_ARMV8                      | --without-armv8       | Build with ARMv8 intrinsics                                         | ON                     |
 | WITH_NEON                       | --without-neon        | Build with NEON intrinsics                                          | ON                     |
 | WITH_ARMV6                      | --without-armv6       | Build with ARMv6 intrinsics                                         | ON                     |
 | WITH_ALTIVEC                    | --without-altivec     | Build with AltiVec (VMX) intrinsics                                 | ON                     |
@@ -217,6 +217,7 @@ Advanced Build Options
 | WITH_INFLATE_ALLOW_INVALID_DIST |                       | Build with zero fill for inflate invalid distances                  | OFF                    |
 | INSTALL_UTILS                   |                       | Copy minigzip and minideflate during install                        | OFF                    |
 | ZLIBNG_ENABLE_TESTS             |                       | Test zlib-ng specific API                                           | ON                     |
+| WITH_ALL_FALLBACKS              |                       | Build with all c-fallbacks (useful for Gbench comparisons)          | OFF                    |
 
 
 Related Projects

--- a/configure
+++ b/configure
@@ -1777,6 +1777,16 @@ if test $without_new_strategies -eq 1; then
     SFLAGS="${SFLAGS} -DNO_QUICK_STRATEGY -DNO_MEDIUM_STRATEGY"
 fi
 
+# CMake can exclude building some of the generic fallback functions,
+# configure does not have the detection code to do so.
+CFLAGS="${CFLAGS} -DWITH_ALL_FALLBACKS"
+SFLAGS="${SFLAGS} -DWITH_ALL_FALLBACKS"
+
+if test $without_optimizations -eq 0; then
+    CFLAGS="${CFLAGS} -DWITH_OPTIM"
+    SFLAGS="${SFLAGS} -DWITH_OPTIM"
+fi
+
 ARCHDIR='arch/generic'
 ARCH_STATIC_OBJS=''
 ARCH_SHARED_OBJS=''

--- a/test/benchmarks/benchmark_slidehash.cc
+++ b/test/benchmarks/benchmark_slidehash.cc
@@ -68,7 +68,9 @@ public:
     } \
     BENCHMARK_REGISTER_F(slide_hash, name)->RangeMultiplier(2)->Range(512, MAX_RANDOM_INTS);
 
+#if defined(WITH_ALL_FALLBACKS) || !defined(__x86_64__)
 BENCHMARK_SLIDEHASH(c, slide_hash_c, 1);
+#endif
 
 #ifdef DISABLE_RUNTIME_CPU_DETECTION
 BENCHMARK_SLIDEHASH(native, native_slide_hash, 1);


### PR DESCRIPTION
x86_64 always has SSE2, therefore we can use the SSE2 functions as fallbacks instead of 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a build option WITH_ALL_FALLBACKS to enable all generic fallback implementations; defaults on when optimizations are off.

- **Refactor**
  - Reworked source composition and runtime initialization to integrate configurable generic fallbacks with optimized variants.

- **Tests**
  - Adjusted benchmarks to conditionally include the C-variant depending on architecture and the new option.

- **Documentation**
  - Updated README to document the new build option.

- **Chores**
  - CI and build config updated to expose and pass the new flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->