### PR TITLE
Add ALIGN_DIFF to perform alignment needed to next boundary

### DIFF
--- a/arch/arm/crc32_armv8.c
+++ b/arch/arm/crc32_armv8.c
@@ -10,12 +10,7 @@
 #include "crc32.h"
 
 Z_INTERNAL Z_TARGET_CRC uint32_t crc32_armv8(uint32_t crc, const uint8_t *buf, size_t len) {
-    Z_REGISTER uint32_t c;
-    Z_REGISTER uint16_t buf2;
-    Z_REGISTER uint32_t buf4;
-    Z_REGISTER uint64_t buf8;
-
-    c = ~crc;
+    uint32_t c = ~crc;
 
     if (UNLIKELY(len == 1)) {
         c = __crc32b(c, *buf);
@@ -30,36 +25,31 @@ Z_INTERNAL Z_TARGET_CRC uint32_t crc32_armv8(uint32_t crc, const uint8_t *buf, s
         }
 
         if ((len >= sizeof(uint16_t)) && ((ptrdiff_t)buf & (sizeof(uint32_t) - 1))) {
-            buf2 = *((uint16_t*)buf);
-            c = __crc32h(c, buf2);
+            c = __crc32h(c, *((uint16_t*)buf));
             buf += sizeof(uint16_t);
             len -= sizeof(uint16_t);
         }
 
         if ((len >= sizeof(uint32_t)) && ((ptrdiff_t)buf & (sizeof(uint64_t) - 1))) {
-            buf4 = *((uint32_t*)buf);
-            c = __crc32w(c, buf4);
+            c = __crc32w(c, *((uint32_t*)buf));
             len -= sizeof(uint32_t);
             buf += sizeof(uint32_t);
         }
     }
 
     while (len >= sizeof(uint64_t)) {
-        buf8 = *((uint64_t*)buf);
-        c = __crc32d(c, buf8);
+        c = __crc32d(c, *((uint64_t*)buf));
         len -= sizeof(uint64_t);
         buf += sizeof(uint64_t);
     }
 
     if (len & sizeof(uint32_t)) {
-        buf4 = *((uint32_t*)buf);
-        c = __crc32w(c, buf4);
+        c = __crc32w(c, *((uint32_t*)buf));
         buf += sizeof(uint32_t);
     }
 
     if (len & sizeof(uint16_t)) {
-        buf2 = *((uint16_t*)buf);
-        c = __crc32h(c, buf2);
+        c = __crc32h(c, *((uint16_t*)buf));
         buf += sizeof(uint16_t);
     }
 

--- a/arch/arm/crc32_armv8.c
+++ b/arch/arm/crc32_armv8.c
@@ -18,42 +18,43 @@ Z_INTERNAL Z_TARGET_CRC uint32_t crc32_armv8(uint32_t crc, const uint8_t *buf, s
         return c;
     }
 
-    if ((ptrdiff_t)buf & (sizeof(uint64_t) - 1)) {
-        if (len && ((ptrdiff_t)buf & 1)) {
+    uintptr_t align_diff = ALIGN_DIFF(buf, 8);
+    if (align_diff) {
+        if (len && (align_diff & 1)) {
             c = __crc32b(c, *buf++);
             len--;
         }
 
-        if ((len >= sizeof(uint16_t)) && ((ptrdiff_t)buf & (sizeof(uint32_t) - 1))) {
+        if (len >= 2 && (align_diff & 2)) {
             c = __crc32h(c, *((uint16_t*)buf));
-            buf += sizeof(uint16_t);
-            len -= sizeof(uint16_t);
+            buf += 2;
+            len -= 2;
         }
 
-        if ((len >= sizeof(uint32_t)) && ((ptrdiff_t)buf & (sizeof(uint64_t) - 1))) {
+        if (len >= 4 && (align_diff & 4)) {
             c = __crc32w(c, *((uint32_t*)buf));
-            len -= sizeof(uint32_t);
-            buf += sizeof(uint32_t);
+            len -= 4;
+            buf += 4;
         }
     }
 
-    while (len >= sizeof(uint64_t)) {
+    while (len >= 8) {
         c = __crc32d(c, *((uint64_t*)buf));
-        len -= sizeof(uint64_t);
-        buf += sizeof(uint64_t);
+        len -= 8;
+        buf += 8;
     }
 
-    if (len & sizeof(uint32_t)) {
+    if (len & 4) {
         c = __crc32w(c, *((uint32_t*)buf));
-        buf += sizeof(uint32_t);
+        buf += 4;
     }
 
-    if (len & sizeof(uint16_t)) {
+    if (len & 2) {
         c = __crc32h(c, *((uint16_t*)buf));
-        buf += sizeof(uint16_t);
+        buf += 2;
     }
 
-    if (len & sizeof(uint8_t)) {
+    if (len & 1) {
         c = __crc32b(c, *buf);
     }
 

--- a/arch/generic/crc32_braid_c.c
+++ b/arch/generic/crc32_braid_c.c
@@ -208,17 +208,11 @@ Z_INTERNAL uint32_t crc32_braid_internal(uint32_t c, const uint8_t *buf, size_t 
         CRC_DO1;
     }
 
-    /* Return the CRC, post-conditioned. */
     return c;
 }
 
 Z_INTERNAL uint32_t crc32_braid(uint32_t crc, const uint8_t *buf, size_t len) {
-    crc = (~crc) & 0xffffffff;
-
-    crc = crc32_braid_internal(crc, buf, len);
-
-    /* Return the CRC, post-conditioned. */
-    return crc ^ 0xffffffff;
+    return ~crc32_braid_internal(~crc, buf, len);
 }
 
 Z_INTERNAL uint32_t crc32_copy_braid(uint32_t crc, uint8_t *dst, const uint8_t *src, size_t len) {

--- a/arch/generic/crc32_braid_c.c
+++ b/arch/generic/crc32_braid_c.c
@@ -70,10 +70,10 @@ Z_INTERNAL uint32_t crc32_braid_internal(uint32_t c, const uint8_t *buf, size_t 
         int k;
 
         /* Compute the CRC up to a z_word_t boundary. */
-        while (len && ((uintptr_t)buf & (BRAID_W - 1)) != 0) {
-            len--;
+        size_t align_diff = (size_t)MIN(ALIGN_DIFF(buf, BRAID_W), len);
+        len -= align_diff;
+        while (align_diff--)
             CRC_DO1;
-        }
 
         /* Compute the CRC on as many BRAID_N z_word_t blocks as are available. */
         blks = len / (BRAID_N * BRAID_W);

--- a/arch/generic/crc32_chorba_c.c
+++ b/arch/generic/crc32_chorba_c.c
@@ -1448,27 +1448,27 @@ Z_INTERNAL uint32_t crc32_chorba_small_nondestructive_32bit (uint32_t crc, const
 #endif // OPTIMAL_CMP == 64
 
 Z_INTERNAL uint32_t crc32_chorba(uint32_t crc, const uint8_t *buf, size_t len) {
-    uint64_t* aligned_buf;
+    uint64_t *aligned_buf;
     uint32_t c = (~crc) & 0xffffffff;
-    uintptr_t algn_diff = ((uintptr_t)8 - ((uintptr_t)buf & 7)) & 7;
+    uintptr_t align_diff = ALIGN_DIFF(buf, 8);
 
-    if (len > algn_diff + CHORBA_SMALL_THRESHOLD) {
-        if (algn_diff) {
-            c = crc32_braid_internal(c, buf, algn_diff);
-            len -= algn_diff;
+    if (len > align_diff + CHORBA_SMALL_THRESHOLD) {
+        if (align_diff) {
+            c = crc32_braid_internal(c, buf, align_diff);
+            len -= align_diff;
         }
-        aligned_buf = (uint64_t*) (buf + algn_diff);
+        aligned_buf = (uint64_t*)(buf + align_diff);
         if(len > CHORBA_LARGE_THRESHOLD) {
-            c = crc32_chorba_118960_nondestructive(c, (z_word_t*) aligned_buf, len);
+            c = crc32_chorba_118960_nondestructive(c, (z_word_t*)aligned_buf, len);
 #  if OPTIMAL_CMP == 64
         } else if (len > CHORBA_MEDIUM_LOWER_THRESHOLD && len <= CHORBA_MEDIUM_UPPER_THRESHOLD) {
-            c = crc32_chorba_32768_nondestructive(c, (uint64_t*) aligned_buf, len);
+            c = crc32_chorba_32768_nondestructive(c, (uint64_t*)aligned_buf, len);
 #  endif
         } else {
 #  if OPTIMAL_CMP == 64
-            c = crc32_chorba_small_nondestructive(c, (uint64_t*) aligned_buf, len);
+            c = crc32_chorba_small_nondestructive(c, (uint64_t*)aligned_buf, len);
 #  else
-            c = crc32_chorba_small_nondestructive_32bit(c, (uint32_t*) aligned_buf, len);
+            c = crc32_chorba_small_nondestructive_32bit(c, (uint32_t*)aligned_buf, len);
 #  endif
         }
     } else {

--- a/arch/generic/crc32_chorba_c.c
+++ b/arch/generic/crc32_chorba_c.c
@@ -1449,7 +1449,7 @@ Z_INTERNAL uint32_t crc32_chorba_small_nondestructive_32bit (uint32_t crc, const
 
 Z_INTERNAL uint32_t crc32_chorba(uint32_t crc, const uint8_t *buf, size_t len) {
     uint64_t *aligned_buf;
-    uint32_t c = (~crc) & 0xffffffff;
+    uint32_t c = ~crc;
     uintptr_t align_diff = ALIGN_DIFF(buf, 8);
 
     if (len > align_diff + CHORBA_SMALL_THRESHOLD) {
@@ -1477,7 +1477,7 @@ Z_INTERNAL uint32_t crc32_chorba(uint32_t crc, const uint8_t *buf, size_t len) {
     }
 
     /* Return the CRC, post-conditioned. */
-    return c ^ 0xffffffff;
+    return ~c;
 }
 
 uint32_t crc32_copy_chorba(uint32_t crc, uint8_t *dst, const uint8_t *src, size_t len) {

--- a/arch/loongarch/crc32_la.c
+++ b/arch/loongarch/crc32_la.c
@@ -10,12 +10,7 @@
 #include <larchintrin.h>
 
 Z_INTERNAL uint32_t crc32_loongarch64(uint32_t crc, const uint8_t *buf, size_t len) {
-    Z_REGISTER uint32_t c;
-    Z_REGISTER uint16_t buf2;
-    Z_REGISTER uint32_t buf4;
-    Z_REGISTER uint64_t buf8;
-
-    c = ~crc;
+    uint32_t c = ~crc;
 
     if (UNLIKELY(len == 1)) {
         c = (uint32_t)__crc_w_b_w((char)(*buf), (int)c);
@@ -30,15 +25,13 @@ Z_INTERNAL uint32_t crc32_loongarch64(uint32_t crc, const uint8_t *buf, size_t l
         }
 
         if ((len >= sizeof(uint16_t)) && ((ptrdiff_t)buf & (sizeof(uint32_t) - 1))) {
-            buf2 = *((uint16_t*)buf);
-            c = (uint32_t)__crc_w_h_w((short)buf2, (int)c);
+            c = (uint32_t)__crc_w_h_w((short)*((uint16_t*)buf), (int)c);
             buf += sizeof(uint16_t);
             len -= sizeof(uint16_t);
         }
 
         if ((len >= sizeof(uint32_t)) && ((ptrdiff_t)buf & (sizeof(uint64_t) - 1))) {
-            buf4 = *((uint32_t*)buf);
-            c = (uint32_t)__crc_w_w_w((int)buf4, (int)c);
+            c = (uint32_t)__crc_w_w_w((int)*((uint32_t*)buf), (int)c);
             len -= sizeof(uint32_t);
             buf += sizeof(uint32_t);
         }
@@ -46,21 +39,18 @@ Z_INTERNAL uint32_t crc32_loongarch64(uint32_t crc, const uint8_t *buf, size_t l
     }
 
     while (len >= sizeof(uint64_t)) {
-        buf8 = *((uint64_t*)buf);
-        c = (uint32_t)__crc_w_d_w((long int)buf8, (int)c);
+        c = (uint32_t)__crc_w_d_w((long int)*((uint64_t*)buf), (int)c);
         len -= sizeof(uint64_t);
         buf += sizeof(uint64_t);
     }
 
     if (len & sizeof(uint32_t)) {
-        buf4 = *((uint32_t*)buf);
-        c = (uint32_t)__crc_w_w_w((int)buf4, (int)c);
+        c = (uint32_t)__crc_w_w_w((int)*((uint32_t*)buf), (int)c);
         buf += sizeof(uint32_t);
     }
 
     if (len & sizeof(uint16_t)) {
-        buf2 = *((uint16_t*)buf);
-        c = (uint32_t)__crc_w_h_w((short)buf2, (int)c);
+        c = (uint32_t)__crc_w_h_w((short)*((uint16_t*)buf), (int)c);
         buf += sizeof(uint16_t);
     }
 

--- a/arch/loongarch/crc32_la.c
+++ b/arch/loongarch/crc32_la.c
@@ -18,43 +18,44 @@ Z_INTERNAL uint32_t crc32_loongarch64(uint32_t crc, const uint8_t *buf, size_t l
         return c;
     }
 
-    if ((ptrdiff_t)buf & (sizeof(uint64_t) - 1)) {
-        if (len && ((ptrdiff_t)buf & 1)) {
+    uintptr_t align_diff = ALIGN_DIFF(buf, 8);
+    if (align_diff) {
+        if (len && (align_diff & 1)) {
             c = (uint32_t)__crc_w_b_w((char)(*buf++), (int)c);
             len--;
         }
 
-        if ((len >= sizeof(uint16_t)) && ((ptrdiff_t)buf & (sizeof(uint32_t) - 1))) {
+        if (len >= 2 && (align_diff & 2)) {
             c = (uint32_t)__crc_w_h_w((short)*((uint16_t*)buf), (int)c);
-            buf += sizeof(uint16_t);
-            len -= sizeof(uint16_t);
+            buf += 2;
+            len -= 2;
         }
 
-        if ((len >= sizeof(uint32_t)) && ((ptrdiff_t)buf & (sizeof(uint64_t) - 1))) {
+        if (len >= 4 && (align_diff & 4)) {
             c = (uint32_t)__crc_w_w_w((int)*((uint32_t*)buf), (int)c);
-            len -= sizeof(uint32_t);
-            buf += sizeof(uint32_t);
+            len -= 4;
+            buf += 4;
         }
 
     }
 
-    while (len >= sizeof(uint64_t)) {
+    while (len >= 8) {
         c = (uint32_t)__crc_w_d_w((long int)*((uint64_t*)buf), (int)c);
-        len -= sizeof(uint64_t);
-        buf += sizeof(uint64_t);
+        len -= 8;
+        buf += 8;
     }
 
-    if (len & sizeof(uint32_t)) {
+    if (len & 4) {
         c = (uint32_t)__crc_w_w_w((int)*((uint32_t*)buf), (int)c);
-        buf += sizeof(uint32_t);
+        buf += 4;
     }
 
-    if (len & sizeof(uint16_t)) {
+    if (len & 2) {
         c = (uint32_t)__crc_w_h_w((short)*((uint16_t*)buf), (int)c);
-        buf += sizeof(uint16_t);
+        buf += 2;
     }
 
-    if (len & sizeof(uint8_t)) {
+    if (len & 1) {
         c = (uint32_t)__crc_w_b_w((char)(*buf), (int)c);
     }
 

--- a/arch/power/crc32_power8.c
+++ b/arch/power/crc32_power8.c
@@ -63,7 +63,7 @@ Z_INTERNAL uint32_t crc32_power8(uint32_t crc, const unsigned char *p, size_t _l
     }
 
     if ((unsigned long)p & VMX_ALIGN_MASK) {
-        prealign = VMX_ALIGN - ((unsigned long)p & VMX_ALIGN_MASK);
+        prealign = (unsigned int)ALIGN_DIFF(p, VMX_ALIGN);
         crc = crc32_align(crc, p, prealign);
         len -= prealign;
         p += prealign;

--- a/arch/s390/crc32-vx.c
+++ b/arch/s390/crc32-vx.c
@@ -205,7 +205,7 @@ uint32_t Z_INTERNAL crc32_s390_vx(uint32_t crc, const unsigned char *buf, size_t
         return crc32_braid(crc, buf, len);
 
     if ((uintptr_t)buf & VX_ALIGN_MASK) {
-        prealign = VX_ALIGNMENT - ((uintptr_t)buf & VX_ALIGN_MASK);
+        prealign = (size_t)ALIGN_DIFF(buf, VX_ALIGNMENT);
         len -= prealign;
         crc = crc32_braid(crc, buf, prealign);
         buf += prealign;

--- a/arch/s390/crc32-vx.c
+++ b/arch/s390/crc32-vx.c
@@ -213,7 +213,7 @@ uint32_t Z_INTERNAL crc32_s390_vx(uint32_t crc, const unsigned char *buf, size_t
     aligned = len & ~VX_ALIGN_MASK;
     remaining = len & VX_ALIGN_MASK;
 
-    crc = crc32_le_vgfm_16(crc ^ 0xffffffff, buf, aligned) ^ 0xffffffff;
+    crc = ~crc32_le_vgfm_16(~crc, buf, aligned);
 
     if (remaining)
         crc = crc32_braid(crc, buf + aligned, remaining);

--- a/arch/x86/chorba_sse2.c
+++ b/arch/x86/chorba_sse2.c
@@ -847,19 +847,19 @@ Z_INTERNAL uint32_t chorba_small_nondestructive_sse2(uint32_t crc, const uint64_
 }
 
 Z_INTERNAL uint32_t crc32_chorba_sse2(uint32_t crc, const uint8_t *buf, size_t len) {
-    uint64_t* aligned_buf;
+    uint64_t *aligned_buf;
     uint32_t c = (~crc) & 0xffffffff;
-    uintptr_t algn_diff = ((uintptr_t)16 - ((uintptr_t)buf & 15)) & 15;
+    uintptr_t align_diff = ALIGN_DIFF(buf, 16);
 
-    if (len > algn_diff + CHORBA_SMALL_THRESHOLD_64BIT) {
-        if (algn_diff) {
-            c = crc32_braid_internal(c, buf, algn_diff);
-            len -= algn_diff;
+    if (len > align_diff + CHORBA_SMALL_THRESHOLD_64BIT) {
+        if (align_diff) {
+            c = crc32_braid_internal(c, buf, align_diff);
+            len -= align_diff;
         }
-        aligned_buf = (uint64_t*) (buf + algn_diff);
+        aligned_buf = (uint64_t*)(buf + align_diff);
 #if !defined(WITHOUT_CHORBA)
-        if(len > CHORBA_LARGE_THRESHOLD) {
-            c = crc32_chorba_118960_nondestructive(c, (z_word_t*) aligned_buf, len);
+        if (len > CHORBA_LARGE_THRESHOLD) {
+            c = crc32_chorba_118960_nondestructive(c, (z_word_t*)aligned_buf, len);
         } else
 #endif
         {

--- a/arch/x86/chorba_sse2.c
+++ b/arch/x86/chorba_sse2.c
@@ -848,7 +848,7 @@ Z_INTERNAL uint32_t chorba_small_nondestructive_sse2(uint32_t crc, const uint64_
 
 Z_INTERNAL uint32_t crc32_chorba_sse2(uint32_t crc, const uint8_t *buf, size_t len) {
     uint64_t *aligned_buf;
-    uint32_t c = (~crc) & 0xffffffff;
+    uint32_t c = ~crc;
     uintptr_t align_diff = ALIGN_DIFF(buf, 16);
 
     if (len > align_diff + CHORBA_SMALL_THRESHOLD_64BIT) {
@@ -871,7 +871,7 @@ Z_INTERNAL uint32_t crc32_chorba_sse2(uint32_t crc, const uint8_t *buf, size_t l
     }
 
     /* Return the CRC, post-conditioned. */
-    return c ^ 0xffffffff;
+    return ~c;
 }
 
 Z_INTERNAL uint32_t crc32_copy_chorba_sse2(uint32_t crc, uint8_t *dst, const uint8_t *src, size_t len) {

--- a/arch/x86/chorba_sse41.c
+++ b/arch/x86/chorba_sse41.c
@@ -306,7 +306,7 @@ static Z_FORCEINLINE uint32_t crc32_chorba_32768_nondestructive_sse41(uint32_t c
 
 Z_INTERNAL uint32_t crc32_chorba_sse41(uint32_t crc, const uint8_t *buf, size_t len) {
     uint64_t *aligned_buf;
-    uint32_t c = (~crc) & 0xffffffff;
+    uint32_t c = ~crc;
     uintptr_t align_diff = ALIGN_DIFF(buf, 16);
 
     if (len > align_diff + CHORBA_SMALL_THRESHOLD_64BIT) {
@@ -331,7 +331,7 @@ Z_INTERNAL uint32_t crc32_chorba_sse41(uint32_t crc, const uint8_t *buf, size_t 
     }
 
     /* Return the CRC, post-conditioned. */
-    return c ^ 0xffffffff;
+    return ~c;
 }
 
 Z_INTERNAL uint32_t crc32_copy_chorba_sse41(uint32_t crc, uint8_t *dst, const uint8_t *src, size_t len) {

--- a/arch/x86/chorba_sse41.c
+++ b/arch/x86/chorba_sse41.c
@@ -305,19 +305,19 @@ static Z_FORCEINLINE uint32_t crc32_chorba_32768_nondestructive_sse41(uint32_t c
 }
 
 Z_INTERNAL uint32_t crc32_chorba_sse41(uint32_t crc, const uint8_t *buf, size_t len) {
-    uint64_t* aligned_buf;
+    uint64_t *aligned_buf;
     uint32_t c = (~crc) & 0xffffffff;
-    uintptr_t algn_diff = ((uintptr_t)16 - ((uintptr_t)buf & 15)) & 15;
+    uintptr_t align_diff = ALIGN_DIFF(buf, 16);
 
-    if (len > algn_diff + CHORBA_SMALL_THRESHOLD_64BIT) {
-        if (algn_diff) {
-            c = crc32_braid_internal(c, buf, algn_diff);
-            len -= algn_diff;
+    if (len > align_diff + CHORBA_SMALL_THRESHOLD_64BIT) {
+        if (align_diff) {
+            c = crc32_braid_internal(c, buf, align_diff);
+            len -= align_diff;
         }
-        aligned_buf = (uint64_t*) (buf + algn_diff);
+        aligned_buf = (uint64_t*)(buf + align_diff);
 #if !defined(WITHOUT_CHORBA)
-        if(len > CHORBA_LARGE_THRESHOLD) {
-            c = crc32_chorba_118960_nondestructive(c, (z_word_t*) aligned_buf, len);
+        if (len > CHORBA_LARGE_THRESHOLD) {
+            c = crc32_chorba_118960_nondestructive(c, (z_word_t*)aligned_buf, len);
         } else
 #endif
         if (len > CHORBA_MEDIUM_LOWER_THRESHOLD && len <= CHORBA_MEDIUM_UPPER_THRESHOLD) {

--- a/arch/x86/crc32_pclmulqdq_tpl.h
+++ b/arch/x86/crc32_pclmulqdq_tpl.h
@@ -337,11 +337,11 @@ Z_FORCEINLINE static uint32_t crc32_copy_impl(uint32_t crc, uint8_t *dst, const 
     size_t copy_len = len;
     if (len >= 16) {
         /* Calculate 16-byte alignment offset */
-        unsigned algn_diff = ((uintptr_t)16 - ((uintptr_t)src & 0xF)) & 0xF;
+        uintptr_t align_diff = ALIGN_DIFF(src, 16);
 
         /* If total length is less than (alignment bytes + 16), use the faster small method.
          * Handles both initially small buffers and cases where alignment would leave < 16 bytes */
-        copy_len = len < algn_diff + 16 ? len : algn_diff;
+        copy_len = len < align_diff + 16 ? len : align_diff;
     }
 
     if (copy_len > 0) {

--- a/arch/x86/crc32_pclmulqdq_tpl.h
+++ b/arch/x86/crc32_pclmulqdq_tpl.h
@@ -285,7 +285,7 @@ static inline void partial_fold(const size_t len, __m128i *xmm_crc0, __m128i *xm
 }
 
 static inline uint32_t crc32_copy_small(uint32_t crc, uint8_t *dst, const uint8_t *buf, size_t len, const int COPY) {
-    uint32_t c = (~crc) & 0xffffffff;
+    uint32_t c = ~crc;
 
     while (len) {
         len--;
@@ -295,7 +295,7 @@ static inline uint32_t crc32_copy_small(uint32_t crc, uint8_t *dst, const uint8_
         CRC_DO1;
     }
 
-    return c ^ 0xffffffff;
+    return ~c;
 }
 
 static inline uint32_t fold_final(__m128i *xmm_crc0, __m128i *xmm_crc1, __m128i *xmm_crc2, __m128i *xmm_crc3) {

--- a/zbuild.h
+++ b/zbuild.h
@@ -245,6 +245,10 @@
 #define HINT_ALIGNED_64(p) HINT_ALIGNED((p),64)
 #define HINT_ALIGNED_4096(p) HINT_ALIGNED((p),4096)
 
+/* Number of bytes needed to align ptr to the next alignment boundary */
+#define ALIGN_DIFF(ptr, align) \
+    (((uintptr_t)(align) - ((uintptr_t)(ptr) & ((align) - 1))) & ((align) - 1))
+
 /* PADSZ returns needed bytes to pad bpos to pad size
  * PAD_NN calculates pad size and adds it to bpos, returning the result.
  * All take an integer or a pointer as bpos input.

--- a/zutil.c
+++ b/zutil.c
@@ -114,8 +114,8 @@ void Z_INTERNAL PREFIX(zcfree)(void *opaque, void *ptr) {
 
 /* Provide aligned allocations, only used by gz* code */
 void Z_INTERNAL *zng_alloc_aligned(unsigned size, unsigned align) {
-    uintptr_t return_ptr, original_ptr;
-    uint32_t alloc_size, align_diff;
+    uintptr_t return_ptr, original_ptr, align_diff;
+    uint32_t alloc_size;
     void *ptr;
 
     /* Allocate enough memory for proper alignment and to store the original memory pointer */
@@ -125,7 +125,7 @@ void Z_INTERNAL *zng_alloc_aligned(unsigned size, unsigned align) {
         return NULL;
 
     /* Calculate return pointer address with space enough to store original pointer */
-    align_diff = align - ((uintptr_t)ptr % align);
+    align_diff = ALIGN_DIFF(ptr, align);
     return_ptr = (uintptr_t)ptr + align_diff;
     if (align_diff < sizeof(void *))
         return_ptr += align;


### PR DESCRIPTION
This simplies some of the align calculations and checks.. I've also use constants in some of the crc32 code. It just makes the code easier to read, doesn't rely on a typedef, and there are so many other areas of code that use constants in these situations of `len` checks it makes more sense.