### PR TITLE
[Configure] Fix SFLAGS and improve sed portability

### DIFF
--- a/arch/x86/Makefile.in
+++ b/arch/x86/Makefile.in
@@ -79,13 +79,13 @@ chorba_sse2.o:
 	$(CC) $(CFLAGS) $(SSE2FLAG) $(NOLTOFLAG) $(INCLUDES) -c -o $@ $(SRCDIR)/chorba_sse2.c
 
 chorba_sse2.lo:
-	$(CC) $(CFLAGS) $(SSE2FLAG) $(NOLTOFLAG) -DPIC $(INCLUDES) -c -o $@ $(SRCDIR)/chorba_sse2.c
+	$(CC) $(SFLAGS) $(SSE2FLAG) $(NOLTOFLAG) -DPIC $(INCLUDES) -c -o $@ $(SRCDIR)/chorba_sse2.c
 
 chorba_sse41.o:
 	$(CC) $(CFLAGS) $(SSE41FLAG) $(NOLTOFLAG) $(INCLUDES) -c -o $@ $(SRCDIR)/chorba_sse41.c
 
 chorba_sse41.lo:
-	$(CC) $(CFLAGS) $(SSE41FLAG) $(NOLTOFLAG) -DPIC $(INCLUDES) -c -o $@ $(SRCDIR)/chorba_sse41.c
+	$(CC) $(SFLAGS) $(SSE41FLAG) $(NOLTOFLAG) -DPIC $(INCLUDES) -c -o $@ $(SRCDIR)/chorba_sse41.c
 
 compare256_avx2.o:
 	$(CC) $(CFLAGS) $(AVX2FLAG) $(NOLTOFLAG) $(INCLUDES) -c -o $@ $(SRCDIR)/compare256_avx2.c

--- a/configure
+++ b/configure
@@ -2412,7 +2412,7 @@ for file in $SRCDIR/*.c $SRCDIR/test/*.c $SRCDIR/test/fuzz/*.c $SRCDIR/$ARCHDIR/
     fi
 
     short_name=$(echo $file | sed -e "s#$SRCDIR/##g")
-    incs=$(grep -h include $file | sed -n 's/# *\include *"\(.*\.h\)".*/\1/p' | sort | uniq)
+    incs=$(grep -h include $file | sed -n 's/# *include *"\(.*\.h\)".*/\1/p' | sort | uniq)
     includes=$(for i in $incs; do
                    # Check that the include file exists in the current dir,
                    # otherwise it may be one of the system include header.
@@ -2493,7 +2493,7 @@ for file in $SRCDIR/$ARCHDIR/*.c; do
         continue
     fi
 
-    incs=$(grep -h include $file | sed -n 's/# *\include *"\(.*\.h\)".*/\1/p' | sort | uniq)
+    incs=$(grep -h include $file | sed -n 's/# *include *"\(.*\.h\)".*/\1/p' | sort | uniq)
     includes=$(for i in $incs; do
                    # Check that the include file exists in the current dir,
                    # otherwise it may be one of the system include header.


### PR DESCRIPTION
* "\i" is not valid escape code in BSD sed
* Some x86 shared sources were missing -fPIC due to using wrong variable in build rule

Fixes #2015.