### PR TITLE
Add new benchmark inflate_nocrc, and improve benchmark_(un)compress

### DIFF
--- a/test/benchmarks/CMakeLists.txt
+++ b/test/benchmarks/CMakeLists.txt
@@ -46,6 +46,7 @@ add_executable(benchmark_zlib
     benchmark_crc32.cc
     benchmark_crc32_copy.cc
     benchmark_insert_string.cc
+    benchmark_inflate.cc
     benchmark_main.cc
     benchmark_slidehash.cc
     benchmark_uncompress.cc

--- a/test/benchmarks/benchmark_compress.cc
+++ b/test/benchmarks/benchmark_compress.cc
@@ -18,7 +18,7 @@ extern "C" {
 #  include "compressible_data_p.h"
 }
 
-#define MAX_SIZE (32 * 1024)
+#define MAX_SIZE (64 * 1024)
 
 class compress_bench: public benchmark::Fixture {
 private:
@@ -69,6 +69,6 @@ public:
     BENCHMARK_DEFINE_F(compress_bench, name)(benchmark::State& state) { \
         Bench(state); \
     } \
-    BENCHMARK_REGISTER_F(compress_bench, name)->Arg(1)->Arg(8)->Arg(16)->Arg(32)->Arg(64)->Arg(512)->Arg(4<<10)->Arg(32<<10);
+    BENCHMARK_REGISTER_F(compress_bench, name)->Arg(1)->Arg(16)->Arg(48)->Arg(256)->Arg(1<<10)->Arg(4<<10)->Arg(16<<10)->Arg(64<<10);
 
 BENCHMARK_COMPRESS(compress_bench);

--- a/test/benchmarks/benchmark_compress.cc
+++ b/test/benchmarks/benchmark_compress.cc
@@ -1,5 +1,5 @@
 /* benchmark_compress.cc -- benchmark compress()
- * Copyright (C) 2024 Hans Kristian Rosbach
+ * Copyright (C) 2024-2025 Hans Kristian Rosbach
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
@@ -15,30 +15,32 @@ extern "C" {
 #  else
 #    include "zlib-ng.h"
 #  endif
+#  include "compressible_data_p.h"
 }
 
 #define MAX_SIZE (32 * 1024)
 
 class compress_bench: public benchmark::Fixture {
 private:
-    size_t maxlen;
     uint8_t *inbuff;
     uint8_t *outbuff;
 
 public:
-    void SetUp(const ::benchmark::State&) {
-        const char teststr[42] = "Hello hello World broken Test tast mello.";
-        maxlen = MAX_SIZE;
+    void SetUp(::benchmark::State& state) {
+        outbuff = (uint8_t *)malloc(MAX_SIZE + 16);
+        if (outbuff == NULL) {
+            state.SkipWithError("malloc failed");
+            return;
+        }
 
-        inbuff = (uint8_t *)zng_alloc(MAX_SIZE + 1);
-        assert(inbuff != NULL);
-
-        outbuff = (uint8_t *)zng_alloc(MAX_SIZE + 1);
-        assert(outbuff != NULL);
-
-        int pos = 0;
-        for (int32_t i = 0; i < MAX_SIZE - 42 ; i+=42){
-           pos += sprintf((char *)inbuff+pos, "%s", teststr);
+        // Initialize input buffer with highly compressible data, interspersed
+        // with small amounts of random data and 3-byte matches.
+        inbuff = gen_compressible_data(MAX_SIZE);
+        if (inbuff == NULL) {
+            free(outbuff);
+            outbuff = NULL;
+            state.SkipWithError("gen_compressible_data() failed");
+            return;
         }
     }
 
@@ -46,15 +48,20 @@ public:
         int err = 0;
 
         for (auto _ : state) {
-            err = PREFIX(compress)(outbuff, &maxlen, inbuff, (size_t)state.range(0));
+            z_uintmax_t compressed_size = MAX_SIZE + 16;
+            err = PREFIX(compress)(outbuff, &compressed_size, inbuff, (size_t)state.range(0));
+            if (err != Z_OK) {
+                fprintf(stderr, "compress() failed with error %d\n", err);
+                abort();
+            }
         }
 
         benchmark::DoNotOptimize(err);
     }
 
     void TearDown(const ::benchmark::State&) {
-        zng_free(inbuff);
-        zng_free(outbuff);
+        free(inbuff);
+        free(outbuff);
     }
 };
 

--- a/test/benchmarks/benchmark_inflate.cc
+++ b/test/benchmarks/benchmark_inflate.cc
@@ -1,0 +1,169 @@
+/* benchmark_inflate.cc -- benchmark inflate() without crc32/adler32
+ * Copyright (C) 2024-2025 Hans Kristian Rosbach
+ * For conditions of distribution and use, see copyright notice in zlib.h
+ */
+
+#include <stdio.h>
+#include <assert.h>
+#include <benchmark/benchmark.h>
+
+extern "C" {
+#  include "zbuild.h"
+#  include "zutil_p.h"
+#  if defined(ZLIB_COMPAT)
+#    include "zlib.h"
+#  else
+#    include "zlib-ng.h"
+#  endif
+#  include "compressible_data_p.h"
+}
+
+#define MAX_SIZE (1024 * 1024)
+#define NUM_TESTS 6
+
+class inflate: public benchmark::Fixture {
+private:
+    uint8_t *inbuff;
+    uint8_t *outbuff;
+    uint8_t *compressed_buff[NUM_TESTS];
+    z_uintmax_t compressed_sizes[NUM_TESTS];
+    uint32_t sizes[NUM_TESTS] = {1, 64, 1024, 16384, 128*1024, 1024*1024};
+
+public:
+    void SetUp(::benchmark::State& state) {
+        int err;
+        outbuff = (uint8_t *)malloc(MAX_SIZE + 16);
+        if (outbuff == NULL) {
+            state.SkipWithError("malloc failed");
+            return;
+        }
+
+        // Initialize input buffer with highly compressible data, interspersed
+        // with small amounts of random data and 3-byte matches.
+        inbuff = gen_compressible_data(MAX_SIZE);
+        if (inbuff == NULL) {
+            free(outbuff);
+            outbuff = NULL;
+            state.SkipWithError("gen_compressible_data() failed");
+            return;
+        }
+
+        // Initialize Deflate state
+        PREFIX3(stream) strm;
+        strm.zalloc = NULL;
+        strm.zfree = NULL;
+        strm.opaque = NULL;
+        strm.total_in = 0;
+        strm.total_out = 0;
+        strm.next_out = NULL;
+        strm.avail_out = 0;
+
+        err = PREFIX(deflateInit2)(&strm, Z_BEST_COMPRESSION, Z_DEFLATED, -15, MAX_MEM_LEVEL, Z_DEFAULT_STRATEGY);
+        if (err != Z_OK) {
+            state.SkipWithError("deflateInit2 did not return Z_OK");
+            return;
+        }
+
+
+        // Compress data into different buffers
+        for (int i = 0; i < NUM_TESTS; ++i) {
+            compressed_buff[i] = (uint8_t *)malloc(sizes[i] + 64);
+            if (compressed_buff[i] == NULL) {
+                state.SkipWithError("malloc failed");
+                return;
+            }
+
+            strm.avail_in = sizes[i];                   // Size of the input buffer
+            strm.next_in = (z_const uint8_t *)inbuff;   // Pointer to the input buffer
+            strm.next_out = compressed_buff[i];         // Pointer to the output buffer
+            strm.avail_out = sizes[i] + 64;             // Maximum size of the output buffer
+
+            err = PREFIX(deflate)(&strm, Z_FINISH);     // Perform compression
+            if (err != Z_STREAM_END ) {
+                state.SkipWithError("deflate did not return Z_STREAM_END");
+                PREFIX(deflateEnd)(&strm);
+                return;
+            }
+
+            compressed_sizes[i] = strm.total_out;       // Total compressed size
+
+            err = PREFIX(deflateReset)(&strm);                // Reset Deflate state
+            if (err != Z_OK) {
+                state.SkipWithError("deflateReset did not return Z_OK");
+                return;
+            }
+        }
+
+        err = PREFIX(deflateEnd)(&strm);                // Clean up the deflate stream
+        if (err != Z_OK) {
+            state.SkipWithError("deflateEnd did not return Z_OK");
+            return;
+        }
+    }
+
+    void Bench(benchmark::State& state) {
+        int err;
+        int index = 0;
+        while (sizes[index] != (uint32_t)state.range(0)) ++index;
+
+        // Initialize the inflate stream
+        PREFIX3(stream) strm;
+        strm.zalloc = NULL;
+        strm.zfree = NULL;
+        strm.opaque = NULL;
+        strm.next_in = NULL;
+        strm.avail_in = 0;
+
+        err = PREFIX(inflateInit2)(&strm, -15);  // Initialize the inflate state, no crc/adler
+        if (err != Z_OK) {
+            state.SkipWithError("inflateInit did not return Z_OK");
+            return;
+        }
+
+        for (auto _ : state) {
+            // Perform reset, avoids benchmarking inflateInit and inflateEnd
+            err = PREFIX(inflateReset)(&strm);
+            if (err != Z_OK) {
+                state.SkipWithError("inflateReset did not return Z_OK");
+                return;
+            }
+
+            strm.avail_in = compressed_sizes[index];    // Size of the input
+            strm.next_in = compressed_buff[index];      // Pointer to the compressed data
+            strm.avail_out = MAX_SIZE;                  // Max size for output
+            strm.next_out = outbuff;                    // Output buffer
+
+            // Perform decompression
+            err = PREFIX(inflate)(&strm, Z_FINISH);
+            if (err != Z_STREAM_END) {
+                state.SkipWithError("inflate did not return Z_STREAM_END");
+                PREFIX(inflateEnd)(&strm);
+                return;
+            }
+        }
+
+        // Finalize the inflation process
+        err = PREFIX(inflateEnd)(&strm);
+        if (err != Z_OK) {
+            state.SkipWithError("inflateEnd did not return Z_OK");
+            return;
+        }
+    }
+
+    void TearDown(const ::benchmark::State&) {
+        free(inbuff);
+        free(outbuff);
+
+        for (int i = 0; i < NUM_TESTS; ++i) {
+            free(compressed_buff[i]);
+        }
+    }
+};
+
+#define BENCHMARK_INFLATE(name) \
+    BENCHMARK_DEFINE_F(inflate, name)(benchmark::State& state) { \
+        Bench(state); \
+    } \
+    BENCHMARK_REGISTER_F(inflate, name)->Arg(1)->Arg(64)->Arg(1024)->Arg(16<<10)->Arg(128<<10)->Arg(1024<<10);
+
+BENCHMARK_INFLATE(inflate_nocrc);

--- a/test/benchmarks/compressible_data_p.h
+++ b/test/benchmarks/compressible_data_p.h
@@ -1,0 +1,37 @@
+/* compressible_data_p.h -- generate compressible data
+ * Copyright (C) 2025 Hans Kristian Rosbach
+ * For conditions of distribution and use, see copyright notice in zlib.h
+ */
+
+#ifndef COMPRESSIBLE_DATA_P_H
+#define COMPRESSIBLE_DATA_P_H
+
+// Alloc and initialize buffer with highly compressible data,
+// interspersed with small amounts of random data and 3-byte matches.
+static uint8_t *gen_compressible_data(int bufsize) {
+    const char teststr1[42] = "Hello hello World broken Test tast mello.";
+    const char teststr2[32] = "llollollollollo He Te me orld";
+    const char teststr3[4] = "bro";
+    int loops = 0;
+
+    uint8_t *buffer = (uint8_t *)malloc(bufsize + 96); // Need extra space for init loop overrun
+    if (buffer == NULL) {
+        return NULL;
+    }
+
+    for (int pos = 0; pos < bufsize; ){
+        pos += sprintf((char *)buffer+pos, "%s", teststr1);
+        buffer[pos++] = (uint8_t)(rand() & 0xFF);
+        // Every so often, add a few other little bits to break the pattern
+        if (loops % 13 == 0) {
+            pos += sprintf((char *)buffer+pos, "%s", teststr3);
+            buffer[pos++] = (uint8_t)(rand() & 0xFF);
+        }
+        if (loops % 300 == 0) { // Only found once or twice per window
+            pos += sprintf((char *)buffer+pos, "%s", teststr2);
+        }
+        loops++;
+    }
+    return buffer;
+}
+#endif

--- a/test/benchmarks/compressible_data_p.h
+++ b/test/benchmarks/compressible_data_p.h
@@ -6,31 +6,48 @@
 #ifndef COMPRESSIBLE_DATA_P_H
 #define COMPRESSIBLE_DATA_P_H
 
+
+static inline size_t append_raw(uint8_t *dest, size_t size, const void *src, size_t len) {
+    if (len > size) len = size;
+    if (len == 0) return 0;
+    memcpy(dest, src, len);
+    return len;
+}
+static inline size_t append_str(uint8_t *dest, size_t size, const char *src) {
+    return append_raw(dest, size, src, strlen(src));
+}
+static inline size_t append_uint8_t(uint8_t *dest, size_t size, uint8_t src) {
+    return append_raw(dest, size, &src, 1);
+}
+
 // Alloc and initialize buffer with highly compressible data,
 // interspersed with small amounts of random data and 3-byte matches.
-static uint8_t *gen_compressible_data(int bufsize) {
+static uint8_t *gen_compressible_data(size_t bufsize) {
     const char teststr1[42] = "Hello hello World broken Test tast mello.";
     const char teststr2[32] = "llollollollollo He Te me orld";
     const char teststr3[4] = "bro";
     int loops = 0;
 
-    uint8_t *buffer = (uint8_t *)malloc(bufsize + 96); // Need extra space for init loop overrun
+    uint8_t *buffer = (uint8_t *)malloc(bufsize);
     if (buffer == NULL) {
         return NULL;
     }
 
-    for (int pos = 0; pos < bufsize; ){
-        pos += sprintf((char *)buffer+pos, "%s", teststr1);
-        buffer[pos++] = (uint8_t)(rand() & 0xFF);
+    for (size_t pos = 0; pos < bufsize; ) {
+        pos += append_str(buffer+pos, bufsize-pos, teststr1);
+        pos += append_uint8_t(buffer+pos, bufsize-pos, (uint8_t)(rand() & 0xFF));
         // Every so often, add a few other little bits to break the pattern
         if (loops % 13 == 0) {
-            pos += sprintf((char *)buffer+pos, "%s", teststr3);
-            buffer[pos++] = (uint8_t)(rand() & 0xFF);
+            pos += append_str(buffer+pos, bufsize-pos, teststr3);
+            pos += append_uint8_t(buffer+pos, bufsize-pos, (uint8_t)(rand() & 0xFF));
         }
         if (loops % 300 == 0) { // Only found once or twice per window
-            pos += sprintf((char *)buffer+pos, "%s", teststr2);
+            pos += append_str(buffer+pos, bufsize-pos, teststr2);
         }
         loops++;
+    }
+    if (bufsize > 0) {
+        buffer[bufsize-1] = 0;
     }
     return buffer;
 }


### PR DESCRIPTION
Add new benchmark inflate_nocrc.
- This lets us benchmark just the inflate process more accurately.
- Compared to benchmark_uncompress, this skips crc32, and avoids benchmarking the alloc/free that uncompress does to init/end its operation. We use inflateReset to reuse state/strm.

Also add a new shared function for generating highly compressible data that avoids very long matches.
The old benchmarks effectively always get 258byte matches, this exercises some parts of the code, but avoids a lot of the code to handle smaller matches too. The new data is still highly compressible, but avoids very long matches and also adds some random bytes that will need to become literals, and some 3-byte matches so that we exercise those paths too.

Also improve benchmark_compress and benchmark_uncompress along a similar vein:
- These now use the same generated data as benchmark_inflate.
- benchmark_uncompress now also uses level 9 for compression, so that
  we also have 3-byte matches for uncompress.
- benchmark_compress still uses level 6, the default.
- Improve error checking
- Unify code with benchmark_inflate

### Develop
```
------------------------------------------------------------------------------------
Benchmark                                          Time             CPU   Iterations
------------------------------------------------------------------------------------
compress_bench/compress_bench/1                 1956 ns         1953 ns      1434416
compress_bench/compress_bench/8                 2084 ns         2081 ns      1347316
compress_bench/compress_bench/16                2161 ns         2158 ns      1282059
compress_bench/compress_bench/32                2373 ns         2370 ns      1182243
compress_bench/compress_bench/64                2534 ns         2530 ns      1108434
compress_bench/compress_bench/512               2583 ns         2579 ns      1086732
compress_bench/compress_bench/4096              2997 ns         2992 ns       937141
compress_bench/compress_bench/32768             5932 ns         5923 ns       473084
uncompress_bench/uncompress_bench/1             40.7 ns         40.6 ns     68766625
uncompress_bench/uncompress_bench/64             126 ns          126 ns     22229206
uncompress_bench/uncompress_bench/1024           182 ns          181 ns     14579813
uncompress_bench/uncompress_bench/16384         1271 ns         1269 ns      2271114
uncompress_bench/uncompress_bench/131072        5159 ns         5151 ns       534307
uncompress_bench/uncompress_bench/1048576      38837 ns        38765 ns        72500
```

### PR
```
------------------------------------------------------------------------------------
Benchmark                                          Time             CPU   Iterations
------------------------------------------------------------------------------------
compress_bench/compress_bench/1                 1953 ns         1950 ns      1436570
compress_bench/compress_bench/8                 2089 ns         2086 ns      1345185
compress_bench/compress_bench/16                2169 ns         2166 ns      1292328
compress_bench/compress_bench/32                2383 ns         2379 ns      1176058
compress_bench/compress_bench/64                2666 ns         2662 ns      1062336
compress_bench/compress_bench/512               3460 ns         3455 ns       812569
compress_bench/compress_bench/4096             12573 ns        12554 ns       226458
compress_bench/compress_bench/32768            80012 ns        79895 ns        35061
inflate/inflate_nocrc/1                         13.7 ns         13.7 ns    204194534
inflate/inflate_nocrc/64                         111 ns          111 ns     25132817
inflate/inflate_nocrc/1024                       261 ns          260 ns     10569587
inflate/inflate_nocrc/16384                     3732 ns         3727 ns       733649
inflate/inflate_nocrc/131072                   14401 ns        14381 ns       195287
inflate/inflate_nocrc/1048576                  96520 ns        96343 ns        28995
uncompress_bench/uncompress_bench/1             41.4 ns         41.4 ns     67586234
uncompress_bench/uncompress_bench/64             136 ns          136 ns     20599418
uncompress_bench/uncompress_bench/1024           296 ns          296 ns      9566277
uncompress_bench/uncompress_bench/16384         3925 ns         3919 ns       704082
uncompress_bench/uncompress_bench/131072       15671 ns        15649 ns       178648
uncompress_bench/uncompress_bench/1048576     109852 ns       109650 ns        25465
```
As can be seen from the new benchmark results, the new data makes things a lot more complicated for both compress_bench and uncompress_bench, now they get a proper workout.
The new inflate_nocrc benchmark inflates the same data, but has a lot lower overhead than uncompress_bench and might let us more accurately benchmark changes to inflate (and chunkset) code.