### PR TITLE
Reset compiler flags after completing intrinsic tests

### DIFF
--- a/cmake/detect-intrinsics.cmake
+++ b/cmake/detect-intrinsics.cmake
@@ -171,6 +171,7 @@ macro(check_avx512_intrinsics)
         int main(void) { return 0; }"
         HAVE_AVX512_INTRIN
     )
+    set(CMAKE_REQUIRED_FLAGS)
 endmacro()
 
 macro(check_avx512vnni_intrinsics)
@@ -623,6 +624,7 @@ macro(check_ssse3_intrinsics)
         int main(void) { return 0; }"
         HAVE_SSSE3_INTRIN
     )
+    set(CMAKE_REQUIRED_FLAGS)
 endmacro()
 
 macro(check_sse41_intrinsics)


### PR DESCRIPTION
Add missing reset of compiler flags after completing a test, avoids the next test inheriting the previous flags.