### PR TITLE
riscv: features: support hwprobe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -458,6 +458,10 @@ check_include_file(linux/auxvec.h HAVE_LINUX_AUXVEC_H)
 if(HAVE_LINUX_AUXVEC_H)
     add_definitions(-DHAVE_LINUX_AUXVEC_H)
 endif()
+check_include_file(asm/hwprobe.h  HAVE_ASM_HWPROBE_H)
+if(HAVE_ASM_HWPROBE_H)
+    add_definitions(-DHAVE_ASM_HWPROBE_H)
+endif()
 
 #
 # Check to see if we have large file support

--- a/arch/riscv/riscv_features.c
+++ b/arch/riscv/riscv_features.c
@@ -1,5 +1,7 @@
 #ifdef RISCV_FEATURES
 
+#define _DEFAULT_SOURCE 1 /* For syscall() */
+
 #include "zbuild.h"
 #include "riscv_features.h"
 
@@ -9,8 +11,48 @@
 #  include <sys/auxv.h>
 #endif
 
+#if defined(__linux__) && defined(HAVE_ASM_HWPROBE_H)
+#  include <asm/hwprobe.h>
+#  include <sys/syscall.h> /* For __NR_riscv_hwprobe */
+#  include <unistd.h> /* For syscall() */
+#endif
+
 #define ISA_V_HWCAP (1 << ('v' - 'a'))
 #define ISA_ZBC_HWCAP (1 << 29)
+
+static int riscv_check_features_runtime_hwprobe(struct riscv_cpu_features *features) {
+#if defined(__NR_riscv_hwprobe) && defined(RISCV_HWPROBE_KEY_IMA_EXT_0)
+    struct riscv_hwprobe probes[] = {
+        {RISCV_HWPROBE_KEY_IMA_EXT_0, 0},
+    };
+    int ret;
+    unsigned i;
+
+    ret = syscall(__NR_riscv_hwprobe, probes, sizeof(probes) / sizeof(probes[0]), 0, NULL, 0);
+
+    if (ret != 0) {
+        /* Kernel does not support hwprobe */
+        return 0;
+    }
+
+    for (i = 0; i < sizeof(probes) / sizeof(probes[0]); i++) {
+        switch (probes[i].key) {
+        case RISCV_HWPROBE_KEY_IMA_EXT_0:
+#  ifdef RISCV_HWPROBE_IMA_V
+            features->has_rvv = !!(probes[i].value & RISCV_HWPROBE_IMA_V);
+#  endif
+#  ifdef RISCV_HWPROBE_EXT_ZBC
+            features->has_zbc = !!(probes[i].value & RISCV_HWPROBE_EXT_ZBC);
+#  endif
+            break;
+        }
+    }
+
+    return 1;
+#else
+    return 0;
+#endif
+}
 
 static int riscv_check_features_runtime_hwcap(struct riscv_cpu_features *features) {
 #if defined(__linux__) && defined(HAVE_SYS_AUXV_H)
@@ -26,6 +68,9 @@ static int riscv_check_features_runtime_hwcap(struct riscv_cpu_features *feature
 }
 
 static void riscv_check_features_runtime(struct riscv_cpu_features *features) {
+    if (riscv_check_features_runtime_hwprobe(features))
+        return;
+
     riscv_check_features_runtime_hwcap(features);
 }
 

--- a/arch/riscv/riscv_features.c
+++ b/arch/riscv/riscv_features.c
@@ -12,14 +12,21 @@
 #define ISA_V_HWCAP (1 << ('v' - 'a'))
 #define ISA_ZBC_HWCAP (1 << 29)
 
-void Z_INTERNAL riscv_check_features_runtime(struct riscv_cpu_features *features) {
+static int riscv_check_features_runtime_hwcap(struct riscv_cpu_features *features) {
 #if defined(__linux__) && defined(HAVE_SYS_AUXV_H)
     unsigned long hw_cap = getauxval(AT_HWCAP);
-#else
-    unsigned long hw_cap = 0;
-#endif
+
     features->has_rvv = hw_cap & ISA_V_HWCAP;
     features->has_zbc = hw_cap & ISA_ZBC_HWCAP;
+
+    return 1;
+#else
+    return 0;
+#endif
+}
+
+static void riscv_check_features_runtime(struct riscv_cpu_features *features) {
+    riscv_check_features_runtime_hwcap(features);
 }
 
 void Z_INTERNAL riscv_check_features(struct riscv_cpu_features *features) {

--- a/configure
+++ b/configure
@@ -2185,6 +2185,16 @@ EOF
 
                 ARCH_STATIC_OBJS="${ARCH_STATIC_OBJS} riscv_features.o"
                 ARCH_SHARED_OBJS="${ARCH_SHARED_OBJS} riscv_features.lo"
+                cat > $test.c <<EOF
+#include <asm/hwprobe.h>
+EOF
+                if try $CC -c $CFLAGS $test.c; then
+                    echo "Checking for asm/hwprobe.h... Yes." | tee -a configure.log
+                    CFLAGS="${CFLAGS} -DHAVE_ASM_HWPROBE_H"
+                    SFLAGS="${SFLAGS} -DHAVE_ASM_HWPROBE_H"
+                else
+                    echo "Checking for asm/hwprobe.h... No." | tee -a configure.log
+                fi
             fi
             if test $buildrvv -eq 1; then
             check_rvv_compiler_flag


### PR DESCRIPTION
The PR adds support for detecting RISC-V features via Linux's riscv_hwprobe syscall, which is where more and more extensions are expected to be detected.