### PR TITLE
CI: Misc CI coverage improvements and CI cleanups

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -62,7 +62,8 @@ component_management:
         - arch/generic/crc32*
     - component_id: common
       name: common
-      threshold: 2       # CI changes between AVX2 and AVX-512 capable hosts
+      statuses:
+        - threshold: 2       # CI changes between AVX2 and AVX-512 capable hosts
       paths:
         - arch_functions.h
         - cpu*
@@ -97,7 +98,8 @@ component_management:
         - arch/s390/**
     - component_id: arch_x86
       name: arch_x86
-      threshold: 10      # CI changes between AVX2 and AVX-512 capable hosts
+      statuses:
+        - threshold: 10      # CI changes between AVX2 and AVX-512 capable hosts
       paths:
         - arch/x86/**
     - component_id: minigzip

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -381,8 +381,8 @@ jobs:
 
           - name: ${{ github.repository == 'zlib-ng/zlib-ng' && 'EL10' || 'Ubuntu' }} Clang S390X DFLTCC ${{ (github.repository == 'zlib-ng/zlib-ng' && 'MSAN') || 'Compat' }}
             os: ${{ github.repository == 'zlib-ng/zlib-ng' && 'z15' || 'ubuntu-latest' }}
-            compiler: ${{ github.repository == 'zlib-ng/zlib-ng' && 'clang' || 'clang-15' }}
-            cxx-compiler: ${{ github.repository == 'zlib-ng/zlib-ng' && 'clang++' || 'clang++-15' }}
+            compiler: clang
+            cxx-compiler: clang++
             cmake-args: >-
               ${{ github.repository == 'zlib-ng/zlib-ng' && '-GNinja -DWITH_SANITIZER=Memory' || '-DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-s390x.cmake -DZLIB_COMPAT=ON' }}
               -DWITH_DFLTCC_DEFLATE=ON -DWITH_DFLTCC_INFLATE=ON
@@ -412,84 +412,91 @@ jobs:
              # Limit parallel test jobs to prevent wine errors
             parallels-jobs: 1
 
-          - name: Ubuntu Clang
+          - name: Ubuntu Clang-15
             os: ubuntu-latest
             compiler: clang-15
             cxx-compiler: clang++-15
-            packages: clang-15 llvm-15 llvm-15-tools
+            cmake-args: -DCMAKE_LINKER_TYPE=LLD
+            packages: clang-15 lld
             gcov-exec: llvm-cov-15 gcov
             codecov: ubuntu_clang
 
           - name: Ubuntu Clang C17 MMAP
             os: ubuntu-latest
-            compiler: clang-15
-            cxx-compiler: clang++-15
+            compiler: clang
+            cxx-compiler: clang++
             cmake-args: -DCMAKE_LINKER_TYPE=LLD -DCMAKE_C_STANDARD=17
             cflags: -DUSE_MMAP
-            packages: clang-15 llvm-15 llvm-15-tools lld
+            packages: llvm-18 lld
+            gcov-exec: llvm-cov-18 gcov
+            codecov: ubuntu_clang_c17_mmap
 
-          - name: Ubuntu Clang C23
+          - name: Ubuntu Clang-20 C23
             os: ubuntu-latest
-            compiler: clang-18
-            cxx-compiler: clang++-18
-            cmake-args: -DCMAKE_C_STANDARD=23
-            packages: clang-18 llvm-18 llvm-18-tools
+            compiler: clang-20
+            cxx-compiler: clang++-20
+            cmake-args: -DCMAKE_LINKER_TYPE=LLD -DCMAKE_C_STANDARD=23
+            packages: clang-20 lld
+            # codecov disabled for clang-20, errors
 
           # Check for undefined symbols in the version script for the modern api
-          - name: Ubuntu Clang Undefined Symbols
+          - name: Ubuntu Clang-20 Undefined Symbols
             os: ubuntu-latest
-            compiler: clang-15
-            cxx-compiler: clang++-15
+            compiler: clang-20
+            cxx-compiler: clang++-20
             cmake-args: -DCMAKE_SHARED_LINKER_FLAGS="-fuse-ld=lld -Wl,--no-undefined-version" -DZLIBNG_ENABLE_TESTS=OFF
-            build-shared: ON
-            packages: clang-15 llvm-15 lld
+            build-shared: 'ON'
+            packages: clang-20 lld
+            # codecov disabled, no tests run
 
           # Check for undefined symbols in the version script for the compat api
-          - name: Ubuntu Clang Undefined Symbols Compat
+          - name: Ubuntu Clang-20 Undefined Symbols Compat
             os: ubuntu-latest
-            compiler: clang-15
-            cxx-compiler: clang++-15
+            compiler: clang-20
+            cxx-compiler: clang++-20
             cmake-args: -DCMAKE_SHARED_LINKER_FLAGS="-fuse-ld=lld -Wl,--no-undefined-version" -DZLIBNG_ENABLE_TESTS=OFF -DZLIB_COMPAT=ON
-            build-shared: ON
-            packages: clang-15 llvm-15 lld
+            build-shared: 'ON'
+            packages: clang-20 lld
+            # codecov disabled, no tests run
 
           - name: Ubuntu Clang Inflate Strict REDUCED_MEM
             os: ubuntu-latest
-            compiler: clang-15
-            cxx-compiler: clang++-15
+            compiler: clang
+            cxx-compiler: clang++
             cmake-args: -DWITH_INFLATE_STRICT=ON -DWITH_REDUCED_MEM=ON
-            packages: clang-15 llvm-15 llvm-15-tools
-            gcov-exec: llvm-cov-15 gcov
+            packages: llvm-18
+            gcov-exec: llvm-cov-18 gcov
             codecov: ubuntu_clang_inflate_strict_reduced_mem
 
           - name: Ubuntu Clang Inflate Allow Invalid Dist
             os: ubuntu-latest
-            compiler: clang-15
-            cxx-compiler: clang++-15
+            compiler: clang
+            cxx-compiler: clang++
             cmake-args: -DWITH_INFLATE_ALLOW_INVALID_DIST=ON
-            packages: clang-15 llvm-15 llvm-15-tools
-            gcov-exec: llvm-cov-15 gcov
+            packages: llvm-18
+            gcov-exec: llvm-cov-18 gcov
             codecov: ubuntu_clang_inflate_allow_invalid_dist
 
           - name: Ubuntu Clang Compat Debug
             os: ubuntu-latest
-            compiler: clang-15
-            cxx-compiler: clang++-15
+            compiler: clang
+            cxx-compiler: clang++
             cmake-args: -DZLIB_COMPAT=ON
-            packages: clang-15 llvm-15 llvm-15-tools
-            gcov-exec: llvm-cov-15 gcov
-            codecov: ubuntu_clang_compat_debug
+            packages: llvm-18
+            gcov-exec: llvm-cov-18 gcov
             build-config: Debug
+            codecov: ubuntu_clang_compat_debug
 
-          - name: Ubuntu Clang MSAN
+          - name: Ubuntu Clang-20 MSAN
             os: ubuntu-latest
-            compiler: clang-15
-            cxx-compiler: clang++-15
+            compiler: clang-20
+            cxx-compiler: clang++-20
             cmake-args: -GNinja -DWITH_SANITIZER=Memory
-            packages:  ninja-build clang-15 llvm-15-tools libclang-rt-15-dev
-            gcov-exec: llvm-cov-15 gcov
+            packages: ninja-build clang-20 llvm-20 libclang-rt-20-dev
+            gcov-exec: llvm-cov-20 gcov
             # https://github.com/llvm/llvm-project/issues/55785
             msan-options: use_sigaltstack=0
+            # codecov disabled for clang-20, errors
 
           - name: Ubuntu Emscripten WASM32
             os: ubuntu-latest
@@ -744,7 +751,7 @@ jobs:
     - name: Compile LLVM C++ libraries (MSAN)
       if: contains(matrix.name, 'MSAN')
       run: |
-        git clone --depth=1 https://github.com/llvm/llvm-project --single-branch --branch llvmorg-15.0.7
+        git clone --depth=1 https://github.com/llvm/llvm-project --single-branch --branch release/20.x
         cmake -S llvm-project/runtimes -B llvm-project/build -G Ninja \
           -DCMAKE_BUILD_TYPE=Release \
           -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi" \

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -59,8 +59,8 @@ jobs:
             build-src-dir: ../zlib-ng
             # Build with readonly project directory require CMake 3.19+
             readonly-project-dir: true
-            codecov: ubuntu_gcc_osb
             cflags: -O3
+            # Skipping codecov to allow -O3
 
           - name: Ubuntu GCC OSB add_subdirectory
             os: ubuntu-latest
@@ -69,14 +69,15 @@ jobs:
             build-dir: ../build
             build-src-dir: ../zlib-ng/test/add-subdirectory-project
             readonly-project-dir: true
+            codecov: ubuntu_gcc_osb
 
           - name: Ubuntu GCC -O1 UBSAN
             os: ubuntu-latest
             compiler: gcc
             cxx-compiler: g++
             cmake-args: -DWITH_SANITIZER=Undefined
-            codecov: ubuntu_gcc_o1
             cflags: -O1
+            # Skipping codecov to allow -O1
 
           - name: Ubuntu GCC 32-bit
             os: ubuntu-latest
@@ -92,12 +93,14 @@ jobs:
             cxx-compiler: g++
             cmake-args: -DCMAKE_C_STANDARD=17
             cflags: -DUSE_MMAP
+            codecov: ubuntu_gcc_c17_mmap
 
           - name: Ubuntu GCC C23 REDUCED_MEM
             os: ubuntu-latest
             compiler: gcc
             cxx-compiler: g++
             cmake-args: -DCMAKE_C_STANDARD=23 -DWITH_REDUCED_MEM=ON
+            codecov: ubuntu_gcc_c23_reduced_mem
 
           - name: Ubuntu GCC No Chorba
             os: ubuntu-latest
@@ -160,8 +163,8 @@ jobs:
             compiler: gcc
             cxx-compiler: g++
             cmake-args: -DZLIB_COMPAT=ON -DWITH_NEW_STRATEGIES=OFF -DWITH_OPTIM=OFF -DWITH_SANITIZER=Address
-            codecov: ubuntu_gcc_compat_no_opt
             cflags: -DNOT_TWEAK_COMPILER
+            codecov: ubuntu_gcc_compat_no_opt
 
           - name: Ubuntu GCC ARM SF ASAN
             os: ubuntu-latest
@@ -265,6 +268,7 @@ jobs:
             os: ubuntu-latest
             cmake-args: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-powerpc64-clang.cmake
             packages: qemu-user clang binutils-powerpc64-linux-gnu libgcc-11-dev-ppc64-cross libc-dev-ppc64-cross libstdc++-11-dev-ppc64-cross
+            # Codecov disabled for clang on power9, errors
 
           - name: Ubuntu GCC PPC64LE
             os: ubuntu-latest
@@ -295,6 +299,7 @@ jobs:
             os: ubuntu-latest
             cmake-args: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-powerpc64le-clang.cmake
             packages: qemu-user crossbuild-essential-ppc64el
+            # Codecov disabled for clang on power9, errors
 
           - name: Ubuntu GCC RISC-V
             os: ubuntu-latest
@@ -307,6 +312,7 @@ jobs:
             os: ubuntu-latest
             cmake-args: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-riscv-clang.cmake
             packages: qemu-user crossbuild-essential-riscv64
+            # Codecov disabled for clang on riscv, errors
 
           - name: Ubuntu GCC 14 LoongArch64
             os: ubuntu-latest
@@ -419,7 +425,7 @@ jobs:
             cmake-args: -DCMAKE_LINKER_TYPE=LLD
             packages: clang-15 lld
             gcov-exec: llvm-cov-15 gcov
-            codecov: ubuntu_clang
+            # Codecov disabled for clang-15, errors
 
           - name: Ubuntu Clang C17 MMAP
             os: ubuntu-latest
@@ -502,78 +508,94 @@ jobs:
             os: ubuntu-latest
             chost: wasm32
             cmake-args: -DCMAKE_TOOLCHAIN_FILE=${EMSDK}/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake -DCMAKE_C_COMPILER_TARGET=wasm32 -DCMAKE_CROSSCOMPILING_EMULATOR=${EMSDK_NODE} -DZLIB_COMPAT=ON
+            # codecov disabled for wasm
 
           - name: Windows MSVC 2022 v143 Win32
             os: windows-latest
             compiler: cl
             cmake-args: -G "Visual Studio 17 2022" -A Win32 -T v143
+            # codecov disabled for msvc
 
           - name: Windows MSVC 2022 v143 Win64
             os: windows-latest
             compiler: cl
             cmake-args: -G "Visual Studio 17 2022" -A x64 -T v143
+            # codecov disabled for msvc
 
           - name: Windows MSVC 2022 v143 Win64 Native Instructions (AVX)
             os: windows-latest
             compiler: cl
             cmake-args: -G "Visual Studio 17 2022" -A x64 -T v143 -DWITH_NATIVE_INSTRUCTIONS=ON -DNATIVE_ARCH_OVERRIDE=/arch:AVX
+            # codecov disabled for msvc
 
           - name: Windows MSVC 2022 v143 Win64 C17
             os: windows-latest
             compiler: cl
             cmake-args: -G "Visual Studio 17 2022" -A x64 -T v143 -DCMAKE_C_STANDARD=17
+            # codecov disabled for msvc
 
           - name: Windows MSVC 2022 v142 Win32
             os: windows-latest
             compiler: cl
             cmake-args: -G "Visual Studio 17 2022" -A Win32 -T v142
+            # codecov disabled for msvc
 
           - name: Windows MSVC 2022 v142 Win64
             os: windows-latest
             compiler: cl
             cmake-args: -G "Visual Studio 17 2022" -A x64 -T v142
+            # codecov disabled for msvc
 
           - name: Windows MSVC 2022 v141 Win32
             os: windows-2022
             compiler: cl
             cmake-args: -G "Visual Studio 17 2022" -A Win32 -T v141
+            # codecov disabled for msvc
 
           - name: Windows MSVC 2022 v141 Win64
             os: windows-2022
             compiler: cl
             cmake-args: -G "Visual Studio 17 2022" -A x64 -T v141
+            # codecov disabled for msvc
 
           - name: Windows MSVC 2022 v140 Win32
             os: windows-2022
             compiler: cl
             cmake-args: -G "Visual Studio 17 2022" -A Win32,version=10.0.14393.0 -T v140 -DCMAKE_SYSTEM_VERSION=10.0.14393.0
+            # codecov disabled for msvc
 
           - name: Windows MSVC 2022 v140 Win64
             os: windows-2022
             compiler: cl
             cmake-args: -G "Visual Studio 17 2022" -A x64,version=10.0.14393.0 -T v140 -DCMAKE_SYSTEM_VERSION=10.0.14393.0
+            # codecov disabled for msvc
 
           - name: Windows MSVC ARM No Test
             os: windows-latest
             compiler: cl
             cmake-args: -A ARM,version=10.0.22621.0
+            # codecov disabled for msvc
 
           - name: Windows MSVC ARM64 No Test
             os: windows-latest
             compiler: cl
             cmake-args: -A ARM64
+            # codecov disabled for msvc
 
           - name: Windows ClangCl Win32
             os: windows-latest
             cmake-args: -T ClangCl -A Win32
+            # codecov disabled for clangcl
 
           - name: Windows ClangCl Win64
             os: windows-latest
             cmake-args: -T ClangCl -A x64
+            # codecov disabled for clangcl
 
           - name: Windows ClangCl Win64 Native Instructions (AVX)
             os: windows-latest
             cmake-args: -T ClangCl -A x64 -DWITH_NATIVE_INSTRUCTIONS=ON -DNATIVE_ARCH_OVERRIDE="-mavx -mpclmul"
+            # codecov disabled for clangcl
 
           - name: Windows GCC
             os: windows-latest
@@ -587,6 +609,7 @@ jobs:
             compiler: gcc
             cxx-compiler: g++
             cmake-args: -G Ninja  -DWITH_NATIVE_INSTRUCTIONS=ON -DNATIVE_ARCH_OVERRIDE="-mavx -mpclmul"
+            codecov: win64_gcc_native_avx
 
           - name: Windows GCC Compat No Opt
             os: windows-latest
@@ -601,13 +624,14 @@ jobs:
             cxx-compiler: clang++
             cmake-args: -DCMAKE_OSX_DEPLOYMENT_TARGET=10.10 -DWITH_BENCHMARKS=ON
             ldflags: -ld_classic
+            codecov: macos_clang_intel
 
           - name: macOS Clang (Intel) ASAN
             os: macos-15-intel
             compiler: clang
             cxx-compiler: clang++
             cmake-args: -DWITH_SANITIZER=Address
-            codecov: macos_clang
+            codecov: macos_clang_intel_asan
 
           - name: macOS GCC (Intel) UBSAN
             os: macos-15-intel
@@ -616,7 +640,7 @@ jobs:
             cmake-args: -DWITH_SANITIZER=Undefined
             packages: gcc@13
             gcov-exec: gcov-13
-            codecov: macos_gcc
+            codecov: macos_gcc_intel_ubsan
 
           - name: macOS Clang (Intel) Native Instructions
             os: macos-15-intel
@@ -639,13 +663,14 @@ jobs:
             cmake-args: -DWITH_SANITIZER=Undefined
             packages: gcc@13
             gcov-exec: gcov-13
-            codecov: macos_gcc_arm64
+            codecov: macos_gcc_arm64_ubsan
 
           - name: macOS Clang (ARM64) Native Instructions
             os: macos-latest
             compiler: clang
             cxx-compiler: clang++
             cmake-args: -DWITH_NATIVE_INSTRUCTIONS=ON
+            codecov: macos_clang_arm64_native
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -86,17 +86,18 @@ jobs:
             packages: gcc-multilib g++-multilib
             codecov: ubuntu_gcc_m32
 
-          - name: Ubuntu GCC C17
+          - name: Ubuntu GCC C17 MMAP
             os: ubuntu-latest
             compiler: gcc
             cxx-compiler: g++
             cmake-args: -DCMAKE_C_STANDARD=17
+            cflags: -DUSE_MMAP
 
-          - name: Ubuntu GCC C23
+          - name: Ubuntu GCC C23 REDUCED_MEM
             os: ubuntu-latest
             compiler: gcc
             cxx-compiler: g++
-            cmake-args: -DCMAKE_C_STANDARD=23
+            cmake-args: -DCMAKE_C_STANDARD=23 -DWITH_REDUCED_MEM=ON
 
           - name: Ubuntu GCC No Chorba
             os: ubuntu-latest
@@ -441,12 +442,13 @@ jobs:
             gcov-exec: llvm-cov-15 gcov
             codecov: ubuntu_clang
 
-          - name: Ubuntu Clang C17
+          - name: Ubuntu Clang C17 MMAP
             os: ubuntu-latest
             compiler: clang-15
             cxx-compiler: clang++-15
-            cmake-args: -DCMAKE_C_STANDARD=17
-            packages: clang-15 llvm-15 llvm-15-tools
+            cmake-args: -DCMAKE_LINKER_TYPE=LLD -DCMAKE_C_STANDARD=17
+            cflags: -DUSE_MMAP
+            packages: clang-15 llvm-15 llvm-15-tools lld
 
           - name: Ubuntu Clang C23
             os: ubuntu-latest
@@ -473,14 +475,14 @@ jobs:
             build-shared: ON
             packages: clang-15 llvm-15 lld
 
-          - name: Ubuntu Clang Inflate Strict
+          - name: Ubuntu Clang Inflate Strict REDUCED_MEM
             os: ubuntu-latest
             compiler: clang-15
             cxx-compiler: clang++-15
-            cmake-args: -DWITH_INFLATE_STRICT=ON
+            cmake-args: -DWITH_INFLATE_STRICT=ON -DWITH_REDUCED_MEM=ON
             packages: clang-15 llvm-15 llvm-15-tools
             gcov-exec: llvm-cov-15 gcov
-            codecov: ubuntu_clang_inflate_strict
+            codecov: ubuntu_clang_inflate_strict_reduced_mem
 
           - name: Ubuntu Clang Inflate Allow Invalid Dist
             os: ubuntu-latest
@@ -491,31 +493,14 @@ jobs:
             gcov-exec: llvm-cov-15 gcov
             codecov: ubuntu_clang_inflate_allow_invalid_dist
 
-          - name: Ubuntu Clang Reduced Memory
+          - name: Ubuntu Clang Compat Debug
             os: ubuntu-latest
             compiler: clang-15
             cxx-compiler: clang++-15
-            cmake-args: -DWITH_REDUCED_MEM=ON
+            cmake-args: -DZLIB_COMPAT=ON
             packages: clang-15 llvm-15 llvm-15-tools
             gcov-exec: llvm-cov-15 gcov
-            codecov: ubuntu_clang_reduced_mem
-
-          - name: Ubuntu Clang Memory Map
-            os: ubuntu-latest
-            compiler: clang-15
-            cxx-compiler: clang++-15
-            cflags: -DUSE_MMAP
-            packages: clang-15 llvm-15 llvm-15-tools
-            gcov-exec: llvm-cov-15 gcov
-            codecov: ubuntu_clang_mmap
-
-          - name: Ubuntu Clang Debug
-            os: ubuntu-latest
-            compiler: clang-15
-            cxx-compiler: clang++-15
-            packages: clang-15 llvm-15 llvm-15-tools
-            gcov-exec: llvm-cov-15 gcov
-            codecov: ubuntu_clang_debug
+            codecov: ubuntu_clang_compat_debug
             build-config: Debug
 
           - name: Ubuntu Clang MSAN

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -187,21 +187,13 @@ jobs:
             gcov-exec: arm-linux-gnueabihf-gcov
             codecov: ubuntu_gcc_armhf
 
-          - name: Ubuntu GCC ARM HF No ARMv8 ASAN
+          - name: Ubuntu GCC ARM HF No Neon No ARMv8 ASAN
             os: ubuntu-latest
-            cmake-args: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-armhf.cmake -DWITH_ARMV8=OFF -DWITH_SANITIZER=Address
+            cmake-args: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-armhf.cmake -DWITH_NEON=OFF -DWITH_ARMV8=OFF -DWITH_SANITIZER=Address
             asan-options: detect_leaks=0
             packages: qemu-user crossbuild-essential-armhf
             gcov-exec: arm-linux-gnueabihf-gcov
-            codecov: ubuntu_gcc_armhf_no_armv8
-
-          - name: Ubuntu GCC ARM HF No NEON ASAN
-            os: ubuntu-latest
-            cmake-args: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-armhf.cmake -DWITH_NEON=OFF -DWITH_SANITIZER=Address
-            asan-options: detect_leaks=0
-            packages: qemu-user crossbuild-essential-armhf
-            gcov-exec: arm-linux-gnueabihf-gcov
-            codecov: ubuntu_gcc_armhf_no_neon
+            codecov: ubuntu_gcc_armhf_no_neon_no_armv8
 
           - name: Ubuntu GCC ARM HF Compat No Opt UBSAN
             os: ubuntu-latest
@@ -217,20 +209,6 @@ jobs:
             packages: qemu-user gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libc-dev-arm64-cross
             gcov-exec: aarch64-linux-gnu-gcov
             codecov: ubuntu_gcc_aarch64
-
-          - name: Ubuntu GCC AARCH64 No ARMv8 UBSAN
-            os: ubuntu-22.04
-            cmake-args: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-aarch64.cmake -DWITH_ARMV8=OFF -DWITH_SANITIZER=Undefined
-            packages: qemu-user gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libc-dev-arm64-cross
-            gcov-exec: aarch64-linux-gnu-gcov
-            codecov: ubuntu_gcc_aarch64_no_armv8
-
-          - name: Ubuntu GCC AARCH64 No NEON UBSAN
-            os: ubuntu-22.04
-            cmake-args: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-aarch64.cmake -DWITH_NEON=OFF -DWITH_SANITIZER=Undefined
-            packages: qemu-user gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libc-dev-arm64-cross
-            gcov-exec: aarch64-linux-gnu-gcov
-            codecov: ubuntu_gcc_aarch64_no_neon
 
           - name: Ubuntu GCC AARCH64 Compat No Opt UBSAN
             os: ubuntu-22.04
@@ -330,14 +308,6 @@ jobs:
             cmake-args: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-riscv-clang.cmake
             packages: qemu-user crossbuild-essential-riscv64
 
-          - name: Ubuntu GCC 14 LoongArch64 LSX
-            os: ubuntu-latest
-            cmake-args: -DCOMPILER_SUFFIX=-14 -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-loongarch64-gcc.cmake -DWITH_BENCHMARKS=ON -DWITH_LASX=OFF
-            packages: qemu-user gcc-14-loongarch64-linux-gnu g++-14-loongarch64-linux-gnu libc-dev-loong64-cross
-            ldflags: -static
-            gcov-exec: loongarch64-linux-gnu-gcov-14
-            codecov: ubuntu_gcc14_loongarch64_lsx
-
           - name: Ubuntu GCC 14 LoongArch64
             os: ubuntu-latest
             cmake-args: -DCOMPILER_SUFFIX=-14 -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-loongarch64-gcc.cmake -DWITH_BENCHMARKS=ON
@@ -345,6 +315,14 @@ jobs:
             ldflags: -static
             gcov-exec: loongarch64-linux-gnu-gcov-14
             codecov: ubuntu_gcc14_loongarch64
+
+          - name: Ubuntu GCC 14 LoongArch64 No LASX
+            os: ubuntu-latest
+            cmake-args: -DCOMPILER_SUFFIX=-14 -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-loongarch64-gcc.cmake -DWITH_BENCHMARKS=ON -DWITH_LASX=OFF
+            packages: qemu-user gcc-14-loongarch64-linux-gnu g++-14-loongarch64-linux-gnu libc-dev-loong64-cross
+            ldflags: -static
+            gcov-exec: loongarch64-linux-gnu-gcov-14
+            codecov: ubuntu_gcc14_loongarch64_no_lasx
 
           - name: Ubuntu GCC SPARC64
             os: ubuntu-latest
@@ -406,12 +384,12 @@ jobs:
             compiler: ${{ github.repository == 'zlib-ng/zlib-ng' && 'clang' || 'clang-15' }}
             cxx-compiler: ${{ github.repository == 'zlib-ng/zlib-ng' && 'clang++' || 'clang++-15' }}
             cmake-args: >-
-              ${{ github.repository != 'zlib-ng/zlib-ng' && '-DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-s390x.cmake -DZLIB_COMPAT=ON' || '-GNinja -DWITH_SANITIZER=Memory' }}
+              ${{ github.repository == 'zlib-ng/zlib-ng' && '-GNinja -DWITH_SANITIZER=Memory' || '-DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-s390x.cmake -DZLIB_COMPAT=ON' }}
               -DWITH_DFLTCC_DEFLATE=ON -DWITH_DFLTCC_INFLATE=ON
-            gcov-exec: ${{ github.repository == 'zlib-ng/zlib-ng' && 'gcov' || 's390x-linux-gnu-gcov' }}
             packages: qemu-user gcc-s390x-linux-gnu g++-s390x-linux-gnu libc-dev-s390x-cross
             # The dedicated z15 test VM has 4 cores
             parallels-jobs: 4
+            # codecov disabled, causes MSAN errors
 
           - name: Ubuntu MinGW i686
             os: ubuntu-22.04
@@ -617,21 +595,14 @@ jobs:
             cmake-args: -DCMAKE_OSX_DEPLOYMENT_TARGET=10.10 -DWITH_BENCHMARKS=ON
             ldflags: -ld_classic
 
-          - name: macOS Clang ASAN (Intel)
+          - name: macOS Clang (Intel) ASAN
             os: macos-15-intel
             compiler: clang
             cxx-compiler: clang++
             cmake-args: -DWITH_SANITIZER=Address
             codecov: macos_clang
 
-          - name: macOS Clang ASAN (ARM64)
-            os: macos-latest
-            compiler: clang
-            cxx-compiler: clang++
-            cmake-args: -DWITH_SANITIZER=Address
-            codecov: macos_clang_arm64
-
-          - name: macOS GCC UBSAN (Intel)
+          - name: macOS GCC (Intel) UBSAN
             os: macos-15-intel
             compiler: gcc-13
             cxx-compiler: g++-13
@@ -640,7 +611,21 @@ jobs:
             gcov-exec: gcov-13
             codecov: macos_gcc
 
-          - name: macOS GCC UBSAN (ARM64)
+          - name: macOS Clang (Intel) Native Instructions
+            os: macos-15-intel
+            compiler: clang
+            cxx-compiler: clang++
+            cmake-args: -DWITH_NATIVE_INSTRUCTIONS=ON
+            codecov: macos_clang_native_intel
+
+          - name: macOS Clang (ARM64) ASAN
+            os: macos-latest
+            compiler: clang
+            cxx-compiler: clang++
+            cmake-args: -DWITH_SANITIZER=Address
+            codecov: macos_clang_arm64
+
+          - name: macOS GCC (ARM64) UBSAN
             os: macos-14
             compiler: gcc-13
             cxx-compiler: g++-13
@@ -649,13 +634,7 @@ jobs:
             gcov-exec: gcov-13
             codecov: macos_gcc_arm64
 
-          - name: macOS Clang Native Instructions (Intel)
-            os: macos-15-intel
-            compiler: clang
-            cxx-compiler: clang++
-            cmake-args: -DWITH_NATIVE_INSTRUCTIONS=ON
-
-          - name: macOS Clang Native Instructions (ARM64)
+          - name: macOS Clang (ARM64) Native Instructions
             os: macos-latest
             compiler: clang
             cxx-compiler: clang++

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -296,5 +296,5 @@ jobs:
         name: ${{ matrix.name }} (configure)
         path: |
           **/Makefile
