### PR TITLE
Fix warning sprintf is deprecated and partail inbuf initialization

### DIFF
--- a/test/benchmarks/benchmark_compress.cc
+++ b/test/benchmarks/benchmark_compress.cc
@@ -37,9 +37,11 @@ public:
         assert(outbuff != NULL);
 
         int pos = 0;
-        for (int32_t i = 0; i < MAX_SIZE - 42 ; i+=42){
-           pos += sprintf((char *)inbuff+pos, "%s", teststr);
+        while (pos < MAX_SIZE) {
+            inbuff[pos] = teststr[pos % 41];
+            pos++;
         }
+        inbuff[pos] = '\0';
     }
 
     void Bench(benchmark::State& state) {


### PR DESCRIPTION
1) Fix warning on macos:

```
/Users/.../zlib-ng/test/benchmarks/benchmark_compress.cc:41:19: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
   41 |            pos += sprintf((char *)inbuff+pos, "%s", teststr);
      |                   ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_stdio.h:278:1: note: 'sprintf' has been explicitly marked deprecated here
  278 | __deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
      | ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:227:48: note: expanded from macro '__deprecated_msg'
  227 |         #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
      |                                                       ^
1 warning generated.
```

2) Fix inbuff initialization.

The `inbuff` was not fully initialized because `pos` incremented by 41 and `i` incremented by 42.