### PR TITLE
Move cleanup undefs to insert_string_tpl.h

### DIFF
--- a/insert_string_p.h
+++ b/insert_string_p.h
@@ -24,19 +24,6 @@
 
 #include "insert_string_tpl.h"
 
-// Cleanup
-#undef HASH_SLIDE
-#undef HASH_CALC
-#undef HASH_CALC_READ
-#undef HASH_CALC_MASK
-#undef HASH_CALC_OFFSET
-#undef HASH_CALC_VAR
-#undef HASH_CALC_VAR_INIT
-#undef UPDATE_HASH
-#undef INSERT_STRING
-#undef QUICK_INSERT_STRING
-#undef QUICK_INSERT_VALUE
-
 // Rolling insert_string, level 9
 #define HASH_SLIDE           5
 

--- a/insert_string_tpl.h
+++ b/insert_string_tpl.h
@@ -117,3 +117,16 @@ Z_FORCEINLINE static void INSERT_STRING(deflate_state *const s, uint32_t str, ui
         }
     }
 }
+
+// Cleanup
+#undef HASH_SLIDE
+#undef HASH_CALC
+#undef HASH_CALC_READ
+#undef HASH_CALC_MASK
+#undef HASH_CALC_OFFSET
+#undef HASH_CALC_VAR
+#undef HASH_CALC_VAR_INIT
+#undef UPDATE_HASH
+#undef INSERT_STRING
+#undef QUICK_INSERT_STRING
+#undef QUICK_INSERT_VALUE


### PR DESCRIPTION
This ensures these defines do not leak outside of `insert_string_p.h`