### PR TITLE
Also upload coverage reports to coveralls.io

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -665,7 +665,8 @@ jobs:
       uses: actions/checkout@v6
       # Don't test against all corpora with MinGW due to Wine being unable to run parallel jobs
       # without connection timeout. Without parallel jobs test runs using Wine take close to an hour.
-      if: contains(matrix.name, 'MinGW') == false && !contains(matrix.cmake-args, 'WITH_SANITIZER')
+      # Also don't test the extra corpora with Sanitizer builds or RISC-V, due to their slow testing.
+      if: ${{ !contains(matrix.name, 'MinGW') && !contains(matrix.name, 'RISC-V') && !contains(matrix.cmake-args, 'WITH_SANITIZER') }}
       with:
         repository: zlib-ng/corpora
         path: test/data/corpora

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -5,7 +5,9 @@ env:
   GTEST_COLOR: 1
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # Don't abort on push to avoid incomplete coveralls uploads
+  cancel-in-progress: ${{ github.event_name != 'push' }}
+
 jobs:
   cmake:
     name: ${{ matrix.name }}
@@ -812,6 +814,7 @@ jobs:
         source ./venv/${{ runner.os == 'Windows' && 'Scripts' || 'bin' }}/activate
         python3 -u -m pip install gcovr
         python3 -m gcovr -j 3 --gcov-ignore-parse-errors --verbose \
+          --exclude '(.*/|^)(_deps|benchmarks)/.*' \
           --exclude-unreachable-branches \
           --merge-mode-functions separate \
           --merge-lines \
@@ -825,6 +828,16 @@ jobs:
         name: ${{ matrix.name }} (coverage)
         path: ${{ matrix.codecov }}.xml
         retention-days: 1
+
+    - name: Upload job coverage report to coveralls
+      uses: coverallsapp/github-action@v2
+      if: (matrix.codecov && !contains(matrix.os, 'z15') && (env.COVERALLS_REPO_TOKEN != '' || github.repository == 'zlib-ng/zlib-ng'))
+      with:
+        file: ${{ matrix.codecov }}.xml
+        flag-name: "${{ matrix.name }}-${{ github.event_name }}"
+        parallel: true
+      env:
+        COVERALLS_REPO_TOKEN: "${{ secrets.COVERALLS_REPO_TOKEN }}"
 
     - name: Test benchmarks (crashtest only, no coverage data collection)
       if: contains(matrix.cmake-args, '-DWITH_BENCHMARKS=ON')
@@ -867,15 +880,23 @@ jobs:
     - name: Display all coverage artifacts
       run: |
         ls -R *.xml
-        echo "CODECOV_REPORTS=`ls -p *.xml | grep -v / | tr '\n' ',' | sed 's/,$//g'`" >> $GITHUB_ENV
+        echo "COVERAGE_REPORTS=`ls -p *.xml | grep -v / | tr '\n' ',' | sed 's/,$//g'`" >> $GITHUB_ENV
 
-    - name: Upload reports
+    - name: Upload reports to codecov
       uses: codecov/codecov-action@v5
       if: (env.CODECOV_TOKEN != '' || github.repository == 'zlib-ng/zlib-ng')
       with:
-        files: ${{ env.CODECOV_REPORTS }}
-        name: cmake-umbrella
+        files: ${{ env.COVERAGE_REPORTS }}
+        name: "cmake-umbrella-${{ github.event_name }}"
         verbose: true
         fail_ci_if_error: true
       env:
         CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
+
+    - name: Upload to Coveralls - Final
+      uses: coverallsapp/github-action@v2
+      if: (env.COVERALLS_REPO_TOKEN != '' || github.repository == 'zlib-ng/zlib-ng')
+      with:
+        parallel-finished: true
+      env:
+        COVERALLS_REPO_TOKEN: "${{ secrets.COVERALLS_REPO_TOKEN }}"

--- a/.github/workflows/pigz.yml
+++ b/.github/workflows/pigz.yml
@@ -107,6 +107,7 @@ jobs:
       run: |
         python3 -u -m pip install gcovr
         python3 -m gcovr -j 3 --gcov-ignore-parse-errors --verbose \
+          --exclude '(.*/|^)(_deps|benchmarks)/.*' \
           --exclude-unreachable-branches \
           --merge-mode-functions separate \
           --merge-lines \
@@ -153,14 +154,14 @@ jobs:
     - name: Display all coverage artifacts
       run: |
         ls -R *.xml
-        echo "CODECOV_REPORTS=`ls -p *.xml | grep -v / | tr '\n' ',' | sed 's/,$//g'`" >> $GITHUB_ENV
+        echo "COVERAGE_REPORTS=`ls -p *.xml | grep -v / | tr '\n' ',' | sed 's/,$//g'`" >> $GITHUB_ENV
 
-    - name: Upload reports
+    - name: Upload reports to codecov
       uses: codecov/codecov-action@v5
       if: (env.CODECOV_TOKEN != '' || github.repository == 'zlib-ng/zlib-ng')
       with:
-        files: ${{ env.CODECOV_REPORTS }}
-        name: pigz-umbrella
+        files: ${{ env.COVERAGE_REPORTS }}
+        name: "pigz-umbrella-${{ github.event_name }}"
         verbose: true
         fail_ci_if_error: true
       env:


### PR DESCRIPTION
- Add upload of coverage data to coveralls.io
- Differentiate between PR and Push in codecov upload names. (One diffs against develop head, one against whatever that the PR is based on, each looks backwards until they find a successful coverage upload for a commit.)
- Add filtering of _deps/ and benchmarks/ folders.
- Don't download extra corpora for RISC-V tests, those jobs easily take ~15min to complete.

Coveralls report is looking a lot better than codecov report, for example it has branch coverage, and shows hits per line. It also reports a higher coverage for the project. Coverage difference is probably because codecov does partial line counts where only the first checks of an if is run for example, whereas coveralls counts the whole if as hit no matter how much of it was executed.