### PR TITLE
Minor memory layout alignment changes

### DIFF
--- a/deflate.h
+++ b/deflate.h
@@ -249,6 +249,14 @@ struct ALIGNED_(64) internal_state {
     struct tree_desc_s d_desc;               /* desc. for distance tree */
     struct tree_desc_s bl_desc;              /* desc. for bit length tree */
 
+                /* Cacheline 46 - Symbol tallying (accessed with dyn_ltree/dyn_dtree) */
+
+    unsigned int sym_next;        /* running index in symbol buffer */
+    unsigned int sym_end;         /* symbol table full when sym_next reaches this */
+    unsigned int matches;         /* number of string matches in current block */
+    unsigned int opt_len;         /* bit length of current block with optimal trees */
+    unsigned int static_len;      /* bit length of current block with static trees */
+
     uint16_t bl_count[MAX_BITS+1];
     /* number of codes at each bit length for an optimal tree */
 
@@ -281,6 +289,8 @@ struct ALIGNED_(64) internal_state {
      *   - I can't count above 4
      */
 
+                /* Cacheline 92 */
+
 #ifdef LIT_MEM
 #   define LIT_BUFS 5
     uint16_t *d_buf;              /* buffer for distances */
@@ -289,15 +299,6 @@ struct ALIGNED_(64) internal_state {
 #   define LIT_BUFS 4
     unsigned char *sym_buf;       /* buffer for distances and literals/lengths */
 #endif
-
-    unsigned int sym_next;        /* running index in symbol buffer */
-    unsigned int sym_end;         /* symbol table full when sym_next reaches this */
-    unsigned int matches;         /* number of string matches in current block */
-
-                /* Cacheline 92 - Block statistics */
-
-    unsigned int opt_len;         /* bit length of current block with optimal trees */
-    unsigned int static_len;      /* bit length of current block with static trees */
 
     deflate_allocs *alloc_bufs;
 

--- a/deflate.h
+++ b/deflate.h
@@ -135,7 +135,7 @@ typedef struct deflate_allocs_s {
 } deflate_allocs;
 
 struct ALIGNED_(64) internal_state {
-                /* Cacheline 0 */
+                /* Cacheline 0 - Stream and pending buffer management */
     PREFIX3(stream)      *strm;            /* pointer back to this zlib stream */
     unsigned char        *pending_buf;     /* output still pending */
     unsigned char        *pending_out;     /* next pending byte to output to the stream */
@@ -153,7 +153,7 @@ struct ALIGNED_(64) internal_state {
      * This is set to 1 if there is an active block, or 0 if the block was just closed.
      */
 
-                /* Cacheline 1 */
+                /* Cacheline 1 - Window and hash table pointers */
 
     unsigned int  lookahead;    /* number of valid bytes ahead in window */
     unsigned int strstart;      /* start of string to insert */
@@ -198,7 +198,7 @@ struct ALIGNED_(64) internal_state {
     int          match_available;    /* set if previous match exists */
     uint32_t     prev_match;         /* previous match (used by deflate_slow) */
 
-                /* Cacheline 2 */
+                /* Cacheline 2 - Match finding and compression parameters */
 
     unsigned int match_start;        /* start of matching string */
 
@@ -238,9 +238,8 @@ struct ALIGNED_(64) internal_state {
 
     int32_t padding1[1];
 
-                /* Cacheline 3 */
+                /* Cacheline 3+ - Huffman trees and symbol buffers (trees.c) */
 
-                /* used by trees.c: */
     /* Didn't use ct_data typedef below to suppress compiler warning */
     struct ct_data_s dyn_ltree[HEAP_SIZE];   /* literal and length tree */
     struct ct_data_s dyn_dtree[2*D_CODES+1]; /* distance tree */
@@ -294,6 +293,9 @@ struct ALIGNED_(64) internal_state {
     unsigned int sym_next;        /* running index in symbol buffer */
     unsigned int sym_end;         /* symbol table full when sym_next reaches this */
     unsigned int matches;         /* number of string matches in current block */
+
+                /* Cacheline 92 - Block statistics */
+
     unsigned int opt_len;         /* bit length of current block with optimal trees */
     unsigned int static_len;      /* bit length of current block with static trees */
 

--- a/deflate.h
+++ b/deflate.h
@@ -239,7 +239,6 @@ struct ALIGNED_(64) internal_state {
     int32_t padding1[1];
 
                 /* Cacheline 3 */
-    uint8_t ALIGNED_(16) padding4[68];
 
                 /* used by trees.c: */
     /* Didn't use ct_data typedef below to suppress compiler warning */

--- a/deflate.h
+++ b/deflate.h
@@ -226,7 +226,6 @@ struct ALIGNED_(64) internal_state {
     int strategy;               /* favor or force Huffman coding*/
     unsigned int good_match;    /* Use a faster search when the previous match is longer than this */
     int nice_match;             /* Stop searching when current match exceeds this */
-    unsigned int matches;       /* number of string matches in current block */
     unsigned int insert;        /* bytes at end of window left to insert */
 
     uint64_t bi_buf;            /* Output buffer.
@@ -295,7 +294,7 @@ struct ALIGNED_(64) internal_state {
 
     unsigned int sym_next;        /* running index in symbol buffer */
     unsigned int sym_end;         /* symbol table full when sym_next reaches this */
-
+    unsigned int matches;         /* number of string matches in current block */
     unsigned int opt_len;         /* bit length of current block with optimal trees */
     unsigned int static_len;      /* bit length of current block with static trees */
 

--- a/deflate.h
+++ b/deflate.h
@@ -227,16 +227,15 @@ struct ALIGNED_(64) internal_state {
     unsigned int good_match;    /* Use a faster search when the previous match is longer than this */
     int nice_match;             /* Stop searching when current match exceeds this */
     unsigned int insert;        /* bytes at end of window left to insert */
-
-    uint64_t bi_buf;            /* Output buffer.
-                                 * Bits are inserted starting at the bottom (least significant bits). */
     int32_t bi_valid;           /* Number of valid bits in bi_buf.
                                  * All bits above the last valid bit are always zero. */
+    uint64_t bi_buf;            /* Output buffer.
+                                 * Bits are inserted starting at the bottom (least significant bits). */
 
     int heap_len;               /* number of elements in the heap */
     int heap_max;               /* element of largest frequency */
 
-    int32_t padding1[1];
+    int32_t padding1[2];
 
                 /* Cacheline 3+ - Huffman trees and symbol buffers (trees.c) */
 
@@ -268,6 +267,7 @@ struct ALIGNED_(64) internal_state {
     unsigned char depth[2*L_CODES+1];
     /* Depth of each subtree used as tie breaker for trees of equal frequency
      */
+    uint8_t padding3[3];        /* explicit padding for lit_bufsize alignment */
 
     unsigned int  lit_bufsize;
     /* Size of match buffer for literals/lengths.  There are 4 reasons for

--- a/inffast_tpl.h
+++ b/inffast_tpl.h
@@ -311,9 +311,9 @@ void Z_INTERNAL INFLATE_FAST(PREFIX3(stream) *strm, uint32_t start) {
 
     /* update state and return */
     strm->next_in = in;
-    strm->next_out = out;
     strm->avail_in = (unsigned)(in < last ? (INFLATE_FAST_MIN_HAVE - 1) + (last - in)
                                           : (INFLATE_FAST_MIN_HAVE - 1) - (in - last));
+    strm->next_out = out;
     strm->avail_out = (unsigned)(out < end ? (INFLATE_FAST_MIN_LEFT - 1) + (end - out)
                                            : (INFLATE_FAST_MIN_LEFT - 1) - (out - end));
 

--- a/inflate.c
+++ b/inflate.c
@@ -1326,8 +1326,8 @@ int32_t Z_EXPORT PREFIX(inflateSync)(PREFIX3(stream) *strm) {
 
     /* search available input */
     len = syncsearch(&(state->have), strm->next_in, strm->avail_in);
-    strm->avail_in -= len;
     strm->next_in += len;
+    strm->avail_in -= len;
     strm->total_in += len;
 
     /* return no joy or set up to restart inflate() on a new block */

--- a/inflate.h
+++ b/inflate.h
@@ -102,9 +102,9 @@ struct ALIGNED_(64) inflate_state {
     int last;                   /* true if processing last block */
     int wrap;                   /* bit 0 true for zlib, bit 1 true for gzip,
                                    bit 2 true to validate check value */
-    int havedict;               /* true if dictionary provided */
     int flags;                  /* gzip header method and flags, 0 if zlib, or
                                    -1 if raw or no header yet */
+    int havedict;               /* true if dictionary provided */
     unsigned was;               /* initial length of match, for inflateMark */
     unsigned long check;        /* protected copy of check value */
     unsigned long total;        /* protected copy of output count */
@@ -114,9 +114,9 @@ struct ALIGNED_(64) inflate_state {
         /* sliding window */
     unsigned wbits;             /* log base 2 of requested window size */
     uint32_t wsize;             /* window size or zero if not using window */
-    uint32_t wbufsize;          /* real size of the allocated window buffer, including padding */
     uint32_t whave;             /* valid bytes in the window */
     uint32_t wnext;             /* window write index */
+    uint32_t wbufsize;          /* real size of the allocated window buffer, including padding */
     unsigned char *window;      /* allocated sliding window, if needed */
 
         /* bit accumulator */

--- a/inflate_p.h
+++ b/inflate_p.h
@@ -80,10 +80,10 @@ typedef unsigned bits_t;
 /* Load registers with state in inflate() for speed */
 #define LOAD() \
     do { \
-        put = strm->next_out; \
-        left = strm->avail_out; \
         next = strm->next_in; \
         have = strm->avail_in; \
+        put = strm->next_out; \
+        left = strm->avail_out; \
         hold = state->hold; \
         bits = (bits_t)state->bits; \
     } while (0)
@@ -91,10 +91,10 @@ typedef unsigned bits_t;
 /* Restore state from registers in inflate() */
 #define RESTORE() \
     do { \
-        strm->next_out = put; \
-        strm->avail_out = left; \
         strm->next_in = (z_const unsigned char *)next; \
         strm->avail_in = have; \
+        strm->next_out = put; \
+        strm->avail_out = left; \
         state->hold = hold; \
         state->bits = bits; \
     } while (0)


### PR DESCRIPTION
`matches` and `sym_*` are now in the same cache line.
`strm->avail_in` and `strm->next_out` assignments are ordered sequentially.
`wrap` and `flags` are used often together.
`whave` and `wnext` can now be loaded together on arm in `inflate_fast`.