### PR TITLE
Explicitly define the __SSE__ and __SSE2__ macros, since starting with MSVS 2012 the default instruction set is SSE2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,6 +240,16 @@ elseif(MSVC)
             set(NEONFLAG "/arch:VFPv4")
         endif()
     endif()
+
+    # Workaround for MSVC. By default MSVC does not define the __SSE*__ macros.
+    # We explicitly define the __SSE__ and __SSE2__ macros, since starting with MSVS 2012
+    # the default instruction set is SSE2.
+    if(BASEARCH_X86_FOUND)
+        add_definitions(
+            -D__SSE__=1
+            -D__SSE2__=1
+        )
+    endif()
 elseif(CMAKE_C_COMPILER_ID MATCHES "GNU" OR CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_C_COMPILER_ID MATCHES "NVHPC")
     # Enable warnings in GCC and Clang
     set(WARNFLAGS -Wall)
@@ -361,8 +371,6 @@ if(NOT WITH_RUNTIME_CPU_DETECTION)
         set(CMAKE_REQUIRED_FLAGS)
         if(MSVC_IS_ENABLED_AVX)
             add_definitions(
-                -D__SSE__=1
-                -D__SSE2__=1
                 -D__SSE3__=1
                 -D__SSSE3__=1
                 -D__SSE4_1__=1


### PR DESCRIPTION
Workaround for MSVC. By default MSVC does not define the `__SSE*__` macros.
We explicitly define the `__SSE__` and `__SSE2__` macros, since starting with MSVS 2012 the default instruction set is SSE2.

MSVS 2015: https://learn.microsoft.com/en-us/cpp/build/reference/arch-x86?view=msvc-140
MSVS 2013: https://learn.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2013/7t5yh4fd(v=vs.120)
MSVS 2012: https://learn.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2012/7t5yh4fd(v=vs.110)

