### PR TITLE
2.3.0 RC2

### DIFF
--- a/zlib-ng.h.in
+++ b/zlib-ng.h.in
@@ -49,12 +49,12 @@ extern "C" {
 #endif
 
 #define ZLIBNG_VERSION "2.3.0"
-#define ZLIBNG_VERNUM 0x020300A0L   /* MMNNRRSM: major minor revision status modified */
+#define ZLIBNG_VERNUM 0x020300B0L   /* MMNNRRSM: major minor revision status modified */
 #define ZLIBNG_VER_MAJOR 2
 #define ZLIBNG_VER_MINOR 3
 #define ZLIBNG_VER_REVISION 0
-#define ZLIBNG_VER_STATUS A         /* 0=devel, 1-E=beta, F=Release (DEPRECATED) */
-#define ZLIBNG_VER_STATUSH 0xA      /* Hex values: 0=devel, 1-9=beta, A-E=Release Candidate, F=Release */
+#define ZLIBNG_VER_STATUS B         /* 0=devel, 1-E=beta, F=Release (DEPRECATED) */
+#define ZLIBNG_VER_STATUSH 0xB      /* Hex values: 0=devel, 1-9=beta, A-E=Release Candidate, F=Release */
 #define ZLIBNG_VER_MODIFIED 0       /* non-zero if modified externally from zlib-ng */
 
 /*

--- a/zlib.h.in
+++ b/zlib.h.in
@@ -50,12 +50,12 @@ extern "C" {
 #endif
 
 #define ZLIBNG_VERSION "2.3.0"
-#define ZLIBNG_VERNUM 0x020300A0L   /* MMNNRRSM: major minor revision status modified */
+#define ZLIBNG_VERNUM 0x020300B0L   /* MMNNRRSM: major minor revision status modified */
 #define ZLIBNG_VER_MAJOR 2
 #define ZLIBNG_VER_MINOR 3
 #define ZLIBNG_VER_REVISION 0
-#define ZLIBNG_VER_STATUS A         /* 0=devel, 1-E=beta, F=Release (DEPRECATED) */
-#define ZLIBNG_VER_STATUSH 0xA      /* Hex values: 0=devel, 1-9=beta, A-E=Release Candidate, F=Release */
+#define ZLIBNG_VER_STATUS B         /* 0=devel, 1-E=beta, F=Release (DEPRECATED) */
+#define ZLIBNG_VER_STATUSH 0xB      /* Hex values: 0=devel, 1-9=beta, A-E=Release Candidate, F=Release */
 #define ZLIBNG_VER_MODIFIED 0       /* non-zero if modified externally from zlib-ng */
 
 #define ZLIB_VERSION "1.3.1.zlib-ng"

--- a/zutil.c
+++ b/zutil.c
@@ -21,7 +21,7 @@ z_const char * const PREFIX(z_errmsg)[10] = {
 };
 
 const char PREFIX3(vstring)[] =
-    " zlib-ng 2.3.0-rc1";
+    " zlib-ng 2.3.0-rc2";
 
 #ifdef ZLIB_COMPAT
 const char * Z_EXPORT zlibVersion(void) {


### PR DESCRIPTION
**Release candidate 2** - Please test

After some recent improvements, another release candidate is appropriate.
The biggest changes were in changing to use CTest for enabling building tests in CMake,
also we found some room for improvements around Chorba-specific code.

Tip for distro maintainers:
Distros requiring x86-64v3 or higher, can now choose to disable compiling in the large generic-C
Chorba code by setting the CMake option "WITH_CRC32_CHORBA=OFF", since the pclmul instructions
will always be available and it does not depend on it (unlike the SSE2/SSE4.1 implementations).

2.3.0-rc2
-----

### Optimizations
- Reorganize Chorba activation #2004
- Rewrite chorba dispatch functions #2006

### Arch-Specific improvements/optimizations
- RISC-V
  - RISC-V hwcap fixes #1999
- PowerPC
  - Use elf_aux_info() on OpenBSD PowerPC #2007

### Tests/Benchmarks
- Use CTest to simplify test configuration #2001
- Add tests for crc32_fold_copy functions #2005
- Add benchmark for crc32_fold_copy functions #2008
- Disable benchmark for slide_hash_c with Visual C++ #2009

### Misc
- Update README.md and add missing CMake/Configure option descriptions #2000