### PR TITLE
Add quick_insert_value for optimized hash insertion

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -1137,10 +1137,12 @@ static void lm_set_level(deflate_state *s, int level) {
         s->update_hash = &update_hash_roll;
         s->insert_string = &insert_string_roll;
         s->quick_insert_string = &quick_insert_string_roll;
+        s->quick_insert_value = &quick_insert_value_roll;
     } else {
         s->update_hash = update_hash;
         s->insert_string = insert_string;
         s->quick_insert_string = quick_insert_string;
+        s->quick_insert_value = quick_insert_value;
     }
 
     s->level = level;

--- a/deflate.h
+++ b/deflate.h
@@ -122,14 +122,17 @@ typedef struct internal_state deflate_state;
 typedef uint32_t (* update_hash_cb)        (uint32_t h, uint32_t val);
 typedef void     (* insert_string_cb)      (deflate_state *const s, uint32_t str, uint32_t count);
 typedef Pos      (* quick_insert_string_cb)(deflate_state *const s, uint32_t str);
+typedef Pos      (* quick_insert_value_cb) (deflate_state *const s, uint32_t str, uint32_t val);
 
 uint32_t update_hash             (uint32_t h, uint32_t val);
 void     insert_string           (deflate_state *const s, uint32_t str, uint32_t count);
 Pos      quick_insert_string     (deflate_state *const s, uint32_t str);
+Pos      quick_insert_value      (deflate_state *const s, uint32_t str, uint32_t val);
 
 uint32_t update_hash_roll        (uint32_t h, uint32_t val);
 void     insert_string_roll      (deflate_state *const s, uint32_t str, uint32_t count);
 Pos      quick_insert_string_roll(deflate_state *const s, uint32_t str);
+Pos      quick_insert_value_roll (deflate_state *const s, uint32_t str, uint32_t val);
 
 /* Struct for memory allocation handling */
 typedef struct deflate_allocs_s {
@@ -233,6 +236,7 @@ struct ALIGNED_(64) internal_state {
     update_hash_cb          update_hash;
     insert_string_cb        insert_string;
     quick_insert_string_cb  quick_insert_string;
+    quick_insert_value_cb   quick_insert_value;
     /* Hash function callbacks that can be configured depending on the deflate
      * algorithm being used */
 

--- a/insert_string.c
+++ b/insert_string.c
@@ -17,5 +17,6 @@
 #define UPDATE_HASH          update_hash
 #define INSERT_STRING        insert_string
 #define QUICK_INSERT_STRING  quick_insert_string
+#define QUICK_INSERT_VALUE   quick_insert_value
 
 #include "insert_string_tpl.h"

--- a/insert_string_roll.c
+++ b/insert_string_roll.c
@@ -20,5 +20,6 @@
 #define UPDATE_HASH          update_hash_roll
 #define INSERT_STRING        insert_string_roll
 #define QUICK_INSERT_STRING  quick_insert_string_roll
+#define QUICK_INSERT_VALUE   quick_insert_value_roll
 
 #include "insert_string_tpl.h"

--- a/insert_string_tpl.h
+++ b/insert_string_tpl.h
@@ -52,6 +52,28 @@ Z_INTERNAL uint32_t UPDATE_HASH(uint32_t h, uint32_t val) {
 }
 
 /* ===========================================================================
+ * Quick insert string str in the dictionary using a pre-read value and set match_head
+ * to the previous head of the hash chain (the most recent string with same hash key).
+ * Return the previous length of the hash chain.
+ */
+Z_INTERNAL Pos QUICK_INSERT_VALUE(deflate_state *const s, uint32_t str, uint32_t val) {
+    uint32_t hm;
+    Pos head;
+
+    HASH_CALC_VAR_INIT;
+    HASH_CALC(HASH_CALC_VAR, val);
+    HASH_CALC_VAR &= HASH_CALC_MASK;
+    hm = HASH_CALC_VAR;
+
+    head = s->head[hm];
+    if (LIKELY(head != str)) {
+        s->prev[str & s->w_mask] = head;
+        s->head[hm] = (Pos)str;
+    }
+    return head;
+}
+
+/* ===========================================================================
  * Quick insert string str in the dictionary and set match_head to the previous head
  * of the hash chain (the most recent string with same hash key). Return
  * the previous length of the hash chain.


### PR DESCRIPTION
Reduces the number of reads by two

trifectatechfoundation/zlib-rs#374
trifectatechfoundation/zlib-rs#375

## Basic benchmarks results

#### Develop
```
OS: Darwin 24.6.0 Darwin Kernel Version 24.6.0: Mon Jul 14 11:29:54 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T8122 arm64
CPU: arm
Tool: /Users/nathan/Source/zlib-ng/build-develop/minigzip Size: 159,688 B
Timing: GNU time (gtime)
Levels: 0-2       
Runs: 70         Trim worst: 40        

 Level   Comp   Comptime min/avg/max/stddev   Compressed size
 0    100.008%      0.020/0.022/0.030/0.004       211,973,953
 1     44.409%      0.630/0.630/0.630/0.000        94,127,497
 2     35.519%      0.960/0.970/0.980/0.003        75,286,322

 avg1  59.979%                        0.541                               
 avg2  89.968%                        0.811                               
 tot                                 48.680       381,387,772
```
#### This PR
```
OS: Darwin 24.6.0 Darwin Kernel Version 24.6.0: Mon Jul 14 11:29:54 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T8122 arm64
CPU: arm
Tool: /Users/nathan/Source/zlib-ng/build-mod2/minigzip Size: 159,768 B
Timing: GNU time (gtime)
Levels: 0-2       
Runs: 70         Trim worst: 40        

 Level   Comp   Comptime min/avg/max/stddev   Compressed size
 0    100.008%      0.020/0.020/0.020/0.000       211,973,953
 1     44.409%      0.590/0.626/0.630/0.010        94,127,497
 2     35.519%      0.940/0.962/0.970/0.006        75,286,322

 avg1  59.979%                        0.536                               
 avg2  89.968%                        0.804                               
 tot                                 48.220       381,387,772
```

### AI evaluation

this PR = mod2

<img width="730" height="689" alt="image" src="https://github.com/user-attachments/assets/685dd20c-4222-43c7-8319-ae8adf7aa775" />



