### PR TITLE
Add misalignment to benchmark buffers

### DIFF
--- a/test/benchmarks/benchmark_adler32.cc
+++ b/test/benchmarks/benchmark_adler32.cc
@@ -3,65 +3,79 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-#include <stdio.h>
-#include <assert.h>
-
 #include <benchmark/benchmark.h>
 
 extern "C" {
 #  include "zbuild.h"
-#  include "zutil_p.h"
 #  include "arch_functions.h"
 #  include "../test_cpu_features.h"
 }
 
-#define MAX_RANDOM_INTS (1024 * 1024)
-#define MAX_RANDOM_INTS_SIZE (MAX_RANDOM_INTS * sizeof(uint32_t))
+#define BUFSIZE ((4 * 1024 * 1024) + 64)
 
 class adler32: public benchmark::Fixture {
 private:
-    uint32_t *random_ints;
+    uint32_t *testdata;
 
 public:
-    void SetUp(const ::benchmark::State&) {
-        /* Control the alignment so that we have the best case scenario for loads. With
-         * AVX512, unaligned loads can mean we're crossing a cacheline boundary at every load.
-         * And while this is a realistic scenario, it makes it difficult to compare benchmark
-         * to benchmark because one allocation could have been aligned perfectly for the loads
-         * while the subsequent one happened to not be. This is not to be advantageous to AVX512
-         * (indeed, all lesser SIMD implementations benefit from this aligned allocation), but to
-         * control the _consistency_ of the results */
-        random_ints = (uint32_t *)zng_alloc(MAX_RANDOM_INTS_SIZE);
-        assert(random_ints != NULL);
+    void SetUp(::benchmark::State& state) {
+        testdata = (uint32_t *)zng_alloc_aligned(BUFSIZE, 64);
+        if (testdata == NULL) {
+            state.SkipWithError("malloc failed");
+            return;
+        }
 
-        for (int32_t i = 0; i < MAX_RANDOM_INTS; i++) {
-            random_ints[i] = rand();
+        for (uint32_t i = 0; i < BUFSIZE/sizeof(uint32_t); i++) {
+            testdata[i] = rand();
         }
     }
 
-    void Bench(benchmark::State& state, adler32_func adler32) {
+    // Benchmark Adler32, with rolling buffer misalignment for consistent results
+    void Bench(benchmark::State& state, adler32_func adler32, const int DO_ALIGNED) {
+        int misalign = 0;
         uint32_t hash = 0;
 
         for (auto _ : state) {
-            hash = adler32(hash, (const unsigned char *)random_ints, (size_t)state.range(0));
+            hash = adler32(hash, (const unsigned char*)testdata + misalign, (size_t)state.range(0));
+            if (misalign >= 63)
+                misalign = 0;
+            else
+                misalign += (DO_ALIGNED) ? 16 : 1;
         }
 
+        // Prevent the result from being optimized away
         benchmark::DoNotOptimize(hash);
     }
 
     void TearDown(const ::benchmark::State&) {
-        zng_free(random_ints);
+        zng_free_aligned(testdata);
     }
 };
 
-#define BENCHMARK_ADLER32(name, fptr, support_flag) \
+#define BENCHMARK_ADLER32_MISALIGNED(name, hashfunc, support_flag) \
     BENCHMARK_DEFINE_F(adler32, name)(benchmark::State& state) { \
         if (!(support_flag)) { \
             state.SkipWithError("CPU does not support " #name); \
         } \
-        Bench(state, fptr); \
+        Bench(state, hashfunc, 0); \
     } \
-    BENCHMARK_REGISTER_F(adler32, name)->Arg(1)->Arg(8)->Arg(12)->Arg(16)->Arg(32)->Arg(64)->Arg(512)->Arg(4<<10)->Arg(32<<10)->Arg(256<<10)->Arg(4096<<10)
+    BENCHMARK_REGISTER_F(adler32, name)->Arg(1)->Arg(8)->Arg(12)->Arg(16)->Arg(32)->Arg(64)->Arg(512)->Arg(4<<10)->Arg(32<<10)->Arg(256<<10)->Arg(4096<<10);
+
+// Aligned
+#define ALIGNED_NAME(name) name##_aligned
+#define BENCHMARK_ADLER32_ALIGNED(name, hashfunc, support_flag) \
+    BENCHMARK_DEFINE_F(adler32, ALIGNED_NAME(name))(benchmark::State& state) { \
+        if (!(support_flag)) { \
+            state.SkipWithError("CPU does not support " #name); \
+        } \
+        Bench(state, hashfunc, 1); \
+    } \
+    BENCHMARK_REGISTER_F(adler32, ALIGNED_NAME(name))->Arg(8)->Arg(12)->Arg(16)->Arg(32)->Arg(64)->Arg(512)->Arg(4<<10)->Arg(32<<10)->Arg(256<<10)->Arg(4096<<10);
+
+// Queue both misaligned and aligned for each benchmark
+#define BENCHMARK_ADLER32(name, hashfunc, support_flag) \
+    BENCHMARK_ADLER32_MISALIGNED(name, hashfunc, support_flag); \
+    BENCHMARK_ADLER32_ALIGNED(name, hashfunc, support_flag);
 
 BENCHMARK_ADLER32(c, adler32_c, 1);
 

--- a/test/benchmarks/benchmark_adler32_copy.cc
+++ b/test/benchmarks/benchmark_adler32_copy.cc
@@ -3,75 +3,88 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-#include <stdio.h>
-#include <assert.h>
-#include <string.h>
-
 #include <benchmark/benchmark.h>
 
 extern "C" {
 #  include "zbuild.h"
-#  include "zutil_p.h"
 #  include "arch_functions.h"
 #  include "../test_cpu_features.h"
 }
 
-#define MAX_RANDOM_INTS (1024 * 1024)
-#define MAX_RANDOM_INTS_SIZE (MAX_RANDOM_INTS * sizeof(uint32_t))
-
-typedef uint32_t (*adler32_cpy_func)(uint32_t adler, unsigned char *dst, const uint8_t *buf, size_t len);
+// Hash copy functions are used on strm->next_in buffers, we process
+// 512-32k sizes (x2 for initial fill) at a time if enough data is available.
+#define BUFSIZE (65536 + 64)
 
 class adler32_copy: public benchmark::Fixture {
 private:
-    uint32_t *random_ints_src;
-    uint32_t *random_ints_dst;
+    uint32_t *testdata;
+    uint8_t *dstbuf;
 
 public:
-    void SetUp(const ::benchmark::State&) {
-        /* Control the alignment so that we have the best case scenario for loads. With
-         * AVX512, unaligned loads can mean we're crossing a cacheline boundary at every load.
-         * And while this is a realistic scenario, it makes it difficult to compare benchmark
-         * to benchmark because one allocation could have been aligned perfectly for the loads
-         * while the subsequent one happened to not be. This is not to be advantageous to AVX512
-         * (indeed, all lesser SIMD implementations benefit from this aligned allocation), but to
-         * control the _consistency_ of the results */
-        random_ints_src = (uint32_t *)zng_alloc(MAX_RANDOM_INTS_SIZE);
-        random_ints_dst = (uint32_t *)zng_alloc(MAX_RANDOM_INTS_SIZE);
-        assert(random_ints_src != NULL);
-        assert(random_ints_dst != NULL);
+    void SetUp(::benchmark::State& state) {
+        testdata = (uint32_t *)zng_alloc_aligned(BUFSIZE, 64);
+        dstbuf = (uint8_t *)zng_alloc_aligned(BUFSIZE, 64);
+        if (testdata == NULL || dstbuf == NULL) {
+            state.SkipWithError("malloc failed");
+            return;
+        }
 
-        for (int32_t i = 0; i < MAX_RANDOM_INTS; i++) {
-            random_ints_src[i] = rand();
+        for (uint32_t i = 0; i < BUFSIZE/sizeof(uint32_t); i++) {
+            testdata[i] = rand();
         }
     }
 
-    void Bench(benchmark::State& state, adler32_cpy_func adler32_func) {
+    // Benchmark Adler32_copy, with rolling buffer misalignment for consistent results
+    void Bench(benchmark::State& state, adler32_copy_func adler32_copy, const int DO_ALIGNED) {
+        int misalign = 0;
         uint32_t hash = 0;
 
         for (auto _ : state) {
-            hash = adler32_func(hash, (unsigned char *)random_ints_dst,
-                                (const unsigned char*)random_ints_src, (size_t)state.range(0));
+            hash = adler32_copy(hash, dstbuf + misalign, (const unsigned char*)testdata + misalign, (size_t)state.range(0));
+            if (misalign >= 63)
+                misalign = 0;
+            else
+                misalign += (DO_ALIGNED) ? 16 : 1;
         }
 
+        // Prevent the result from being optimized away
         benchmark::DoNotOptimize(hash);
     }
 
     void TearDown(const ::benchmark::State&) {
-        zng_free(random_ints_src);
-        zng_free(random_ints_dst);
+        zng_free_aligned(testdata);
+        zng_free_aligned(dstbuf);
     }
 };
 
-#define BENCHMARK_ADLER32_COPY(name, fptr, support_flag) \
+// Misaligned
+#define BENCHMARK_ADLER32_COPY_MISALIGNED(name, copyfunc, support_flag) \
     BENCHMARK_DEFINE_F(adler32_copy, name)(benchmark::State& state) { \
         if (!(support_flag)) { \
             state.SkipWithError("CPU does not support " #name); \
         } \
-        Bench(state, fptr); \
+        Bench(state, copyfunc, 0); \
     } \
-    BENCHMARK_REGISTER_F(adler32_copy, name)->Range(8192, MAX_RANDOM_INTS_SIZE);
+    BENCHMARK_REGISTER_F(adler32_copy, name)->Arg(32)->Arg(512)->Arg(8<<10)->Arg(32<<10)->Arg(64<<10);
 
-#define BENCHMARK_ADLER32_BASELINE_COPY(name, fptr, support_flag) \
+// Aligned
+#define ALIGNED_NAME(name) name##_aligned
+#define BENCHMARK_ADLER32_COPY_ALIGNED(name, copyfunc, support_flag) \
+    BENCHMARK_DEFINE_F(adler32_copy, ALIGNED_NAME(name))(benchmark::State& state) { \
+        if (!(support_flag)) { \
+            state.SkipWithError("CPU does not support " #name); \
+        } \
+        Bench(state, copyfunc, 1); \
+    } \
+    BENCHMARK_REGISTER_F(adler32_copy, ALIGNED_NAME(name))->Arg(32)->Arg(512)->Arg(8<<10)->Arg(32<<10)->Arg(64<<10);
+
+// Queue both misaligned and aligned for each benchmark
+#define BENCHMARK_ADLER32_COPY(name, copyfunc, support_flag) \
+    BENCHMARK_ADLER32_COPY_MISALIGNED(name, copyfunc, support_flag); \
+    BENCHMARK_ADLER32_COPY_ALIGNED(name, copyfunc, support_flag);
+
+// Adler32 + memcpy benchmark for reference
+#define BENCHMARK_ADLER32_BASELINE_COPY(name, copyfunc, support_flag) \
     BENCHMARK_DEFINE_F(adler32_copy, name)(benchmark::State& state) { \
         if (!(support_flag)) { \
             state.SkipWithError("CPU does not support " #name); \
@@ -79,10 +92,10 @@ public:
         Bench(state, [](uint32_t init_sum, unsigned char *dst, \
                         const uint8_t *buf, size_t len) -> uint32_t { \
             memcpy(dst, buf, (size_t)len); \
-            return fptr(init_sum, buf, len); \
-        }); \
+            return copyfunc(init_sum, buf, len); \
+        }, 1); \
     } \
-    BENCHMARK_REGISTER_F(adler32_copy, name)->Range(8192, MAX_RANDOM_INTS_SIZE);
+    BENCHMARK_REGISTER_F(adler32_copy, name)->Arg(3)->Arg(16)->Arg(48)->Arg(192)->Arg(512)->Arg(4<<10)->Arg(16<<10)->Arg(32<<10)->Arg(64<<10);
 
 BENCHMARK_ADLER32_BASELINE_COPY(c, adler32_c, 1);
 

--- a/test/benchmarks/benchmark_adler32_copy.cc
+++ b/test/benchmarks/benchmark_adler32_copy.cc
@@ -78,75 +78,99 @@ public:
     } \
     BENCHMARK_REGISTER_F(adler32_copy, ALIGNED_NAME(name))->Arg(32)->Arg(512)->Arg(8<<10)->Arg(32<<10)->Arg(64<<10);
 
-// Queue both misaligned and aligned for each benchmark
-#define BENCHMARK_ADLER32_COPY(name, copyfunc, support_flag) \
-    BENCHMARK_ADLER32_COPY_MISALIGNED(name, copyfunc, support_flag); \
-    BENCHMARK_ADLER32_COPY_ALIGNED(name, copyfunc, support_flag);
 
-// Adler32 + memcpy benchmark for reference
-#define BENCHMARK_ADLER32_BASELINE_COPY(name, copyfunc, support_flag) \
-    BENCHMARK_DEFINE_F(adler32_copy, name)(benchmark::State& state) { \
+// Adler32 + memcpy benchmarks for reference
+#ifdef HASH_BASELINE
+#define MEMCPY_NAME(name) name##_memcpy
+#define BENCHMARK_ADLER32_MEMCPY_MISALIGNED(name, hashfunc, support_flag) \
+    BENCHMARK_DEFINE_F(adler32_copy, MEMCPY_NAME(name))(benchmark::State& state) { \
         if (!(support_flag)) { \
             state.SkipWithError("CPU does not support " #name); \
         } \
         Bench(state, [](uint32_t init_sum, unsigned char *dst, \
                         const uint8_t *buf, size_t len) -> uint32_t { \
             memcpy(dst, buf, (size_t)len); \
-            return copyfunc(init_sum, buf, len); \
+            return hashfunc(init_sum, buf, len); \
+        }, 0); \
+    } \
+    BENCHMARK_REGISTER_F(adler32_copy, MEMCPY_NAME(name))->Arg(32)->Arg(512)->Arg(8<<10)->Arg(32<<10)->Arg(64<<10);
+
+#define MEMCPY_ALIGNED_NAME(name) name##_memcpy_aligned
+#define BENCHMARK_ADLER32_MEMCPY_ALIGNED(name, hashfunc, support_flag) \
+    BENCHMARK_DEFINE_F(adler32_copy, MEMCPY_ALIGNED_NAME(name))(benchmark::State& state) { \
+        if (!(support_flag)) { \
+            state.SkipWithError("CPU does not support " #name); \
+        } \
+        Bench(state, [](uint32_t init_sum, unsigned char *dst, \
+                        const uint8_t *buf, size_t len) -> uint32_t { \
+            memcpy(dst, buf, (size_t)len); \
+            return hashfunc(init_sum, buf, len); \
         }, 1); \
     } \
-    BENCHMARK_REGISTER_F(adler32_copy, name)->Arg(3)->Arg(16)->Arg(48)->Arg(192)->Arg(512)->Arg(4<<10)->Arg(16<<10)->Arg(32<<10)->Arg(64<<10);
+    BENCHMARK_REGISTER_F(adler32_copy, MEMCPY_ALIGNED_NAME(name))->Arg(32)->Arg(512)->Arg(8<<10)->Arg(32<<10)->Arg(64<<10);
+#endif
 
-BENCHMARK_ADLER32_BASELINE_COPY(c, adler32_c, 1);
+
+// Queue both misaligned and aligned for each benchmark
+#define BENCHMARK_ADLER32_COPY_ONLY(name, copyfunc, support_flag) \
+    BENCHMARK_ADLER32_COPY_MISALIGNED(name, copyfunc, support_flag); \
+    BENCHMARK_ADLER32_COPY_ALIGNED(name, copyfunc, support_flag);
+
+// Optionally also benchmark using memcpy with normal hash function for baseline
+#ifdef HASH_BASELINE
+#define BENCHMARK_ADLER32_COPY(name, hashfunc, copyfunc, support_flag) \
+    BENCHMARK_ADLER32_COPY_MISALIGNED(name, copyfunc, support_flag); \
+    BENCHMARK_ADLER32_COPY_ALIGNED(name, copyfunc, support_flag); \
+    BENCHMARK_ADLER32_MEMCPY_MISALIGNED(name, copyfunc, support_flag); \
+    BENCHMARK_ADLER32_MEMCPY_ALIGNED(name, copyfunc, support_flag);
+#else
+#define BENCHMARK_ADLER32_COPY(name, hashfunc, copyfunc, support_flag) \
+    BENCHMARK_ADLER32_COPY_ONLY(name, copyfunc, support_flag)
+#endif
+
+BENCHMARK_ADLER32_COPY(c, adler32_c, adler32_copy_c, 1);
 
 #ifdef DISABLE_RUNTIME_CPU_DETECTION
-BENCHMARK_ADLER32_BASELINE_COPY(native, native_adler32, 1);
+BENCHMARK_ADLER32_COPY(native, native_adler32, native_adler32_copy, 1);
 #else
 
 #ifdef ARM_NEON
-/* If we inline this copy for neon, the function would go here */
-BENCHMARK_ADLER32_COPY(neon, adler32_copy_neon, test_cpu_features.arm.has_neon);
-BENCHMARK_ADLER32_BASELINE_COPY(neon_copy_baseline, adler32_neon, test_cpu_features.arm.has_neon);
+BENCHMARK_ADLER32_COPY(neon, adler32_neon, adler32_copy_neon, test_cpu_features.arm.has_neon);
 #endif
 
 #ifdef PPC_VMX
-BENCHMARK_ADLER32_COPY(vmx, adler32_copy_vmx, test_cpu_features.power.has_altivec);
+BENCHMARK_ADLER32_COPY(vmx, adler32_vmx, adler32_copy_vmx, test_cpu_features.power.has_altivec);
 #endif
 #ifdef POWER8_VSX
-BENCHMARK_ADLER32_COPY(power8, adler32_copy_power8, test_cpu_features.power.has_arch_2_07);
+BENCHMARK_ADLER32_COPY(power8, adler32_power8, adler32_copy_power8, test_cpu_features.power.has_arch_2_07);
 #endif
 
 #ifdef RISCV_RVV
-//BENCHMARK_ADLER32_COPY(rvv, adler32_rvv, test_cpu_features.riscv.has_rvv);
-BENCHMARK_ADLER32_BASELINE_COPY(rvv, adler32_rvv, test_cpu_features.riscv.has_rvv);
+BENCHMARK_ADLER32_COPY(rvv, adler32_rvv, adler32_copy_rvv, test_cpu_features.riscv.has_rvv);
 #endif
+
 #ifdef X86_SSSE3
-BENCHMARK_ADLER32_COPY(ssse3, adler32_copy_ssse3, test_cpu_features.x86.has_ssse3);
+BENCHMARK_ADLER32_COPY(ssse3, adler32_ssse3, adler32_copy_ssse3, test_cpu_features.x86.has_ssse3);
 #endif
 #ifdef X86_SSE42
-BENCHMARK_ADLER32_BASELINE_COPY(sse42_baseline, adler32_ssse3, test_cpu_features.x86.has_ssse3);
-BENCHMARK_ADLER32_COPY(sse42, adler32_copy_sse42, test_cpu_features.x86.has_sse42);
+// There is no adler32_sse42, so only test the copy variant
+BENCHMARK_ADLER32_COPY_ONLY(sse42, adler32_copy_sse42, test_cpu_features.x86.has_sse42);
 #endif
 #ifdef X86_AVX2
-BENCHMARK_ADLER32_BASELINE_COPY(avx2_baseline, adler32_avx2, test_cpu_features.x86.has_avx2);
-BENCHMARK_ADLER32_COPY(avx2, adler32_copy_avx2, test_cpu_features.x86.has_avx2);
+BENCHMARK_ADLER32_COPY(avx2, adler32_avx, adler32_copy_avx2, test_cpu_features.x86.has_avx2);
 #endif
 #ifdef X86_AVX512
-BENCHMARK_ADLER32_BASELINE_COPY(avx512_baseline, adler32_avx512, test_cpu_features.x86.has_avx512_common);
-BENCHMARK_ADLER32_COPY(avx512, adler32_copy_avx512, test_cpu_features.x86.has_avx512_common);
+BENCHMARK_ADLER32_COPY(avx512, adler32_avx512, adler32_copy_avx512, test_cpu_features.x86.has_avx512_common);
 #endif
 #ifdef X86_AVX512VNNI
-BENCHMARK_ADLER32_BASELINE_COPY(avx512_vnni_baseline, adler32_avx512_vnni, test_cpu_features.x86.has_avx512vnni);
-BENCHMARK_ADLER32_COPY(avx512_vnni, adler32_copy_avx512_vnni, test_cpu_features.x86.has_avx512vnni);
+BENCHMARK_ADLER32_COPY(avx512_vnni, adler32_avx512_vnni, adler32_copy_avx512_vnni, test_cpu_features.x86.has_avx512vnni);
 #endif
 
 #ifdef LOONGARCH_LSX
-BENCHMARK_ADLER32_BASELINE_COPY(lsx_baseline, adler32_lsx, test_cpu_features.loongarch.has_lsx);
-BENCHMARK_ADLER32_COPY(lsx, adler32_copy_lsx, test_cpu_features.loongarch.has_lsx);
+BENCHMARK_ADLER32_COPY(lsx, adler32_lsx, adler32_copy_lsx, test_cpu_features.loongarch.has_lsx);
 #endif
 #ifdef LOONGARCH_LASX
-BENCHMARK_ADLER32_BASELINE_COPY(lasx_baseline, adler32_lasx, test_cpu_features.loongarch.has_lasx);
-BENCHMARK_ADLER32_COPY(lasx, adler32_copy_lasx, test_cpu_features.loongarch.has_lasx);
+BENCHMARK_ADLER32_COPY(lasx, adler32_lasx, adler32_copy_lasx, test_cpu_features.loongarch.has_lasx);
 #endif
 
 #endif

--- a/test/benchmarks/benchmark_compare256_rle.cc
+++ b/test/benchmarks/benchmark_compare256_rle.cc
@@ -3,17 +3,14 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-#include <stdio.h>
-
 #include <benchmark/benchmark.h>
 
 extern "C" {
 #  include "zbuild.h"
-#  include "zutil_p.h"
 #  include "compare256_rle.h"
 }
 
-#define MAX_COMPARE_SIZE (256)
+#define MAX_COMPARE_SIZE (256 + 64)
 
 class compare256_rle: public benchmark::Fixture {
 private:
@@ -21,43 +18,55 @@ private:
     uint8_t *str2;
 
 public:
-    void SetUp(const ::benchmark::State&) {
-        str1 = (uint8_t *)zng_alloc(MAX_COMPARE_SIZE);
-        assert(str1 != NULL);
-        memset(str1, 'a', MAX_COMPARE_SIZE);
+    void SetUp(::benchmark::State& state) {
+        str1 = (uint8_t *)malloc(MAX_COMPARE_SIZE);
+        str2 = (uint8_t *)malloc(MAX_COMPARE_SIZE);
+        if (str1 == NULL || str2 == NULL) {
+            state.SkipWithError("malloc failed");
+            return;
+        }
 
-        str2 = (uint8_t *)zng_alloc(MAX_COMPARE_SIZE);
-        assert(str2 != NULL);
+        memset(str1, 'a', MAX_COMPARE_SIZE);
         memset(str2, 'a', MAX_COMPARE_SIZE);
     }
 
+    // Benchmark compare256_rle, with rolling buffer misalignment for consistent results
     void Bench(benchmark::State& state, compare256_rle_func compare256_rle) {
+        int misalign = 0;
         int32_t match_len = (int32_t)state.range(0) - 1;
         uint32_t len = 0;
 
-        str2[match_len] = 0;
         for (auto _ : state) {
-            len = compare256_rle((const uint8_t *)str1, (const uint8_t *)str2);
-        }
-        str2[match_len] = 'a';
+            str2[match_len + misalign] = 0;   // Set new match limit
 
+            len = compare256_rle((const uint8_t *)str1 + misalign, (const uint8_t *)str2 + misalign);
+
+            str2[match_len + misalign] = 'a'; // Reset match limit
+
+            if (misalign >= 63)
+                misalign = 0;
+            else
+                misalign++;
+        }
+
+        // Prevent the result from being optimized away
         benchmark::DoNotOptimize(len);
     }
 
     void TearDown(const ::benchmark::State&) {
-        zng_free(str1);
-        zng_free(str2);
+        free(str1);
+        free(str2);
     }
 };
 
-#define BENCHMARK_COMPARE256_RLE(name, fptr, support_flag) \
+#define BENCHMARK_COMPARE256_RLE(name, comparefunc, support_flag) \
     BENCHMARK_DEFINE_F(compare256_rle, name)(benchmark::State& state) { \
         if (!(support_flag)) { \
             state.SkipWithError("CPU does not support " #name); \
         } \
-        Bench(state, fptr); \
+        Bench(state, comparefunc); \
     } \
-    BENCHMARK_REGISTER_F(compare256_rle, name)->Range(1, MAX_COMPARE_SIZE);
+    BENCHMARK_REGISTER_F(compare256_rle, name)->Arg(1)->Arg(10)->Arg(40)->Arg(80)->Arg(100)->Arg(175)->Arg(256);;
 
 BENCHMARK_COMPARE256_RLE(8, compare256_rle_8, 1);
 BENCHMARK_COMPARE256_RLE(16, compare256_rle_16, 1);

--- a/test/benchmarks/benchmark_crc32.cc
+++ b/test/benchmarks/benchmark_crc32.cc
@@ -3,58 +3,79 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-#include <stdio.h>
-#include <assert.h>
-
 #include <benchmark/benchmark.h>
 
 extern "C" {
 #  include "zbuild.h"
-#  include "zutil_p.h"
 #  include "arch_functions.h"
 #  include "../test_cpu_features.h"
 }
 
-#define MAX_RANDOM_INTS (1024 * 1024)
-#define MAX_RANDOM_INTS_SIZE (MAX_RANDOM_INTS * sizeof(uint32_t))
+#define BUFSIZE ((4 * 1024 * 1024) + 64)
 
 class crc32: public benchmark::Fixture {
 private:
-    uint32_t *random_ints;
+    uint32_t *testdata;
 
 public:
-    void SetUp(const ::benchmark::State&) {
-        random_ints = (uint32_t *)zng_alloc(MAX_RANDOM_INTS_SIZE);
-        assert(random_ints != NULL);
+    void SetUp(::benchmark::State& state) {
+        testdata = (uint32_t *)zng_alloc_aligned(BUFSIZE, 64);
+        if (testdata == NULL) {
+            state.SkipWithError("malloc failed");
+            return;
+        }
 
-        for (int32_t i = 0; i < MAX_RANDOM_INTS; i++) {
-            random_ints[i] = rand();
+        for (uint32_t i = 0; i < BUFSIZE/sizeof(uint32_t); i++) {
+            testdata[i] = rand();
         }
     }
 
-    void Bench(benchmark::State& state, crc32_func crc32) {
+    // Benchmark CRC32, with rolling buffer misalignment for consistent results
+    void Bench(benchmark::State& state, crc32_func crc32, const int DO_ALIGNED) {
+        int misalign = 0;
         uint32_t hash = 0;
 
         for (auto _ : state) {
-            hash = crc32(hash, (const unsigned char *)random_ints, (size_t)state.range(0));
+            hash = crc32(hash, (const unsigned char *)testdata + misalign, (size_t)state.range(0));
+            if (misalign >= 63)
+                misalign = 0;
+            else
+                misalign += (DO_ALIGNED) ? 16 : 1;
         }
 
+        // Prevent the result from being optimized away
         benchmark::DoNotOptimize(hash);
     }
 
     void TearDown(const ::benchmark::State&) {
-        zng_free(random_ints);
+        zng_free_aligned(testdata);
     }
 };
 
-#define BENCHMARK_CRC32(name, fptr, support_flag) \
+#define BENCHMARK_CRC32_MISALIGNED(name, hashfunc, support_flag) \
     BENCHMARK_DEFINE_F(crc32, name)(benchmark::State& state) { \
         if (!(support_flag)) { \
             state.SkipWithError("CPU does not support " #name); \
         } \
-        Bench(state, fptr); \
+        Bench(state, hashfunc, 0); \
     } \
     BENCHMARK_REGISTER_F(crc32, name)->Arg(1)->Arg(8)->Arg(12)->Arg(16)->Arg(32)->Arg(64)->Arg(512)->Arg(4<<10)->Arg(32<<10)->Arg(256<<10)->Arg(4096<<10);
+
+// Aligned
+#define ALIGNED_NAME(name) name##_aligned
+#define BENCHMARK_CRC32_ALIGNED(name, hashfunc, support_flag) \
+    BENCHMARK_DEFINE_F(crc32, ALIGNED_NAME(name))(benchmark::State& state) { \
+        if (!(support_flag)) { \
+            state.SkipWithError("CPU does not support " #name); \
+        } \
+        Bench(state, hashfunc, 1); \
+    } \
+    BENCHMARK_REGISTER_F(crc32, ALIGNED_NAME(name))->Arg(8)->Arg(12)->Arg(16)->Arg(32)->Arg(64)->Arg(512)->Arg(4<<10)->Arg(32<<10)->Arg(256<<10)->Arg(4096<<10);
+
+// Queue both misaligned and aligned for each benchmark
+#define BENCHMARK_CRC32(name, hashfunc, support_flag) \
+    BENCHMARK_CRC32_MISALIGNED(name, hashfunc, support_flag); \
+    BENCHMARK_CRC32_ALIGNED(name, hashfunc, support_flag);
 
 BENCHMARK_CRC32(braid, crc32_braid, 1);
 

--- a/test/benchmarks/benchmark_crc32_copy.cc
+++ b/test/benchmarks/benchmark_crc32_copy.cc
@@ -76,55 +76,99 @@ public:
         } \
         Bench(state, copyfunc, 1); \
     } \
-    BENCHMARK_REGISTER_F(crc32_copy, ALIGNED_NAME(name))->Arg(16)->Arg(32)->Arg(64)->Arg(512);
+    BENCHMARK_REGISTER_F(crc32_copy, ALIGNED_NAME(name))->Arg(32)->Arg(512)->Arg(8<<10)->Arg(32<<10)->Arg(64<<10);
+
+// CRC32 + memcpy benchmarks for reference
+#ifdef HASH_BASELINE
+#define MEMCPY_NAME(name) name##_memcpy
+#define BENCHMARK_CRC32_MEMCPY_MISALIGNED(name, hashfunc, support_flag) \
+    BENCHMARK_DEFINE_F(crc32_copy, MEMCPY_NAME(name))(benchmark::State& state) { \
+        if (!(support_flag)) { \
+            state.SkipWithError("CPU does not support " #name); \
+        } \
+	Bench(state, [](uint32_t init_sum, unsigned char *dst, \
+                        const uint8_t *buf, size_t len) -> uint32_t { \
+            memcpy(dst, buf, (size_t)len); \
+            return hashfunc(init_sum, buf, len); \
+        }, 0); \
+    } \
+    BENCHMARK_REGISTER_F(crc32_copy, MEMCPY_NAME(name))->Arg(32)->Arg(512)->Arg(8<<10)->Arg(32<<10)->Arg(64<<10);
+
+#define MEMCPY_ALIGNED_NAME(name) name##_memcpy_aligned
+#define BENCHMARK_CRC32_MEMCPY_ALIGNED(name, hashfunc, support_flag) \
+    BENCHMARK_DEFINE_F(crc32_copy, MEMCPY_ALIGNED_NAME(name))(benchmark::State& state) { \
+        if (!(support_flag)) { \
+            state.SkipWithError("CPU does not support " #name); \
+        } \
+	Bench(state, [](uint32_t init_sum, unsigned char *dst, \
+                        const uint8_t *buf, size_t len) -> uint32_t { \
+            memcpy(dst, buf, (size_t)len); \
+            return hashfunc(init_sum, buf, len); \
+        }, 1); \
+    } \
+    BENCHMARK_REGISTER_F(crc32_copy, MEMCPY_ALIGNED_NAME(name))->Arg(32)->Arg(512)->Arg(8<<10)->Arg(32<<10)->Arg(64<<10);
+#endif
+
 
 // Queue both misaligned and aligned for each benchmark
-#define BENCHMARK_CRC32_COPY(name, copyfunc, support_flag) \
+#define BENCHMARK_CRC32_COPY_ONLY(name, copyfunc, support_flag) \
     BENCHMARK_CRC32_COPY_MISALIGNED(name, copyfunc, support_flag); \
     BENCHMARK_CRC32_COPY_ALIGNED(name, copyfunc, support_flag);
 
+// Optionally also benchmark using memcpy with normal hash function for baseline
+#ifdef HASH_BASELINE
+#define BENCHMARK_CRC32_COPY(name, hashfunc, copyfunc, support_flag) \
+    BENCHMARK_CRC32_COPY_MISALIGNED(name, copyfunc, support_flag); \
+    BENCHMARK_CRC32_COPY_ALIGNED(name, copyfunc, support_flag); \
+    BENCHMARK_CRC32_MEMCPY_MISALIGNED(name, copyfunc, support_flag); \
+    BENCHMARK_CRC32_MEMCPY_ALIGNED(name, copyfunc, support_flag);
+#else
+#define BENCHMARK_CRC32_COPY(name, hashfunc, copyfunc, support_flag) \
+    BENCHMARK_CRC32_COPY_ONLY(name, copyfunc, support_flag)
+#endif
+
 // Base test
-BENCHMARK_CRC32_COPY(braid, crc32_copy_braid, 1);
+BENCHMARK_CRC32_COPY(braid, crc32_braid, crc32_copy_braid, 1);
 
 #ifdef DISABLE_RUNTIME_CPU_DETECTION
     // Native
-    BENCHMARK_CRC32_COPY(native, native_crc32_copy, 1)
+    BENCHMARK_CRC32_COPY(native, native_crc32, native_crc32_copy, 1)
 #else
     // Optimized functions
 #  ifndef WITHOUT_CHORBA
-    BENCHMARK_CRC32_COPY(chorba, crc32_copy_chorba, 1)
+    BENCHMARK_CRC32_COPY(chorba, crc32_chorba, crc32_copy_chorba, 1)
 #  endif
 #  ifndef WITHOUT_CHORBA_SSE
 #    ifdef X86_SSE2
-    BENCHMARK_CRC32_COPY(chorba_sse2, crc32_copy_chorba_sse2, test_cpu_features.x86.has_sse2);
+    BENCHMARK_CRC32_COPY(chorba_sse2, crc32_chorba_sse2, crc32_copy_chorba_sse2, test_cpu_features.x86.has_sse2);
 #    endif
 #    ifdef X86_SSE41
-    BENCHMARK_CRC32_COPY(chorba_sse41, crc32_copy_chorba_sse41, test_cpu_features.x86.has_sse41);
+    BENCHMARK_CRC32_COPY(chorba_sse41, crc32_chorba_sse41, crc32_copy_chorba_sse41, test_cpu_features.x86.has_sse41);
 #    endif
 #  endif
 #  ifdef ARM_CRC32
-    BENCHMARK_CRC32_COPY(armv8, crc32_copy_armv8, test_cpu_features.arm.has_crc32)
+    BENCHMARK_CRC32_COPY(armv8, crc32_armv8, crc32_copy_armv8, test_cpu_features.arm.has_crc32)
 #  endif
 #  ifdef ARM_PMULL_EOR3
-    BENCHMARK_CRC32_COPY(armv8_pmull_eor3, crc32_copy_armv8_pmull_eor3, test_cpu_features.arm.has_crc32 && test_cpu_features.arm.has_pmull && test_cpu_features.arm.has_eor3)
+    BENCHMARK_CRC32_COPY(armv8_pmull_eor3, crc32_armv8_pmull_eor3, crc32_copy_armv8_pmull_eor3, test_cpu_features.arm.has_crc32 && test_cpu_features.arm.has_pmull && test_cpu_features.arm.has_eor3)
 #  endif
 #  ifdef LOONGARCH_CRC
-    BENCHMARK_CRC32_COPY(loongarch, crc32_copy_loongarch64, test_cpu_features.loongarch.has_crc)
+    BENCHMARK_CRC32_COPY(loongarch, crc32_loongarch64, crc32_copy_loongarch64, test_cpu_features.loongarch.has_crc)
 #  endif
 #  ifdef POWER8_VSX_CRC32
-    BENCHMARK_CRC32_COPY(power8, crc32_copy_power8, test_cpu_features.power.has_arch_2_07)
+    BENCHMARK_CRC32_COPY(power8, crc32_power8, crc32_copy_power8, test_cpu_features.power.has_arch_2_07)
 #  endif
 #  ifdef RISCV_CRC32_ZBC
-    BENCHMARK_CRC32_COPY(riscv, crc32_copy_riscv64_zbc, test_cpu_features.riscv.has_zbc)
+    BENCHMARK_CRC32_COPY(riscv, crc32_riscv, crc32_copy_riscv64_zbc, test_cpu_features.riscv.has_zbc)
 #  endif
 #  ifdef S390_CRC32_VX
-    BENCHMARK_CRC32_COPY(vx, crc32_copy_s390_vx, test_cpu_features.s390.has_vx)
+    BENCHMARK_CRC32_COPY(vx, crc32_s390_vx, crc32_copy_s390_vx, test_cpu_features.s390.has_vx)
 #  endif
 #  ifdef X86_PCLMULQDQ_CRC
-    BENCHMARK_CRC32_COPY(pclmulqdq, crc32_copy_pclmulqdq, test_cpu_features.x86.has_pclmulqdq)
+    BENCHMARK_CRC32_COPY(pclmulqdq, crc32_pclmulqdq, crc32_copy_pclmulqdq, test_cpu_features.x86.has_pclmulqdq)
 #  endif
 #  ifdef X86_VPCLMULQDQ_CRC
-    BENCHMARK_CRC32_COPY(vpclmulqdq, crc32_copy_vpclmulqdq, (test_cpu_features.x86.has_pclmulqdq && test_cpu_features.x86.has_avx512_common && test_cpu_features.x86.has_vpclmulqdq))
+    BENCHMARK_CRC32_COPY(vpclmulqdq, crc32_vpclmulqdq, crc32_copy_vpclmulqdq, (test_cpu_features.x86.has_pclmulqdq && test_cpu_features.x86.has_avx512_common && test_cpu_features.x86.has_vpclmulqdq))
 #  endif
 
 #endif

--- a/test/benchmarks/benchmark_inflate.cc
+++ b/test/benchmarks/benchmark_inflate.cc
@@ -21,7 +21,7 @@ extern "C" {
 #define MAX_SIZE (1024 * 1024)
 #define NUM_TESTS 6
 
-class inflate: public benchmark::Fixture {
+class inflate_bench: public benchmark::Fixture {
 private:
     uint8_t *inbuff;
     uint8_t *outbuff;
@@ -161,9 +161,9 @@ public:
 };
 
 #define BENCHMARK_INFLATE(name) \
-    BENCHMARK_DEFINE_F(inflate, name)(benchmark::State& state) { \
+    BENCHMARK_DEFINE_F(inflate_bench, name)(benchmark::State& state) { \
         Bench(state); \
     } \
-    BENCHMARK_REGISTER_F(inflate, name)->Arg(1)->Arg(64)->Arg(1024)->Arg(16<<10)->Arg(128<<10)->Arg(1024<<10);
+    BENCHMARK_REGISTER_F(inflate_bench, name)->Arg(1)->Arg(64)->Arg(1024)->Arg(16<<10)->Arg(128<<10)->Arg(1024<<10);
 
 BENCHMARK_INFLATE(inflate_nocrc);

--- a/test/benchmarks/benchmark_insert_string.cc
+++ b/test/benchmarks/benchmark_insert_string.cc
@@ -10,7 +10,6 @@
 
 extern "C" {
 #  include "zbuild.h"
-#  include "zutil_p.h"
 #  include "deflate.h"
 #  include "arch_functions.h"
 #  include "../test_cpu_features.h"
@@ -29,7 +28,7 @@ protected:
 
 public:
     void SetUp(const ::benchmark::State&) {
-        s = (deflate_state*)zng_alloc(sizeof(deflate_state));
+        s = (deflate_state*)zng_alloc_aligned(sizeof(deflate_state), 64);
         memset(s, 0, sizeof(deflate_state));
 
         // Set up window parameters
@@ -37,11 +36,11 @@ public:
         s->window_size = TEST_WINDOW_SIZE;
 
         // Allocate window
-        s->window = (uint8_t*)zng_alloc(TEST_WINDOW_SIZE);
+        s->window = (uint8_t*)zng_alloc_aligned(TEST_WINDOW_SIZE, 64);
 
         // Allocate hash tables
-        s->head = (Pos*)zng_alloc(HASH_SIZE * sizeof(Pos));
-        s->prev = (Pos*)zng_alloc(MAX_WSIZE * sizeof(Pos));
+        s->head = (Pos*)zng_alloc_aligned(HASH_SIZE * sizeof(Pos), 64);
+        s->prev = (Pos*)zng_alloc_aligned(MAX_WSIZE * sizeof(Pos), 64);
 
         // Initialize hash tables
         memset(s->head, 0, HASH_SIZE * sizeof(Pos));
@@ -58,10 +57,10 @@ public:
     }
 
     void TearDown(const ::benchmark::State&) {
-        zng_free(s->window);
-        zng_free(s->head);
-        zng_free(s->prev);
-        zng_free(s);
+        zng_free_aligned(s->window);
+        zng_free_aligned(s->head);
+        zng_free_aligned(s->prev);
+        zng_free_aligned(s);
     }
 };
 


### PR DESCRIPTION
- Unify benchmark code.
- Add misalignment to buffers (might be changed)

TODO: Further research into expected real-world alignments

---
As can be seen below, currently 16/32/64 byte buffers are all faster than 8 and 12 byte buffers.
While this is accurate, it is only true for 16-byte aligned input.

Before:
```
crc32/pclmulqdq/1                   2.08 ns         2.08 ns   1005886062
crc32/pclmulqdq/8                   13.4 ns         13.4 ns    156492829
crc32/pclmulqdq/12                  19.9 ns         19.9 ns    104951835
crc32/pclmulqdq/16                  6.83 ns         6.83 ns    307242360
crc32/pclmulqdq/32                  7.74 ns         7.74 ns    273097404
crc32/pclmulqdq/64                  9.95 ns         9.95 ns    213542134
crc32/pclmulqdq/512                 31.0 ns         31.0 ns     67606989
crc32/pclmulqdq/4096                 179 ns          179 ns     11667196
crc32/pclmulqdq/32768               1406 ns         1406 ns      1519562
crc32/pclmulqdq/262144             11055 ns        11055 ns       185596
crc32/pclmulqdq/4194304           179210 ns       179209 ns        11699
```

After:
```
crc32/pclmulqdq/1                   2.06 ns         2.06 ns   1019868718
crc32/pclmulqdq/8                   13.4 ns         13.4 ns    156972088
crc32/pclmulqdq/12                  19.9 ns         19.9 ns    105753664
crc32/pclmulqdq/16                  25.0 ns         25.0 ns     83933752
crc32/pclmulqdq/32                  25.3 ns         25.3 ns     82825755
crc32/pclmulqdq/64                  26.2 ns         26.2 ns     80324722
crc32/pclmulqdq/512                 41.2 ns         41.2 ns     51184838
crc32/pclmulqdq/4096                 193 ns          193 ns     11049203
crc32/pclmulqdq/32768               1396 ns         1396 ns      1342525
crc32/pclmulqdq/262144             10872 ns        10872 ns       193004
crc32/pclmulqdq/4194304           175952 ns       175950 ns        11920
```