-          ${{ matrix.build-dir || '.' }}/configure.log
+          **/configure.log
         retention-days: 30

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -16,17 +16,22 @@ jobs:
             compiler: gcc
             configure-args: --warn
 
-          - name: Ubuntu GCC OSB
+          - name: Ubuntu GCC OSB Symbol Prefix No VPCLMUL
             os: ubuntu-latest
             compiler: gcc
-            configure-args: --warn
+            configure-args: --warn --sprefix=zTest_ --without-vpclmulqdq
             build-dir: ../build
             build-src-dir: ../zlib-ng
 
-          - name: Ubuntu GCC Compat No Opt
+          - name: Ubuntu GCC Compat No Opt Reduced Mem
             os: ubuntu-latest
             compiler: gcc
-            configure-args: --warn --zlib-compat --without-optimizations --without-new-strategies
+            configure-args: --warn --zlib-compat --without-optimizations --without-new-strategies --with-reduced-mem
+
+          - name: Ubuntu GCC Compat Symbol Prefix
+            os: ubuntu-latest
+            compiler: gcc
+            configure-args: --warn --zlib-compat --sprefix=zTest_
 
           - name: Ubuntu GCC ARM SF
             os: ubuntu-latest
@@ -35,10 +40,10 @@ jobs:
             chost: arm-linux-gnueabi
             packages: qemu-user gcc-arm-linux-gnueabi libc-dev-armel-cross
 
