### PR TITLE
Minor cleanups, and tiny optimization of deflate_stored

### DIFF
--- a/deflate.h
+++ b/deflate.h
@@ -155,7 +155,7 @@ struct ALIGNED_(64) internal_state {
     int                  last_flush;       /* value of flush param for previous deflate call */
     int                  reproducible;     /* Whether reproducible compression results are required. */
 
-    int block_open;
+    unsigned int block_open;
     /* Whether or not a block is currently open for the QUICK deflation scheme.
      * This is set to 1 if there is an active block, or 0 if the block was just closed.
      */

--- a/deflate_fast.c
+++ b/deflate_fast.c
@@ -17,9 +17,7 @@
  * matches. It is used only for the fast compression options.
  */
 Z_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
-    Pos hash_head;        /* head of the hash chain */
     int bflush = 0;       /* set if current block must be flushed */
-    int64_t dist;
     uint32_t match_len = 0;
 
     for (;;) {
@@ -41,8 +39,8 @@ Z_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
          * dictionary, and set hash_head to the head of the hash chain:
          */
         if (s->lookahead >= WANT_MIN_MATCH) {
-            hash_head = quick_insert_string(s, s->strstart);
-            dist = (int64_t)s->strstart - hash_head;
+            Pos hash_head = quick_insert_string(s, s->strstart);
+            int64_t dist = (int64_t)s->strstart - hash_head;
 
             /* Find the longest match, discarding those <= prev_length.
              * At this point we have always match length < WANT_MIN_MATCH
@@ -94,6 +92,7 @@ Z_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
             FLUSH_BLOCK(s, 0);
     }
     s->insert = s->strstart < (STD_MIN_MATCH - 1) ? s->strstart : (STD_MIN_MATCH - 1);
+
     if (UNLIKELY(flush == Z_FINISH)) {
         FLUSH_BLOCK(s, 1);
         return finish_done;

--- a/deflate_quick.c
+++ b/deflate_quick.c
@@ -29,7 +29,7 @@ extern const ct_data static_dtree[D_CODES];
 
 #define QUICK_START_BLOCK(s, last) { \
     zng_tr_emit_tree(s, STATIC_TREES, last); \
-    s->block_open = 1 + (int)last; \
+    s->block_open = 1 + last; \
     s->block_start = (int)s->strstart; \
 }
 
@@ -45,12 +45,7 @@ extern const ct_data static_dtree[D_CODES];
 }
 
 Z_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
-    Pos hash_head;
-    int64_t dist;
-    unsigned match_len, last;
-
-
-    last = (flush == Z_FINISH) ? 1 : 0;
+    unsigned last = (flush == Z_FINISH) ? 1 : 0;
     if (UNLIKELY(last && s->block_open != 2)) {
         /* Emit end of previous block */
         QUICK_END_BLOCK(s, 0);
@@ -86,15 +81,15 @@ Z_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
         }
 
         if (LIKELY(s->lookahead >= WANT_MIN_MATCH)) {
-            hash_head = quick_insert_string(s, s->strstart);
-            dist = (int64_t)s->strstart - hash_head;
+            Pos hash_head = quick_insert_string(s, s->strstart);
+            int64_t dist = (int64_t)s->strstart - hash_head;
 
             if (dist <= MAX_DIST(s) && dist > 0) {
                 const uint8_t *str_start = s->window + s->strstart;
                 const uint8_t *match_start = s->window + hash_head;
 
                 if (zng_memcmp_2(str_start, match_start) == 0) {
-                    match_len = FUNCTABLE_CALL(compare256)(str_start+2, match_start+2) + 2;
+                    uint32_t match_len = FUNCTABLE_CALL(compare256)(str_start+2, match_start+2) + 2;
 
                     if (match_len >= WANT_MIN_MATCH) {
                         if (UNLIKELY(match_len > s->lookahead))

--- a/deflate_slow.c
+++ b/deflate_slow.c
@@ -15,10 +15,7 @@
  * no better match at the next window position.
  */
 Z_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
-    Pos hash_head;           /* head of hash chain */
     int bflush;              /* set if current block must be flushed */
-    int64_t dist;
-    uint32_t match_len;
     match_func longest_match;
 
     if (s->max_chain_length <= 1024)
@@ -45,7 +42,7 @@ Z_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
         /* Insert the string window[strstart .. strstart+2] in the
          * dictionary, and set hash_head to the head of the hash chain:
          */
-        hash_head = 0;
+        Pos hash_head = 0;
         if (LIKELY(s->lookahead >= WANT_MIN_MATCH)) {
             hash_head = s->quick_insert_string(s, s->strstart);
         }
@@ -53,8 +50,8 @@ Z_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
         /* Find the longest match, discarding those <= prev_length.
          */
         s->prev_match = (Pos)s->match_start;
-        match_len = STD_MIN_MATCH - 1;
-        dist = (int64_t)s->strstart - hash_head;
+        uint32_t match_len = STD_MIN_MATCH - 1;
+        int64_t dist = (int64_t)s->strstart - hash_head;
 
         if (dist <= MAX_DIST(s) && dist > 0 && s->prev_length < s->max_lazy_match && hash_head != 0) {
             /* To simplify the code, we prevent matches with the string

--- a/deflate_stored.c
+++ b/deflate_stored.c
@@ -29,7 +29,8 @@ Z_INTERNAL block_state deflate_stored(deflate_state *s, int flush) {
      * this is 32K. This can be as small as 507 bytes for memLevel == 1. For
      * large input and output buffers, the stored block size will be larger.
      */
-    unsigned min_block = MIN(s->pending_buf_size - 5, s->w_size);
+    unsigned int w_size = s->w_size;
+    unsigned min_block = MIN(s->pending_buf_size - 5, w_size);
 
     /* Copy as many min_block or larger stored blocks directly to next_out as
      * possible. If flushing, copy the remaining available input to next_out as
@@ -112,23 +113,23 @@ Z_INTERNAL block_state deflate_stored(deflate_state *s, int flush) {
         /* If any input was used, then no unused input remains in the window,
          * therefore s->block_start == s->strstart.
          */
-        if (used >= s->w_size) {    /* supplant the previous history */
+        if (used >= w_size) {    /* supplant the previous history */
             s->matches = 2;         /* clear hash */
-            memcpy(s->window, s->strm->next_in - s->w_size, s->w_size);
-            s->strstart = s->w_size;
+            memcpy(s->window, s->strm->next_in - w_size, w_size);
+            s->strstart = w_size;
             s->insert = s->strstart;
         } else {
             if (s->window_size - s->strstart <= used) {
                 /* Slide the window down. */
-                s->strstart -= s->w_size;
-                memcpy(s->window, s->window + s->w_size, s->strstart);
+                s->strstart -= w_size;
+                memcpy(s->window, s->window + w_size, s->strstart);
                 if (s->matches < 2)
                     s->matches++;   /* add a pending slide_hash() */
                 s->insert = MIN(s->insert, s->strstart);
             }
             memcpy(s->window + s->strstart, s->strm->next_in - used, used);
             s->strstart += used;
-            s->insert += MIN(used, s->w_size - s->insert);
+            s->insert += MIN(used, w_size - s->insert);
         }
         s->block_start = (int)s->strstart;
     }
@@ -144,14 +145,14 @@ Z_INTERNAL block_state deflate_stored(deflate_state *s, int flush) {
 
     /* Fill the window with any remaining input. */
     have = s->window_size - s->strstart;
-    if (s->strm->avail_in > have && s->block_start >= (int)s->w_size) {
+    if (s->strm->avail_in > have && s->block_start >= (int)w_size) {
         /* Slide the window down. */
-        s->block_start -= (int)s->w_size;
-        s->strstart -= s->w_size;
-        memcpy(s->window, s->window + s->w_size, s->strstart);
+        s->block_start -= (int)w_size;
+        s->strstart -= w_size;
+        memcpy(s->window, s->window + w_size, s->strstart);
         if (s->matches < 2)
             s->matches++;           /* add a pending slide_hash() */
-        have += s->w_size;          /* more space now */
+        have += w_size;          /* more space now */
         s->insert = MIN(s->insert, s->strstart);
     }
 
@@ -159,7 +160,7 @@ Z_INTERNAL block_state deflate_stored(deflate_state *s, int flush) {
     if (have) {
         read_buf(s->strm, s->window + s->strstart, have);
         s->strstart += have;
-        s->insert += MIN(have, s->w_size - s->insert);
+        s->insert += MIN(have, w_size - s->insert);
     }
     s->high_water = MAX(s->high_water, s->strstart);
 
@@ -171,7 +172,7 @@ Z_INTERNAL block_state deflate_stored(deflate_state *s, int flush) {
     have = (s->bi_valid + 42) >> 3;         /* number of header bytes */
         /* maximum stored block length that will fit in pending: */
     have = MIN(s->pending_buf_size - have, MAX_STORED);
-    min_block = MIN(have, s->w_size);
+    min_block = MIN(have, w_size);
     left = (int)s->strstart - s->block_start;
     if (left >= min_block || ((left || flush == Z_FINISH) && flush != Z_NO_FLUSH && s->strm->avail_in == 0 && left <= have)) {
         len = MIN(left, have);


### PR DESCRIPTION
Extremely minor performance difference, but it helps.
```
### 2.3.1 deflate_stored w_size
 Level   Comp   Comptime min/avg/max/stddev  Decomptime min/avg/max/stddev  Compressed size
 0    100.008%  0.0101/0.0106/0.0110/0.0004    0.0121/0.0129/0.0130/0.0003      211,973,953

### 2.3.1
 Level   Comp   Comptime min/avg/max/stddev  Decomptime min/avg/max/stddev  Compressed size
 0    100.008%  0.0101/0.0108/0.0110/0.0003    0.0122/0.0130/0.0131/0.0001      211,973,953
```

Coderabbitai summary:
| Cohort / File(s) | Summary |
|---|---|
| **Structure type updates** <br> `deflate.h` | Changed `block_open` field type from `int` to `unsigned int` in `internal_state` structure to remove unnecessary cast. |
| **Variable scope refinement and type annotations** <br> `deflate_fast.c`, `deflate_quick.c`, `deflate_slow.c` | Moved variable declarations (`hash_head`, `dist`, `match_len`) from outer/function scope to inner/loop scope. Added explicit type annotations (`uint32_t`, `int64_t`) for temporal variables. Removed redundant casts in assignment expressions. |
| **Window size caching** <br> `deflate_stored.c` | Introduced local variable `w_size` to cache `s->w_size` and replaced all direct references with cached variable. Added explicit `(int)` casts in arithmetic operations for type alignment. |
