### PR TITLE
Optimize symbol buffer access based on platform unaligned access

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -167,7 +167,7 @@ Z_INTERNAL deflate_allocs* alloc_deflate(PREFIX3(stream) *strm, int windowBits, 
     int window_size = DEFLATE_ADJUST_WINDOW_SIZE((1 << windowBits) * 2);
     int prev_size = (1 << windowBits) * (int)sizeof(Pos);
     int head_size = HASH_SIZE * sizeof(Pos);
-    int pending_size = lit_bufsize * LIT_BUFS;
+    int pending_size = (lit_bufsize * LIT_BUFS) + 1;
     int state_size = sizeof(deflate_state);
     int alloc_size = sizeof(deflate_allocs);
 

--- a/deflate.h
+++ b/deflate.h
@@ -28,9 +28,11 @@
 #  define GZIP
 #endif
 
-/* define LIT_MEM to slightly increase the speed of deflate (order 1% to 2%) at
-   the cost of a larger memory footprint */
-#ifndef NO_LIT_MEM
+/* LIT_MEM uses separate distance/length buffers instead of the overlaid sym_buf.
+   This uses ~20% more memory but is 1-2% faster on platforms without fast unaligned
+   access. By default, LIT_MEM is only enabled when OPTIMAL_CMP < 32. Define LIT_MEM
+   to force separate buffers, or NO_LIT_MEM to force sym_buf usage. */
+#if !defined(LIT_MEM) && !defined(NO_LIT_MEM) && (OPTIMAL_CMP < 32)
 #  define LIT_MEM
 #endif
 

--- a/deflate_p.h
+++ b/deflate_p.h
@@ -62,13 +62,16 @@ extern const unsigned char Z_INTERNAL zng_dist_code[];
 
 static inline int zng_tr_tally_lit(deflate_state *s, unsigned char c) {
     /* c is the unmatched char */
+    unsigned int sym_next = s->sym_next;
 #ifdef LIT_MEM
-    s->d_buf[s->sym_next] = 0;
-    s->l_buf[s->sym_next++] = c;
+    s->d_buf[sym_next] = 0;
+    s->l_buf[sym_next] = c;
+    s->sym_next = sym_next + 1;
 #else
-    s->sym_buf[s->sym_next++] = 0;
-    s->sym_buf[s->sym_next++] = 0;
-    s->sym_buf[s->sym_next++] = c;
+    s->sym_buf[sym_next] = 0;
+    s->sym_buf[sym_next+1] = 0;
+    s->sym_buf[sym_next+2] = c;
+    s->sym_next = sym_next + 3;
 #endif
     s->dyn_ltree[c].Freq++;
     Tracevv((stderr, "%c", c));
@@ -79,15 +82,18 @@ static inline int zng_tr_tally_lit(deflate_state *s, unsigned char c) {
 static inline int zng_tr_tally_dist(deflate_state* s, uint32_t dist, uint32_t len) {
     /* dist: distance of matched string */
     /* len: match length-STD_MIN_MATCH */
+    unsigned int sym_next = s->sym_next;
 #ifdef LIT_MEM
     Assert(dist <= UINT16_MAX, "dist should fit in uint16_t");
     Assert(len <= UINT8_MAX, "len should fit in uint8_t");
-    s->d_buf[s->sym_next] = (uint16_t)dist;
-    s->l_buf[s->sym_next++] = (uint8_t)len;
+    s->d_buf[sym_next] = (uint16_t)dist;
+    s->l_buf[sym_next] = (uint8_t)len;
+    s->sym_next = sym_next + 1;
 #else
-    s->sym_buf[s->sym_next++] = (uint8_t)(dist);
-    s->sym_buf[s->sym_next++] = (uint8_t)(dist >> 8);
-    s->sym_buf[s->sym_next++] = (uint8_t)len;
+    s->sym_buf[sym_next] = (uint8_t)(dist);
+    s->sym_buf[sym_next+1] = (uint8_t)(dist >> 8);
+    s->sym_buf[sym_next+2] = (uint8_t)len;
+    s->sym_next = sym_next + 3;
 #endif
     s->matches++;
     dist--;

--- a/deflate_p.h
+++ b/deflate_p.h
@@ -11,6 +11,7 @@
 
 #include "functable.h"
 #include "fallback_builtins.h"
+#include "zmemory.h"
 
 /* Forward declare common non-inlined functions declared in deflate.c */
 
@@ -68,9 +69,13 @@ static inline int zng_tr_tally_lit(deflate_state *s, unsigned char c) {
     s->l_buf[sym_next] = c;
     s->sym_next = sym_next + 1;
 #else
+#  if OPTIMAL_CMP >= 32
+    zng_memwrite_4(&s->sym_buf[sym_next], Z_U32_TO_LE((uint32_t)c << 16));
+#  else
     s->sym_buf[sym_next] = 0;
     s->sym_buf[sym_next+1] = 0;
     s->sym_buf[sym_next+2] = c;
+#  endif
     s->sym_next = sym_next + 3;
 #endif
     s->dyn_ltree[c].Freq++;
@@ -90,9 +95,13 @@ static inline int zng_tr_tally_dist(deflate_state* s, uint32_t dist, uint32_t le
     s->l_buf[sym_next] = (uint8_t)len;
     s->sym_next = sym_next + 1;
 #else
+#  if OPTIMAL_CMP >= 32
+    zng_memwrite_4(&s->sym_buf[sym_next], Z_U32_TO_LE(dist | ((uint32_t)len << 16)));
+#  else
     s->sym_buf[sym_next] = (uint8_t)(dist);
     s->sym_buf[sym_next+1] = (uint8_t)(dist >> 8);
     s->sym_buf[sym_next+2] = (uint8_t)len;
+#  endif
     s->sym_next = sym_next + 3;
 #endif
     s->matches++;

--- a/trees.c
+++ b/trees.c
@@ -730,9 +730,15 @@ static void compress_block(deflate_state *s, const ct_data *ltree, const ct_data
             dist = d_buf[sx];
             lc = l_buf[sx++];
 #else
-            dist = sym_buf[sx++] & 0xff;
-            dist += (unsigned)(sym_buf[sx++] & 0xff) << 8;
-            lc = sym_buf[sx++];
+#  if OPTIMAL_CMP >= 32
+            uint32_t val = Z_U32_FROM_LE(zng_memread_4(&sym_buf[sx]));
+            dist = val & 0xffff;
+            lc = (val >> 16) & 0xff;
+#  else
+            dist = sym_buf[sx] + ((unsigned)sym_buf[sx + 1] << 8);
+            lc = sym_buf[sx + 2];
+#  endif
+            sx += 3;
 #endif
             if (dist == 0) {
                 zng_emit_lit(s, ltree, lc);


### PR DESCRIPTION
I [micro-benchmarked](https://gist.github.com/nmoinvaz/556d98fa31c391bda5afff3b43645d2d) using `LIT_MEM` vs unaligned access vs `NO_LIT_MEM` and unaligned access was fastest to the point where `LIT_MEM` is not necessary.

We can remove `LIT_MEM`, but I figured somebody wouldn't like it. It only might be 1% faster on big-endian machines or where `OPTIMAL_CMP < 32`.