### PR TITLE
Short-circuit loop continuation after match copy in inflate_fast

### DIFF
--- a/infback.c
+++ b/infback.c
@@ -393,9 +393,7 @@ int32_t Z_EXPORT PREFIX(inflateBack)(PREFIX3(stream) *strm, in_func in, void *in
 
             /* process literal */
             if ((int)(here.op) == 0) {
-                Tracevv((stderr, here.val >= 0x20 && here.val < 0x7f ?
-                        "inflate:         literal '%c'\n" :
-                        "inflate:         literal 0x%02x\n", here.val));
+                TRACE_LITERAL(here.val);
                 ROOM();
                 *put++ = (unsigned char)(state->length);
                 left--;
@@ -405,7 +403,7 @@ int32_t Z_EXPORT PREFIX(inflateBack)(PREFIX3(stream) *strm, in_func in, void *in
 
             /* process end of block */
             if (here.op & 32) {
-                Tracevv((stderr, "inflate:         end of block\n"));
+                TRACE_END_OF_BLOCK();
                 state->mode = TYPE;
                 break;
             }
@@ -423,7 +421,7 @@ int32_t Z_EXPORT PREFIX(inflateBack)(PREFIX3(stream) *strm, in_func in, void *in
                 state->length += BITS(state->extra);
                 DROPBITS(state->extra);
             }
-            Tracevv((stderr, "inflate:         length %u\n", state->length));
+            TRACE_LENGTH(state->length);
 
             /* get distance code */
             for (;;) {
@@ -462,7 +460,7 @@ int32_t Z_EXPORT PREFIX(inflateBack)(PREFIX3(stream) *strm, in_func in, void *in
                 break;
             }
 #endif
-            Tracevv((stderr, "inflate:         distance %u\n", state->offset));
+            TRACE_DISTANCE(state->offset);
 
             /* copy match from window to output */
             do {

--- a/inffast_tpl.h
+++ b/inffast_tpl.h
@@ -148,9 +148,9 @@ void Z_INTERNAL INFLATE_FAST(PREFIX3(stream) *strm, uint32_t start) {
     /* decode literals and length/distances until end-of-block or not enough
        input data or output space */
     do {
+      dolenlit:
         REFILL();
         here = lcode[hold & lmask];
-      dolenlit:
         Z_TOUCH(here);
         DROPBITS(here.bits);
         if (here.op == 0) {
@@ -283,13 +283,9 @@ void Z_INTERNAL INFLATE_FAST(PREFIX3(stream) *strm, uint32_t start) {
                     else
                         out = CHUNKMEMSET(out, out - dist, len);
                 }
-                /* After match copy, jump directly to next decode if safe.
-                   This avoids the loop condition check and REFILL at the top. */
-                if (LIKELY(in < last && out < end)) {
-                    REFILL();
-                    here = lcode[hold & lmask];
+                /* Short-circuit loop continuation. */
+                if (LIKELY(in < last && out < end))
                     goto dolenlit;
-                }
             } else if ((op & 64) == 0) {          /* 2nd level distance code */
                 here = dcode[here.val + BITS(op)];
                 Z_TOUCH(here);

--- a/inffast_tpl.h
+++ b/inffast_tpl.h
@@ -150,6 +150,7 @@ void Z_INTERNAL INFLATE_FAST(PREFIX3(stream) *strm, uint32_t start) {
     do {
         REFILL();
         here = lcode[hold & lmask];
+      dolenlit:
         Z_TOUCH(here);
         DROPBITS(here.bits);
         if (here.op == 0) {
@@ -281,6 +282,13 @@ void Z_INTERNAL INFLATE_FAST(PREFIX3(stream) *strm, uint32_t start) {
                         out = CHUNKCOPY(out, out - dist, len);
                     else
                         out = CHUNKMEMSET(out, out - dist, len);
+                }
+                /* After match copy, jump directly to next decode if safe.
+                   This avoids the loop condition check and REFILL at the top. */
+                if (LIKELY(in < last && out < end)) {
+                    REFILL();
+                    here = lcode[hold & lmask];
+                    goto dolenlit;
                 }
             } else if ((op & 64) == 0) {          /* 2nd level distance code */
                 here = dcode[here.val + BITS(op)];

--- a/inffast_tpl.h
+++ b/inffast_tpl.h
@@ -153,11 +153,13 @@ void Z_INTERNAL INFLATE_FAST(PREFIX3(stream) *strm, uint32_t start) {
         Z_TOUCH(here);
         DROPBITS(here.bits);
         if (here.op == 0) {
+            TRACE_LITERAL(here.val);
             *out++ = (unsigned char)(here.val);
             here = lcode[hold & lmask];
             Z_TOUCH(here);
             DROPBITS(here.bits);
             if (here.op == 0) {
+                TRACE_LITERAL(here.val);
                 *out++ = (unsigned char)(here.val);
                 here = lcode[hold & lmask];
                 Z_TOUCH(here);
@@ -167,16 +169,14 @@ void Z_INTERNAL INFLATE_FAST(PREFIX3(stream) *strm, uint32_t start) {
       dolen:
         op = here.op;
         if (op == 0) {                          /* literal */
-            Tracevv((stderr, here.val >= 0x20 && here.val < 0x7f ?
-                    "inflate:         literal '%c'\n" :
-                    "inflate:         literal 0x%02x\n", here.val));
+            TRACE_LITERAL(here.val);
             *out++ = (unsigned char)(here.val);
         } else if (op & 16) {                     /* length base */
             len = here.val;
             op &= MAX_BITS;                       /* number of extra bits */
             len += BITS(op);
             DROPBITS(op);
-            Tracevv((stderr, "inflate:         length %u\n", len));
+            TRACE_LENGTH(len);
             here = dcode[hold & dmask];
             Z_TOUCH(here);
             if (bits < MAX_BITS + MAX_DIST_EXTRA_BITS) {
@@ -196,7 +196,7 @@ void Z_INTERNAL INFLATE_FAST(PREFIX3(stream) *strm, uint32_t start) {
                 }
 #endif
                 DROPBITS(op);
-                Tracevv((stderr, "inflate:         distance %u\n", dist));
+                TRACE_DISTANCE(dist);
                 op = (unsigned)(out - beg);     /* max distance in output */
                 if (dist > op) {                /* see if copy from window */
                     op = dist - op;             /* distance back in window */
@@ -294,7 +294,7 @@ void Z_INTERNAL INFLATE_FAST(PREFIX3(stream) *strm, uint32_t start) {
             DROPBITS(here.bits);
             goto dolen;
         } else if (op & 32) {                     /* end-of-block */
-            Tracevv((stderr, "inflate:         end of block\n"));
+            TRACE_END_OF_BLOCK();
             state->mode = TYPE;
             break;
         } else {

--- a/inffast_tpl.h
+++ b/inffast_tpl.h
@@ -163,17 +163,19 @@ void Z_INTERNAL INFLATE_FAST(PREFIX3(stream) *strm, uint32_t start) {
                 *out++ = (unsigned char)(here.val);
                 here = lcode[hold & lmask];
                 Z_TOUCH(here);
+            dolen:
                 DROPBITS(here.bits);
+                if (here.op == 0) {
+                    TRACE_LITERAL(here.val);
+                    *out++ = (unsigned char)(here.val);
+                    continue;
+                }
             }
         }
-      dolen:
         op = here.op;
-        if (op == 0) {                          /* literal */
-            TRACE_LITERAL(here.val);
-            *out++ = (unsigned char)(here.val);
-        } else if (op & 16) {                     /* length base */
+        if (op & 16) {                          /* length base */
             len = here.val;
-            op &= MAX_BITS;                       /* number of extra bits */
+            op &= MAX_BITS;                     /* number of extra bits */
             len += BITS(op);
             DROPBITS(op);
             TRACE_LENGTH(len);
@@ -291,7 +293,6 @@ void Z_INTERNAL INFLATE_FAST(PREFIX3(stream) *strm, uint32_t start) {
         } else if ((op & 64) == 0) {              /* 2nd level length code */
             here = lcode[here.val + BITS(op)];
             Z_TOUCH(here);
-            DROPBITS(here.bits);
             goto dolen;
         } else if (op & 32) {                     /* end-of-block */
             TRACE_END_OF_BLOCK();

--- a/inflate.c
+++ b/inflate.c
@@ -960,16 +960,14 @@ int32_t Z_EXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int32_t flush) {
 
             /* process literal */
             if ((int)(here.op) == 0) {
-                Tracevv((stderr, here.val >= 0x20 && here.val < 0x7f ?
-                        "inflate:         literal '%c'\n" :
-                        "inflate:         literal 0x%02x\n", here.val));
+                TRACE_LITERAL(here.val);
                 state->mode = LIT;
                 break;
             }
 
             /* process end of block */
             if (here.op & 32) {
-                Tracevv((stderr, "inflate:         end of block\n"));
+                TRACE_END_OF_BLOCK();
                 state->back = -1;
                 state->mode = TYPE;
                 break;
@@ -994,7 +992,7 @@ int32_t Z_EXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int32_t flush) {
                 DROPBITS(state->extra);
                 state->back += state->extra;
             }
-            Tracevv((stderr, "inflate:         length %u\n", state->length));
+            TRACE_LENGTH(state->length);
             state->was = state->length;
             state->mode = DIST;
             Z_FALLTHROUGH;
@@ -1043,7 +1041,7 @@ int32_t Z_EXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int32_t flush) {
                 break;
             }
 #endif
-            Tracevv((stderr, "inflate:         distance %u\n", state->offset));
+            TRACE_DISTANCE(state->offset);
             state->mode = MATCH;
             Z_FALLTHROUGH;
 

--- a/inflate_p.h
+++ b/inflate_p.h
@@ -141,6 +141,21 @@ typedef unsigned bits_t;
         strm->msg = (char *)errmsg; \
     } while (0)
 
+/* Trace macros for debugging */
+#define TRACE_LITERAL(val) \
+    Tracevv((stderr, val >= 0x20 && val < 0x7f ? \
+            "inflate:         literal '%c'\n" : \
+            "inflate:         literal 0x%02x\n", val))
+
+#define TRACE_LENGTH(len) \
+    Tracevv((stderr, "inflate:         length %u\n", len))
+
+#define TRACE_DISTANCE(dist) \
+    Tracevv((stderr, "inflate:         distance %u\n", dist))
+
+#define TRACE_END_OF_BLOCK() \
+    Tracevv((stderr, "inflate:         end of block\n"))
+
 #define INFLATE_FAST_MIN_HAVE 15
 #define INFLATE_FAST_MIN_LEFT 260
 


### PR DESCRIPTION
After completing a length/distance match copy, jump directly to the next symbol decode instead of falling through the else-if chain.

Requires #2106.

@dougallj similar to your `preloaded` jmp here:
https://gist.github.com/dougallj/7d8a8b2e1a7ccf3c65ae8216a5d8d675#file-0001-decode-the-next-iteration-s-symbol-before-chunk-copy-patch