### PR TITLE
[CI] Downgrade "Windows GCC Native Instructions (AVX)" workflow

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -606,7 +606,7 @@ jobs:
             codecov: win64_gcc
 
           - name: Windows GCC Native Instructions (AVX)
-            os: windows-latest
+            os: windows-2022
             compiler: gcc
             cxx-compiler: g++
             cmake-args: -G Ninja  -DWITH_NATIVE_INSTRUCTIONS=ON -DNATIVE_ARCH_OVERRIDE="-mavx -mpclmul"


### PR DESCRIPTION
* Windows Server 2025 runner has broken GCC, so use Windows Server 2022 runner instead until fix is propagated to all runners