### PR TITLE
configure: Check cc in addition to gcc for GCC compatible compiler

### DIFF
--- a/configure
+++ b/configure
@@ -283,6 +283,14 @@ case $($cc -v 2>&1) in
   *clang*) gcc=1 ;;
 esac
 
+if test "$gcc" -eq 0; then
+  cc=${CC-${CROSS_PREFIX}cc}
+  case $($cc -v 2>&1) in
+    *gcc*) gcc=1 ;;
+    *clang*) gcc=1 ;;
+  esac
+fi
+
 if test $build32 -eq 1; then
   CFLAGS="${CFLAGS} -m32"
   SFLAGS="${SFLAGS} -m32"


### PR DESCRIPTION
If the first try checking for a GCC compatible compiler did not
find anything with gcc(1) then fallback to cc(1).

FreeBSD / OpenBSD no longer use GCC as the system compiler, so gcc(1)
no longer exists. Running ./configure on its own will not find what
it thinks should be GCC compatible compiler and will build a shared
library without -fPIC and fail, but Clang does exist as cc(1).

Fixes building on FreeBSD.