### PR TITLE
Use bitrev instruction on LoongArch.

### DIFF
--- a/fallback_builtins.h
+++ b/fallback_builtins.h
@@ -45,6 +45,15 @@ Z_FORCEINLINE static int __builtin_ctzll(unsigned long long value) {
 #endif // _MSC_VER & !clang
 
 #ifndef HAVE_BUILTIN_BITREVERSE16
+
+#ifdef __loongarch__
+/* LoongArch bit reversal for 16-bit values */
+Z_FORCEINLINE static uint16_t __builtin_bitreverse16(uint16_t value) {
+    uint32_t res;
+    __asm__ volatile("bitrev.w %0, %1" : "=r"(res) : "r"(value));
+    return (uint16_t)(res >> 16);
+}
+#else
 /* Bit reversal for 8-bit values using multiplication method */
 #define bitrev8(value) \
     (uint8_t)((((uint8_t)(value) * 0x80200802ULL) & 0x0884422110ULL) * 0x0101010101ULL >> 32)
@@ -53,6 +62,9 @@ Z_FORCEINLINE static int __builtin_ctzll(unsigned long long value) {
 Z_FORCEINLINE static uint16_t __builtin_bitreverse16(uint16_t value) {
     return ((bitrev8(value >> 8) | (uint16_t)bitrev8(value) << 8));
 }
+#undef bitrev8
+#endif
+
 #define HAVE_BUILTIN_BITREVERSE16
 #endif
 


### PR DESCRIPTION
**First run:**

develop:

```
CPU: loongarch64
Tool: minigzip Size: 163,944 B
Timing: perf
Levels: 0-9
Runs: 15         Trim worst: 5

 Level   Comp   Comptime min/avg/max/stddev  Decomptime min/avg/max/stddev  Compressed size
 0    100.008%  0.0154/0.0278/0.0361/0.0069    0.0239/0.0345/0.0428/0.0067      211,973,953
 1     44.409%  1.3517/1.3697/1.3798/0.0095    0.5072/0.5278/0.5384/0.0096       94,127,497
 2     35.519%  2.0875/2.1033/2.1178/0.0103    0.5077/0.5229/0.5337/0.0101       75,286,322
 3     33.882%  2.6214/2.6360/2.6478/0.0092    0.4709/0.4983/0.5148/0.0159       71,815,206
 4     33.175%  3.0895/3.1118/3.1239/0.0098    0.4614/0.4773/0.4859/0.0075       70,317,229
 5     32.661%  3.6270/3.6513/3.6670/0.0143    0.4488/0.4720/0.4844/0.0114       69,228,146
 6     32.507%  4.4307/4.4503/4.4682/0.0123    0.4482/0.4721/0.4848/0.0106       68,902,143
 7     32.255%  6.3754/6.3953/6.4186/0.0160    0.4272/0.4686/0.4831/0.0163       68,366,759
 8     32.167% 10.7249/10.7632/10.7820/0.0157    0.4218/0.4683/0.4903/0.0206       68,180,762
 9     31.887% 10.5153/10.5328/10.5540/0.0114    0.4539/0.4632/0.4703/0.0053       67,586,442

 avg1  40.847%                       4.5041                         0.4405
 avg2  45.386%                       5.0046                         0.4895
 tot                               450.4126                        44.0506      865,784,459
```

PR:

```
CPU: loongarch64
Tool: minigzip Size: 163,944 B
Timing: perf
Levels: 0-9
Runs: 15         Trim worst: 5

 Level   Comp   Comptime min/avg/max/stddev  Decomptime min/avg/max/stddev  Compressed size
 0    100.008%  0.0194/0.0268/0.0362/0.0052    0.0236/0.0303/0.0391/0.0055      211,973,953
 1     44.409%  1.3362/1.3568/1.3686/0.0091    0.5106/0.5317/0.5423/0.0099       94,127,497
 2     35.519%  2.0830/2.1090/2.1219/0.0131    0.4872/0.5191/0.5306/0.0130       75,286,322
 3     33.882%  2.6406/2.6445/2.6514/0.0045    0.4776/0.4937/0.5049/0.0086       71,815,206
 4     33.175%  3.1100/3.1235/3.1349/0.0092    0.4664/0.4835/0.4953/0.0086       70,317,229
 5     32.661%  3.6292/3.6470/3.6652/0.0116    0.4550/0.4719/0.4822/0.0076       69,228,146
 6     32.507%  4.4121/4.4413/4.4548/0.0121    0.4588/0.4681/0.4795/0.0084       68,902,143
 7     32.255%  6.3885/6.4107/6.4255/0.0132    0.4610/0.4716/0.4788/0.0064       68,366,759
 8     32.167% 10.7666/10.7820/10.7923/0.0098    0.4399/0.4645/0.4788/0.0119       68,180,762
 9     31.887% 10.5219/10.5472/10.5649/0.0128    0.4443/0.4539/0.4623/0.0058       67,586,442

 avg1  40.847%                       4.5089                         0.4388
 avg2  45.386%                       5.0099                         0.4876
 tot                               450.8885                        43.8812      865,784,459
```

**Second run:**

develop:

```
CPU: loongarch64
Tool: minigzip Size: 163,944 B
Timing: perf
Levels: 0-9
Runs: 15         Trim worst: 5

 Level   Comp   Comptime min/avg/max/stddev  Decomptime min/avg/max/stddev  Compressed size
 0    100.008%  0.0196/0.0255/0.0366/0.0052    0.0203/0.0338/0.0431/0.0071      211,973,953
 1     44.409%  1.3452/1.3649/1.3847/0.0120    0.5214/0.5313/0.5389/0.0070       94,127,497
 2     35.519%  2.0951/2.1127/2.1241/0.0094    0.4939/0.5192/0.5268/0.0098       75,286,322
 3     33.882%  2.6251/2.6407/2.6509/0.0087    0.4804/0.4995/0.5166/0.0105       71,815,206
 4     33.175%  3.0996/3.1187/3.1277/0.0095    0.4566/0.4767/0.5012/0.0135       70,317,229
 5     32.661%  3.6392/3.6560/3.6681/0.0080    0.4512/0.4731/0.4835/0.0113       69,228,146
 6     32.507%  4.4295/4.4437/4.4620/0.0089    0.4604/0.4705/0.4867/0.0085       68,902,143
 7     32.255%  6.3765/6.3999/6.4200/0.0114    0.4490/0.4685/0.4838/0.0121       68,366,759
 8     32.167% 10.7496/10.7675/10.7791/0.0111    0.4458/0.4665/0.4849/0.0137       68,180,762
 9     31.887% 10.5220/10.5366/10.5446/0.0076    0.4482/0.4567/0.4718/0.0081       67,586,442

 avg1  40.847%                       4.5066                         0.4396
 avg2  45.386%                       5.0074                         0.4884
 tot                               450.6620                        43.9570      865,784,459
```

PR:

```
CPU: loongarch64
Tool: minigzip Size: 163,944 B
Timing: perf
Levels: 0-9
Runs: 15         Trim worst: 5

 Level   Comp   Comptime min/avg/max/stddev  Decomptime min/avg/max/stddev  Compressed size
 0    100.008%  0.0156/0.0250/0.0322/0.0062    0.0198/0.0326/0.0405/0.0071      211,973,953
 1     44.409%  1.3512/1.3694/1.3812/0.0093    0.5000/0.5251/0.5409/0.0133       94,127,497
 2     35.519%  2.0904/2.1054/2.1154/0.0086    0.4894/0.5091/0.5225/0.0100       75,286,322
 3     33.882%  2.6237/2.6431/2.6564/0.0117    0.4771/0.4983/0.5087/0.0102       71,815,206
 4     33.175%  3.1021/3.1208/3.1308/0.0123    0.4614/0.4807/0.4928/0.0103       70,317,229
 5     32.661%  3.6563/3.6669/3.6756/0.0061    0.4416/0.4725/0.4868/0.0152       69,228,146
 6     32.507%  4.4139/4.4433/4.4632/0.0153    0.4567/0.4676/0.4762/0.0073       68,902,143
 7     32.255%  6.3895/6.4105/6.4259/0.0117    0.4203/0.4648/0.4807/0.0177       68,366,759
 8     32.167% 10.7577/10.7921/10.8132/0.0175    0.4493/0.4685/0.4799/0.0102       68,180,762
 9     31.887% 10.5167/10.5504/10.5669/0.0150    0.4328/0.4451/0.4555/0.0086       67,586,442

 avg1  40.847%                       4.5127                         0.4364
 avg2  45.386%                       5.0141                         0.4849
 tot                               451.2681                        43.6429      865,784,459
```

`BITREV.W`

https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html

Instruction formats:

```
bitrev.w        rd, rj
```

The `BITREV.W` instruction performs the operation that the [31:0] bit in general register `rj` is arranged in reverse order; the 32-bit intermediate result sign extension is written into general register `rd` in turn.
```
BITREV.W:
    bstr32[31:0] = BITREV(GR[rj][31:0])
    GR[rd] = SignExtend(bstr32, GRLEN)
```

P.S. Test in VM :(