### PR TITLE
Fixed casting warning in benchmark_uncompress on MSVC

### DIFF
--- a/test/benchmarks/benchmark_uncompress.cc
+++ b/test/benchmarks/benchmark_uncompress.cc
@@ -27,7 +27,7 @@ private:
     uint8_t *outbuff;
     uint8_t *compressed_buff[NUM_TESTS];
     z_uintmax_t compressed_sizes[NUM_TESTS];
-    int64_t sizes[NUM_TESTS] = {1, 64, 1024, 16384, 128*1024, 1024*1024};
+    size_t sizes[NUM_TESTS] = {1, 64, 1024, 16384, 128*1024, 1024*1024};
 
 public:
     void SetUp(const ::benchmark::State& state) {


### PR DESCRIPTION
benchmark_uncompress.cc(55,93): warning C4244: 'argument': conversion from 'int64_t' to 'size_t', possible loss of data