### PR TITLE
Move DoNotOptimize in benchmark loop to prevent it being optimized away

### DIFF
--- a/test/benchmarks/benchmark_adler32.cc
+++ b/test/benchmarks/benchmark_adler32.cc
@@ -41,10 +41,10 @@ public:
                 misalign = 0;
             else
                 misalign += (DO_ALIGNED) ? 16 : 1;
-        }
 
-        // Prevent the result from being optimized away
-        benchmark::DoNotOptimize(hash);
+            // Prevent the result from being optimized away
+            benchmark::DoNotOptimize(hash);
+        }
     }
 
     void TearDown(const ::benchmark::State&) {

--- a/test/benchmarks/benchmark_adler32_copy.cc
+++ b/test/benchmarks/benchmark_adler32_copy.cc
@@ -45,10 +45,10 @@ public:
                 misalign = 0;
             else
                 misalign += (DO_ALIGNED) ? 16 : 1;
-        }
 
-        // Prevent the result from being optimized away
-        benchmark::DoNotOptimize(hash);
+            // Prevent the result from being optimized away
+            benchmark::DoNotOptimize(hash);
+        }
     }
 
     void TearDown(const ::benchmark::State&) {

--- a/test/benchmarks/benchmark_compare256.cc
+++ b/test/benchmarks/benchmark_compare256.cc
@@ -49,10 +49,10 @@ public:
                 misalign = 0;
             else
                 misalign++;
-        }
 
-        // Prevent the result from being optimized away
-        benchmark::DoNotOptimize(len);
+            // Prevent the result from being optimized away
+            benchmark::DoNotOptimize(len);
+        }
     }
 
     void TearDown(const ::benchmark::State&) {

--- a/test/benchmarks/benchmark_compare256_rle.cc
+++ b/test/benchmarks/benchmark_compare256_rle.cc
@@ -47,10 +47,10 @@ public:
                 misalign = 0;
             else
                 misalign++;
-        }
 
-        // Prevent the result from being optimized away
-        benchmark::DoNotOptimize(len);
+            // Prevent the result from being optimized away
+            benchmark::DoNotOptimize(len);
+        }
     }
 
     void TearDown(const ::benchmark::State&) {

--- a/test/benchmarks/benchmark_compress.cc
+++ b/test/benchmarks/benchmark_compress.cc
@@ -54,9 +54,10 @@ public:
                 fprintf(stderr, "compress() failed with error %d\n", err);
                 abort();
             }
-        }
 
-        benchmark::DoNotOptimize(err);
+            // Prevent the result from being optimized away
+            benchmark::DoNotOptimize(err);
+        }
     }
 
     void TearDown(const ::benchmark::State&) {

--- a/test/benchmarks/benchmark_crc32.cc
+++ b/test/benchmarks/benchmark_crc32.cc
@@ -41,10 +41,10 @@ public:
                 misalign = 0;
             else
                 misalign += (DO_ALIGNED) ? 16 : 1;
-        }
 
-        // Prevent the result from being optimized away
-        benchmark::DoNotOptimize(hash);
+            // Prevent the result from being optimized away
+            benchmark::DoNotOptimize(hash);
+        }
     }
 
     void TearDown(const ::benchmark::State&) {

--- a/test/benchmarks/benchmark_crc32_copy.cc
+++ b/test/benchmarks/benchmark_crc32_copy.cc
@@ -45,10 +45,10 @@ public:
                 misalign = 0;
             else
                 misalign += (DO_ALIGNED) ? 16 : 1;
-        }
 
-        // Prevent the result from being optimized away
-        benchmark::DoNotOptimize(hash);
+            // Prevent the result from being optimized away
+            benchmark::DoNotOptimize(hash);
+        }
     }
 
     void TearDown(const ::benchmark::State&) {


### PR DESCRIPTION
In some cases I've noticed incorrect 0 benchmark results from compiler optimizing away len during hash benchmarks.

It happened while testing changes to compare256 implementations. DoNotOptimize should go inside for loop.