-          - name: Ubuntu GCC ARM SF Compat No Opt
+          - name: Ubuntu GCC ARM SF Compat No Opt No Gzfileops
             os: ubuntu-latest
             compiler: arm-linux-gnueabi-gcc
-            configure-args: --warn --zlib-compat --without-optimizations --without-new-strategies
+            configure-args: --warn --zlib-compat --without-optimizations --without-new-strategies --without-gzfileops
             chost: arm-linux-gnueabi
             packages: qemu-user gcc-arm-linux-gnueabi libc-dev-armel-cross
 
@@ -100,10 +105,10 @@ jobs:
             cflags: -static
             ldflags: -static
 
-          - name: Ubuntu GCC PPC No Power8
+          - name: Ubuntu GCC PPC No Opt
             os: ubuntu-latest
             compiler: powerpc-linux-gnu-gcc
-            configure-args: --warn --without-power8
+            configure-args: --warn --without-optimizations
             chost: powerpc-linux-gnu
             packages: qemu-user gcc-powerpc-linux-gnu libc-dev-powerpc-cross
 
@@ -168,36 +173,16 @@ jobs:
             ldflags: -static
             emu-run: node
 
-          - name: macOS GCC Symbol Prefix (Intel)
-            os: macos-15-intel
-            compiler: gcc-11
-            configure-args: --sprefix=zTest_
-            packages: gcc@11
-
-          - name: macOS GCC Symbol Prefix (ARM64)
-            os: macos-latest
-            compiler: gcc-11
-            cflags: -std=gnu11
-            configure-args: --sprefix=zTest_
-            packages: gcc@11
-
-          - name: macOS GCC Symbol Prefix & Compat (Intel)
-            os: macos-15-intel
-            compiler: gcc-11
-            configure-args: --zlib-compat --sprefix=zTest_
-            packages: gcc@11
-
-          - name: macOS GCC Symbol Prefix & Compat (ARM64)
-            os: macos-latest
-            compiler: gcc-11
-            cflags: -std=gnu11
-            configure-args: --zlib-compat --sprefix=zTest_
-            packages: gcc@11
-
           - name: macOS GCC (Intel)
             os: macos-15-intel
             compiler: gcc-11
             configure-args: --warn
