### PR TITLE
Slide 32 hash entries per loop iteration when using AVX2.

### DIFF
--- a/arch/x86/slide_hash_avx2.c
+++ b/arch/x86/slide_hash_avx2.c
@@ -19,17 +19,20 @@
 
 static inline void slide_hash_chain(Pos *table, uint32_t entries, const __m256i wsize) {
     table += entries;
-    table -= 16;
+    table -= 32;
 
     do {
-        __m256i value, result;
+        __m256i value1, value2, result1, result2;
 
-        value = _mm256_load_si256((__m256i *)table);
-        result = _mm256_subs_epu16(value, wsize);
-        _mm256_store_si256((__m256i *)table, result);
+        value1 = _mm256_load_si256((__m256i *)table);
+        value2 = _mm256_load_si256((__m256i *)(table+16));
+        result1 = _mm256_subs_epu16(value1, wsize);
+        result2 = _mm256_subs_epu16(value2, wsize);
+        _mm256_store_si256((__m256i *)table, result1);
+        _mm256_store_si256((__m256i *)(table+16), result2);
 
-        table -= 16;
-        entries -= 16;
+        table -= 32;
+        entries -= 32;
     } while (entries > 0);
 }
 


### PR DESCRIPTION
On i5-9600k sliding 32 elements vs. 16 elements per loop iteration is about 18% faster.

Develop:
```
----------------------------------------------------------------
Benchmark                      Time             CPU   Iterations
----------------------------------------------------------------
slide_hash/avx2/512         1892 ns         1973 ns       356113
slide_hash/avx2/1024        1899 ns         1981 ns       353401
slide_hash/avx2/2048        1925 ns         2008 ns       347429
slide_hash/avx2/4096        2011 ns         2097 ns       329176
slide_hash/avx2/8192        2160 ns         2253 ns       309100
slide_hash/avx2/16384       2398 ns         2501 ns       278234
slide_hash/avx2/32768       2895 ns         3019 ns       230334
```

PR2136:
```
----------------------------------------------------------------
Benchmark                      Time             CPU   Iterations
----------------------------------------------------------------
slide_hash/avx2/512         1532 ns         1624 ns       429911
slide_hash/avx2/1024        1540 ns         1632 ns       427064
slide_hash/avx2/2048        1568 ns         1663 ns       418308
slide_hash/avx2/4096        1626 ns         1724 ns       406258
slide_hash/avx2/8192        1712 ns         1801 ns       386926
slide_hash/avx2/16384       1907 ns         1986 ns       349533
slide_hash/avx2/32768       2528 ns         2633 ns       264802
```