### PR TITLE
Change OS_CODE definition for Windows platform

### DIFF
--- a/zutil.h
+++ b/zutil.h
@@ -112,7 +112,7 @@ extern z_const char * const PREFIX(z_errmsg)[10]; /* indexed by 2-zlib_error */
 #endif
 
 #if defined(_WIN32) && !defined(__CYGWIN__)
-#  define OS_CODE  10
+#  define OS_CODE  11
 #endif
 
 #ifdef __APPLE__


### PR DESCRIPTION
[gzip RFC](https://datatracker.ietf.org/doc/html/rfc1952#section-2.2) lists the previous value (10) as TOPS-20, this change replaces it with value value 11 (NTFS filesystem) which is more suited to represent Windows OS.