### PR TITLE
riscv: features: Detect extensions always and only through AT_HWCAP

### DIFF
--- a/arch/riscv/riscv_features.c
+++ b/arch/riscv/riscv_features.c
@@ -1,8 +1,3 @@
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sys/utsname.h>
-
 #if defined(__linux__) && defined(HAVE_SYS_AUXV_H)
 #  include <sys/auxv.h>
 #endif
@@ -13,39 +8,7 @@
 #define ISA_V_HWCAP (1 << ('v' - 'a'))
 #define ISA_ZBC_HWCAP (1 << 29)
 
-int Z_INTERNAL is_kernel_version_greater_or_equal_to_6_5(void) {
-    struct utsname buffer;
-    if (uname(&buffer) == -1) {
-        // uname failed
-        return 0;
-    }
-
-    int major, minor;
-    if (sscanf(buffer.release, "%d.%d", &major, &minor) != 2) {
-        // Something bad with uname()
-        return 0;
-    }
-
-    if (major > 6 || (major == 6 && minor >= 5))
-        return 1;
-    return 0;
-}
-
-void Z_INTERNAL riscv_check_features_compile_time(struct riscv_cpu_features *features) {
-#if defined(__riscv_v) && defined(__linux__)
-    features->has_rvv = 1;
-#else
-    features->has_rvv = 0;
-#endif
-
-#if defined(__riscv_zbc) && defined(__linux__)
-    features->has_zbc = 1;
-#else
-    features->has_zbc = 0;
-#endif
-}
-
-void Z_INTERNAL riscv_check_features_runtime(struct riscv_cpu_features *features) {
+void Z_INTERNAL riscv_check_features(struct riscv_cpu_features *features) {
 #if defined(__linux__) && defined(HAVE_SYS_AUXV_H)
     unsigned long hw_cap = getauxval(AT_HWCAP);
 #else
@@ -53,29 +16,4 @@ void Z_INTERNAL riscv_check_features_runtime(struct riscv_cpu_features *features
 #endif
     features->has_rvv = hw_cap & ISA_V_HWCAP;
     features->has_zbc = hw_cap & ISA_ZBC_HWCAP;
-}
-
-void Z_INTERNAL riscv_check_features(struct riscv_cpu_features *features) {
-    if (is_kernel_version_greater_or_equal_to_6_5())
-        riscv_check_features_runtime(features);
-    else
-        riscv_check_features_compile_time(features);
-#ifdef RISCV_RVV
-    if (features->has_rvv) {
-        size_t e8m1_vec_len;
-        intptr_t vtype_reg_val;
-        // Check that a vuint8m1_t vector is at least 16 bytes and that tail
-        // agnostic and mask agnostic mode are supported
-        //
-        __asm__ volatile(
-                "vsetvli %0, zero, e8, m1, ta, ma\n\t"
-                "csrr %1, vtype"
-                : "=r"(e8m1_vec_len), "=r"(vtype_reg_val));
-
-        // The RVV target is supported if the VILL bit of VTYPE (the MSB bit of
-        // VTYPE) is not set and the length of a vuint8m1_t vector is at least 16
-        // bytes
-        features->has_rvv = (vtype_reg_val >= 0 && e8m1_vec_len >= 16);
-    }
-#endif
 }


### PR DESCRIPTION
Previously, RVV/Zbc is used when

- Linux kernel version (detected by uname(2)) is greater or equal to 6.5, and HWCAP claims support for such extension, or
- Linux kernel version is less than 6.5, but compiler claims support for the extension

and for RVV, we additionally check whether it's (the earlier, draft) v0.7.1 release or the (the later, ratified) v1.0 release. Zlib-ng only supports v1.0.

This strategy is problematic in several aspects,

- Fallback to compile-time constants with Linux kernel earlier than 6.5 makes it hard for distributions to ship the same binary for different machines with different kernel versions.
- Detecting Linux kernel version through uname(2) could violate sandbox enforcement[1].

And since RVV introduces special vector registers, RVV usage in userspace relies on the kernel to implement proper context switching, which is only present since Linux kernel 6.5, which is also the version when COMPAT_HWCAP_ISA_V was introduced. This makes it reasonable to only do HWCAP-based extension detection for RVV.

The additional check for RVV version is also unnecessary since in mainline Linux kernel, COMPAT_HWCAP_ISA_V is only set when a ratified v1.0 implementation of RVV is present. A downstream kernel claiming COMPAT_HWCAP_ISA_V with a v0.7.1 RVV implementation breaks the kABI, and userspace shouldn't pay for the mistake.

This patch removes extra detection logic, now RVV is and only is used when the kernel claims COMPAT_HWCAP_ISA_V. The detection logic of Zbc checks an undefined HWCAP bit, thus doesn't detect Zbc correctly with any current Linux kernel, which should be fixed with another patch.

Fixes: 6ff8b52cefe5 ("Support RVV hwcap detect at runtime")
Link: https://github.com/openssh/openssh-portable/pull/605 # [1]
Closes: https://github.com/zlib-ng/zlib-ng/issues/1705
Closes: https://github.com/zlib-ng/zlib-ng/issues/1769