+            packages: gcc@11
+
+          - name: macOS GCC (Intel) Compat No Opt
+            os: macos-15-intel
+            compiler: gcc-11
+            configure-args: --warn --zlib-compat --without-optimizations --without-new-strategies
             packages: gcc@11
 
           - name: macOS GCC (ARM64)
@@ -207,6 +192,13 @@ jobs:
             configure-args: --warn
             packages: gcc@11
 
+          - name: macOS GCC (ARM64) Compat No Opt
+            os: macos-latest
+            compiler: gcc-11
+            cflags: -std=gnu11
+            configure-args: --warn --zlib-compat --without-optimizations --without-new-strategies
+            packages: gcc@11
+
           - name: Ubuntu GCC RISCV64
             os: ubuntu-latest
             compiler: riscv64-linux-gnu-gcc
@@ -214,10 +206,10 @@ jobs:
             chost: riscv64-linux-gnu
             packages: qemu-user crossbuild-essential-riscv64
 
-          - name: Ubuntu GCC RISCV64 No RVV
+          - name: Ubuntu GCC RISCV64 No RVV No ZBC
             os: ubuntu-latest
             compiler: riscv64-linux-gnu-gcc
-            configure-args: --warn --without-rvv
+            configure-args: --warn --without-rvv --without-zbc
             chost: riscv64-linux-gnu
             packages: qemu-user crossbuild-essential-riscv64
 

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -49,17 +49,10 @@ jobs:
             chost: arm-linux-gnueabihf
             packages: qemu-user gcc-arm-linux-gnueabihf libc-dev-armel-cross
 
