### PR TITLE
__builtin_bitreverse16 CMake compiler check fails for GCC 13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -652,24 +652,6 @@ endif()
 set(CMAKE_REQUIRED_FLAGS)
 
 #
-# check for __builtin_bitreverse16() support in the compiler
-#
-set(CMAKE_REQUIRED_FLAGS ${ZNOLTOFLAG})
-check_c_source_compiles(
-    "int main(void) {
-        unsigned short val = 0x1234;
-        unsigned short test = __builtin_bitreverse16(val);
-        (void)test;
-        return 0;
-    }"
-    HAVE_BUILTIN_BITREVERSE16
-)
-if(HAVE_BUILTIN_BITREVERSE16)
-    add_definitions(-DHAVE_BUILTIN_BITREVERSE16)
-endif()
-set(CMAKE_REQUIRED_FLAGS)
-
-#
 # check for ptrdiff_t support
 #
 check_c_source_compiles(

--- a/configure
+++ b/configure
@@ -1167,19 +1167,6 @@ else
     echo "Checking for __builtin_ctzll ... No." | tee -a configure.log
 fi
 
-# Check for __builtin_bitreverse16() support in compiler
-cat > $test.c << EOF
-unsigned short f(unsigned short x) { return __builtin_bitreverse16(x); }
-int main(void) { return 0; }
-EOF
-if try ${CC} ${CFLAGS} $test.c $LDSHAREDLIBC; then
-    echo "Checking for __builtin_bitreverse16 ... Yes." | tee -a configure.log
-    CFLAGS="$CFLAGS -DHAVE_BUILTIN_BITREVERSE16"
-    SFLAGS="$SFLAGS -DHAVE_BUILTIN_BITREVERSE16"
-else
-    echo "Checking for __builtin_bitreverse16 ... No." | tee -a configure.log
-fi
-
 check_avx2_intrinsics() {
     # Check whether compiler supports AVX2 intrinsics
     cat > $test.c << EOF

--- a/fallback_builtins.h
+++ b/fallback_builtins.h
@@ -42,15 +42,7 @@ Z_FORCEINLINE static int __builtin_ctzll(unsigned long long value) {
 
 #endif // _MSC_VER && !__clang__
 
-/* Double-check whether or not __builtin_bitreverse16 is available. It
-   may not be defined unless compiled for arch. */
-#if !defined(HAVE_BUILTIN_BITREVERSE16) && defined(__has_builtin)
-#  if __has_builtin(__builtin_bitreverse16)
-#    define HAVE_BUILTIN_BITREVERSE16
-#  endif
-#endif
-
-#ifndef HAVE_BUILTIN_BITREVERSE16
+#if !(defined(__has_builtin) && __has_builtin(__builtin_bitreverse16))
 
 #  ifdef __loongarch__
 /* LoongArch bit reversal for 16-bit values */
@@ -71,7 +63,6 @@ Z_FORCEINLINE static uint16_t __builtin_bitreverse16(uint16_t value) {
 #    undef bitrev8
 #  endif
 
-#define HAVE_BUILTIN_BITREVERSE16
-#endif
+#endif // __builtin_bitreverse16
 
 #endif // include guard FALLBACK_BUILTINS_H

--- a/fallback_builtins.h
+++ b/fallback_builtins.h
@@ -1,6 +1,11 @@
 #ifndef FALLBACK_BUILTINS_H
 #define FALLBACK_BUILTINS_H
 
+/* Provide fallback for compilers that don't support __has_builtin */
+#  ifndef __has_builtin
+#    define __has_builtin(x) 0
+#  endif
+
 #if defined(_MSC_VER) && !defined(__clang__)
 
 #include <intrin.h>
@@ -42,13 +47,13 @@ Z_FORCEINLINE static int __builtin_ctzll(unsigned long long value) {
 
 #endif // _MSC_VER && !__clang__
 
-#if !(defined(__has_builtin) && __has_builtin(__builtin_bitreverse16))
+#if !__has_builtin(__builtin_bitreverse16)
 
 #  if defined(ARCH_ARM) && defined(ARCH_64BIT) && !defined(_MSC_VER)
 /* ARM bit reversal for 16-bit values using rbit instruction */
 Z_FORCEINLINE static uint16_t __builtin_bitreverse16(uint16_t value) {
     uint32_t res;
-#    if defined(__has_builtin) && __has_builtin(__builtin_rbit)
+#    if __has_builtin(__builtin_rbit)
     res = __builtin_rbit((uint32_t)value);
 #    else
     __asm__ volatile("rbit %w0, %w1" : "=r"(res) : "r"((uint32_t)value));

--- a/fallback_builtins.h
+++ b/fallback_builtins.h
@@ -42,6 +42,14 @@ Z_FORCEINLINE static int __builtin_ctzll(unsigned long long value) {
 
 #endif // _MSC_VER && !__clang__
 
+/* Double-check whether or not __builtin_bitreverse16 is available. It
+   may not be defined unless compiled for arch. */
+#if !defined(HAVE_BUILTIN_BITREVERSE16) && defined(__has_builtin)
+#  if __has_builtin(__builtin_bitreverse16)
+#    define HAVE_BUILTIN_BITREVERSE16
+#  endif
+#endif
+
 #ifndef HAVE_BUILTIN_BITREVERSE16
 
 #  ifdef __loongarch__

--- a/fallback_builtins.h
+++ b/fallback_builtins.h
@@ -44,7 +44,18 @@ Z_FORCEINLINE static int __builtin_ctzll(unsigned long long value) {
 
 #if !(defined(__has_builtin) && __has_builtin(__builtin_bitreverse16))
 
-#  ifdef __loongarch__
+#  if defined(ARCH_ARM) && defined(ARCH_64BIT) && !defined(_MSC_VER)
+/* ARM bit reversal for 16-bit values using rbit instruction */
+Z_FORCEINLINE static uint16_t __builtin_bitreverse16(uint16_t value) {
+    uint32_t res;
+#    if defined(__has_builtin) && __has_builtin(__builtin_rbit)
+    res = __builtin_rbit((uint32_t)value);
+#    else
+    __asm__ volatile("rbit %w0, %w1" : "=r"(res) : "r"((uint32_t)value));
+#    endif
+    return (uint16_t)(res >> 16);
+}
+#  elif defined(ARCH_LOONGARCH)
 /* LoongArch bit reversal for 16-bit values */
 Z_FORCEINLINE static uint16_t __builtin_bitreverse16(uint16_t value) {
     uint32_t res;


### PR DESCRIPTION
On AWS Graviton 4 I ran into an issue where `__builtin_bitreverse16` is not defined when doing the compiler check, but it is defined when compiling `fallback_builtins.h`, causing an error because we try to redefine it.

I now check for the builtin using `__has_builtin` and am wondering if we should just remove the `HAVE_BUILTIN_BITREVERSE16` compiler check altogether.
