### PR TITLE
Unroll some of the adler checksum for LASX

### DIFF
--- a/arch/loongarch/lasxintrin_ext.h
+++ b/arch/loongarch/lasxintrin_ext.h
@@ -38,6 +38,14 @@ static inline __m256i lasx_sad_bu(__m256i a, __m256i b) {
     return __lasx_xvhaddw_du_wu(tmp, tmp);
 }
 
+static inline __m256i lasx_maddubs_w_h(__m256i a, __m256i b) {
+    return __lasx_xvsadd_h(__lasx_xvmulwod_h_bu_b(a, b), __lasx_xvmulwev_h_bu_b(a, b));
+}
+
+static inline __m256i lasx_madd_w_h(__m256i a, __m256i b) {
+    return __lasx_xvmaddwod_w_h(__lasx_xvmulwev_w_h(a, b), a, b);
+}
+
 static inline int lasx_movemask_b(__m256i v) {
     v = __lasx_xvmskltz_b(v);
     return __lasx_xvpickve2gr_w(v, 0) | (__lasx_xvpickve2gr_w(v, 4) << 16);


### PR DESCRIPTION
Like #1949

develop:

```
adler32/lasx/1                                               6.57 ns         6.56 ns    106436828
adler32/lasx/8                                               10.5 ns         10.5 ns     66805597
adler32/lasx/12                                              12.2 ns         12.2 ns     57380436
adler32/lasx/16                                              14.5 ns         14.5 ns     48283917
adler32/lasx/32                                              16.6 ns         16.6 ns     42159486
adler32/lasx/64                                              19.2 ns         19.1 ns     36567736
adler32/lasx/512                                             54.8 ns         54.7 ns     12763509
adler32/lasx/4096                                             359 ns          359 ns      1944984
adler32/lasx/32768                                           2914 ns         2912 ns       240646
adler32/lasx/262144                                         30091 ns        30062 ns        23372
adler32/lasx/4194304                                       476805 ns       476327 ns         1458
```

PR:

```
adler32/lasx/1                                               6.58 ns         6.56 ns    106807694
adler32/lasx/8                                               11.5 ns         11.5 ns     60995853
adler32/lasx/12                                              15.1 ns         15.0 ns     46538113
adler32/lasx/16                                              15.0 ns         15.0 ns     46596300
adler32/lasx/32                                              17.1 ns         17.1 ns     41039717
adler32/lasx/64                                              18.3 ns         18.2 ns     38393807
adler32/lasx/512                                             48.1 ns         48.0 ns     14574603
adler32/lasx/4096                                             310 ns          310 ns      2260928
adler32/lasx/32768                                           2462 ns         2460 ns       283829
adler32/lasx/262144                                         24902 ns        24881 ns        28126
adler32/lasx/4194304                                       377948 ns       377576 ns         1855
```
