### PR TITLE
Series of minor deflate optimizations/cleanups

### DIFF
--- a/arch/arm/arm_functions.h
+++ b/arch/arm/arm_functions.h
@@ -12,8 +12,8 @@ uint8_t* chunkmemset_safe_neon(uint8_t *out, uint8_t *from, unsigned len, unsign
 
 #  ifdef HAVE_BUILTIN_CTZLL
 uint32_t compare256_neon(const uint8_t *src0, const uint8_t *src1);
-uint32_t longest_match_neon(deflate_state *const s, Pos cur_match);
-uint32_t longest_match_slow_neon(deflate_state *const s, Pos cur_match);
+uint32_t longest_match_neon(deflate_state *const s, uint32_t cur_match);
+uint32_t longest_match_slow_neon(deflate_state *const s, uint32_t cur_match);
 #  endif
 void slide_hash_neon(deflate_state *s);
 void inflate_fast_neon(PREFIX3(stream) *strm, uint32_t start);

--- a/arch/generic/generic_functions.h
+++ b/arch/generic/generic_functions.h
@@ -43,8 +43,8 @@ uint32_t crc32_fold_final_c(crc32_fold *crc);
 
 void     inflate_fast_c(PREFIX3(stream) *strm, uint32_t start);
 
-uint32_t longest_match_c(deflate_state *const s, Pos cur_match);
-uint32_t longest_match_slow_c(deflate_state *const s, Pos cur_match);
+uint32_t longest_match_c(deflate_state *const s, uint32_t cur_match);
+uint32_t longest_match_slow_c(deflate_state *const s, uint32_t cur_match);
 
 void     slide_hash_c(deflate_state *s);
 

--- a/arch/loongarch/loongarch_functions.h
+++ b/arch/loongarch/loongarch_functions.h
@@ -20,8 +20,8 @@ uint32_t adler32_copy_lsx(uint32_t adler, uint8_t *dst, const uint8_t *src, size
 void slide_hash_lsx(deflate_state *s);
 #  ifdef HAVE_BUILTIN_CTZ
     uint32_t compare256_lsx(const uint8_t *src0, const uint8_t *src1);
-    uint32_t longest_match_lsx(deflate_state *const s, Pos cur_match);
-    uint32_t longest_match_slow_lsx(deflate_state *const s, Pos cur_match);
+    uint32_t longest_match_lsx(deflate_state *const s, uint32_t cur_match);
+    uint32_t longest_match_slow_lsx(deflate_state *const s, uint32_t cur_match);
 #  endif
 uint8_t* chunkmemset_safe_lsx(uint8_t *out, uint8_t *from, unsigned len, unsigned left);
 void inflate_fast_lsx(PREFIX3(stream) *strm, uint32_t start);
@@ -33,8 +33,8 @@ uint32_t adler32_copy_lasx(uint32_t adler, uint8_t *dst, const uint8_t *src, siz
 void slide_hash_lasx(deflate_state *s);
 #  ifdef HAVE_BUILTIN_CTZ
     uint32_t compare256_lasx(const uint8_t *src0, const uint8_t *src1);
-    uint32_t longest_match_lasx(deflate_state *const s, Pos cur_match);
-    uint32_t longest_match_slow_lasx(deflate_state *const s, Pos cur_match);
+    uint32_t longest_match_lasx(deflate_state *const s, uint32_t cur_match);
+    uint32_t longest_match_slow_lasx(deflate_state *const s, uint32_t cur_match);
 #  endif
 uint8_t* chunkmemset_safe_lasx(uint8_t *out, uint8_t *from, unsigned len, unsigned left);
 void inflate_fast_lasx(PREFIX3(stream) *strm, uint32_t start);

--- a/arch/power/power_functions.h
+++ b/arch/power/power_functions.h
@@ -22,8 +22,8 @@ void inflate_fast_power8(PREFIX3(stream) *strm, uint32_t start);
 
 #ifdef POWER9
 uint32_t compare256_power9(const uint8_t *src0, const uint8_t *src1);
-uint32_t longest_match_power9(deflate_state *const s, Pos cur_match);
-uint32_t longest_match_slow_power9(deflate_state *const s, Pos cur_match);
+uint32_t longest_match_power9(deflate_state *const s, uint32_t cur_match);
+uint32_t longest_match_slow_power9(deflate_state *const s, uint32_t cur_match);
 #endif
 
 

--- a/arch/riscv/riscv_functions.h
+++ b/arch/riscv/riscv_functions.h
@@ -15,8 +15,8 @@ uint32_t adler32_copy_rvv(uint32_t adler, uint8_t *dst, const uint8_t *src, size
 uint8_t* chunkmemset_safe_rvv(uint8_t *out, uint8_t *from, unsigned len, unsigned left);
 uint32_t compare256_rvv(const uint8_t *src0, const uint8_t *src1);
 
-uint32_t longest_match_rvv(deflate_state *const s, Pos cur_match);
-uint32_t longest_match_slow_rvv(deflate_state *const s, Pos cur_match);
+uint32_t longest_match_rvv(deflate_state *const s, uint32_t cur_match);
+uint32_t longest_match_slow_rvv(deflate_state *const s, uint32_t cur_match);
 void slide_hash_rvv(deflate_state *s);
 void inflate_fast_rvv(PREFIX3(stream) *strm, uint32_t start);
 #endif

--- a/arch/x86/x86_functions.h
+++ b/arch/x86/x86_functions.h
@@ -19,8 +19,8 @@ uint8_t* chunkmemset_safe_sse2(uint8_t *out, uint8_t *from, unsigned len, unsign
 
 #  ifdef HAVE_BUILTIN_CTZ
     uint32_t compare256_sse2(const uint8_t *src0, const uint8_t *src1);
-    uint32_t longest_match_sse2(deflate_state *const s, Pos cur_match);
-    uint32_t longest_match_slow_sse2(deflate_state *const s, Pos cur_match);
+    uint32_t longest_match_sse2(deflate_state *const s, uint32_t cur_match);
+    uint32_t longest_match_slow_sse2(deflate_state *const s, uint32_t cur_match);
 #  endif
     void slide_hash_sse2(deflate_state *s);
     void inflate_fast_sse2(PREFIX3(stream)* strm, uint32_t start);
@@ -51,8 +51,8 @@ uint8_t* chunkmemset_safe_avx2(uint8_t *out, uint8_t *from, unsigned len, unsign
 
 #  ifdef HAVE_BUILTIN_CTZ
     uint32_t compare256_avx2(const uint8_t *src0, const uint8_t *src1);
-    uint32_t longest_match_avx2(deflate_state *const s, Pos cur_match);
-    uint32_t longest_match_slow_avx2(deflate_state *const s, Pos cur_match);
+    uint32_t longest_match_avx2(deflate_state *const s, uint32_t cur_match);
+    uint32_t longest_match_slow_avx2(deflate_state *const s, uint32_t cur_match);
 #  endif
     void slide_hash_avx2(deflate_state *s);
     void inflate_fast_avx2(PREFIX3(stream)* strm, uint32_t start);
@@ -64,8 +64,8 @@ uint8_t* chunkmemset_safe_avx512(uint8_t *out, uint8_t *from, unsigned len, unsi
 void inflate_fast_avx512(PREFIX3(stream)* strm, uint32_t start);
 #  ifdef HAVE_BUILTIN_CTZLL
     uint32_t compare256_avx512(const uint8_t *src0, const uint8_t *src1);
-    uint32_t longest_match_avx512(deflate_state *const s, Pos cur_match);
-    uint32_t longest_match_slow_avx512(deflate_state *const s, Pos cur_match);
+    uint32_t longest_match_avx512(deflate_state *const s, uint32_t cur_match);
+    uint32_t longest_match_slow_avx512(deflate_state *const s, uint32_t cur_match);
 #  endif
 #endif
 #ifdef X86_AVX512VNNI

--- a/deflate.h
+++ b/deflate.h
@@ -196,7 +196,7 @@ struct ALIGNED_(64) internal_state {
      */
 
     unsigned int match_length;       /* length of best match */
-    Pos          prev_match;         /* previous match */
+    uint32_t     prev_match;         /* previous match */
     int          match_available;    /* set if previous match exists */
     unsigned int strstart;           /* start of string to insert */
     unsigned int match_start;        /* start of matching string */

--- a/deflate.h
+++ b/deflate.h
@@ -221,17 +221,12 @@ struct ALIGNED_(64) internal_state {
      * max_insert_length is used only for compression levels <= 6.
      */
 
-    int level;    /* compression level (1..9) */
-    int strategy; /* favor or force Huffman coding*/
-
-    unsigned int good_match;
-    /* Use a faster search when the previous match is longer than this */
-
-    int nice_match; /* Stop searching when current match exceeds this */
-
-#if defined(_M_IX86) || defined(_M_ARM)
-    int padding[2];
-#endif
+    int level;                  /* compression level (1..9) */
+    int strategy;               /* favor or force Huffman coding*/
+    unsigned int good_match;    /* Use a faster search when the previous match is longer than this */
+    int nice_match;             /* Stop searching when current match exceeds this */
+    unsigned int matches;       /* number of string matches in current block */
+    unsigned int insert;        /* bytes at end of window left to insert */
 
     struct crc32_fold_s ALIGNED_(16) crc_fold;
 
@@ -291,14 +286,8 @@ struct ALIGNED_(64) internal_state {
     unsigned int sym_next;        /* running index in symbol buffer */
     unsigned int sym_end;         /* symbol table full when sym_next reaches this */
 
-    unsigned long opt_len;        /* bit length of current block with optimal trees */
-    unsigned long static_len;     /* bit length of current block with static trees */
-    unsigned int matches;         /* number of string matches in current block */
-    unsigned int insert;          /* bytes at end of window left to insert */
-
-    /* compressed_len and bits_sent are only used if ZLIB_DEBUG is defined */
-    unsigned long compressed_len; /* total bit length of compressed file mod 2^32 */
-    unsigned long bits_sent;      /* bit length of compressed data sent mod 2^32 */
+    unsigned int opt_len;         /* bit length of current block with optimal trees */
+    unsigned int static_len;      /* bit length of current block with static trees */
 
     deflate_allocs *alloc_bufs;
 
@@ -312,11 +301,14 @@ struct ALIGNED_(64) internal_state {
     int32_t bi_valid;
     /* Number of valid bits in bi_buf.  All bits above the last valid bit are always zero. */
 
+    /* compressed_len and bits_sent are only used if ZLIB_DEBUG is defined */
+#ifdef ZLIB_DEBUG
+    unsigned long compressed_len; /* total bit length of compressed file mod 2^32 */
+    unsigned long bits_sent;      /* bit length of compressed data sent mod 2^32 */
+#endif
+
     /* Reserved for future use and alignment purposes */
     int32_t reserved[19];
-#if defined(_M_IX86) || defined(_M_ARM)
-    int32_t padding2[4];
-#endif
 };
 
 typedef enum {

--- a/deflate_fast.c
+++ b/deflate_fast.c
@@ -49,7 +49,7 @@ Z_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
 #else
             uint32_t str_val = ZSWAP32(zng_memread_4(window + s->strstart));
 #endif
-            Pos hash_head = quick_insert_value(s, s->strstart, str_val);
+            uint32_t hash_head = quick_insert_value(s, s->strstart, str_val);
             int64_t dist = (int64_t)s->strstart - hash_head;
             lc = (uint8_t)str_val;
 
@@ -71,7 +71,7 @@ Z_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
         if (match_len >= WANT_MIN_MATCH) {
             Assert(s->strstart <= UINT16_MAX, "strstart should fit in uint16_t");
             Assert(s->match_start <= UINT16_MAX, "match_start should fit in uint16_t");
-            check_match(s, (Pos)s->strstart, (Pos)s->match_start, match_len);
+            check_match(s, s->strstart, s->match_start, match_len);
 
             bflush = zng_tr_tally_dist(s, s->strstart - s->match_start, match_len - STD_MIN_MATCH);
 

--- a/deflate_fast.c
+++ b/deflate_fast.c
@@ -45,9 +45,9 @@ Z_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
          */
         if (s->lookahead >= WANT_MIN_MATCH) {
 #if BYTE_ORDER == LITTLE_ENDIAN
-            uint32_t str_val = zng_memread_4(&window[s->strstart]);
+            uint32_t str_val = zng_memread_4(window + s->strstart);
 #else
-            uint32_t str_val = ZSWAP32(zng_memread_4(&window[s->strstart]));
+            uint32_t str_val = ZSWAP32(zng_memread_4(window + s->strstart));
 #endif
             Pos hash_head = quick_insert_value(s, s->strstart, str_val);
             int64_t dist = (int64_t)s->strstart - hash_head;

--- a/deflate_fast.c
+++ b/deflate_fast.c
@@ -19,6 +19,7 @@
  * matches. It is used only for the fast compression options.
  */
 Z_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
+    unsigned char *window = s->window;
     int bflush = 0;       /* set if current block must be flushed */
     uint32_t match_len = 0;
 
@@ -44,9 +45,9 @@ Z_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
          */
         if (s->lookahead >= WANT_MIN_MATCH) {
 #if BYTE_ORDER == LITTLE_ENDIAN
-            uint32_t str_val = zng_memread_4(&s->window[s->strstart]);
+            uint32_t str_val = zng_memread_4(&window[s->strstart]);
 #else
-            uint32_t str_val = ZSWAP32(zng_memread_4(&s->window[s->strstart]));
+            uint32_t str_val = ZSWAP32(zng_memread_4(&window[s->strstart]));
 #endif
             Pos hash_head = quick_insert_value(s, s->strstart, str_val);
             int64_t dist = (int64_t)s->strstart - hash_head;
@@ -64,7 +65,7 @@ Z_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
                 /* longest_match() sets match_start */
             }
         } else {
-            lc = s->window[s->strstart];
+            lc = window[s->strstart];
         }
 
         if (match_len >= WANT_MIN_MATCH) {

--- a/deflate_fast.c
+++ b/deflate_fast.c
@@ -61,7 +61,7 @@ Z_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
                  * of window index 0 (in particular we have to avoid a match
                  * of the string with itself at the start of the input file).
                  */
-                match_len = FUNCTABLE_CALL(longest_match)(s, hash_head);
+                match_len = FUNCTABLE_CALL(longest_match)(s, (uint32_t)hash_head);
                 /* longest_match() sets match_start */
             }
         } else {

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -96,10 +96,11 @@ static void insert_match(deflate_state *s, struct match match) {
 }
 
 static void fizzle_matches(deflate_state *s, struct match *current, struct match *next) {
-    Pos limit;
+    unsigned char *window;
     unsigned char *match, *orig;
-    int changed = 0;
     struct match c, n;
+    int changed = 0;
+    Pos limit;
     /* step zero: sanity checks */
 
     if (current->match_length <= 1)
@@ -111,8 +112,10 @@ static void fizzle_matches(deflate_state *s, struct match *current, struct match
     if (UNLIKELY(current->match_length > 1 + next->strstart))
         return;
 
-    match = s->window - current->match_length + 1 + next->match_start;
-    orig  = s->window - current->match_length + 1 + next->strstart;
+    window = s->window;
+
+    match = window - current->match_length + 1 + next->match_start;
+    orig  = window - current->match_length + 1 + next->strstart;
 
     /* quick exit check.. if this fails then don't bother with anything else */
     if (LIKELY(*match != *orig))
@@ -124,8 +127,8 @@ static void fizzle_matches(deflate_state *s, struct match *current, struct match
     /* step one: try to move the "next" match to the left as much as possible */
     limit = next->strstart > MAX_DIST(s) ? next->strstart - (Pos)MAX_DIST(s) : 0;
 
-    match = s->window + n.match_start - 1;
-    orig = s->window + n.strstart - 1;
+    match = window + n.match_start - 1;
+    orig = window + n.strstart - 1;
 
     while (*match == *orig) {
         if (UNLIKELY(c.match_length < 1))

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -219,7 +219,7 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
                  * of window index 0 (in particular we have to avoid a match
                  * of the string with itself at the start of the input file).
                  */
-                current_match.match_length = (uint16_t)FUNCTABLE_CALL(longest_match)(s, hash_head);
+                current_match.match_length = (uint16_t)FUNCTABLE_CALL(longest_match)(s, (uint32_t)hash_head);
                 current_match.match_start = (uint16_t)s->match_start;
                 if (UNLIKELY(current_match.match_length < WANT_MIN_MATCH))
                     current_match.match_length = 1;

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -173,7 +173,7 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
     memset(&next_match, 0, sizeof(struct match));
 
     for (;;) {
-        Pos hash_head = 0;    /* head of the hash chain */
+        uint32_t hash_head = 0;    /* head of the hash chain */
         int bflush = 0;       /* set if current block must be flushed */
         int64_t dist;
 
@@ -219,7 +219,7 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
                  * of window index 0 (in particular we have to avoid a match
                  * of the string with itself at the start of the input file).
                  */
-                current_match.match_length = (uint16_t)FUNCTABLE_CALL(longest_match)(s, (uint32_t)hash_head);
+                current_match.match_length = (uint16_t)FUNCTABLE_CALL(longest_match)(s, hash_head);
                 current_match.match_start = (uint16_t)s->match_start;
                 if (UNLIKELY(current_match.match_length < WANT_MIN_MATCH))
                     current_match.match_length = 1;

--- a/deflate_p.h
+++ b/deflate_p.h
@@ -192,6 +192,6 @@ Z_FORCEINLINE static unsigned read_buf(PREFIX3(stream) *strm, unsigned char *buf
 /* Compression function. Returns the block state after the call. */
 typedef block_state (*compress_func) (deflate_state *s, int flush);
 /* Match function. Returns the longest match. */
-typedef uint32_t    (*match_func)    (deflate_state *const s, Pos cur_match);
+typedef uint32_t    (*match_func)    (deflate_state *const s, uint32_t cur_match);
 
 #endif

--- a/deflate_p.h
+++ b/deflate_p.h
@@ -18,7 +18,7 @@
 /* ===========================================================================
  * Check that the match at match_start is indeed a match.
  */
-static inline void check_match(deflate_state *s, Pos start, Pos match, int length) {
+static inline void check_match(deflate_state *s, uint32_t start, uint32_t match, int length) {
     /* check that the match length is valid*/
     if (length < STD_MIN_MATCH || length > STD_MAX_MATCH) {
         fprintf(stderr, " start %u, match %u, length %d\n", start, match, length);

--- a/deflate_quick.c
+++ b/deflate_quick.c
@@ -89,9 +89,9 @@ Z_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
 
         if (LIKELY(s->lookahead >= WANT_MIN_MATCH)) {
 #if BYTE_ORDER == LITTLE_ENDIAN
-            uint32_t str_val = zng_memread_4(&window[s->strstart]);
+            uint32_t str_val = zng_memread_4(window + s->strstart);
 #else
-            uint32_t str_val = ZSWAP32(zng_memread_4(&window[s->strstart]));
+            uint32_t str_val = ZSWAP32(zng_memread_4(window + s->strstart));
 #endif
             Pos hash_head = quick_insert_value(s, s->strstart, str_val);
             int64_t dist = (int64_t)s->strstart - hash_head;

--- a/deflate_quick.c
+++ b/deflate_quick.c
@@ -93,7 +93,7 @@ Z_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
 #else
             uint32_t str_val = ZSWAP32(zng_memread_4(window + s->strstart));
 #endif
-            Pos hash_head = quick_insert_value(s, s->strstart, str_val);
+            uint32_t hash_head = quick_insert_value(s, s->strstart, str_val);
             int64_t dist = (int64_t)s->strstart - hash_head;
             lc = (uint8_t)str_val;
 
@@ -115,7 +115,7 @@ Z_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
 
                         Assert(match_len <= STD_MAX_MATCH, "match too long");
                         Assert(s->strstart <= UINT16_MAX, "strstart should fit in uint16_t");
-                        check_match(s, (Pos)s->strstart, hash_head, match_len);
+                        check_match(s, s->strstart, hash_head, match_len);
 
                         zng_tr_emit_dist(s, static_ltree, static_dtree, match_len - STD_MIN_MATCH, (uint32_t)dist);
                         s->lookahead -= match_len;

--- a/deflate_quick.c
+++ b/deflate_quick.c
@@ -108,9 +108,8 @@ Z_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
                     if (match_len >= WANT_MIN_MATCH) {
                         if (UNLIKELY(match_len > s->lookahead))
                             match_len = s->lookahead;
-                        if (UNLIKELY(match_len > STD_MAX_MATCH))
-                            match_len = STD_MAX_MATCH;
 
+                        Assert(match_len <= STD_MAX_MATCH, "match too long");
                         Assert(s->strstart <= UINT16_MAX, "strstart should fit in uint16_t");
                         check_match(s, (Pos)s->strstart, hash_head, match_len);
 

--- a/deflate_rle.c
+++ b/deflate_rle.c
@@ -57,7 +57,7 @@ Z_INTERNAL block_state deflate_rle(deflate_state *s, int flush) {
         /* Emit match if have run of STD_MIN_MATCH or longer, else emit literal */
         if (match_len >= STD_MIN_MATCH) {
             Assert(s->strstart <= UINT16_MAX, "strstart should fit in uint16_t");
-            check_match(s, (Pos)s->strstart, (Pos)(s->strstart - 1), match_len);
+            check_match(s, s->strstart, s->strstart - 1, match_len);
 
             bflush = zng_tr_tally_dist(s, 1, match_len - STD_MIN_MATCH);
 

--- a/deflate_slow.c
+++ b/deflate_slow.c
@@ -49,7 +49,7 @@ Z_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
         /* Insert the string window[strstart .. strstart+2] in the
          * dictionary, and set hash_head to the head of the hash chain:
          */
-        Pos hash_head = 0;
+        uint32_t hash_head = 0;
         if (LIKELY(s->lookahead >= WANT_MIN_MATCH)) {
             if (level >= 9)
                 hash_head = quick_insert_string_roll(s, s->strstart);
@@ -59,7 +59,7 @@ Z_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
 
         /* Find the longest match, discarding those <= prev_length.
          */
-        s->prev_match = (Pos)s->match_start;
+        s->prev_match = s->match_start;
         uint32_t match_len = STD_MIN_MATCH - 1;
         int64_t dist = (int64_t)s->strstart - hash_head;
 
@@ -68,7 +68,7 @@ Z_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
              * of window index 0 (in particular we have to avoid a match
              * of the string with itself at the start of the input file).
              */
-            match_len = longest_match(s, (uint32_t)hash_head);
+            match_len = longest_match(s, hash_head);
             /* longest_match() sets match_start */
 
             if (match_len <= 5 && (s->strategy == Z_FILTERED)) {
@@ -86,7 +86,7 @@ Z_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
             /* Do not insert strings in hash table beyond this. */
 
             Assert((s->strstart-1) <= UINT16_MAX, "strstart-1 should fit in uint16_t");
-            check_match(s, (Pos)(s->strstart - 1), s->prev_match, s->prev_length);
+            check_match(s, s->strstart - 1, s->prev_match, s->prev_length);
 
             bflush = zng_tr_tally_dist(s, s->strstart -1 - s->prev_match, s->prev_length - STD_MIN_MATCH);
 

--- a/deflate_slow.c
+++ b/deflate_slow.c
@@ -68,7 +68,7 @@ Z_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
              * of window index 0 (in particular we have to avoid a match
              * of the string with itself at the start of the input file).
              */
-            match_len = longest_match(s, hash_head);
+            match_len = longest_match(s, (uint32_t)hash_head);
             /* longest_match() sets match_start */
 
             if (match_len <= 5 && (s->strategy == Z_FILTERED)) {

--- a/functable.c
+++ b/functable.c
@@ -428,12 +428,12 @@ static void inflate_fast_stub(PREFIX3(stream) *strm, uint32_t start) {
     functable.inflate_fast(strm, start);
 }
 
-static uint32_t longest_match_stub(deflate_state* const s, Pos cur_match) {
+static uint32_t longest_match_stub(deflate_state* const s, uint32_t cur_match) {
     FUNCTABLE_INIT_ABORT;
     return functable.longest_match(s, cur_match);
 }
 
-static uint32_t longest_match_slow_stub(deflate_state* const s, Pos cur_match) {
+static uint32_t longest_match_slow_stub(deflate_state* const s, uint32_t cur_match) {
     FUNCTABLE_INIT_ABORT;
     return functable.longest_match_slow(s, cur_match);
 }

--- a/functable.h
+++ b/functable.h
@@ -35,8 +35,8 @@ struct functable_s {
     uint32_t (* crc32_fold_final)   (struct crc32_fold_s *crc);
     uint32_t (* crc32_fold_reset)   (struct crc32_fold_s *crc);
     void     (* inflate_fast)       (PREFIX3(stream) *strm, uint32_t start);
-    uint32_t (* longest_match)      (deflate_state *const s, Pos cur_match);
-    uint32_t (* longest_match_slow) (deflate_state *const s, Pos cur_match);
+    uint32_t (* longest_match)      (deflate_state *const s, uint32_t cur_match);
+    uint32_t (* longest_match_slow) (deflate_state *const s, uint32_t cur_match);
     void     (* slide_hash)         (deflate_state *s);
 };
 

--- a/insert_string_tpl.h
+++ b/insert_string_tpl.h
@@ -45,9 +45,8 @@ Z_FORCEINLINE static uint32_t UPDATE_HASH(uint32_t h, uint32_t val) {
  * to the previous head of the hash chain (the most recent string with same hash key).
  * Return the previous length of the hash chain.
  */
-Z_FORCEINLINE static Pos QUICK_INSERT_VALUE(deflate_state *const s, uint32_t str, uint32_t val) {
-    uint32_t hm;
-    Pos head;
+Z_FORCEINLINE static uint32_t QUICK_INSERT_VALUE(deflate_state *const s, uint32_t str, uint32_t val) {
+    uint32_t hm, head;
 
     HASH_CALC_VAR_INIT;
     HASH_CALC(HASH_CALC_VAR, val);
@@ -56,7 +55,7 @@ Z_FORCEINLINE static Pos QUICK_INSERT_VALUE(deflate_state *const s, uint32_t str
 
     head = s->head[hm];
     if (LIKELY(head != str)) {
-        s->prev[str & W_MASK(s)] = head;
+        s->prev[str & W_MASK(s)] = (Pos)head;
         s->head[hm] = (Pos)str;
     }
     return head;
@@ -67,10 +66,9 @@ Z_FORCEINLINE static Pos QUICK_INSERT_VALUE(deflate_state *const s, uint32_t str
  * of the hash chain (the most recent string with same hash key). Return
  * the previous length of the hash chain.
  */
-Z_FORCEINLINE static Pos QUICK_INSERT_STRING(deflate_state *const s, uint32_t str) {
+Z_FORCEINLINE static uint32_t QUICK_INSERT_STRING(deflate_state *const s, uint32_t str) {
     uint8_t *strstart = s->window + str + HASH_CALC_OFFSET;
-    uint32_t val, hm;
-    Pos head;
+    uint32_t val, hm, head;
 
     HASH_CALC_VAR_INIT;
     HASH_CALC_READ;
@@ -80,7 +78,7 @@ Z_FORCEINLINE static Pos QUICK_INSERT_STRING(deflate_state *const s, uint32_t st
 
     head = s->head[hm];
     if (LIKELY(head != str)) {
-        s->prev[str & W_MASK(s)] = head;
+        s->prev[str & W_MASK(s)] = (Pos)head;
         s->head[hm] = (Pos)str;
     }
     return head;
@@ -103,8 +101,8 @@ Z_FORCEINLINE static void INSERT_STRING(deflate_state *const s, uint32_t str, ui
     Pos *prevp = s->prev;
     const unsigned int w_mask = W_MASK(s);
 
-    for (Pos idx = (Pos)str; strstart < strend; idx++, strstart++) {
-        uint32_t val, hm;
+    for (uint32_t idx = str; strstart < strend; idx++, strstart++) {
+        uint32_t val, hm, head;
 
         HASH_CALC_VAR_INIT;
         HASH_CALC_READ;
@@ -112,10 +110,10 @@ Z_FORCEINLINE static void INSERT_STRING(deflate_state *const s, uint32_t str, ui
         HASH_CALC_VAR &= HASH_CALC_MASK;
         hm = HASH_CALC_VAR;
 
-        Pos head = headp[hm];
+        head = headp[hm];
         if (LIKELY(head != idx)) {
-            prevp[idx & w_mask] = head;
-            headp[hm] = idx;
+            prevp[idx & w_mask] = (Pos)head;
+            headp[hm] = (Pos)idx;
         }
     }
 }

--- a/match_tpl.h
+++ b/match_tpl.h
@@ -238,10 +238,10 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
 #ifdef LONGEST_MATCH_SLOW
 break_matching:
 
-    if (best_len < s->lookahead)
+    if (best_len < lookahead)
         return best_len;
 
-    return s->lookahead;
+    return lookahead;
 #endif
 }
 

--- a/match_tpl.h
+++ b/match_tpl.h
@@ -28,7 +28,7 @@
  * The LONGEST_MATCH_SLOW variant spends more time to attempt to find longer
  * matches once a match has already been found.
  */
-Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
+Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, uint32_t cur_match) {
     const unsigned wmask = W_MASK(s);
     unsigned int strstart = s->strstart;
     const unsigned char *window = s->window;
@@ -39,9 +39,9 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
     const unsigned char *scan;
     const unsigned char *mbase_start = window;
     const unsigned char *mbase_end;
-    Pos limit;
+    uint32_t limit;
 #ifdef LONGEST_MATCH_SLOW
-    Pos limit_base;
+    uint32_t limit_base;
 #else
     int32_t early_exit;
 #endif
@@ -49,7 +49,7 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
     uint32_t nice_match = (uint32_t)s->nice_match;
     uint32_t best_len, offset;
     uint32_t lookahead = s->lookahead;
-    Pos match_offset = 0;
+    uint32_t match_offset = 0;
     uint64_t scan_start;
     uint64_t scan_end;
 
@@ -80,13 +80,13 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
     /* Stop when cur_match becomes <= limit. To simplify the code,
      * we prevent matches with the string of window index 0
      */
-    limit = strstart > MAX_DIST(s) ? (Pos)(strstart - MAX_DIST(s)) : 0;
+    limit = strstart > MAX_DIST(s) ? (strstart - MAX_DIST(s)) : 0;
 #ifdef LONGEST_MATCH_SLOW
     limit_base = limit;
     if (best_len >= STD_MIN_MATCH) {
         /* We're continuing search (lazy evaluation). */
         uint32_t hash;
-        Pos pos;
+        uint32_t pos;
 
         /* Find a most distant chain starting from scan with index=1 (index=0 corresponds
          * to cur_match). We cannot use s->prev[strstart+1,...] immediately, because
@@ -102,7 +102,7 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
             /* If we're starting with best_len >= 3, we can use offset search. */
             pos = head[hash];
             if (pos < cur_match) {
-                match_offset = (Pos)(i - 2);
+                match_offset = i - 2;
                 cur_match = pos;
             }
         }
@@ -180,7 +180,7 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
             if (UNLIKELY(len > STD_MIN_MATCH && match_start + len < strstart)) {
                 const unsigned char *scan_endstr;
                 uint32_t hash;
-                Pos pos, next_pos;
+                uint32_t pos, next_pos;
 
                 /* Go back to offset 0 */
                 cur_match -= match_offset;
@@ -193,7 +193,7 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
                         if (pos <= limit_base + i)
                             goto break_matching;
                         next_pos = pos;
-                        match_offset = (Pos)i;
+                        match_offset = i;
                     }
                 }
                 /* Switch cur_match to next_pos chain */
@@ -213,7 +213,7 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
 
                 pos = head[hash];
                 if (pos < cur_match) {
-                    match_offset = (Pos)(len - (STD_MIN_MATCH+1));
+                    match_offset = len - (STD_MIN_MATCH+1);
                     if (pos <= limit_base + match_offset)
                         goto break_matching;
                     cur_match = pos;

--- a/match_tpl.h
+++ b/match_tpl.h
@@ -12,6 +12,11 @@
 
 #define EARLY_EXIT_TRIGGER_LEVEL 5
 
+#define GOTO_NEXT_CHAIN \
+    if (--chain_length && (cur_match = prev[cur_match & wmask]) > limit) \
+        continue; \
+    return best_len;
+
 /* Set match_start to the longest match starting at the given string and
  * return its length. Matches shorter or equal to prev_length are discarded,
  * in which case the result is equal to prev_length and match_start is garbage.
@@ -42,11 +47,6 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
     Pos match_offset = 0;
     uint64_t scan_start;
     uint64_t scan_end;
-
-#define GOTO_NEXT_CHAIN \
-    if (--chain_length && (cur_match = prev[cur_match & wmask]) > limit) \
-        continue; \
-    return best_len;
 
     /* The code is optimized for STD_MAX_MATCH-2 multiple of 16. */
     Assert(STD_MAX_MATCH == 258, "Code too clever");

--- a/match_tpl.h
+++ b/match_tpl.h
@@ -29,20 +29,25 @@
  * matches once a match has already been found.
  */
 Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
-    unsigned int strstart = s->strstart;
     const unsigned wmask = W_MASK(s);
-    unsigned char *window = s->window;
-    unsigned char *scan = window + strstart;
-    Z_REGISTER unsigned char *mbase_start = window;
-    Z_REGISTER unsigned char *mbase_end;
+    unsigned int strstart = s->strstart;
+    const unsigned char *window = s->window;
     const Pos *prev = s->prev;
+#ifdef LONGEST_MATCH_SLOW
+    const Pos *head = s->head;
+#endif
+    const unsigned char *scan;
+    const unsigned char *mbase_start = window;
+    const unsigned char *mbase_end;
     Pos limit;
 #ifdef LONGEST_MATCH_SLOW
     Pos limit_base;
 #else
     int32_t early_exit;
 #endif
-    uint32_t chain_length, nice_match, best_len, offset;
+    uint32_t chain_length = s->max_chain_length;
+    uint32_t nice_match = (uint32_t)s->nice_match;
+    uint32_t best_len, offset;
     uint32_t lookahead = s->lookahead;
     Pos match_offset = 0;
     uint64_t scan_start;
@@ -51,6 +56,7 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
     /* The code is optimized for STD_MAX_MATCH-2 multiple of 16. */
     Assert(STD_MAX_MATCH == 258, "Code too clever");
 
+    scan = window + strstart;
     best_len = s->prev_length ? s->prev_length : STD_MIN_MATCH-1;
 
     /* Calculate read offset which should only extend an extra byte
@@ -68,10 +74,8 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
     mbase_end  = (mbase_start+offset);
 
     /* Do not waste too much time if we already have a good match */
-    chain_length = s->max_chain_length;
     if (best_len >= s->good_match)
         chain_length >>= 2;
-    nice_match = (uint32_t)s->nice_match;
 
     /* Stop when cur_match becomes <= limit. To simplify the code,
      * we prevent matches with the string of window index 0
@@ -81,7 +85,7 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
     limit_base = limit;
     if (best_len >= STD_MIN_MATCH) {
         /* We're continuing search (lazy evaluation). */
-        uint32_t i, hash;
+        uint32_t hash;
         Pos pos;
 
         /* Find a most distant chain starting from scan with index=1 (index=0 corresponds
@@ -92,11 +96,11 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
         hash = update_hash_roll(0, scan[1]);
         hash = update_hash_roll(hash, scan[2]);
 
-        for (i = 3; i <= best_len; i++) {
+        for (uint32_t i = 3; i <= best_len; i++) {
             // use update_hash_roll for deflate_slow
             hash = update_hash_roll(hash, scan[i]);
             /* If we're starting with best_len >= 3, we can use offset search. */
-            pos = s->head[hash];
+            pos = head[hash];
             if (pos < cur_match) {
                 match_offset = (Pos)(i - 2);
                 cur_match = pos;
@@ -157,9 +161,10 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
             /* Do not look for matches beyond the end of the input. */
             if (len > lookahead)
                 return lookahead;
+            if (len >= nice_match)
+                return len;
+
             best_len = len;
-            if (best_len >= nice_match)
-                return best_len;
 
             offset = best_len-1;
             if (best_len >= sizeof(uint32_t)) {
@@ -173,15 +178,15 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
 #ifdef LONGEST_MATCH_SLOW
             /* Look for a better string offset */
             if (UNLIKELY(len > STD_MIN_MATCH && match_start + len < strstart)) {
+                const unsigned char *scan_endstr;
+                uint32_t hash;
                 Pos pos, next_pos;
-                uint32_t i, hash;
-                unsigned char *scan_endstr;
 
                 /* Go back to offset 0 */
                 cur_match -= match_offset;
                 match_offset = 0;
                 next_pos = cur_match;
-                for (i = 0; i <= len - STD_MIN_MATCH; i++) {
+                for (uint32_t i = 0; i <= len - STD_MIN_MATCH; i++) {
                     pos = prev[(cur_match + i) & wmask];
                     if (pos < next_pos) {
                         /* Hash chain is more distant, use it */
@@ -206,7 +211,7 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, Pos cur_match) {
                 hash = update_hash_roll(hash, scan_endstr[1]);
                 hash = update_hash_roll(hash, scan_endstr[2]);
 
-                pos = s->head[hash];
+                pos = head[hash];
                 if (pos < cur_match) {
                     match_offset = (Pos)(len - (STD_MIN_MATCH+1));
                     if (pos <= limit_base + match_offset)

--- a/test/benchmarks/benchmark_insert_string.cc
+++ b/test/benchmarks/benchmark_insert_string.cc
@@ -20,7 +20,7 @@ extern "C" {
 #define MAX_WSIZE 32768
 #define TEST_WINDOW_SIZE (MAX_WSIZE * 2)
 
-typedef Pos (* quick_insert_string_cb)(deflate_state *const s, uint32_t str);
+typedef uint32_t (* quick_insert_string_cb)(deflate_state *const s, uint32_t str);
 
 // Base class with common setup/teardown for both insert_string benchmarks
 class insert_string_base: public benchmark::Fixture {
@@ -141,7 +141,7 @@ public:
 
             // Benchmark quick_insert_string (single insertions)
             for (uint32_t i = 0; i < count; i++) {
-                Pos result = quick_insert_func(s, start_pos + i);
+                uint32_t result = quick_insert_func(s, start_pos + i);
                 benchmark::DoNotOptimize(result);
             }
         }

--- a/trees.c
+++ b/trees.c
@@ -116,7 +116,7 @@ static void init_block(deflate_state *s) {
         s->bl_tree[n].Freq = 0;
 
     s->dyn_ltree[END_BLOCK].Freq = 1;
-    s->opt_len = s->static_len = 0L;
+    s->opt_len = s->static_len = 0;
     s->sym_next = s->matches = 0;
 }
 
@@ -319,9 +319,9 @@ static void gen_bitlen(deflate_state *s, tree_desc *desc) {
         if (n >= base)
             xbits = extra[n-base];
         f = tree[n].Freq;
-        s->opt_len += (unsigned long)f * (unsigned int)(bits + xbits);
+        s->opt_len += (unsigned int)f * (unsigned int)(bits + xbits);
         if (stree)
-            s->static_len += (unsigned long)f * (unsigned int)(stree[n].Len + xbits);
+            s->static_len += (unsigned int)f * (unsigned int)(stree[n].Len + xbits);
     }
     if (overflow == 0)
         return;
@@ -356,8 +356,8 @@ static void gen_bitlen(deflate_state *s, tree_desc *desc) {
                 continue;
             if (tree[m].Len != bits) {
                 Tracev((stderr, "code %d bits %d->%u\n", m, tree[m].Len, bits));
-                s->opt_len += (unsigned long)(bits * tree[m].Freq);
-                s->opt_len -= (unsigned long)(tree[m].Len * tree[m].Freq);
+                s->opt_len += (unsigned int)(bits * tree[m].Freq);
+                s->opt_len -= (unsigned int)(tree[m].Len * tree[m].Freq);
                 tree[m].Len = (uint16_t)bits;
             }
             n--;
@@ -547,8 +547,8 @@ static int build_bl_tree(deflate_state *s) {
             break;
     }
     /* Update opt_len to include the bit length tree and counts */
-    s->opt_len += 3*((unsigned long)max_blindex+1) + 5+5+4;
-    Tracev((stderr, "\ndyn trees: dyn %lu, stat %lu", s->opt_len, s->static_len));
+    s->opt_len += 3*((unsigned int)max_blindex+1) + 5+5+4;
+    Tracev((stderr, "\ndyn trees: dyn %u, stat %u", s->opt_len, s->static_len));
 
     return max_blindex;
 }
@@ -629,7 +629,7 @@ void Z_INTERNAL zng_tr_flush_block(deflate_state *s, char *buf, uint32_t stored_
     /* buf: input block, or NULL if too old */
     /* stored_len: length of input block */
     /* last: one if this is the last block for a file */
-    unsigned long opt_lenb, static_lenb; /* opt_len and static_len in bytes */
+    unsigned int opt_lenb, static_lenb; /* opt_len and static_len in bytes */
     int max_blindex = 0;  /* index of last bit length code of non zero freq */
 
     /* Build the Huffman trees unless a stored block is forced */
@@ -644,10 +644,10 @@ void Z_INTERNAL zng_tr_flush_block(deflate_state *s, char *buf, uint32_t stored_
 
         /* Construct the literal and distance trees */
         build_tree(s, (tree_desc *)(&(s->l_desc)));
-        Tracev((stderr, "\nlit data: dyn %lu, stat %lu", s->opt_len, s->static_len));
+        Tracev((stderr, "\nlit data: dyn %u, stat %u", s->opt_len, s->static_len));
 
         build_tree(s, (tree_desc *)(&(s->d_desc)));
-        Tracev((stderr, "\ndist data: dyn %lu, stat %lu", s->opt_len, s->static_len));
+        Tracev((stderr, "\ndist data: dyn %u, stat %u", s->opt_len, s->static_len));
         /* At this point, opt_len and static_len are the total bit lengths of
          * the compressed block data, excluding the tree representations.
          */
@@ -658,10 +658,10 @@ void Z_INTERNAL zng_tr_flush_block(deflate_state *s, char *buf, uint32_t stored_
         max_blindex = build_bl_tree(s);
 
         /* Determine the best encoding. Compute the block lengths in bytes. */
-        opt_lenb = (s->opt_len+3+7) >> 3;
-        static_lenb = (s->static_len+3+7) >> 3;
+        opt_lenb = (s->opt_len + 3 + 7) >> 3;
+        static_lenb = (s->static_len + 3 + 7) >> 3;
 
-        Tracev((stderr, "\nopt %lu(%lu) stat %lu(%lu) stored %u lit %u ",
+        Tracev((stderr, "\nopt %u(%u) stat %u(%u) stored %u lit %u ",
                 opt_lenb, s->opt_len, static_lenb, s->static_len, stored_len,
                 s->sym_next / 3));
 

--- a/trees_emit.h
+++ b/trees_emit.h
@@ -78,7 +78,7 @@ extern Z_INTERNAL const int base_dist[D_CODES];
 /* ===========================================================================
  * Flush the bit buffer and align the output on a byte boundary
  */
-static void bi_windup(deflate_state *s) {
+static inline void bi_windup(deflate_state *s) {
     if (s->bi_valid > 56) {
         put_uint64(s, s->bi_buf);
     } else {
@@ -120,7 +120,7 @@ static inline uint32_t zng_emit_lit(deflate_state *s, const ct_data *ltree, unsi
 /* ===========================================================================
  * Emit match distance/length code
  */
-static inline uint32_t zng_emit_dist(deflate_state *s, const ct_data *ltree, const ct_data *dtree,
+static uint32_t zng_emit_dist(deflate_state *s, const ct_data *ltree, const ct_data *dtree,
     uint32_t lc, uint32_t dist) {
     uint32_t c, extra;
     uint8_t code;


### PR DESCRIPTION
- Don't check for too long match in deflate_quick, it cannot happen.
- Minor inlining change in trees_emit.h
      - Inline the small bi_windup function
      - Don't attempt inlining for the big zng_emit_dist
- Reduce opt_len/static_len sizes.
- Add local window pointer to:
  - deflate_quick
  - deflate_fast
  - deflate_medium
  - fill_window
- Add local strm pointer in fill_window.
- Fix missed change to use local lookahead variable in match_tpl
- Move matches/insert in deflate_state closer to their related varibles.
   These also fill a 8-byte hole in the struct on 64-bit platforms.
- Exclude compressed_len and bits_sent if ZLIB_DEBUG is not enabled. Also move them to the end.
- Add local window pointer to deflate_quick, deflate_fast and deflate_medium.
- Reorder variables in longest_match, reducing gaps.
- Move GOTO_NEXT_CHAIN macro outside of longest_match function to improve readability.
- Make window-based pointers in match_tpl.h const, only the pointers move, never the data.
- Use pointer arithmetic to access window in deflate_quick/deflate_fast.
- Use uint32_t for Pos in match_tpl.h
- Use uint32_t for hash_head in update_hash/insert_string
- Reorder deflate.h variables to improve cache locality

Compression performance on x86_64 is about 5-6% faster.
On aarch64 it is around 1.3% faster.