### PR TITLE
Fix for potentially uninitialized local variable ft used.

### DIFF
--- a/functable.c
+++ b/functable.c
@@ -71,6 +71,7 @@ static int init_functable(void) {
     struct functable_s ft;
     struct cpu_features cf;
 
+    memset(&ft, 0, sizeof(struct functable_s));
     cpu_check_features(&cf);
     ft.force_init = &force_init_empty;
 


### PR DESCRIPTION
The `FUNCTABLE_VERIFY_ASSIGN` macro reads values from `ft` and checks that they are not NULL, but the `ft` variable is not initialized.