### PR TITLE
Simplify the gzread.c name mangling workaround

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,7 +79,7 @@ a.out
 Makefile.tmp
 /makecrct
 /maketrees
-gzread.c
+gzread_mangle.h
 
 /Debug
 /example.dir

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1439,7 +1439,7 @@ set(ZLIB_GZFILE_PRIVATE_HDRS
 )
 set(ZLIB_GZFILE_SRCS
     gzlib.c
-    ${CMAKE_CURRENT_BINARY_DIR}/gzread.c
+    gzread.c
     gzwrite.c
 )
 
@@ -1596,8 +1596,8 @@ configure_file(${CMAKE_CURRENT_BINARY_DIR}/zconf${SUFFIX}.h.cmakein
     ${CMAKE_CURRENT_BINARY_DIR}/zconf${SUFFIX}.h @ONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/zlib${SUFFIX}.h.in
     ${CMAKE_CURRENT_BINARY_DIR}/zlib${SUFFIX}.h @ONLY)
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/gzread.c.in
-    ${CMAKE_CURRENT_BINARY_DIR}/gzread.c @ONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/gzread_mangle.h.in
+    ${CMAKE_CURRENT_BINARY_DIR}/gzread_mangle.h @ONLY)
 
 if (NOT ZLIB_SYMBOL_PREFIX STREQUAL "")
     add_feature_info(ZLIB_SYMBOL_PREFIX ON "Publicly exported symbols have a custom prefix")

--- a/Makefile.in
+++ b/Makefile.in
@@ -235,10 +235,10 @@ gzlib.o: $(SRCDIR)/gzlib.c
 gzlib.lo: $(SRCDIR)/gzlib.c
 	$(CC) $(SFLAGS) -DPIC -DWITH_GZFILEOP $(INCLUDES) -c -o $@ $<
 
-gzread.o: gzread.c
+gzread.o: $(SRCDIR)/gzread.c
 	$(CC) $(CFLAGS) -DWITH_GZFILEOP $(INCLUDES) -c -o $@ $<
 
-gzread.lo: gzread.c
+gzread.lo: $(SRCDIR)/gzread.c
 	$(CC) $(SFLAGS) -DPIC -DWITH_GZFILEOP $(INCLUDES) -c -o $@ $<
 
 gzwrite.o: $(SRCDIR)/gzwrite.c
@@ -381,7 +381,7 @@ maintainer-clean: distclean
 distclean: clean
 	@if [ -f $(ARCHDIR)/Makefile ]; then $(MAKE) -C $(ARCHDIR) distclean; fi
 	@if [ -f test/Makefile ]; then $(MAKE) -C test distclean; fi
-	rm -f $(PKGFILE) configure.log zconf.h zconf.h.cmakein zlib$(SUFFIX).h zlib_name_mangling$(SUFFIX).h *.pc gzread.c
+	rm -f $(PKGFILE) configure.log zconf.h zconf.h.cmakein zlib$(SUFFIX).h zlib_name_mangling$(SUFFIX).h *.pc gzread_mangle.h
 	-@rm -f .DS_Store
 # Reset Makefile if building inside source tree
 	@if [ -f Makefile.in ]; then \

--- a/configure
+++ b/configure
@@ -889,8 +889,8 @@ if [ "$SRCDIR" != "$BUILDDIR" ]; then
     rm -f $SRCDIR/zlib_name_mangling${SUFFIX}.h
 fi
 
-# Rename @ZLIB_SYMBOL_PREFIX@ to $symbol_prefix in gzread.c, zlib.h and zlib_name_mangling.h
-sed < $SRCDIR/gzread.c.in "s/@ZLIB_SYMBOL_PREFIX@/$symbol_prefix/g" > gzread.c
+# Substitute @ZLIB_SYMBOL_PREFIX@ with $symbol_prefix in gzread_mangle.h, zlib.h and zlib_name_mangling.h
+sed < $SRCDIR/gzread_mangle.h.in "s/@ZLIB_SYMBOL_PREFIX@/$symbol_prefix/g" > gzread_mangle.h
 sed < $SRCDIR/zlib${SUFFIX}.h.in "s/@ZLIB_SYMBOL_PREFIX@/$symbol_prefix/g" > zlib${SUFFIX}.h
 if [ ! -z "$symbol_prefix" ]; then
   sed < $SRCDIR/zlib_name_mangling${SUFFIX}.h.in "s/@ZLIB_SYMBOL_PREFIX@/$symbol_prefix/g" > zlib_name_mangling${SUFFIX}.h

--- a/gzread.c
+++ b/gzread.c
@@ -6,6 +6,7 @@
 #include "zbuild.h"
 #include "zutil_p.h"
 #include "gzguts.h"
+#include "gzread_mangle.h"
 
 /* Local functions */
 static int gz_read_init(gz_state *state);
@@ -402,8 +403,6 @@ size_t Z_EXPORT PREFIX(gzfread)(void *buf, size_t size, size_t nitems, gzFile fi
 }
 
 /* -- see zlib.h -- */
-#undef @ZLIB_SYMBOL_PREFIX@gzgetc
-#undef @ZLIB_SYMBOL_PREFIX@zng_gzgetc
 z_int32_t Z_EXPORT PREFIX(gzgetc)(gzFile file) {
     unsigned char buf[1];
     gz_state *state;

--- a/gzread_mangle.h.in
+++ b/gzread_mangle.h.in
@@ -1,0 +1,7 @@
+/* gzread_mangle.h.in -- gzgetc name mangling helper
+ * This file undefines the macro from zlib.h/zlib-ng.h to allow the real
+ * function to be defined in gzread.c. This is tricky because the prefix
+ * is not known ahead of time, thus the need for sed or similar.
+ */
+#undef @ZLIB_SYMBOL_PREFIX@gzgetc
+#undef @ZLIB_SYMBOL_PREFIX@zng_gzgetc


### PR DESCRIPTION
Simplify the gzread.c name mangling workaround by splitting out just the workaround into a separate file.

This enables:
- We can now browse gzread.c with code highlighting without adding `*.c.in` as a special case in editors
- Codecov can record coverage data for gzread.c

Likely other tools like static analyzers will also have an easier time understanding this file now.