### PR TITLE
CMake: Improve and cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,6 @@
 cmake_minimum_required(VERSION 3.14...4.2.1)
 message(STATUS "Using CMake version ${CMAKE_VERSION}")
 
-if(POLICY CMP0169)
-    cmake_policy(SET CMP0169 OLD) # CMake 3.30: call FetchContent_Populate() with just the name of a dependency
-endif()
-
 # If not specified on the command line, enable C11 as the default
 # Configuration items that affect the global compiler environment standards
 # should be issued before the "project" command.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14...3.31.0)
+cmake_minimum_required(VERSION 3.14...4.2.1)
 message(STATUS "Using CMake version ${CMAKE_VERSION}")
 
 if(POLICY CMP0169)

--- a/cmake/detect-coverage.cmake
+++ b/cmake/detect-coverage.cmake
@@ -3,13 +3,8 @@
 
 macro(add_code_coverage)
     # Check for -coverage flag support for Clang/GCC
-    if(CMAKE_VERSION VERSION_LESS 3.14)
-        set(CMAKE_REQUIRED_LIBRARIES -lgcov)
-    else()
-        set(CMAKE_REQUIRED_LINK_OPTIONS -coverage)
-    endif()
+    set(CMAKE_REQUIRED_LINK_OPTIONS -coverage)
     check_c_compiler_flag(-coverage HAVE_COVERAGE)
-    set(CMAKE_REQUIRED_LIBRARIES)
     set(CMAKE_REQUIRED_LINK_OPTIONS)
 
     if(HAVE_COVERAGE)
@@ -18,13 +13,8 @@ macro(add_code_coverage)
         message(STATUS "Code coverage enabled using: -coverage")
     else()
         # Some versions of GCC don't support -coverage shorthand
-        if(CMAKE_VERSION VERSION_LESS 3.14)
-            set(CMAKE_REQUIRED_LIBRARIES -lgcov)
-        else()
-            set(CMAKE_REQUIRED_LINK_OPTIONS -lgcov -fprofile-arcs)
-        endif()
+        set(CMAKE_REQUIRED_LINK_OPTIONS -lgcov -fprofile-arcs)
         check_c_compiler_flag("-ftest-coverage -fprofile-arcs -fprofile-values" HAVE_TEST_COVERAGE)
-        set(CMAKE_REQUIRED_LIBRARIES)
         set(CMAKE_REQUIRED_LINK_OPTIONS)
 
         if(HAVE_TEST_COVERAGE)

--- a/cmake/fallback-macros.cmake
+++ b/cmake/fallback-macros.cmake
@@ -2,18 +2,3 @@
 # Copyright (C) 2022 Nathan Moinvaziri
 # Licensed under the Zlib license, see LICENSE.md for details
 
-# CMake less than version 3.5.2
-if(NOT COMMAND add_compile_options)
-    macro(add_compile_options options)
-        string(APPEND CMAKE_C_FLAGS ${options})
-        string(APPEND CMAKE_CXX_FLAGS ${options})
-    endmacro()
-endif()
-
-# CMake less than version 3.14
-if(NOT COMMAND add_link_options)
-    macro(add_link_options options)
-        string(APPEND CMAKE_EXE_LINKER_FLAGS ${options})
-        string(APPEND CMAKE_SHARED_LINKER_FLAGS ${options})
-    endmacro()
-endif()

--- a/cmake/fallback-macros.cmake
+++ b/cmake/fallback-macros.cmake
@@ -1,4 +1,29 @@
 # fallback-macros.cmake -- CMake fallback macros
-# Copyright (C) 2022 Nathan Moinvaziri
+# Copyright (C) 2026 Vladislav Shchapov
 # Licensed under the Zlib license, see LICENSE.md for details
 
+# Workaround for FetchContent EXCLUDE_FROM_ALL implementation for CMake before 3.28.
+# The EXCLUDE_FROM_ALL argument for FetchContent_Declare added in version 3.28.
+# Before CMake 3.28, FetchContent_MakeAvailable would add dependencies to the ALL target.
+macro(ZNG_FetchContent_MakeAvailable)
+    if(CMAKE_VERSION VERSION_LESS 3.28)
+        foreach(__zng_contentName IN ITEMS ${ARGV})
+            string(TOLOWER ${__zng_contentName} __zng_contentNameLower)
+            FetchContent_GetProperties(${__zng_contentName})
+            if(NOT ${__zng_contentNameLower}_POPULATED)
+                FetchContent_Populate(${__zng_contentName})
+                add_subdirectory(${${__zng_contentNameLower}_SOURCE_DIR} ${${__zng_contentNameLower}_BINARY_DIR} EXCLUDE_FROM_ALL)
+            endif()
+        endforeach()
+        unset(__zng_contentName)
+        unset(__zng_contentNameLower)
+    else()
+        FetchContent_MakeAvailable(${ARGV})
+    endif()
+endmacro()
+
+if(CMAKE_VERSION VERSION_LESS 3.28)
+    set(ZNG_FetchContent_Declare_EXCLUDE_FROM_ALL)
+else()
+    set(ZNG_FetchContent_Declare_EXCLUDE_FROM_ALL EXCLUDE_FROM_ALL)
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -134,13 +134,10 @@ if(WITH_GTEST)
         message(STATUS "Git checking out GoogleTest ${GTEST_TAG}")
         FetchContent_Declare(googletest
             GIT_REPOSITORY ${GTEST_REPOSITORY}
-            GIT_TAG ${GTEST_TAG})
+            GIT_TAG ${GTEST_TAG}
+            ${ZNG_FetchContent_Declare_EXCLUDE_FROM_ALL})
 
