### PR TITLE
Update static analyzer to GCC-14, fix infinite loop warning, add Z_UNREACHABLE

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -5,7 +5,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   static-analysis:
-    name: GCC
+    name: GCC-14
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -21,7 +21,7 @@ jobs:
         sudo sed -i 's#http://azure.archive.ubuntu.com/ubuntu/#mirror+file:/etc/apt/mirrors.txt#' /etc/apt/sources.list
 
     - name: Install packages (Ubuntu)
-      run: sudo apt-get install -y gcc-10
+      run: sudo apt-get install -y gcc-14
 
     - name: Generate project files
       run: |
@@ -32,7 +32,7 @@ jobs:
           -DWITH_CODE_COVERAGE=OFF \
           -DWITH_MAINTAINER_WARNINGS=OFF
       env:
-        CC: gcc-10
+        CC: gcc-14
         CFLAGS:
           -fanalyzer
           -Werror

--- a/deflate.c
+++ b/deflate.c
@@ -711,6 +711,7 @@ unsigned long Z_EXPORT PREFIX(deflateBound)(PREFIX3(stream) *strm, unsigned long
         break;
 #endif
     default:                                /* for compiler happiness */
+        Z_UNREACHABLE();
         wraplen = ZLIB_WRAPLEN;
     }
 

--- a/gzread.c
+++ b/gzread.c
@@ -232,6 +232,7 @@ static int gz_fetch(gz_state *state) {
                 return -1;
             continue;
         default:    // Can't happen
+            Z_UNREACHABLE();
             return -1;
         }
     } while (state->x.have == 0 && (!state->eof || strm->avail_in));

--- a/gzread.c
+++ b/gzread.c
@@ -209,6 +209,7 @@ static int gz_decomp(gz_state *state) {
    end of the input file has been reached and all data has been processed.  */
 static int gz_fetch(gz_state *state) {
     PREFIX3(stream) *strm = &(state->strm);
+    Assert(state->x.have == 0, "Invalid state->x.have");
 
     do {
         switch (state->how) {
@@ -229,6 +230,9 @@ static int gz_fetch(gz_state *state) {
             strm->next_out = state->out;
             if (gz_decomp(state) == -1)
                 return -1;
+            continue;
+        default:    // Can't happen
+            return -1;
         }
     } while (state->x.have == 0 && (!state->eof || strm->avail_in));
     return 0;

--- a/zbuild.h
+++ b/zbuild.h
@@ -48,6 +48,17 @@
 #  endif
 #endif
 
+/* Hint to compiler that a block of code is unreachable, typically in a switch default condition */
+#ifndef Z_UNREACHABLE
+#  if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+#    define Z_UNREACHABLE() unreachable()           // C23 approach
+#  elif (defined(__GNUC__) && (__GNUC__ >= 5)) || defined(__clang__)
+#    define Z_UNREACHABLE() __builtin_unreachable()
+#  else
+#    define Z_UNREACHABLE()
+#  endif
+#endif
+
 #ifndef Z_TARGET
 #  if Z_HAS_ATTRIBUTE(__target__)
 #    define Z_TARGET(x) __attribute__((__target__(x)))


### PR DESCRIPTION
Updating to the newer static analyzer in GCC-14 from GCC-10 revealed a possible infinite loop in gz_fetch(), it doesn't happen, but the compiler/analyzer can't know that.
Ref: https://github.com/zlib-ng/zlib-ng/actions/runs/20957066511/job/60224228645?pr=2096

- Update static analyzer to GCC-14
- Add default case that returns error in gz_fetch()
- According to the comment, gz_fetch() also assumes that state->x.have == 0, so lets add an Assert to that effect.
- Add Z_UNREACHABLE hint and use it for unreachable default cases.


