### PR TITLE
CI: Resolve merge conflicts in coverage data, instead of aborting.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -62,7 +62,7 @@ jobs:
             codecov: ubuntu_gcc_osb
             cflags: -O3
 
-          - name: Ubuntu GCC -O3 OSB add_subdirectory
+          - name: Ubuntu GCC OSB add_subdirectory
             os: ubuntu-latest
             compiler: gcc
             cxx-compiler: g++
@@ -847,6 +847,8 @@ jobs:
         python3 -u -m pip install gcovr
         python3 -m gcovr ${{ matrix.build-dir || '' }} -j 3 --gcov-ignore-parse-errors --verbose \
           --exclude-unreachable-branches \
+          --merge-mode-functions separate \
+          --merge-lines \
           --gcov-executable "${{ matrix.gcov-exec || 'gcov' }}" \
           --root ${{ matrix.build-src-dir || '.' }} \
           --xml --output ${{ matrix.codecov }}.xml

--- a/.github/workflows/pigz.yml
+++ b/.github/workflows/pigz.yml
@@ -108,6 +108,8 @@ jobs:
         python3 -u -m pip install gcovr
         python3 -m gcovr -j 3 --gcov-ignore-parse-errors --verbose \
           --exclude-unreachable-branches \
+          --merge-mode-functions separate \
+          --merge-lines \
           --gcov-executable "${{ matrix.gcov-exec || 'gcov' }}" \
           --root . \
           --xml --output ${{ matrix.codecov }}.xml


### PR DESCRIPTION
Gcov has become more strict in how it handles conflicts of finding the same function on different lines.
It thinks adler32_p.h lines 22 and 34 contain the same function.

Those lines are the starts of two nearly identical blocks of code in separate functions (one being the function itself, one being the contents of a loop), and I suspect the compiler is being smart and merging those two blocks, and lets the second function just loop over the first function. This is purely my speculation.

If my speculation is correct, I can easily imagine gcov thinking it is a problem. I don't know enough about this to tell whether this might be a gcov bug/oversight or just us doing weird things.

Setting `--merge-mode-functions` to separate instead of strict will keep both reports, instead of aborting. Whether that is strictly correct or not, I do not know.

Adding `--merge-lines` also seemed like a good idea for us. It merges coverage reports for the same line used from multiple places, supposed to be good for templates and such.

Hopefully CI passes again. :crossed_fingers: 