-          - name: Ubuntu GCC ARM HF No ARMv8
+          - name: Ubuntu GCC ARM HF No Neon No ARMv8
             os: ubuntu-latest
             compiler: arm-linux-gnueabihf-gcc
-            configure-args: --warn --without-armv8
-            chost: arm-linux-gnueabihf
-            packages: qemu-user gcc-arm-linux-gnueabihf libc-dev-armel-cross
-
-          - name: Ubuntu GCC ARM HF No NEON
-            os: ubuntu-latest
-            compiler: arm-linux-gnueabihf-gcc
-            configure-args: --warn --without-neon
+            configure-args: --warn --without-neon --without-armv8
             chost: arm-linux-gnueabihf
             packages: qemu-user gcc-arm-linux-gnueabihf libc-dev-armel-cross
 
@@ -74,20 +67,6 @@ jobs:
             os: ubuntu-latest
             compiler: aarch64-linux-gnu-gcc
             configure-args: --warn
-            chost: aarch64-linux-gnu
-            packages: qemu-user gcc-aarch64-linux-gnu libc-dev-arm64-cross
-
-          - name: Ubuntu GCC AARCH64 No ARMv8
-            os: ubuntu-latest
-            compiler: aarch64-linux-gnu-gcc
-            configure-args: --warn --without-armv8
-            chost: aarch64-linux-gnu
-            packages: qemu-user gcc-aarch64-linux-gnu libc-dev-arm64-cross
-
-          - name: Ubuntu GCC AARCH64 No NEON
-            os: ubuntu-latest
-            compiler: aarch64-linux-gnu-gcc
-            configure-args: --warn --without-neon
             chost: aarch64-linux-gnu
             packages: qemu-user gcc-aarch64-linux-gnu libc-dev-arm64-cross
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1661,6 +1661,16 @@ if(BUILD_TESTING)
     add_subdirectory(test)
 endif()
 
