### PR TITLE
Fix warnings: unused parameter state, comparison of integer expressions of different signedness: size_t and int64_t.

### DIFF
--- a/test/benchmarks/benchmark_adler32.cc
+++ b/test/benchmarks/benchmark_adler32.cc
@@ -23,7 +23,7 @@ private:
     uint32_t *random_ints;
 
 public:
-    void SetUp(const ::benchmark::State& state) {
+    void SetUp(const ::benchmark::State&) {
         /* Control the alignment so that we have the best case scenario for loads. With
          * AVX512, unaligned loads can mean we're crossing a cacheline boundary at every load.
          * And while this is a realistic scenario, it makes it difficult to compare benchmark
@@ -49,7 +49,7 @@ public:
         benchmark::DoNotOptimize(hash);
     }
 
-    void TearDown(const ::benchmark::State& state) {
+    void TearDown(const ::benchmark::State&) {
         zng_free(random_ints);
     }
 };

--- a/test/benchmarks/benchmark_adler32_copy.cc
+++ b/test/benchmarks/benchmark_adler32_copy.cc
@@ -27,7 +27,7 @@ private:
     uint32_t *random_ints_dst;
 
 public:
-    void SetUp(const ::benchmark::State& state) {
+    void SetUp(const ::benchmark::State&) {
         /* Control the alignment so that we have the best case scenario for loads. With
          * AVX512, unaligned loads can mean we're crossing a cacheline boundary at every load.
          * And while this is a realistic scenario, it makes it difficult to compare benchmark
@@ -56,7 +56,7 @@ public:
         benchmark::DoNotOptimize(hash);
     }
 
-    void TearDown(const ::benchmark::State& state) {
+    void TearDown(const ::benchmark::State&) {
         zng_free(random_ints_src);
         zng_free(random_ints_dst);
     }

--- a/test/benchmarks/benchmark_compare256.cc
+++ b/test/benchmarks/benchmark_compare256.cc
@@ -23,7 +23,7 @@ private:
     uint8_t *str2;
 
 public:
-    void SetUp(const ::benchmark::State& state) {
+    void SetUp(const ::benchmark::State&) {
         str1 = (uint8_t *)zng_alloc(MAX_COMPARE_SIZE);
         assert(str1 != NULL);
         memset(str1, 'a', MAX_COMPARE_SIZE);
@@ -46,7 +46,7 @@ public:
         benchmark::DoNotOptimize(len);
     }
 
-    void TearDown(const ::benchmark::State& state) {
+    void TearDown(const ::benchmark::State&) {
         zng_free(str1);
         zng_free(str2);
     }

--- a/test/benchmarks/benchmark_compare256_rle.cc
+++ b/test/benchmarks/benchmark_compare256_rle.cc
@@ -21,7 +21,7 @@ private:
     uint8_t *str2;
 
 public:
-    void SetUp(const ::benchmark::State& state) {
+    void SetUp(const ::benchmark::State&) {
         str1 = (uint8_t *)zng_alloc(MAX_COMPARE_SIZE);
         assert(str1 != NULL);
         memset(str1, 'a', MAX_COMPARE_SIZE);
@@ -44,7 +44,7 @@ public:
         benchmark::DoNotOptimize(len);
     }
 
-    void TearDown(const ::benchmark::State& state) {
+    void TearDown(const ::benchmark::State&) {
         zng_free(str1);
         zng_free(str2);
     }

--- a/test/benchmarks/benchmark_compress.cc
+++ b/test/benchmarks/benchmark_compress.cc
@@ -26,7 +26,7 @@ private:
     uint8_t *outbuff;
 
 public:
-    void SetUp(const ::benchmark::State& state) {
+    void SetUp(const ::benchmark::State&) {
         const char teststr[42] = "Hello hello World broken Test tast mello.";
         maxlen = MAX_SIZE;
 
@@ -52,7 +52,7 @@ public:
         benchmark::DoNotOptimize(err);
     }
 
-    void TearDown(const ::benchmark::State& state) {
+    void TearDown(const ::benchmark::State&) {
         zng_free(inbuff);
         zng_free(outbuff);
     }

--- a/test/benchmarks/benchmark_crc32.cc
+++ b/test/benchmarks/benchmark_crc32.cc
@@ -23,7 +23,7 @@ private:
     uint32_t *random_ints;
 
 public:
-    void SetUp(const ::benchmark::State& state) {
+    void SetUp(const ::benchmark::State&) {
         random_ints = (uint32_t *)zng_alloc(MAX_RANDOM_INTS_SIZE);
         assert(random_ints != NULL);
 
@@ -42,7 +42,7 @@ public:
         benchmark::DoNotOptimize(hash);
     }
 
-    void TearDown(const ::benchmark::State& state) {
+    void TearDown(const ::benchmark::State&) {
         zng_free(random_ints);
     }
 };

--- a/test/benchmarks/benchmark_crc32_fold_copy.cc
+++ b/test/benchmarks/benchmark_crc32_fold_copy.cc
@@ -47,7 +47,7 @@ protected:
     uint32_t crc;
 
 public:
-    void SetUp(const ::benchmark::State& state) {
+    void SetUp(const ::benchmark::State&) {
         testdata = (uint32_t *)malloc(BUFSIZE);
         dstbuf = (uint8_t *)malloc(BUFSIZE);
         assert((testdata != NULL) && (dstbuf != NULL));
@@ -80,7 +80,7 @@ public:
         benchmark::DoNotOptimize(crc);
     }
 
-    void TearDown(const ::benchmark::State& state) {
+    void TearDown(const ::benchmark::State&) {
         free(testdata);
         free(dstbuf);
     }

--- a/test/benchmarks/benchmark_insert_string.cc
+++ b/test/benchmarks/benchmark_insert_string.cc
@@ -28,7 +28,7 @@ protected:
     deflate_state *s;
 
 public:
-    void SetUp(const ::benchmark::State& state) {
+    void SetUp(const ::benchmark::State&) {
         s = (deflate_state*)zng_alloc(sizeof(deflate_state));
         memset(s, 0, sizeof(deflate_state));
 
@@ -57,7 +57,7 @@ public:
         }
     }
 
-    void TearDown(const ::benchmark::State& state) {
+    void TearDown(const ::benchmark::State&) {
         zng_free(s->window);
         zng_free(s->head);
         zng_free(s->prev);

--- a/test/benchmarks/benchmark_png_decode.cc
+++ b/test/benchmarks/benchmark_png_decode.cc
@@ -16,7 +16,7 @@ public:
         init_compressible(img_bytes, width*height);
     }
 
-    void SetUp(const ::benchmark::State& state) {
+    void SetUp(const ::benchmark::State&) {
         output_img_buf = (uint8_t*)malloc(IMWIDTH * IMHEIGHT * 3);
         assert(output_img_buf != NULL);
         init_img(output_img_buf, IMWIDTH, IMHEIGHT);
@@ -38,7 +38,7 @@ public:
         }
     }
 
-    void TearDown(const ::benchmark::State &state) {
+    void TearDown(const ::benchmark::State &) {
         free(output_img_buf);
         for (int i = 0; i < 10; ++i) {
             free(inpng[i].buf);
@@ -51,7 +51,7 @@ private:
     bool test_files_found = false;
 
 public:
-    void SetUp(const ::benchmark::State &state) {
+    void SetUp(const ::benchmark::State &) {
         output_img_buf = NULL;
         output_img_buf = (uint8_t*)malloc(IMWIDTH * IMHEIGHT * 3);
         /* Let's take all the images at different compression levels and jam their bytes into buffers */

--- a/test/benchmarks/benchmark_png_encode.cc
+++ b/test/benchmarks/benchmark_png_encode.cc
@@ -19,7 +19,7 @@ public:
         init_compressible(img_bytes, width * height);
     }
 
-    void SetUp(const ::benchmark::State& state) {
+    void SetUp(const ::benchmark::State&) {
         input_img_buf = (uint8_t*)malloc(IMWIDTH * IMHEIGHT * 3);
         outpng.buf = (uint8_t*)malloc(IMWIDTH * IMHEIGHT * 3);
         /* Using malloc rather than zng_alloc so that we can call realloc.
@@ -42,7 +42,7 @@ public:
         }
     }
 
-    void TearDown(const ::benchmark::State &state) {
+    void TearDown(const ::benchmark::State &) {
         free(input_img_buf);
         free(outpng.buf);
     }

--- a/test/benchmarks/benchmark_slidehash.cc
+++ b/test/benchmarks/benchmark_slidehash.cc
@@ -33,7 +33,7 @@ public:
      *
      * @param state Benchmark-provided state object from Google Benchmark (supplied by the framework).
      */
-    void SetUp(const ::benchmark::State& state) {
+    void SetUp(const ::benchmark::State&) {
         l0 = (uint16_t *)zng_alloc_aligned(HASH_SIZE * sizeof(uint16_t), 64);
 
         for (uint32_t i = 0; i < HASH_SIZE; i++) {
@@ -61,7 +61,7 @@ public:
         }
     }
 
-    void TearDown(const ::benchmark::State& state) {
+    void TearDown(const ::benchmark::State&) {
         zng_free_aligned(l0);
         zng_free_aligned(l1);
         free(s_g);

--- a/test/benchmarks/benchmark_uncompress.cc
+++ b/test/benchmarks/benchmark_uncompress.cc
@@ -30,7 +30,7 @@ private:
     size_t sizes[NUM_TESTS] = {1, 64, 1024, 16384, 128*1024, 1024*1024};
 
 public:
-    void SetUp(const ::benchmark::State& state) {
+    void SetUp(const ::benchmark::State&) {
         const char teststr[42] = "Hello hello World broken Test tast mello.";
         maxlen = MAX_SIZE;
 
@@ -66,7 +66,7 @@ public:
 
         for (auto _ : state) {
             int index = 0;
-            while (sizes[index] != state.range(0)) ++index;
+            while (sizes[index] != (size_t)state.range(0)) ++index;
 
             z_uintmax_t out_size = maxlen;
             err = PREFIX(uncompress)(outbuff, &out_size, compressed_buff[index], compressed_sizes[index]);
@@ -75,7 +75,7 @@ public:
         benchmark::DoNotOptimize(err);
     }
 
-    void TearDown(const ::benchmark::State& state) {
+    void TearDown(const ::benchmark::State&) {
         zng_free(inbuff);
         zng_free(outbuff);
 


### PR DESCRIPTION
Warnings:

```
[ 69%] Building CXX object test/benchmarks/CMakeFiles/benchmark_zlib.dir/benchmark_adler32.cc.o
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_adler32.cc: In member function ‘virtual void adler32::SetUp(const benchmark::State&)’:
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_adler32.cc:26:42: warning: unused parameter ‘state’ [-Wunused-parameter]
   26 |     void SetUp(const ::benchmark::State& state) {
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_adler32.cc: In member function ‘virtual void adler32::TearDown(const benchmark::State&)’:
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_adler32.cc:52:45: warning: unused parameter ‘state’ [-Wunused-parameter]
   52 |     void TearDown(const ::benchmark::State& state) {
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
[ 70%] Building CXX object test/benchmarks/CMakeFiles/benchmark_zlib.dir/benchmark_adler32_copy.cc.o
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_adler32_copy.cc: In member function ‘virtual void adler32_copy::SetUp(const benchmark::State&)’:
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_adler32_copy.cc:30:42: warning: unused parameter ‘state’ [-Wunused-parameter]
   30 |     void SetUp(const ::benchmark::State& state) {
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_adler32_copy.cc: In member function ‘virtual void adler32_copy::TearDown(const benchmark::State&)’:
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_adler32_copy.cc:59:45: warning: unused parameter ‘state’ [-Wunused-parameter]
   59 |     void TearDown(const ::benchmark::State& state) {
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
[ 71%] Building CXX object test/benchmarks/CMakeFiles/benchmark_zlib.dir/benchmark_compare256.cc.o
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_compare256.cc: In member function ‘virtual void compare256::SetUp(const benchmark::State&)’:
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_compare256.cc:26:42: warning: unused parameter ‘state’ [-Wunused-parameter]
   26 |     void SetUp(const ::benchmark::State& state) {
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_compare256.cc: In member function ‘virtual void compare256::TearDown(const benchmark::State&)’:
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_compare256.cc:49:45: warning: unused parameter ‘state’ [-Wunused-parameter]
   49 |     void TearDown(const ::benchmark::State& state) {
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
[ 72%] Building CXX object test/benchmarks/CMakeFiles/benchmark_zlib.dir/benchmark_compare256_rle.cc.o
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_compare256_rle.cc: In member function ‘virtual void compare256_rle::SetUp(const benchmark::State&)’:
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_compare256_rle.cc:24:42: warning: unused parameter ‘state’ [-Wunused-parameter]
   24 |     void SetUp(const ::benchmark::State& state) {
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_compare256_rle.cc: In member function ‘virtual void compare256_rle::TearDown(const benchmark::State&)’:
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_compare256_rle.cc:47:45: warning: unused parameter ‘state’ [-Wunused-parameter]
   47 |     void TearDown(const ::benchmark::State& state) {
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
[ 72%] Building CXX object test/CMakeFiles/gtest_zlib.dir/test_cve-2003-0107.cc.o
[ 72%] Building CXX object test/benchmarks/CMakeFiles/benchmark_zlib.dir/benchmark_compress.cc.o
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_compress.cc: In member function ‘virtual void compress_bench::SetUp(const benchmark::State&)’:
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_compress.cc:29:42: warning: unused parameter ‘state’ [-Wunused-parameter]
   29 |     void SetUp(const ::benchmark::State& state) {
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_compress.cc: In member function ‘virtual void compress_bench::TearDown(const benchmark::State&)’:
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_compress.cc:55:45: warning: unused parameter ‘state’ [-Wunused-parameter]
   55 |     void TearDown(const ::benchmark::State& state) {
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
[ 73%] Building CXX object test/CMakeFiles/gtest_zlib.dir/test_deflate_bound.cc.o
[ 74%] Building CXX object test/benchmarks/CMakeFiles/benchmark_zlib.dir/benchmark_crc32.cc.o
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_crc32.cc: In member function ‘virtual void crc32::SetUp(const benchmark::State&)’:
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_crc32.cc:26:42: warning: unused parameter ‘state’ [-Wunused-parameter]
   26 |     void SetUp(const ::benchmark::State& state) {
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_crc32.cc: In member function ‘virtual void crc32::TearDown(const benchmark::State&)’:
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_crc32.cc:45:45: warning: unused parameter ‘state’ [-Wunused-parameter]
   45 |     void TearDown(const ::benchmark::State& state) {
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
[ 75%] Building CXX object test/benchmarks/CMakeFiles/benchmark_zlib.dir/benchmark_crc32_fold_copy.cc.o
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_crc32_fold_copy.cc: In member function ‘virtual void crc32_fc::SetUp(const benchmark::State&)’:
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_crc32_fold_copy.cc:50:42: warning: unused parameter ‘state’ [-Wunused-parameter]
   50 |     void SetUp(const ::benchmark::State& state) {
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_crc32_fold_copy.cc: In member function ‘virtual void crc32_fc::TearDown(const benchmark::State&)’:
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_crc32_fold_copy.cc:83:45: warning: unused parameter ‘state’ [-Wunused-parameter]
   83 |     void TearDown(const ::benchmark::State& state) {
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
[ 76%] Building CXX object test/benchmarks/CMakeFiles/benchmark_zlib.dir/benchmark_insert_string.cc.o
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_insert_string.cc: In member function ‘virtual void insert_string_base::SetUp(const benchmark::State&)’:
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_insert_string.cc:31:42: warning: unused parameter ‘state’ [-Wunused-parameter]
   31 |     void SetUp(const ::benchmark::State& state) {
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_insert_string.cc: In member function ‘virtual void insert_string_base::TearDown(const benchmark::State&)’:
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_insert_string.cc:60:45: warning: unused parameter ‘state’ [-Wunused-parameter]
   60 |     void TearDown(const ::benchmark::State& state) {
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
[ 76%] Building CXX object test/benchmarks/CMakeFiles/benchmark_zlib.dir/benchmark_main.cc.o
[ 77%] Building CXX object test/benchmarks/CMakeFiles/benchmark_zlib.dir/benchmark_slidehash.cc.o
[ 78%] Building CXX object test/CMakeFiles/gtest_zlib.dir/test_deflate_copy.cc.o
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_slidehash.cc: In member function ‘virtual void slide_hash::SetUp(const benchmark::State&)’:
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_slidehash.cc:36:42: warning: unused parameter ‘state’ [-Wunused-parameter]
   36 |     void SetUp(const ::benchmark::State& state) {
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_slidehash.cc: In member function ‘virtual void slide_hash::TearDown(const benchmark::State&)’:
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_slidehash.cc:64:45: warning: unused parameter ‘state’ [-Wunused-parameter]
   64 |     void TearDown(const ::benchmark::State& state) {
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
[ 79%] Building CXX object test/benchmarks/CMakeFiles/benchmark_zlib.dir/benchmark_uncompress.cc.o
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_uncompress.cc: In member function ‘virtual void uncompress_bench::SetUp(const benchmark::State&)’:
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_uncompress.cc:33:42: warning: unused parameter ‘state’ [-Wunused-parameter]
   33 |     void SetUp(const ::benchmark::State& state) {
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_uncompress.cc: In member function ‘void uncompress_bench::Bench(benchmark::State&)’:
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_uncompress.cc:69:33: warning: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘int64_t’ {aka ‘long int’} [-Wsign-compare]
   69 |             while (sizes[index] != state.range(0)) ++index;
      |                    ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_uncompress.cc: In member function ‘virtual void uncompress_bench::TearDown(const benchmark::State&)’:
/home/runner/work/zlib-ng/zlib-ng/test/benchmarks/benchmark_uncompress.cc:78:45: warning: unused parameter ‘state’ [-Wunused-parameter]
   78 |     void TearDown(const ::benchmark::State& state) {
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
```