-        FetchContent_GetProperties(googletest)
-        if(NOT googletest_POPULATED)
-            FetchContent_Populate(googletest)
-            add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR} EXCLUDE_FROM_ALL)
-        endif()
+        ZNG_FetchContent_MakeAvailable(googletest)
         add_library(GTest::GTest ALIAS gtest)
         add_library(GTest::Main ALIAS gtest_main)
     endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -94,7 +94,12 @@ endif()
 if(WITH_GTEST)
     # Google test requires at least C++11
     if(NOT DEFINED CMAKE_CXX_STANDARD)
-        set(CMAKE_CXX_STANDARD 11)
+        # Use older version of Google test to support older versions of GCC
+        if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS_EQUAL 5.3)
+            set(CMAKE_CXX_STANDARD 11)
+        else()
+            set(CMAKE_CXX_STANDARD 14)
+        endif()
     endif()
 
     # Google test requires MSAN instrumented LLVM C++ libraries
@@ -126,7 +131,7 @@ if(WITH_GTEST)
             if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS_EQUAL 5.3)
                 set(GTEST_TAG release-1.10.0)
             else()
-                set(GTEST_TAG release-1.12.1)
+                set(GTEST_TAG v1.16.0)
             endif()
         endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -110,7 +110,7 @@ if(WITH_GTEST)
         find_package(GTest)
     endif()
 
-    if(NOT TARGET GTest::GTest AND NOT CMAKE_VERSION VERSION_LESS 3.11)
+    if(NOT TARGET GTest::GTest)
         include(FetchContent)
 
         # Prevent overriding the parent project's compiler/linker settings for Windows

--- a/test/add-subdirectory-project/CMakeLists.txt
+++ b/test/add-subdirectory-project/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1...3.29.0)
+cmake_minimum_required(VERSION 3.14...4.2.1)
 
 project(zlib-ng-add-subdirecory-test C)
 

--- a/test/benchmarks/CMakeLists.txt
+++ b/test/benchmarks/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.14...4.2.1)
 
 include(FetchContent)
 

--- a/test/benchmarks/CMakeLists.txt
+++ b/test/benchmarks/CMakeLists.txt
@@ -28,13 +28,10 @@ if(NOT benchmark_FOUND)
 
     FetchContent_Declare(benchmark
         GIT_REPOSITORY ${GBENCHMARK_REPOSITORY}
-        GIT_TAG ${GBENCHMARK_TAG})
+        GIT_TAG ${GBENCHMARK_TAG}
+        ${ZNG_FetchContent_Declare_EXCLUDE_FROM_ALL})
 
-    FetchContent_GetProperties(benchmark)
-    if(NOT benchmark_POPULATED)
-        FetchContent_Populate(benchmark)
-        add_subdirectory(${benchmark_SOURCE_DIR} ${benchmark_BINARY_DIR} EXCLUDE_FROM_ALL)
-    endif()
+    ZNG_FetchContent_MakeAvailable(benchmark)
 endif()
 
 add_executable(benchmark_zlib
@@ -74,14 +71,11 @@ if(WITH_BENCHMARK_APPS)
 
     if(NOT PNG_FOUND)
         FetchContent_Declare(PNG
-            GIT_REPOSITORY https://github.com/glennrp/libpng.git)
+            GIT_REPOSITORY https://github.com/glennrp/libpng.git
+            ${ZNG_FetchContent_Declare_EXCLUDE_FROM_ALL})
 
-        FetchContent_GetProperties(PNG)
-        if(NOT PNG_POPULATED)
-            FetchContent_Populate(PNG)
-            set(PNG_INCLUDE_DIR ${png_SOURCE_DIR})
-            add_subdirectory(${png_SOURCE_DIR} ${png_BINARY_DIR})
-        endif()
+        ZNG_FetchContent_MakeAvailable(PNG)
+        set(PNG_INCLUDE_DIR ${png_SOURCE_DIR})
     endif()
 
     set(BENCH_APP_SRCS

--- a/test/fuzz/CMakeLists.txt
+++ b/test/fuzz/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1...3.29.0)
+cmake_minimum_required(VERSION 3.14...4.2.1)
 
 if(CMAKE_C_COMPILER_ID MATCHES "Clang")
     if(DEFINED ENV{LIB_FUZZING_ENGINE})

--- a/test/pigz/CMakeLists.txt
+++ b/test/pigz/CMakeLists.txt
@@ -18,7 +18,7 @@
 #   PTHREADS4W_ROOT     - Path to pthreads4w source directory on Windows.
 #                         If not specified then threading will be disabled.
 
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.14...4.2.1)
 
 include(CheckCCompilerFlag)
 include(FeatureSummary)

--- a/test/pigz/CMakeLists.txt
+++ b/test/pigz/CMakeLists.txt
@@ -65,10 +65,7 @@ FetchContent_Declare(pigz
     GIT_REPOSITORY https://github.com/madler/pigz.git
     GIT_TAG ${PIGZ_TAG})
 
-FetchContent_GetProperties(pigz)
-if(NOT pigz_POPULATED)
-    FetchContent_Populate(pigz)
-endif()
+FetchContent_MakeAvailable(pigz)
 
 set(PIGZ_SRCS
     ${pigz_SOURCE_DIR}/pigz.c


### PR DESCRIPTION
1) All modules now have the same CMake version requirements.
2) Removed obsolete CMake version checks.
3) Replaced deprecated `FetchContent_Populate` with `FetchContent_MakeAvailable` (with workaround for CMake < 3.28).
4) Update GoogleTest to 1.16.0. (Fix googletest cmake warning: Compatibility with CMake < 3.10 will be removed from a future version of CMake).