### PR TITLE
Add copying to crc32_armv8 implementation.

### DIFF
--- a/arch/arm/crc32_armv8.c
+++ b/arch/arm/crc32_armv8.c
@@ -7,6 +7,7 @@
 #if defined(ARM_CRC32)
 #include "acle_intrins.h"
 #include "zbuild.h"
+#include "zmemory.h"
 #include "crc32.h"
 
 static Z_FORCEINLINE Z_TARGET_CRC uint32_t crc32_armv8_copy_impl(uint32_t crc, uint8_t *dst, const uint8_t *src, size_t len, const int COPY) {
@@ -36,7 +37,7 @@ static Z_FORCEINLINE Z_TARGET_CRC uint32_t crc32_armv8_copy_impl(uint32_t crc, u
         if ((len >= sizeof(uint16_t)) && ((ptrdiff_t)src & (sizeof(uint32_t) - 1))) {
             val2 = *((uint16_t*)src);
             if (COPY) {
-                *((uint16_t*)dst) = val2;
+                zng_memwrite_2(dst, val2);
                 dst += sizeof(uint16_t);
             }
             c = __crc32h(c, val2);
@@ -47,7 +48,7 @@ static Z_FORCEINLINE Z_TARGET_CRC uint32_t crc32_armv8_copy_impl(uint32_t crc, u
         if ((len >= sizeof(uint32_t)) && ((ptrdiff_t)src & (sizeof(uint64_t) - 1))) {
             val4 = *((uint32_t*)src);
             if (COPY) {
-                *((uint32_t*)dst) = val4;
+                zng_memwrite_4(dst, val4);
                 dst += sizeof(uint32_t);
             }
             c = __crc32w(c, val4);
@@ -59,7 +60,7 @@ static Z_FORCEINLINE Z_TARGET_CRC uint32_t crc32_armv8_copy_impl(uint32_t crc, u
     while (len >= sizeof(uint64_t)) {
         val8 = *((uint64_t*)src);
         if (COPY) {
-            *((uint64_t*)dst) = val8;
+            zng_memwrite_8(dst, val8);
             dst += sizeof(uint64_t);
         }
         c = __crc32d(c, val8);
@@ -70,7 +71,7 @@ static Z_FORCEINLINE Z_TARGET_CRC uint32_t crc32_armv8_copy_impl(uint32_t crc, u
     if (len & sizeof(uint32_t)) {
         val4 = *((uint32_t*)src);
         if (COPY) {
-            *((uint32_t*)dst) = val4;
+            zng_memwrite_4(dst, val4);
             dst += sizeof(uint32_t);
         }
         c = __crc32w(c, val4);
@@ -80,7 +81,7 @@ static Z_FORCEINLINE Z_TARGET_CRC uint32_t crc32_armv8_copy_impl(uint32_t crc, u
     if (len & sizeof(uint16_t)) {
         val2 = *((uint16_t*)src);
         if (COPY) {
-            *((uint16_t*)dst) = val2;
+            zng_memwrite_2(dst, val2);
             dst += sizeof(uint16_t);
         }
         c = __crc32h(c, val2);

--- a/arch/arm/crc32_armv8.c
+++ b/arch/arm/crc32_armv8.c
@@ -9,78 +9,106 @@
 #include "zbuild.h"
 #include "crc32.h"
 
-Z_INTERNAL Z_TARGET_CRC uint32_t crc32_armv8(uint32_t crc, const uint8_t *buf, size_t len) {
+static Z_FORCEINLINE Z_TARGET_CRC uint32_t crc32_armv8_copy_impl(uint32_t crc, uint8_t *dst, const uint8_t *src, size_t len, const int COPY) {
     Z_REGISTER uint32_t c;
-    Z_REGISTER uint16_t buf2;
-    Z_REGISTER uint32_t buf4;
-    Z_REGISTER uint64_t buf8;
+    Z_REGISTER uint16_t val2;
+    Z_REGISTER uint32_t val4;
+    Z_REGISTER uint64_t val8;
 
     c = ~crc;
 
     if (UNLIKELY(len == 1)) {
-        c = __crc32b(c, *buf);
+        if (COPY)
+            *dst = *src;
+        c = __crc32b(c, *src);
         c = ~c;
         return c;
     }
 
-    if ((ptrdiff_t)buf & (sizeof(uint64_t) - 1)) {
-        if (len && ((ptrdiff_t)buf & 1)) {
-            c = __crc32b(c, *buf++);
+    if ((ptrdiff_t)src & (sizeof(uint64_t) - 1)) {
+        if (len && ((ptrdiff_t)src & 1)) {
+            if (COPY)
+                *dst++ = *src;
+            c = __crc32b(c, *src++);
             len--;
         }
 
-        if ((len >= sizeof(uint16_t)) && ((ptrdiff_t)buf & (sizeof(uint32_t) - 1))) {
-            buf2 = *((uint16_t*)buf);
-            c = __crc32h(c, buf2);
-            buf += sizeof(uint16_t);
+        if ((len >= sizeof(uint16_t)) && ((ptrdiff_t)src & (sizeof(uint32_t) - 1))) {
+            val2 = *((uint16_t*)src);
+            if (COPY) {
+                *((uint16_t*)dst) = val2;
+                dst += sizeof(uint16_t);
+            }
+            c = __crc32h(c, val2);
+            src += sizeof(uint16_t);
             len -= sizeof(uint16_t);
         }
 
-        if ((len >= sizeof(uint32_t)) && ((ptrdiff_t)buf & (sizeof(uint64_t) - 1))) {
-            buf4 = *((uint32_t*)buf);
-            c = __crc32w(c, buf4);
+        if ((len >= sizeof(uint32_t)) && ((ptrdiff_t)src & (sizeof(uint64_t) - 1))) {
+            val4 = *((uint32_t*)src);
+            if (COPY) {
+                *((uint32_t*)dst) = val4;
+                dst += sizeof(uint32_t);
+            }
+            c = __crc32w(c, val4);
+            src += sizeof(uint32_t);
             len -= sizeof(uint32_t);
-            buf += sizeof(uint32_t);
         }
-
     }
 
     while (len >= sizeof(uint64_t)) {
-        buf8 = *((uint64_t*)buf);
-        c = __crc32d(c, buf8);
+        val8 = *((uint64_t*)src);
+        if (COPY) {
+            *((uint64_t*)dst) = val8;
+            dst += sizeof(uint64_t);
+        }
+        c = __crc32d(c, val8);
+        src += sizeof(uint64_t);
         len -= sizeof(uint64_t);
-        buf += sizeof(uint64_t);
     }
 
     if (len & sizeof(uint32_t)) {
-        buf4 = *((uint32_t*)buf);
-        c = __crc32w(c, buf4);
-        buf += sizeof(uint32_t);
+        val4 = *((uint32_t*)src);
+        if (COPY) {
+            *((uint32_t*)dst) = val4;
+            dst += sizeof(uint32_t);
+        }
+        c = __crc32w(c, val4);
+        src += sizeof(uint32_t);
     }
 
     if (len & sizeof(uint16_t)) {
-        buf2 = *((uint16_t*)buf);
-        c = __crc32h(c, buf2);
-        buf += sizeof(uint16_t);
+        val2 = *((uint16_t*)src);
+        if (COPY) {
+            *((uint16_t*)dst) = val2;
+            dst += sizeof(uint16_t);
+        }
+        c = __crc32h(c, val2);
+        src += sizeof(uint16_t);
     }
 
     if (len & sizeof(uint8_t)) {
-        c = __crc32b(c, *buf);
+        if (COPY)
+            *dst = *src;
+        c = __crc32b(c, *src);
     }
 
     c = ~c;
     return c;
 }
 
+Z_INTERNAL Z_TARGET_CRC uint32_t crc32_armv8(uint32_t crc, const uint8_t *src, size_t len) {
+    return crc32_armv8_copy_impl(crc, NULL, src, len, 0);
+}
+
 /* Note: Based on generic crc32_fold_* implementation with functable call replaced by direct call. */
 Z_INTERNAL Z_TARGET_CRC void crc32_fold_copy_armv8(crc32_fold *crc, uint8_t *dst, const uint8_t *src, size_t len) {
-    crc->value = crc32_armv8(crc->value, src, len);
-    memcpy(dst, src, len);
+    crc->value = crc32_armv8_copy_impl(crc->value, dst, src, len, 1);
 }
 
 Z_INTERNAL Z_TARGET_CRC void crc32_fold_armv8(crc32_fold *crc, const uint8_t *src, size_t len, uint32_t init_crc) {
     Z_UNUSED(init_crc);
-    crc->value = crc32_armv8(crc->value, src, len);
+    crc->value = crc32_armv8_copy_impl(crc->value, NULL, src, len, 0);
 }
 
 #endif


### PR DESCRIPTION
## Basic benchmarks
### Before
```
crc32_fc/armv8/16                    5.94 ns         5.94 ns    120332806
crc32_fc/armv8/48                    9.00 ns         9.00 ns     80628441
crc32_fc/armv8/192                   21.0 ns         21.0 ns     33802218
crc32_fc/armv8/512                   52.3 ns         52.3 ns     13570099
crc32_fc/armv8/4096                   425 ns          425 ns      1653724
crc32_fc/armv8/16384                 1665 ns         1665 ns       419677
crc32_fc/armv8/32768                 3459 ns         3458 ns       202706
```
### After
```
crc32_fc/armv8/16                    3.78 ns         3.78 ns    188316318
crc32_fc/armv8/48                    6.84 ns         6.84 ns    105582286
crc32_fc/armv8/192                   20.1 ns         20.1 ns     35236082
crc32_fc/armv8/512                   49.5 ns         49.5 ns     13978473
crc32_fc/armv8/4096                   391 ns          391 ns      1821887
crc32_fc/armv8/16384                 1527 ns         1527 ns       455572
crc32_fc/armv8/32768                 3045 ns         3045 ns       229668
```

I did 2 commits of cleanup for consistency across implementations. I plan to make updates to some other crc32 implementations to also follow the `copy_impl` style same as what @KungFuJesus did with adler32.