### PR TITLE
Add missing adler32_copy implementations

### DIFF
--- a/arch/power/adler32_power8.c
+++ b/arch/power/adler32_power8.c
@@ -52,7 +52,7 @@ static inline vector unsigned int vec_sumsu(vector unsigned int __a, vector unsi
     return __a;
 }
 
-Z_INTERNAL uint32_t adler32_power8(uint32_t adler, const uint8_t *buf, size_t len) {
+static inline uint32_t adler32_impl(uint32_t adler, const uint8_t *buf, size_t len) {
     uint32_t s1 = adler & 0xffff;
     uint32_t s2 = (adler >> 16) & 0xffff;
 
@@ -150,4 +150,14 @@ Z_INTERNAL uint32_t adler32_power8(uint32_t adler, const uint8_t *buf, size_t le
     return adler32_copy_len_16(s1, NULL, buf, len, s2, 0);
 }
 
+Z_INTERNAL uint32_t adler32_power8(uint32_t adler, const uint8_t *buf, size_t len) {
+    return adler32_impl(adler, buf, len);
+}
+
+/* VSX/VMX stores can have higher latency than optimized memcpy on POWER8+ */
+Z_INTERNAL uint32_t adler32_copy_power8(uint32_t adler, uint8_t *dst, const uint8_t *buf, size_t len) {
+    adler = adler32_impl(adler, buf, len);
+    memcpy(dst, buf, len);
+    return adler;
+}
 #endif /* POWER8_VSX */

--- a/arch/power/adler32_vmx.c
+++ b/arch/power/adler32_vmx.c
@@ -118,7 +118,7 @@ static void vmx_accum32(uint32_t *s, const uint8_t *buf, size_t len) {
     vec_ste(s2acc, 0, s+1);
 }
 
-Z_INTERNAL uint32_t adler32_vmx(uint32_t adler, const uint8_t *buf, size_t len) {
+static inline uint32_t adler32_impl(uint32_t adler, const uint8_t *buf, size_t len) {
     uint32_t sum2;
     uint32_t pair[16] ALIGNED_(16);
     memset(&pair[2], 0, 14);
@@ -182,5 +182,16 @@ Z_INTERNAL uint32_t adler32_vmx(uint32_t adler, const uint8_t *buf, size_t len) 
 
     /* D = B * 65536 + A, see: https://en.wikipedia.org/wiki/Adler-32. */
     return (pair[1] << 16) | pair[0];
+}
+
+Z_INTERNAL uint32_t adler32_vmx(uint32_t adler, const uint8_t *buf, size_t len) {
+    return adler32_impl(adler, buf, len);
+}
+
+/* VMX stores can have higher latency than optimized memcpy */
+Z_INTERNAL uint32_t adler32_copy_vmx(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len) {
+    adler = adler32_impl(adler, src, len);
+    memcpy(dst, src, len);
+    return adler;
 }
 #endif

--- a/arch/power/power_functions.h
+++ b/arch/power/power_functions.h
@@ -9,6 +9,7 @@
 
 #ifdef PPC_VMX
 uint32_t adler32_vmx(uint32_t adler, const uint8_t *buf, size_t len);
+uint32_t adler32_copy_vmx(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len);
 void slide_hash_vmx(deflate_state *s);
 #endif
 
@@ -32,6 +33,8 @@ uint32_t longest_match_slow_power9(deflate_state *const s, uint32_t cur_match);
 #  if defined(PPC_VMX) && defined(__ALTIVEC__)
 #    undef native_adler32
 #    define native_adler32 adler32_vmx
+#    undef native_adler32_copy
+#    define native_adler32_copy adler32_copy_vmx
 #    undef native_slide_hash
 #    define native_slide_hash slide_hash_vmx
 #  endif

--- a/arch/power/power_functions.h
+++ b/arch/power/power_functions.h
@@ -15,6 +15,7 @@ void slide_hash_vmx(deflate_state *s);
 
 #ifdef POWER8_VSX
 uint32_t adler32_power8(uint32_t adler, const uint8_t *buf, size_t len);
+uint32_t adler32_copy_power8(uint32_t adler, uint8_t *dst, const uint8_t *buf, size_t len);
 uint8_t* chunkmemset_safe_power8(uint8_t *out, uint8_t *from, unsigned len, unsigned left);
 uint32_t crc32_power8(uint32_t crc, const uint8_t *buf, size_t len);
 void slide_hash_power8(deflate_state *s);
@@ -42,6 +43,8 @@ uint32_t longest_match_slow_power9(deflate_state *const s, uint32_t cur_match);
 #  if defined(POWER8_VSX) && defined(_ARCH_PWR8) && defined(__VSX__)
 #    undef native_adler32
 #    define native_adler32 adler32_power8
+#    undef native_adler32_copy
+#    define native_adler32_copy adler32_copy_power8
 #    undef native_chunkmemset_safe
 #    define native_chunkmemset_safe chunkmemset_safe_power8
 #    undef native_inflate_fast

--- a/arch/x86/adler32_avx512_vnni.c
+++ b/arch/x86/adler32_avx512_vnni.c
@@ -109,6 +109,7 @@ rem_peel:
     return adler;
 }
 
+/* Use 256-bit vectors when copying because 512-bit variant is slower. */
 Z_INTERNAL uint32_t adler32_copy_avx512_vnni(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len) {
     if (UNLIKELY(src == NULL)) return 1L;
     if (UNLIKELY(len == 0)) return adler;

--- a/arch/x86/adler32_ssse3.c
+++ b/arch/x86/adler32_ssse3.c
@@ -14,7 +14,7 @@
 
 #include <immintrin.h>
 
-Z_INTERNAL uint32_t adler32_ssse3(uint32_t adler, const uint8_t *buf, size_t len) {
+static inline uint32_t adler32_impl(uint32_t adler, const uint8_t *buf, size_t len) {
     uint32_t sum2;
 
      /* split Adler-32 into component sums */
@@ -153,4 +153,14 @@ unaligned_jmp:
     return adler32_copy_len_16(adler, NULL, buf, len, sum2, 0);
 }
 
+Z_INTERNAL uint32_t adler32_ssse3(uint32_t adler, const uint8_t *buf, size_t len) {
+    return adler32_impl(adler, buf, len);
+}
+
+/* SSSE3 unaligned stores have a huge penalty, so we use memcpy. */
+Z_INTERNAL uint32_t adler32_copy_ssse3(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len) {
+    adler = adler32_impl(adler, src, len);
+    memcpy(dst, src, len);
+    return adler;
+}
 #endif

--- a/arch/x86/x86_functions.h
+++ b/arch/x86/x86_functions.h
@@ -32,6 +32,7 @@ uint8_t* chunkmemset_safe_sse2(uint8_t *out, uint8_t *from, unsigned len, unsign
 
 #ifdef X86_SSSE3
 uint32_t adler32_ssse3(uint32_t adler, const uint8_t *buf, size_t len);
+uint32_t adler32_copy_ssse3(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len);
 uint8_t* chunkmemset_safe_ssse3(uint8_t *out, uint8_t *from, unsigned len, unsigned left);
 void inflate_fast_ssse3(PREFIX3(stream) *strm, uint32_t start);
 #endif
@@ -114,6 +115,8 @@ uint32_t crc32_vpclmulqdq(uint32_t crc32, const uint8_t *buf, size_t len);
 #  if defined(X86_SSSE3) && defined(__SSSE3__)
 #    undef native_adler32
 #    define native_adler32 adler32_ssse3
+#    undef native_adler32_copy
+#    define native_adler32_copy adler32_copy_ssse3
 #    undef native_chunkmemset_safe
 #    define native_chunkmemset_safe chunkmemset_safe_ssse3
 #    undef native_inflate_fast

--- a/functable.c
+++ b/functable.c
@@ -259,6 +259,7 @@ static int init_functable(void) {
 #ifdef PPC_VMX
     if (cf.power.has_altivec) {
         ft.adler32 = &adler32_vmx;
+        ft.adler32_copy = &adler32_copy_vmx;
         ft.slide_hash = &slide_hash_vmx;
     }
 #endif

--- a/functable.c
+++ b/functable.c
@@ -139,6 +139,7 @@ static int init_functable(void) {
 #ifdef X86_SSSE3
     if (cf.x86.has_ssse3) {
         ft.adler32 = &adler32_ssse3;
+        ft.adler32_copy = &adler32_copy_ssse3;
         ft.chunkmemset_safe = &chunkmemset_safe_ssse3;
         ft.inflate_fast = &inflate_fast_ssse3;
     }

--- a/functable.c
+++ b/functable.c
@@ -268,6 +268,7 @@ static int init_functable(void) {
 #ifdef POWER8_VSX
     if (cf.power.has_arch_2_07) {
         ft.adler32 = &adler32_power8;
+        ft.adler32_copy = &adler32_copy_power8;
         ft.chunkmemset_safe = &chunkmemset_safe_power8;
         ft.inflate_fast = &inflate_fast_power8;
         ft.slide_hash = &slide_hash_power8;

--- a/test/benchmarks/benchmark_adler32_copy.cc
+++ b/test/benchmarks/benchmark_adler32_copy.cc
@@ -108,7 +108,9 @@ BENCHMARK_ADLER32_BASELINE_COPY(power8, adler32_power8, test_cpu_features.power.
 //BENCHMARK_ADLER32_COPY(rvv, adler32_rvv, test_cpu_features.riscv.has_rvv);
 BENCHMARK_ADLER32_BASELINE_COPY(rvv, adler32_rvv, test_cpu_features.riscv.has_rvv);
 #endif
-
+#ifdef X86_SSSE3
+BENCHMARK_ADLER32_COPY(ssse3, adler32_copy_ssse3, test_cpu_features.x86.has_ssse3);
+#endif
 #ifdef X86_SSE42
 BENCHMARK_ADLER32_BASELINE_COPY(sse42_baseline, adler32_ssse3, test_cpu_features.x86.has_ssse3);
 BENCHMARK_ADLER32_COPY(sse42, adler32_copy_sse42, test_cpu_features.x86.has_sse42);

--- a/test/benchmarks/benchmark_adler32_copy.cc
+++ b/test/benchmarks/benchmark_adler32_copy.cc
@@ -97,8 +97,7 @@ BENCHMARK_ADLER32_BASELINE_COPY(neon_copy_baseline, adler32_neon, test_cpu_featu
 #endif
 
 #ifdef PPC_VMX
-//BENCHMARK_ADLER32_COPY(vmx_inline_copy, adler32_copy_vmx, test_cpu_features.power.has_altivec);
-BENCHMARK_ADLER32_BASELINE_COPY(vmx_copy_baseline, adler32_vmx, test_cpu_features.power.has_altivec);
+BENCHMARK_ADLER32_COPY(vmx, adler32_copy_vmx, test_cpu_features.power.has_altivec);
 #endif
 #ifdef POWER8_VSX
 //BENCHMARK_ADLER32_COPY(power8_inline_copy, adler32_copy_power8, test_cpu_features.power.has_arch_2_07);

--- a/test/benchmarks/benchmark_adler32_copy.cc
+++ b/test/benchmarks/benchmark_adler32_copy.cc
@@ -100,8 +100,7 @@ BENCHMARK_ADLER32_BASELINE_COPY(neon_copy_baseline, adler32_neon, test_cpu_featu
 BENCHMARK_ADLER32_COPY(vmx, adler32_copy_vmx, test_cpu_features.power.has_altivec);
 #endif
 #ifdef POWER8_VSX
-//BENCHMARK_ADLER32_COPY(power8_inline_copy, adler32_copy_power8, test_cpu_features.power.has_arch_2_07);
-BENCHMARK_ADLER32_BASELINE_COPY(power8, adler32_power8, test_cpu_features.power.has_arch_2_07);
+BENCHMARK_ADLER32_COPY(power8, adler32_copy_power8, test_cpu_features.power.has_arch_2_07);
 #endif
 
 #ifdef RISCV_RVV


### PR DESCRIPTION
Without these implementations, it would default to `adler32_c` which causes another functable jump.