+#============================================================================
+# Config summary
+#============================================================================
+message("")
+message(STATUS "The following defines have been set (partial list):\n")
+get_property(propvalraw DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY COMPILE_DEFINITIONS)
+list(SORT propvalraw)
+string(REPLACE ";" " " propval "${propvalraw}")
+message("CURRENT_SOURCE_DIR: ${propval}\n")
+
 add_feature_info(WITH_GZFILEOP WITH_GZFILEOP "Compile with support for gzFile related functions")
 add_feature_info(ZLIB_COMPAT ZLIB_COMPAT "Compile with zlib compatible API")
 add_feature_info(ZLIB_ALIASES ZLIB_ALIASES "Compile with zlib compatible CMake targets")
@@ -1715,7 +1725,7 @@ endif()
 
 add_feature_info(INSTALL_UTILS INSTALL_UTILS "Copy minigzip and minideflate during install")
 
-FEATURE_SUMMARY(WHAT ALL INCLUDE_QUIET_PACKAGES)
+feature_summary(WHAT ALL INCLUDE_QUIET_PACKAGES)
 
 #============================================================================
 # CPack

--- a/cmake/detect-coverage.cmake
+++ b/cmake/detect-coverage.cmake
@@ -1,28 +1,42 @@
 # detect-coverage.cmake -- Detect supported compiler coverage flags
 # Licensed under the Zlib license, see LICENSE.md for details
 
