### PR TITLE
Remove w_mask and w_bits from deflate_struct

### DIFF
--- a/arch/s390/dfltcc_deflate.c
+++ b/arch/s390/dfltcc_deflate.c
@@ -60,7 +60,7 @@ static inline int dfltcc_can_deflate_with_params(PREFIX3(streamp) strm, int leve
 int Z_INTERNAL PREFIX(dfltcc_can_deflate)(PREFIX3(streamp) strm) {
     deflate_state *state = (deflate_state *)strm->state;
 
-    return dfltcc_can_deflate_with_params(strm, state->level, state->w_bits, state->strategy, state->reproducible);
+    return dfltcc_can_deflate_with_params(strm, state->level, W_BITS(state), state->strategy, state->reproducible);
 }
 
 static inline void dfltcc_gdht(PREFIX3(streamp) strm) {
@@ -319,7 +319,7 @@ static int dfltcc_was_deflate_used(PREFIX3(streamp) strm) {
 int Z_INTERNAL PREFIX(dfltcc_deflate_params)(PREFIX3(streamp) strm, int level, int strategy, int *flush) {
     deflate_state *state = (deflate_state *)strm->state;
     int could_deflate = PREFIX(dfltcc_can_deflate)(strm);
-    int can_deflate = dfltcc_can_deflate_with_params(strm, level, state->w_bits, strategy, state->reproducible);
+    int can_deflate = dfltcc_can_deflate_with_params(strm, level, W_BITS(state), strategy, state->reproducible);
 
     if (can_deflate == could_deflate)
         /* We continue to work in the same mode - no changes needed */

--- a/deflate.c
+++ b/deflate.c
@@ -303,7 +303,6 @@ int32_t ZNG_CONDEXPORT PREFIX(deflateInit2)(PREFIX3(stream) *strm, int32_t level
     s->gzhead = NULL;
     s->w_bits = (unsigned int)windowBits;
     s->w_size = 1 << s->w_bits;
-    s->w_mask = s->w_size - 1;
 
     s->high_water = 0;      /* nothing written to s->window yet */
 

--- a/deflate.c
+++ b/deflate.c
@@ -301,8 +301,7 @@ int32_t ZNG_CONDEXPORT PREFIX(deflateInit2)(PREFIX3(stream) *strm, int32_t level
 
     s->wrap = wrap;
     s->gzhead = NULL;
-    s->w_bits = (unsigned int)windowBits;
-    s->w_size = 1 << s->w_bits;
+    s->w_size = 1 << windowBits;
 
     s->high_water = 0;      /* nothing written to s->window yet */
 
@@ -717,7 +716,7 @@ unsigned long Z_EXPORT PREFIX(deflateBound)(PREFIX3(stream) *strm, unsigned long
 
     /* if not default parameters, return conservative bound */
     if (DEFLATE_NEED_CONSERVATIVE_BOUND(strm) ||  /* hook for IBM Z DFLTCC */
-            s->w_bits != MAX_WBITS || HASH_BITS < 15) {
+            W_BITS(s) != MAX_WBITS || HASH_BITS < 15) {
         if (s->level == 0) {
             /* upper bound for stored blocks with length 127 (memLevel == 1) --
                ~4% overhead plus a small constant */
@@ -807,7 +806,7 @@ int32_t Z_EXPORT PREFIX(deflate)(PREFIX3(stream) *strm, int32_t flush) {
         s->status = BUSY_STATE;
     if (s->status == INIT_STATE) {
         /* zlib header */
-        unsigned int header = (Z_DEFLATED + ((s->w_bits-8)<<4)) << 8;
+        unsigned int header = (Z_DEFLATED + ((W_BITS(s)-8)<<4)) << 8;
         unsigned int level_flags;
 
         if (s->strategy >= Z_HUFFMAN_ONLY || s->level < 2)
@@ -1079,7 +1078,7 @@ int32_t Z_EXPORT PREFIX(deflateCopy)(PREFIX3(stream) *dest, PREFIX3(stream) *sou
 
     memcpy((void *)dest, (void *)source, sizeof(PREFIX3(stream)));
 
-    deflate_allocs *alloc_bufs = alloc_deflate(dest, ss->w_bits, ss->lit_bufsize);
+    deflate_allocs *alloc_bufs = alloc_deflate(dest, W_BITS(ss), ss->lit_bufsize);
     if (alloc_bufs == NULL)
         return Z_MEM_ERROR;
 

--- a/deflate.h
+++ b/deflate.h
@@ -167,7 +167,6 @@ struct ALIGNED_(64) internal_state {
 
     unsigned int  w_size;            /* LZ77 window size (32K by default) */
     unsigned int  w_bits;            /* log2(w_size)  (8..16) */
-    unsigned int  w_mask;            /* w_size - 1 */
     unsigned int  lookahead;         /* number of valid bytes ahead in window */
 
     unsigned int high_water;
@@ -421,6 +420,9 @@ static inline void put_uint64(deflate_state *s, uint64_t lld) {
 /* In order to simplify the code, particularly on 16 bit machines, match
  * distances are limited to MAX_DIST instead of WSIZE.
  */
+
+#define W_MASK(s)  ((s)->w_size - 1)
+/* Window mask: w_size is always a power of 2, so w_mask = w_size - 1 */
 
 #define WIN_INIT STD_MAX_MATCH
 /* Number of bytes after end of data in window to initialize in order to avoid

--- a/deflate.h
+++ b/deflate.h
@@ -166,6 +166,7 @@ struct ALIGNED_(64) internal_state {
                 /* used by deflate.c: */
 
     unsigned int  w_size;            /* LZ77 window size (32K by default) */
+    unsigned int  padding3[2];
     unsigned int  lookahead;         /* number of valid bytes ahead in window */
 
     unsigned int high_water;

--- a/deflate.h
+++ b/deflate.h
@@ -166,7 +166,6 @@ struct ALIGNED_(64) internal_state {
                 /* used by deflate.c: */
 
     unsigned int  w_size;            /* LZ77 window size (32K by default) */
-    unsigned int  w_bits;            /* log2(w_size)  (8..16) */
     unsigned int  lookahead;         /* number of valid bytes ahead in window */
 
     unsigned int high_water;
@@ -423,6 +422,29 @@ static inline void put_uint64(deflate_state *s, uint64_t lld) {
 
 #define W_MASK(s)  ((s)->w_size - 1)
 /* Window mask: w_size is always a power of 2, so w_mask = w_size - 1 */
+
+#ifdef HAVE_BUILTIN_CTZ
+#  define W_BITS(s)  ((unsigned int)__builtin_ctz((s)->w_size))
+#else
+/* Fallback for w_size which is always a power of 2 between 256 and 32768 */
+static inline unsigned int compute_w_bits(unsigned int w_size) {
+    /* Switch ordered by likelihood - most common first (MAX_WBITS=15 -> 32768) */
+    switch (w_size) {
+        case 32768: return 15;  /* MAX_WBITS default */
+        case 16384: return 14;
+        case  8192: return 13;
+        case  4096: return 12;
+        case  2048: return 11;
+        case  1024: return 10;
+        case   512: return  9;
+        case   256: return  8;
+    }
+    Assert(w_size >= 256 && w_size <= 32768, "invalid w_size");
+    return 0;
+}
+#  define W_BITS(s)  compute_w_bits((s)->w_size)
+#endif
+/* Window bits: log2(w_size), computed from w_size since w_size is a power of 2 */
 
 #define WIN_INIT STD_MAX_MATCH
 /* Number of bytes after end of data in window to initialize in order to avoid

--- a/insert_string_tpl.h
+++ b/insert_string_tpl.h
@@ -67,7 +67,7 @@ Z_INTERNAL Pos QUICK_INSERT_VALUE(deflate_state *const s, uint32_t str, uint32_t
 
     head = s->head[hm];
     if (LIKELY(head != str)) {
-        s->prev[str & s->w_mask] = head;
+        s->prev[str & W_MASK(s)] = head;
         s->head[hm] = (Pos)str;
     }
     return head;
@@ -91,7 +91,7 @@ Z_INTERNAL Pos QUICK_INSERT_STRING(deflate_state *const s, uint32_t str) {
 
     head = s->head[hm];
     if (LIKELY(head != str)) {
-        s->prev[str & s->w_mask] = head;
+        s->prev[str & W_MASK(s)] = head;
         s->head[hm] = (Pos)str;
     }
     return head;
@@ -112,7 +112,7 @@ Z_INTERNAL void INSERT_STRING(deflate_state *const s, uint32_t str, uint32_t cou
     /* Local pointers to avoid indirection */
     Pos *headp = s->head;
     Pos *prevp = s->prev;
-    const unsigned int w_mask = s->w_mask;
+    const unsigned int w_mask = W_MASK(s);
 
     for (Pos idx = (Pos)str; strstart < strend; idx++, strstart++) {
         uint32_t val, hm;

--- a/match_tpl.h
+++ b/match_tpl.h
@@ -28,7 +28,7 @@
  */
 Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
     unsigned int strstart = s->strstart;
-    const unsigned wmask = s->w_mask;
+    const unsigned wmask = W_MASK(s);
     unsigned char *window = s->window;
     unsigned char *scan = window + strstart;
     Z_REGISTER unsigned char *mbase_start = window;

--- a/test/benchmarks/benchmark_insert_string.cc
+++ b/test/benchmarks/benchmark_insert_string.cc
@@ -31,7 +31,6 @@ public:
 
         // Set up window parameters
         s->w_size = MAX_WSIZE;
-        s->w_bits = 15;
         s->window_size = TEST_WINDOW_SIZE;
 
         // Allocate window

--- a/test/benchmarks/benchmark_insert_string.cc
+++ b/test/benchmarks/benchmark_insert_string.cc
@@ -32,7 +32,6 @@ public:
         // Set up window parameters
         s->w_size = MAX_WSIZE;
         s->w_bits = 15;
-        s->w_mask = MAX_WSIZE - 1;
         s->window_size = TEST_WINDOW_SIZE;
 
         // Allocate window


### PR DESCRIPTION
### Develop
```
OS: Darwin 24.6.0 Darwin Kernel Version 24.6.0: Mon Jul 14 11:29:54 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T8122 arm64
CPU: arm
Tool: /Users/nathan/Source/zlib-ng/build-develop/minigzip Size: 159,864 B
Timing: Python perf_counter (GNU time not available)
Levels: 0-9       
Runs: 70         Trim worst: 40        

 Level   Comp   Comptime min/avg/max/stddev  Decomptime min/avg/max/stddev  Compressed size
 0    100.008%      0.112/0.140/0.154/0.011        0.124/0.145/0.161/0.011      211,973,953
 1     44.409%      0.669/0.696/0.702/0.006        0.388/0.400/0.409/0.006       94,127,497
 2     35.519%      1.009/1.019/1.025/0.005        0.380/0.391/0.400/0.007       75,286,322
 3     33.882%      1.238/1.248/1.254/0.004        0.364/0.376/0.384/0.006       71,815,206
 4     33.175%      1.403/1.415/1.424/0.006        0.357/0.365/0.373/0.005       70,317,229
 5     32.661%      1.492/1.501/1.506/0.004        0.355/0.362/0.370/0.004       69,228,146
 6     32.507%      1.755/1.773/1.782/0.007        0.354/0.364/0.371/0.005       68,902,143
 7     32.255%      2.545/2.562/2.569/0.006        0.354/0.362/0.370/0.005       68,366,759
 8     32.167%      3.957/3.990/3.999/0.009        0.354/0.365/0.373/0.005       68,180,762
 9     31.887%      4.362/4.378/4.390/0.007        0.344/0.351/0.358/0.004       67,586,442

 avg1  40.847%                        1.872                          0.348
 avg2  45.386%                        2.080                          0.387
 tot                                561.685                        104.488      865,784,459
```
### PR 
```
OS: Darwin 24.6.0 Darwin Kernel Version 24.6.0: Mon Jul 14 11:29:54 PDT 2025; root:xnu-11417.140.69~1/RELEASE_ARM64_T8122 arm64
CPU: arm
Tool: /Users/nathan/Source/zlib-ng/build-literal/minigzip Size: 159,864 B
Timing: Python perf_counter (GNU time not available)
Levels: 0-9       
Runs: 70         Trim worst: 40        

 Level   Comp   Comptime min/avg/max/stddev  Decomptime min/avg/max/stddev  Compressed size
 0    100.008%      0.105/0.133/0.145/0.010        0.111/0.135/0.149/0.010      211,973,953
 1     44.409%      0.684/0.692/0.696/0.003        0.383/0.397/0.404/0.005       94,127,497
 2     35.519%      0.999/1.010/1.015/0.004        0.373/0.382/0.391/0.006       75,286,322
 3     33.882%      1.242/1.252/1.257/0.004        0.357/0.369/0.377/0.006       71,815,206
 4     33.175%      1.407/1.415/1.420/0.004        0.350/0.362/0.372/0.006       70,317,229
 5     32.661%      1.479/1.488/1.495/0.005        0.345/0.357/0.367/0.006       69,228,146
 6     32.507%      1.747/1.761/1.768/0.005        0.347/0.356/0.363/0.005       68,902,143
 7     32.255%      2.528/2.533/2.539/0.003        0.344/0.355/0.366/0.006       68,366,759
 8     32.167%      3.951/3.962/3.967/0.004        0.347/0.357/0.364/0.005       68,180,762
 9     31.887%      4.371/4.380/4.386/0.005        0.334/0.342/0.350/0.005       67,586,442

 avg1  40.847%                        1.863                          0.341
 avg2  45.386%                        2.070                          0.379
 tot                                558.815                        102.344      865,784,459
```