### PR TITLE
Test feature macros in all implementation files

### DIFF
--- a/arch/arm/adler32_neon.c
+++ b/arch/arm/adler32_neon.c
@@ -5,10 +5,12 @@
  *   Adam Stylinski <kungfujesus06@gmail.com>
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
+
 #ifdef ARM_NEON
-#include "neon_intrins.h"
+
 #include "zbuild.h"
 #include "adler32_p.h"
+#include "neon_intrins.h"
 
 static const uint16_t ALIGNED_(64) taps[64] = {
     64, 63, 62, 61, 60, 59, 58, 57,

--- a/arch/arm/arm_features.c
+++ b/arch/arm/arm_features.c
@@ -1,6 +1,8 @@
 #include "zbuild.h"
 #include "arm_features.h"
 
+#ifdef ARM_FEATURES
+
 #if defined(HAVE_SYS_AUXV_H)
 #  include <sys/auxv.h>
 #  ifdef ARM_ASM_HWCAP
@@ -328,3 +330,5 @@ void Z_INTERNAL arm_check_features(struct arm_cpu_features *features) {
     features->has_eor3 = arm_has_eor3();
     features->has_fast_pmull = features->has_pmull && arm_cpu_has_fast_pmull();
 }
+
+#endif

--- a/arch/arm/arm_features.c
+++ b/arch/arm/arm_features.c
@@ -1,7 +1,7 @@
+#ifdef ARM_FEATURES
+
 #include "zbuild.h"
 #include "arm_features.h"
-
-#ifdef ARM_FEATURES
 
 #if defined(HAVE_SYS_AUXV_H)
 #  include <sys/auxv.h>

--- a/arch/arm/chunkset_neon.c
+++ b/arch/arm/chunkset_neon.c
@@ -3,9 +3,10 @@
  */
 
 #ifdef ARM_NEON
-#include "neon_intrins.h"
+
 #include "zbuild.h"
 #include "zmemory.h"
+#include "neon_intrins.h"
 #include "arch/generic/chunk_128bit_perm_idx_lut.h"
 
 typedef uint8x16_t chunk_t;

--- a/arch/arm/crc32_armv8.c
+++ b/arch/arm/crc32_armv8.c
@@ -4,10 +4,11 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-#if defined(ARM_CRC32)
-#include "acle_intrins.h"
+#ifdef ARM_CRC32
+
 #include "zbuild.h"
 #include "crc32.h"
+#include "acle_intrins.h"
 
 Z_INTERNAL Z_TARGET_CRC uint32_t crc32_armv8(uint32_t crc, const uint8_t *buf, size_t len) {
     uint32_t c = ~crc;

--- a/arch/arm/crc32_armv8_pmull_eor3.c
+++ b/arch/arm/crc32_armv8_pmull_eor3.c
@@ -7,7 +7,8 @@
  * Uses 3-way parallel scalar CRC + 9 PMULL vector lanes, processing 192 bytes/iter.
  */
 
-#if defined(ARM_PMULL_EOR3)
+#ifdef ARM_PMULL_EOR3
+
 #include "zbuild.h"
 #include "zutil.h"
 #include "acle_intrins.h"

--- a/arch/arm/slide_hash_armv6.c
+++ b/arch/arm/slide_hash_armv6.c
@@ -3,10 +3,11 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-#if defined(ARM_SIMD)
-#include "acle_intrins.h"
+#ifdef ARM_SIMD
+
 #include "zbuild.h"
 #include "deflate.h"
+#include "acle_intrins.h"
 
 /* SIMD version of hash_chain rebase */
 static inline void slide_hash_chain(Pos *table, uint32_t entries, uint16_t wsize) {

--- a/arch/arm/slide_hash_neon.c
+++ b/arch/arm/slide_hash_neon.c
@@ -9,9 +9,10 @@
  */
 
 #ifdef ARM_NEON
-#include "neon_intrins.h"
+
 #include "zbuild.h"
 #include "deflate.h"
+#include "neon_intrins.h"
 
 /* SIMD version of hash_chain rebase */
 static inline void slide_hash_chain(Pos *table, uint32_t entries, uint16_t wsize) {

--- a/arch/loongarch/adler32_lsx.c
+++ b/arch/loongarch/adler32_lsx.c
@@ -7,10 +7,10 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
+#ifdef LOONGARCH_LSX
+
 #include "zbuild.h"
 #include "adler32_p.h"
-
-#ifdef LOONGARCH_LSX
 
 #include <lsxintrin.h>
 #include "lsxintrin_ext.h"

--- a/arch/loongarch/chunkset_lasx.c
+++ b/arch/loongarch/chunkset_lasx.c
@@ -2,10 +2,11 @@
  * Copyright (C) 2025 Vladislav Shchapov <vladislav@shchapov.ru>
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
-#include "zbuild.h"
-#include "zmemory.h"
 
 #ifdef LOONGARCH_LASX
+
+#include "zbuild.h"
+#include "zmemory.h"
 
 #include <lasxintrin.h>
 #include "lasxintrin_ext.h"

--- a/arch/loongarch/chunkset_lsx.c
+++ b/arch/loongarch/chunkset_lsx.c
@@ -3,10 +3,11 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
+#ifdef LOONGARCH_LSX
+
 #include "zbuild.h"
 #include "zmemory.h"
 
-#if defined(LOONGARCH_LSX)
 #include <lsxintrin.h>
 #include "lsxintrin_ext.h"
 #include "arch/generic/chunk_128bit_perm_idx_lut.h"

--- a/arch/loongarch/crc32_la.c
+++ b/arch/loongarch/crc32_la.c
@@ -3,9 +3,11 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-#if defined(LOONGARCH_CRC)
+#ifdef LOONGARCH_CRC
+
 #include "zbuild.h"
 #include "crc32.h"
+
 #include <stdint.h>
 #include <larchintrin.h>
 

--- a/arch/loongarch/crc32_la.c
+++ b/arch/loongarch/crc32_la.c
@@ -8,7 +8,6 @@
 #include "zbuild.h"
 #include "crc32.h"
 
-#include <stdint.h>
 #include <larchintrin.h>
 
 Z_INTERNAL uint32_t crc32_loongarch64(uint32_t crc, const uint8_t *buf, size_t len) {

--- a/arch/loongarch/loongarch_features.c
+++ b/arch/loongarch/loongarch_features.c
@@ -5,10 +5,10 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
+#ifdef LOONGARCH_FEATURES
+
 #include "zbuild.h"
 #include "loongarch_features.h"
-
-#ifdef LOONGARCH_FEATURES
 
 #include <larchintrin.h>
 

--- a/arch/loongarch/loongarch_features.c
+++ b/arch/loongarch/loongarch_features.c
@@ -8,6 +8,8 @@
 #include "zbuild.h"
 #include "loongarch_features.h"
 
+#ifdef LOONGARCH_FEATURES
+
 #include <larchintrin.h>
 
 /*
@@ -25,3 +27,5 @@ void Z_INTERNAL loongarch_check_features(struct loongarch_cpu_features *features
     features->has_lsx = w1 & 0x40;
     features->has_lasx = w1 & 0x80;
 }
+
+#endif

--- a/arch/loongarch/slide_hash_lasx.c
+++ b/arch/loongarch/slide_hash_lasx.c
@@ -10,10 +10,11 @@
  *
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
-#include "zbuild.h"
-#include "deflate.h"
 
 #ifdef LOONGARCH_LASX
+
+#include "zbuild.h"
+#include "deflate.h"
 
 #include <lasxintrin.h>
 

--- a/arch/loongarch/slide_hash_lasx.c
+++ b/arch/loongarch/slide_hash_lasx.c
@@ -13,6 +13,8 @@
 #include "zbuild.h"
 #include "deflate.h"
 
+#ifdef LOONGARCH_LASX
+
 #include <lasxintrin.h>
 
 static inline void slide_hash_chain(Pos *table, uint32_t entries, const __m256i wsize) {
@@ -39,3 +41,5 @@ Z_INTERNAL void slide_hash_lasx(deflate_state *s) {
     slide_hash_chain(s->head, HASH_SIZE, ymm_wsize);
     slide_hash_chain(s->prev, wsize, ymm_wsize);
 }
+
+#endif

--- a/arch/loongarch/slide_hash_lsx.c
+++ b/arch/loongarch/slide_hash_lsx.c
@@ -12,6 +12,8 @@
 #include "zbuild.h"
 #include "deflate.h"
 
+#ifdef LOONGARCH_LSX
+
 #include <lsxintrin.h>
 #include <assert.h>
 
@@ -62,3 +64,5 @@ Z_INTERNAL void slide_hash_lsx(deflate_state *s) {
 
     slide_hash_chain(s->head, s->prev, HASH_SIZE, wsize, xmm_wsize);
 }
+
+#endif

--- a/arch/loongarch/slide_hash_lsx.c
+++ b/arch/loongarch/slide_hash_lsx.c
@@ -9,10 +9,11 @@
  *
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
-#include "zbuild.h"
-#include "deflate.h"
 
 #ifdef LOONGARCH_LSX
+
+#include "zbuild.h"
+#include "deflate.h"
 
 #include <lsxintrin.h>
 #include <assert.h>

--- a/arch/power/adler32_power8.c
+++ b/arch/power/adler32_power8.c
@@ -38,9 +38,10 @@
 
 #ifdef POWER8_VSX
 
-#include <altivec.h>
 #include "zbuild.h"
 #include "adler32_p.h"
+
+#include <altivec.h>
 
 /* Vector across sum unsigned int (saturate).  */
 static inline vector unsigned int vec_sumsu(vector unsigned int __a, vector unsigned int __b) {

--- a/arch/power/adler32_vmx.c
+++ b/arch/power/adler32_vmx.c
@@ -6,10 +6,12 @@
  */
 
 #ifdef PPC_VMX
-#include <altivec.h>
+
 #include "zbuild.h"
 #include "zendian.h"
 #include "adler32_p.h"
+
+#include <altivec.h>
 
 #define vmx_zero()  (vec_splat_u32(0))
 

--- a/arch/power/chunkset_power8.c
+++ b/arch/power/chunkset_power8.c
@@ -3,9 +3,11 @@
  */
 
 #ifdef POWER8_VSX
-#include <altivec.h>
+
 #include "zbuild.h"
 #include "zmemory.h"
+
+#include <altivec.h>
 
 typedef vector unsigned char chunk_t;
 

--- a/arch/power/compare256_power9.c
+++ b/arch/power/compare256_power9.c
@@ -4,11 +4,13 @@
  */
 
 #ifdef POWER9
-#include <altivec.h>
+
 #include "zbuild.h"
 #include "zmemory.h"
 #include "deflate.h"
 #include "zendian.h"
+
+#include <altivec.h>
 
 /* Older versions of GCC misimplemented semantics for these bit counting builtins.
  * https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;h=3f30f2d1dbb3228b8468b26239fe60c2974ce2ac */

--- a/arch/power/crc32_power8.c
+++ b/arch/power/crc32_power8.c
@@ -25,6 +25,8 @@
  * This code uses gcc vector builtins instead using assembly directly.
  */
 
+#ifdef POWER8_VSX_CRC32
+
 #include <altivec.h>
 #include "zendian.h"
 #include "zbuild.h"
@@ -588,3 +590,5 @@ static unsigned int ALIGNED_(32) __crc32_vpmsum(unsigned int crc, const void* p,
     return v0[1];
 #endif
 }
+
+#endif

--- a/arch/power/crc32_power8.c
+++ b/arch/power/crc32_power8.c
@@ -27,9 +27,8 @@
 
 #ifdef POWER8_VSX_CRC32
 
-#include <altivec.h>
-#include "zendian.h"
 #include "zbuild.h"
+#include "zendian.h"
 
 #include "crc32_constants.h"
 #include "crc32_braid_tbl.h"

--- a/arch/power/power_features.c
+++ b/arch/power/power_features.c
@@ -4,6 +4,11 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
+#if defined(PPC_FEATURES) || defined(POWER_FEATURES)
+
+#include "zbuild.h"
+#include "power_features.h"
+
 #ifdef HAVE_SYS_AUXV_H
 #  include <sys/auxv.h>
 #endif
@@ -13,8 +18,6 @@
 #ifdef __FreeBSD__
 #  include <machine/cpu.h>
 #endif
-#include "zbuild.h"
-#include "power_features.h"
 
 void Z_INTERNAL power_check_features(struct power_cpu_features *features) {
 #ifdef PPC_FEATURES
@@ -47,3 +50,5 @@ void Z_INTERNAL power_check_features(struct power_cpu_features *features) {
 #endif
 #endif
 }
+
+#endif

--- a/arch/power/power_intrins.h
+++ b/arch/power/power_intrins.h
@@ -12,6 +12,8 @@
 #ifndef POWER_INTRINS_H
 #define POWER_INTRINS_H
 
+#include <altivec.h>
+
 #if defined (__clang__)
 /*
  * These stubs fix clang incompatibilities with GCC builtins.

--- a/arch/riscv/adler32_rvv.c
+++ b/arch/riscv/adler32_rvv.c
@@ -10,7 +10,6 @@
 #include "adler32_p.h"
 
 #include <riscv_vector.h>
-#include <stdint.h>
 
 Z_FORCEINLINE static uint32_t adler32_copy_impl(uint32_t adler, uint8_t* restrict dst, const uint8_t *src, size_t len, int COPY) {
     /* split Adler-32 into component sums */

--- a/arch/riscv/adler32_rvv.c
+++ b/arch/riscv/adler32_rvv.c
@@ -6,11 +6,11 @@
 
 #ifdef RISCV_RVV
 
-#include <riscv_vector.h>
-#include <stdint.h>
-
 #include "zbuild.h"
 #include "adler32_p.h"
+
+#include <riscv_vector.h>
+#include <stdint.h>
 
 Z_FORCEINLINE static uint32_t adler32_copy_impl(uint32_t adler, uint8_t* restrict dst, const uint8_t *src, size_t len, int COPY) {
     /* split Adler-32 into component sums */

--- a/arch/riscv/chunkset_rvv.c
+++ b/arch/riscv/chunkset_rvv.c
@@ -3,6 +3,9 @@
  * Contributed by Alex Chiang <alex.chiang@sifive.com>
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
+
+#ifdef RISCV_RVV
+
 #include <riscv_vector.h>
 #include "zbuild.h"
 
@@ -118,3 +121,5 @@ static inline uint8_t* CHUNKCOPY(uint8_t *out, uint8_t const *from, unsigned len
 #define INFLATE_FAST     inflate_fast_rvv
 
 #include "inffast_tpl.h"
+
+#endif

--- a/arch/riscv/chunkset_rvv.c
+++ b/arch/riscv/chunkset_rvv.c
@@ -6,8 +6,9 @@
 
 #ifdef RISCV_RVV
 
-#include <riscv_vector.h>
 #include "zbuild.h"
+
+#include <riscv_vector.h>
 
 /*
  * RISC-V glibc would enable RVV optimized memcpy at runtime by IFUNC,

--- a/arch/riscv/crc32_zbc.c
+++ b/arch/riscv/crc32_zbc.c
@@ -4,9 +4,11 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-#if defined(RISCV_CRC32_ZBC)
+#ifdef RISCV_CRC32_ZBC
+
 #include "zbuild.h"
 #include "arch_functions.h"
+
 #include <stdint.h>
 
 #define CLMUL_MIN_LEN 16   // Minimum size of buffer for _crc32_clmul

--- a/arch/riscv/crc32_zbc.c
+++ b/arch/riscv/crc32_zbc.c
@@ -9,8 +9,6 @@
 #include "zbuild.h"
 #include "arch_functions.h"
 
-#include <stdint.h>
-
 #define CLMUL_MIN_LEN 16   // Minimum size of buffer for _crc32_clmul
 #define CLMUL_CHUNK_LEN 16 // Length of chunk for clmul
 

--- a/arch/riscv/riscv_features.c
+++ b/arch/riscv/riscv_features.c
@@ -3,9 +3,6 @@
 #include "zbuild.h"
 #include "riscv_features.h"
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <sys/utsname.h>
 
 #if defined(__linux__) && defined(HAVE_SYS_AUXV_H)

--- a/arch/riscv/riscv_features.c
+++ b/arch/riscv/riscv_features.c
@@ -1,3 +1,5 @@
+#ifdef RISCV_FEATURES
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -44,3 +46,5 @@ void Z_INTERNAL riscv_check_features(struct riscv_cpu_features *features) {
     }
 #endif
 }
+
+#endif

--- a/arch/riscv/riscv_features.c
+++ b/arch/riscv/riscv_features.c
@@ -1,5 +1,8 @@
 #ifdef RISCV_FEATURES
 
+#include "zbuild.h"
+#include "riscv_features.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -8,9 +11,6 @@
 #if defined(__linux__) && defined(HAVE_SYS_AUXV_H)
 #  include <sys/auxv.h>
 #endif
-
-#include "zbuild.h"
-#include "riscv_features.h"
 
 #define ISA_V_HWCAP (1 << ('v' - 'a'))
 #define ISA_ZBC_HWCAP (1 << 29)

--- a/arch/riscv/slide_hash_rvv.c
+++ b/arch/riscv/slide_hash_rvv.c
@@ -6,10 +6,10 @@
 
 #ifdef RISCV_RVV
 
-#include <riscv_vector.h>
-
 #include "zbuild.h"
 #include "deflate.h"
+
+#include <riscv_vector.h>
 
 static inline void slide_hash_chain(Pos *table, uint32_t entries, uint16_t wsize) {
     size_t vl;

--- a/arch/s390/crc32-vx.c
+++ b/arch/s390/crc32-vx.c
@@ -12,10 +12,10 @@
  * relicensed under the zlib license.
  */
 
+#ifdef S390_CRC32_VX
+
 #include "zbuild.h"
 #include "arch_functions.h"
-
-#ifdef S390_CRC32_VX
 
 #include <vecintrin.h>
 

--- a/arch/s390/crc32-vx.c
+++ b/arch/s390/crc32-vx.c
@@ -15,6 +15,8 @@
 #include "zbuild.h"
 #include "arch_functions.h"
 
+#ifdef S390_CRC32_VX
+
 #include <vecintrin.h>
 
 typedef unsigned char uv16qi __attribute__((vector_size(16)));
@@ -226,3 +228,5 @@ Z_INTERNAL uint32_t crc32_copy_s390_vx(uint32_t crc, uint8_t *dst, const uint8_t
     memcpy(dst, src, len);
     return crc;
 }
+
+#endif

--- a/arch/s390/dfltcc_deflate.c
+++ b/arch/s390/dfltcc_deflate.c
@@ -13,6 +13,8 @@
         $ make
 */
 
+#ifdef S390_DFLTCC_DEFLATE
+
 #include "zbuild.h"
 #include "deflate.h"
 #include "deflate_p.h"
@@ -384,3 +386,5 @@ int Z_INTERNAL PREFIX(dfltcc_deflate_get_dictionary)(PREFIX3(streamp) strm, unsi
         *dict_length = param->hl;
     return Z_OK;
 }
+
+#endif

--- a/arch/s390/dfltcc_inflate.c
+++ b/arch/s390/dfltcc_inflate.c
@@ -13,6 +13,8 @@
         $ make
 */
 
+#ifdef S390_DFLTCC_INFLATE
+
 #include "zbuild.h"
 #include "zutil.h"
 #include "inftrees.h"
@@ -189,3 +191,5 @@ int Z_INTERNAL PREFIX(dfltcc_inflate_get_dictionary)(PREFIX3(streamp) strm,
         *dict_length = param->hl;
     return Z_OK;
 }
+
+#endif

--- a/arch/s390/s390_features.c
+++ b/arch/s390/s390_features.c
@@ -1,7 +1,7 @@
+#ifdef S390_FEATURES
+
 #include "zbuild.h"
 #include "s390_features.h"
-
-#ifdef S390_FEATURES
 
 #ifdef HAVE_SYS_AUXV_H
 #  include <sys/auxv.h>

--- a/arch/s390/s390_features.c
+++ b/arch/s390/s390_features.c
@@ -1,6 +1,8 @@
 #include "zbuild.h"
 #include "s390_features.h"
 
+#ifdef S390_FEATURES
+
 #ifdef HAVE_SYS_AUXV_H
 #  include <sys/auxv.h>
 #endif
@@ -12,3 +14,5 @@
 void Z_INTERNAL s390_check_features(struct s390_cpu_features *features) {
     features->has_vx = getauxval(AT_HWCAP) & HWCAP_S390_VXRS;
 }
+
+#endif

--- a/arch/x86/adler32_sse42.c
+++ b/arch/x86/adler32_sse42.c
@@ -6,11 +6,11 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
+#ifdef X86_SSE42
+
 #include "zbuild.h"
 #include "adler32_p.h"
 #include "adler32_ssse3_p.h"
-
-#ifdef X86_SSE42
 
 #include <immintrin.h>
 

--- a/arch/x86/adler32_sse42.c
+++ b/arch/x86/adler32_sse42.c
@@ -9,9 +9,10 @@
 #include "zbuild.h"
 #include "adler32_p.h"
 #include "adler32_ssse3_p.h"
-#include <immintrin.h>
 
 #ifdef X86_SSE42
+
+#include <immintrin.h>
 
 Z_INTERNAL uint32_t adler32_copy_sse42(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len) {
     uint32_t adler0, adler1;

--- a/arch/x86/adler32_ssse3.c
+++ b/arch/x86/adler32_ssse3.c
@@ -6,11 +6,11 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
+#ifdef X86_SSSE3
+
 #include "zbuild.h"
 #include "adler32_p.h"
 #include "adler32_ssse3_p.h"
-
-#ifdef X86_SSSE3
 
 #include <immintrin.h>
 

--- a/arch/x86/chunkset_avx2.c
+++ b/arch/x86/chunkset_avx2.c
@@ -1,10 +1,12 @@
 /* chunkset_avx2.c -- AVX2 inline functions to copy small data chunks.
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
+
+#ifdef X86_AVX2
+
 #include "zbuild.h"
 #include "zmemory.h"
 
-#ifdef X86_AVX2
 #include "arch/generic/chunk_256bit_perm_idx_lut.h"
 #include <immintrin.h>
 #include "x86_intrins.h"

--- a/arch/x86/chunkset_avx512.c
+++ b/arch/x86/chunkset_avx512.c
@@ -1,10 +1,11 @@
 /* chunkset_avx512.c -- AVX512 inline functions to copy small data chunks.
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
-#include "zbuild.h"
-#include "zmemory.h"
 
 #ifdef X86_AVX512
+
+#include "zbuild.h"
+#include "zmemory.h"
 
 #include "arch/generic/chunk_256bit_perm_idx_lut.h"
 #include <immintrin.h>

--- a/arch/x86/chunkset_sse2.c
+++ b/arch/x86/chunkset_sse2.c
@@ -2,10 +2,11 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
+#ifdef X86_SSE2
+
 #include "zbuild.h"
 #include "zmemory.h"
 
-#ifdef X86_SSE2
 #include <immintrin.h>
 
 typedef __m128i chunk_t;

--- a/arch/x86/chunkset_ssse3.c
+++ b/arch/x86/chunkset_ssse3.c
@@ -2,10 +2,11 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
+#ifdef X86_SSSE3
+
 #include "zbuild.h"
 #include "zmemory.h"
 
-#if defined(X86_SSSE3)
 #include <immintrin.h>
 #include "arch/generic/chunk_128bit_perm_idx_lut.h"
 

--- a/arch/x86/slide_hash_avx2.c
+++ b/arch/x86/slide_hash_avx2.c
@@ -12,6 +12,8 @@
 #include "zbuild.h"
 #include "deflate.h"
 
+#ifdef X86_AVX2
+
 #include <immintrin.h>
 
 static inline void slide_hash_chain(Pos *table, uint32_t entries, const __m256i wsize) {
@@ -38,3 +40,5 @@ Z_INTERNAL void slide_hash_avx2(deflate_state *s) {
     slide_hash_chain(s->head, HASH_SIZE, ymm_wsize);
     slide_hash_chain(s->prev, wsize, ymm_wsize);
 }
+
+#endif

--- a/arch/x86/slide_hash_avx2.c
+++ b/arch/x86/slide_hash_avx2.c
@@ -9,10 +9,11 @@
  *
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
-#include "zbuild.h"
-#include "deflate.h"
 
 #ifdef X86_AVX2
+
+#include "zbuild.h"
+#include "deflate.h"
 
 #include <immintrin.h>
 

--- a/arch/x86/slide_hash_sse2.c
+++ b/arch/x86/slide_hash_sse2.c
@@ -8,10 +8,11 @@
  *
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
-#include "zbuild.h"
-#include "deflate.h"
 
 #ifdef X86_SSE2
+
+#include "zbuild.h"
+#include "deflate.h"
 
 #include <immintrin.h>
 #include <assert.h>

--- a/arch/x86/slide_hash_sse2.c
+++ b/arch/x86/slide_hash_sse2.c
@@ -11,6 +11,8 @@
 #include "zbuild.h"
 #include "deflate.h"
 
+#ifdef X86_SSE2
+
 #include <immintrin.h>
 #include <assert.h>
 
@@ -61,3 +63,5 @@ Z_INTERNAL void slide_hash_sse2(deflate_state *s) {
 
     slide_hash_chain(s->head, s->prev, HASH_SIZE, wsize, xmm_wsize);
 }
+
+#endif

--- a/arch/x86/x86_features.c
+++ b/arch/x86/x86_features.c
@@ -10,6 +10,7 @@
 #include "zbuild.h"
 #include "x86_features.h"
 
+#ifdef X86_FEATURES
 
 #if defined(HAVE_CPUID_MS)
 #   include <intrin.h>
@@ -125,3 +126,5 @@ void Z_INTERNAL x86_check_features(struct x86_cpu_features *features) {
         }
     }
 }
+
+#endif

--- a/arch/x86/x86_features.c
+++ b/arch/x86/x86_features.c
@@ -7,10 +7,10 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
+#ifdef X86_FEATURES
+
 #include "zbuild.h"
 #include "x86_features.h"
-
-#ifdef X86_FEATURES
 
 #if defined(HAVE_CPUID_MS)
 #   include <intrin.h>


### PR DESCRIPTION
Most architecture-specific implementation files already check the corresponding feature macro, but not all.

This commit adds the missing feature macro checks and fixes one instance in adler32_sse42.c where immintrin.h was included before the macro check.