### PR TITLE
Use GCC's may_alias attribute for access to buffers in crc32_chorba

### DIFF
--- a/arch/generic/generic_functions.h
+++ b/arch/generic/generic_functions.h
@@ -30,9 +30,9 @@ uint32_t crc32_copy_braid(uint32_t crc, uint8_t *dst, const uint8_t *src, size_t
 #ifndef WITHOUT_CHORBA
   uint32_t crc32_chorba(uint32_t crc, const uint8_t *buf, size_t len);
   uint32_t crc32_chorba_118960_nondestructive (uint32_t crc, const z_word_t* input, size_t len);
-  uint32_t crc32_chorba_32768_nondestructive (uint32_t crc, const uint64_t* buf, size_t len);
-  uint32_t crc32_chorba_small_nondestructive (uint32_t crc, const uint64_t* buf, size_t len);
-  uint32_t crc32_chorba_small_nondestructive_32bit (uint32_t crc, const uint32_t* buf, size_t len);
+  uint32_t crc32_chorba_32768_nondestructive (uint32_t crc, const uint64_t* input, size_t len);
+  uint32_t crc32_chorba_small_nondestructive (uint32_t crc, const uint64_t* input, size_t len);
+  uint32_t crc32_chorba_small_nondestructive_32bit (uint32_t crc, const uint32_t* input, size_t len);
   uint32_t crc32_copy_chorba(uint32_t crc, uint8_t *dst, const uint8_t *src, size_t len);
 #endif
 


### PR DESCRIPTION
Converting a pointer from type `z_word_t*` (on 32-bit systems: `uint32_t*`) to `uint64_t*` breaks strict aliasing rules.

On GCC `-fstrict-aliasing` is `on` by default at `-O2` or above ( https://gcc.gnu.org/onlinedocs/gcc-10.2.0/gcc/Common-Type-Attributes.html ).

Fix #1926 
The compiler warning is no longer present.

Develop: https://github.com/zlib-ng/zlib-ng/actions/runs/20773110891/job/59653058832#step:17:46
PR: https://github.com/phprus/zlib-ng/actions/runs/20795098755/job/59726505687#step:17:46

@mtl1979 @samrussell 