### PR TITLE
Use elf_aux_info() on FreeBSD and OpenBSD ARM / AArch64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -802,6 +802,54 @@ if(WITH_OPTIM)
                 endif()
             endif()
         endif()
+        if(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD" OR
+           ${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD")
+            if("${ARCH}" MATCHES "aarch64")
+                check_c_source_compiles(
+                    "#include <sys/auxv.h>
+                    int main() {
+                        unsigned long hwcap;
+                        elf_aux_info(AT_HWCAP, &hwcap, sizeof(hwcap));
+                        return (hwcap & HWCAP_CRC32);
+                    }"
+                    ARM_AUXV_HAS_CRC32
+                )
+                if(ARM_AUXV_HAS_CRC32)
+                    add_definitions(-DARM_AUXV_HAS_CRC32)
+                else()
+                    message(STATUS "HWCAP_CRC32 not present in sys/auxv.h; cannot detect support at runtime.")
+                endif()
+            else()
+                check_c_source_compiles(
+                    "#include <sys/auxv.h>
+                    int main() {
+                        unsigned long hwcap2;
+                        elf_aux_info(AT_HWCAP2, &hwcap2, sizeof(hwcap2));
+                        return (hwcap2 & HWCAP2_CRC32);
+                    }"
+                    ARM_AUXV_HAS_CRC32
+                )
+                if(ARM_AUXV_HAS_CRC32)
+                    add_definitions(-DARM_AUXV_HAS_CRC32)
+                else()
+                    message(STATUS "HWCAP2_CRC32 not present in sys/auxv.h; cannot detect support at runtime.")
+                endif()
+                check_c_source_compiles(
+                    "#include <sys/auxv.h>
+                    int main() {
+                      unsigned long hwcap;
+                      elf_aux_info(AT_HWCAP, &hwcap, sizeof(hwcap));
+                      return (hwcap & HWCAP_NEON);
+                    }"
+                    ARM_AUXV_HAS_NEON
+                )
+                if(ARM_AUXV_HAS_NEON)
+                    add_definitions(-DARM_AUXV_HAS_NEON)
+                else()
+                    message(STATUS "HWCAP_NEON not present in sys/auxv.h; cannot detect support at runtime.")
+                endif()
+            endif()
+        endif()
         list(APPEND ZLIB_ARCH_HDRS ${ARCHDIR}/arm_functions.h)
         if(WITH_RUNTIME_CPU_DETECTION)
             list(APPEND ZLIB_ARCH_HDRS ${ARCHDIR}/arm_features.h)

--- a/configure
+++ b/configure
@@ -569,11 +569,17 @@ case "$uname" in
 esac
 
 # Simplify some later conditionals
+LINUX=0
+FREEBSD=0
+OPENBSD=0
+
 case "$uname" in
 Linux* | linux*)
   LINUX=1 ;;
-*)
-  LINUX=0 ;;
+FreeBSD*)
+  FREEBSD=1 ;;
+OpenBSD*)
+  OPENBSD=1 ;;
 esac
 
 # destination names for shared library if not defined above
@@ -2033,6 +2039,55 @@ EOF
                         else
                             echo "Neither HWCAP_ARM_NEON or HWCAP_NEON present in sys/auxv.h; cannot detect support at runtime." | tee -a configure.log
                         fi
+                    fi
+                fi
+            fi
+
+            if test $FREEBSD -eq 1 -o $OPENBSD -eq 1; then
+                if test "$ARCH" = "aarch64"; then
+                    cat > $test.c <<EOF
+#include <sys/auxv.h>
+int main() {
+    unsigned long hwcap;
+    elf_aux_info(AT_HWCAP, &hwcap, sizeof(hwcap));
+    return (hwcap & HWCAP_CRC32);
+}
+EOF
+                    if try $CC -c $CFLAGS $test.c; then
+                        CFLAGS="${CFLAGS} -DARM_AUXV_HAS_CRC32"
+                        SFLAGS="${SFLAGS} -DARM_AUXV_HAS_CRC32"
+                    else
+                        echo "HWCAP_CRC32 not present in sys/auxv.h; cannot detect support at runtime." | tee -a configure.log
+                    fi
+                else
+                    cat > $test.c <<EOF
+#include <sys/auxv.h>
+int main() {
+    unsigned long hwcap2;
+    elf_aux_info(AT_HWCAP2, &hwcap2, sizeof(hwcap2));
+    return (hwcap2 & HWCAP2_CRC32);
+}
+EOF
+                    if try $CC -c $CFLAGS $test.c; then
+                        CFLAGS="${CFLAGS} -DARM_AUXV_HAS_CRC32"
+                        SFLAGS="${SFLAGS} -DARM_AUXV_HAS_CRC32"
+                    else
+                        echo "HWCAP2_CRC32 not present in sys/auxv.h; cannot detect support at runtime." | tee -a configure.log
+                    fi
+
+                    cat > $test.c <<EOF
+#include <sys/auxv.h>
+int main() {
+    unsigned long hwcap;
+    elf_aux_info(AT_HWCAP, &hwcap, sizeof(hwcap));
+    return (hwcap & HWCAP_NEON);
+}
+EOF
+                    if try $CC -c $CFLAGS $test.c; then
+                        CFLAGS="${CFLAGS} -DARM_AUXV_HAS_NEON"
+                        SFLAGS="${SFLAGS} -DARM_AUXV_HAS_NEON"
+                    else
+                        echo "HWCAP_NEON not present in sys/auxv.h; cannot detect support at runtime." | tee -a configure.log
                     fi
                 fi
             fi


### PR DESCRIPTION
Use elf_aux_info() as the prefered API for modern FreeBSD and OpenBSD
ARM and AArch64. This adds 32-bit ARM support.