+# Attempt to enable gcov-style code coverage
 macro(add_code_coverage)
-    # Check for -coverage flag support for Clang/GCC
+    # Check for --coverage flag support
     set(CMAKE_REQUIRED_LINK_OPTIONS -coverage)
-    check_c_compiler_flag(-coverage HAVE_COVERAGE)
+    check_c_compiler_flag("--coverage" HAVE_COVERAGE)
     set(CMAKE_REQUIRED_LINK_OPTIONS)
-
     if(HAVE_COVERAGE)
-        add_compile_options(-coverage)
-        add_link_options(-coverage)
-        message(STATUS "Code coverage enabled using: -coverage")
+        # Check for --coverage -fcondition-coverage flag support
+        set(CMAKE_REQUIRED_LINK_OPTIONS -coverage -fcondition-coverage)
+        check_c_compiler_flag("--coverage -fcondition-coverage -Wno-coverage-too-many-conditions" HAVE_CONDITION_COVERAGE)
+        set(CMAKE_REQUIRED_LINK_OPTIONS)
+
+        if(HAVE_CONDITION_COVERAGE)
+            # Both --coverage and -fcondition-coverage supported
+            add_link_options(-coverage -fcondition-coverage)
+            add_compile_options(--coverage -fcondition-coverage -Wno-coverage-too-many-conditions)
+            message(STATUS "Code coverage enabled using: --coverage -fcondition-coverage")
+        else()
+            # Only --coverage supported.
+            add_link_options(-coverage)
+            add_compile_options(--coverage)
+            message(STATUS "Code coverage enabled using: --coverage")
+        endif()
     else()
