### PR TITLE
CI: Disable downloading extra test corpora for builds running with sanitizers enabled.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -686,7 +686,7 @@ jobs:
       uses: actions/checkout@v6
       # Don't test against all corpora with MinGW due to Wine being unable to run parallel jobs
       # without connection timeout. Without parallel jobs test runs using Wine take close to an hour.
-      if: contains(matrix.name, 'MinGW') == false
+      if: contains(matrix.name, 'MinGW') == false && !contains(matrix.cmake-args, 'WITH_SANITIZER')
       with:
         repository: zlib-ng/corpora
         path: test/data/corpora


### PR DESCRIPTION
Testing currently takes about ~2-4 hours to complete, the extra test corpora that was added to the CI increased it from about 30 minutes total.

The slowest tests are those running with sanitizers enabled, especially when those are also run on emulated architectures. A few of those often take more than 1 hour to complete, blocking other tests from utilizing the few runners we have access to.

Therefore, disable downloading extra tests for WITH_SANITIZER builds to speed up testing.