-        # Some versions of GCC don't support -coverage shorthand
+        # Some versions of GCC don't support --coverage shorthand
         set(CMAKE_REQUIRED_LINK_OPTIONS -lgcov -fprofile-arcs)
-        check_c_compiler_flag("-ftest-coverage -fprofile-arcs -fprofile-values" HAVE_TEST_COVERAGE)
+        check_c_compiler_flag("-ftest-coverage -fprofile-arcs" HAVE_TEST_COVERAGE)
         set(CMAKE_REQUIRED_LINK_OPTIONS)
 
         if(HAVE_TEST_COVERAGE)
-            add_compile_options(-ftest-coverage -fprofile-arcs -fprofile-values)
             add_link_options(-lgcov -fprofile-arcs)
-            message(STATUS "Code coverage enabled using: -ftest-coverage")
+            add_compile_options(-ftest-coverage -fprofile-arcs)
+            message(STATUS "Code coverage enabled using: -ftest-coverage -fprofile-arcs")
         else()
-            message(WARNING "Compiler does not support code coverage")
+            # Failed to enable coverage, this is fatal to avoid silent failures in CI
+            message(FATAL_ERROR "WITH_CODE_COVERAGE requested, but unable to turn on code coverage with compiler/linker")
             set(WITH_CODE_COVERAGE OFF)
         endif()
     endif()


### PR DESCRIPTION
- Improve detection of compiler code coverage
  - Enable -fcondition-coverage if it is supported
- Enable codecov for more CI jobs
  - Disable codecov if -O1 or higher is requested, as coverage generation sets -O0
  - Disable codecov if tests are not run
  - Add comments for jobs without codecov, makes it easier to see what is missing and why
- Merge several jobs that do not need to be run separately
  - Remove some jobs that end up being redundant, saving some CI time
- Expand testing of configure parameters
- Use clang-20 for most builds
  - Let one job use clang-15 and one clang-19
- Add compiler defines information output to CMake
- Fix .codecov.yaml parameter placement warnings