### PR TITLE
NATIVE and FALLBACK defines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1264,7 +1264,7 @@ set(ZLIB_SRCS
     zutil.c
 )
 
-set(ZLIB_ALL_FALLBACK_SRCS
+set(ZLIB_GENERIC_SRCS
     arch/generic/adler32_c.c
     arch/generic/chunkset_c.c
     arch/generic/compare256_c.c
@@ -1273,16 +1273,6 @@ set(ZLIB_ALL_FALLBACK_SRCS
 )
 
 if(WITH_ALL_FALLBACKS)
-    list(APPEND ZLIB_GENERIC_SRCS ${ZLIB_ALL_FALLBACK_SRCS})
-    add_definitions(-DWITH_ALL_FALLBACKS)
-elseif(BASEARCH_X86_FOUND AND ARCH_64BIT AND WITH_SSE2)
-    # x86_64 always has SSE2, so let the SSE2 functions act as fallbacks.
-    list(APPEND ZLIB_GENERIC_SRCS
-        arch/generic/adler32_c.c
-        arch/generic/crc32_braid_c.c
-    )
-else()
-    list(APPEND ZLIB_GENERIC_SRCS ${ZLIB_ALL_FALLBACK_SRCS})
     add_definitions(-DWITH_ALL_FALLBACKS)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,10 +244,6 @@ elseif(MSVC)
     if(MSVC_VERSION VERSION_LESS 1800)
         message(SEND_ERROR "Unsupported Visual Studio compiler version (requires 2013 or later).")
     endif()
-    if(MSVC_VERSION VERSION_LESS 1930)
-        message(STATUS "Old Visual Studio compiler version, disabling SSE2/SSE4.1 Chorba variants (requires 2022 or later).")
-        add_definitions(-DWITHOUT_CHORBA_SSE)
-    endif()
     # TODO. ICC can be used through MSVC. I'm not sure if we'd ever see that combination
     # (who'd use cmake from an IDE...) but checking for ICC before checking for MSVC should
     # avoid mistakes.

--- a/arch/arm/arm_functions.h
+++ b/arch/arm/arm_functions.h
@@ -5,6 +5,8 @@
 #ifndef ARM_FUNCTIONS_H_
 #define ARM_FUNCTIONS_H_
 
+#include "arm_natives.h"
+
 #ifdef ARM_NEON
 uint32_t adler32_neon(uint32_t adler, const uint8_t *buf, size_t len);
 uint32_t adler32_copy_neon(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len);
@@ -29,15 +31,14 @@ uint32_t crc32_copy_armv8_pmull_eor3(uint32_t crc, uint8_t *dst, const uint8_t *
 void slide_hash_armv6(deflate_state *s);
 #endif
 
-
 #ifdef DISABLE_RUNTIME_CPU_DETECTION
 // ARM - SIMD
-#  if (defined(ARM_SIMD) && defined(__ARM_FEATURE_SIMD32)) || defined(ARM_NOCHECK_SIMD)
+#  ifdef ARM_SIMD_NATIVE
 #    undef native_slide_hash
 #    define native_slide_hash slide_hash_armv6
 #  endif
 // ARM - NEON
-#  if (defined(ARM_NEON) && (defined(__ARM_NEON__) || defined(__ARM_NEON))) || ARM_NOCHECK_NEON
+#  ifdef ARM_NEON_NATIVE
 #    undef native_adler32
 #    define native_adler32 adler32_neon
 #    undef native_adler32_copy
@@ -56,14 +57,14 @@ void slide_hash_armv6(deflate_state *s);
 #    define native_slide_hash slide_hash_neon
 #  endif
 // ARM - CRC32
-#  if (defined(ARM_CRC32) && defined(__ARM_FEATURE_CRC32))
+#  ifdef ARM_CRC32_NATIVE
 #    undef native_crc32
 #    define native_crc32 crc32_armv8
 #    undef native_crc32_copy
 #    define native_crc32_copy crc32_copy_armv8
 #  endif
 // ARM - PMULL EOR3
-#  if (defined(ARM_PMULL_EOR3) && defined(__ARM_FEATURE_CRC32) && defined(__ARM_FEATURE_CRYPTO) && defined(__ARM_FEATURE_SHA3))
+#  ifdef ARM_PMULL_EOR3_NATIVE
 #    undef native_crc32
 #    define native_crc32 crc32_armv8_pmull_eor3
 #    undef native_crc32_copy

--- a/arch/arm/arm_functions.h
+++ b/arch/arm/arm_functions.h
@@ -18,13 +18,27 @@ uint32_t longest_match_slow_neon(deflate_state *const s, uint32_t cur_match);
 void slide_hash_neon(deflate_state *s);
 #endif
 
+#ifndef ARM_NEON_NATIVE
+#  define ADLER32_FALLBACK
+#  define CHUNKSET_FALLBACK
+#  define COMPARE256_FALLBACK
+#  ifndef ARM_SIMD_NATIVE
+#    define SLIDE_HASH_FALLBACK
+#  endif
+#endif
+
 #ifdef ARM_CRC32
 uint32_t crc32_armv8(uint32_t crc, const uint8_t *buf, size_t len);
 uint32_t crc32_copy_armv8(uint32_t crc, uint8_t *dst, const uint8_t *src, size_t len);
 #endif
+
 #ifdef ARM_PMULL_EOR3
 uint32_t crc32_armv8_pmull_eor3(uint32_t crc, const uint8_t *buf, size_t len);
 uint32_t crc32_copy_armv8_pmull_eor3(uint32_t crc, uint8_t *dst, const uint8_t *src, size_t len);
+#endif
+
+#if !defined(ARM_CRC32_NATIVE) && !defined(ARM_PMULL_EOR3_NATIVE)
+#  define CRC32_BRAID_FALLBACK
 #endif
 
 #ifdef ARM_SIMD

--- a/arch/arm/arm_functions.h
+++ b/arch/arm/arm_functions.h
@@ -48,24 +48,16 @@ void slide_hash_armv6(deflate_state *s);
 #ifdef DISABLE_RUNTIME_CPU_DETECTION
 // ARM - SIMD
 #  ifdef ARM_SIMD_NATIVE
-#    undef native_slide_hash
 #    define native_slide_hash slide_hash_armv6
 #  endif
 // ARM - NEON
 #  ifdef ARM_NEON_NATIVE
-#    undef native_adler32
 #    define native_adler32 adler32_neon
-#    undef native_adler32_copy
 #    define native_adler32_copy adler32_copy_neon
-#    undef native_chunkmemset_safe
 #    define native_chunkmemset_safe chunkmemset_safe_neon
-#    undef native_compare256
 #    define native_compare256 compare256_neon
-#    undef native_inflate_fast
 #    define native_inflate_fast inflate_fast_neon
-#    undef native_longest_match
 #    define native_longest_match longest_match_neon
-#    undef native_longest_match_slow
 #    define native_longest_match_slow longest_match_slow_neon
 #    undef native_slide_hash
 #    define native_slide_hash slide_hash_neon

--- a/arch/arm/arm_natives.h
+++ b/arch/arm/arm_natives.h
@@ -1,0 +1,32 @@
+/* arm_natives.h -- ARM compile-time feature detection macros.
+ * For conditions of distribution and use, see copyright notice in zlib.h
+ */
+
+#ifndef ARM_NATIVES_H_
+#define ARM_NATIVES_H_
+
+/* Compile-time feature detection macros */
+#if defined(__ARM_FEATURE_SIMD32)
+#  ifdef ARM_SIMD
+#    define ARM_SIMD_NATIVE
+#  endif
+#endif
+/* NEON is guaranteed on ARM64 (like SSE2 on x86-64) */
+#if defined(__ARM_NEON) || defined(__ARM_NEON__) || defined(ARCH_64BIT)
+#  ifdef ARM_NEON
+#    define ARM_NEON_NATIVE
+#  endif
+#endif
+/* CRC32 is optional in ARMv8.0, mandatory in ARMv8.1+ */
+#if defined(__ARM_FEATURE_CRC32) || (defined(__ARM_ARCH) && __ARM_ARCH >= 801)
+#  ifdef ARM_CRC32
+#    define ARM_CRC32_NATIVE
+#  endif
+#endif
+#if defined(__ARM_FEATURE_CRC32) && defined(__ARM_FEATURE_CRYPTO) && defined(__ARM_FEATURE_SHA3)
+#  ifdef ARM_PMULL_EOR3
+#    define ARM_PMULL_EOR3_NATIVE
+#  endif
+#endif
+
+#endif /* ARM_NATIVES_H_ */

--- a/arch/generic/adler32_c.c
+++ b/arch/generic/adler32_c.c
@@ -4,6 +4,10 @@
  */
 
 #include "zbuild.h"
+#include "arch_functions.h"
+
+#ifdef ADLER32_FALLBACK
+
 #include "functable.h"
 #include "adler32_p.h"
 
@@ -53,3 +57,5 @@ Z_INTERNAL uint32_t adler32_copy_c(uint32_t adler, uint8_t *dst, const uint8_t *
     memcpy(dst, src, len);
     return adler;
 }
+
+#endif /* ADLER32_FALLBACK */

--- a/arch/generic/chunkset_c.c
+++ b/arch/generic/chunkset_c.c
@@ -3,6 +3,10 @@
  */
 
 #include "zbuild.h"
+#include "arch_functions.h"
+
+#ifdef CHUNKSET_FALLBACK
+
 #include "zmemory.h"
 
 typedef uint64_t chunk_t;
@@ -38,3 +42,5 @@ static inline void storechunk(uint8_t *out, chunk_t *chunk) {
 #define INFLATE_FAST     inflate_fast_c
 
 #include "inffast_tpl.h"
+
+#endif /* CHUNKSET_FALLBACK */

--- a/arch/generic/compare256_c.c
+++ b/arch/generic/compare256_c.c
@@ -4,6 +4,10 @@
  */
 
 #include "zbuild.h"
+#include "arch_functions.h"
+
+#ifdef COMPARE256_FALLBACK
+
 #include "zendian.h"
 #include "deflate.h"
 #include "fallback_builtins.h"
@@ -64,7 +68,6 @@ static inline uint32_t compare256_64_static(const uint8_t *src0, const uint8_t *
 #  define COMPARE256 compare256_64_static
 #endif
 
-#ifdef WITH_ALL_FALLBACKS
 Z_INTERNAL uint32_t compare256_8(const uint8_t *src0, const uint8_t *src1) {
     return compare256_8_static(src0, src1);
 }
@@ -72,7 +75,6 @@ Z_INTERNAL uint32_t compare256_8(const uint8_t *src0, const uint8_t *src1) {
 Z_INTERNAL uint32_t compare256_64(const uint8_t *src0, const uint8_t *src1) {
     return compare256_64_static(src0, src1);
 }
-#endif
 
 Z_INTERNAL uint32_t compare256_c(const uint8_t *src0, const uint8_t *src1) {
     return COMPARE256(src0, src1);
@@ -86,3 +88,5 @@ Z_INTERNAL uint32_t compare256_c(const uint8_t *src0, const uint8_t *src1) {
 #define LONGEST_MATCH_SLOW
 #define LONGEST_MATCH       longest_match_slow_c
 #include "match_tpl.h"
+
+#endif /* COMPARE256_FALLBACK */

--- a/arch/generic/crc32_braid_c.c
+++ b/arch/generic/crc32_braid_c.c
@@ -8,6 +8,11 @@
  */
 
 #include "zbuild.h"
+#include "arch_functions.h"
+
+/* Used by chorba fallback and by arch-specific implementations (s390 vx, risc-v zbc). */
+#ifdef CRC32_BRAID_FALLBACK
+
 #include "crc32_braid_p.h"
 #include "crc32_braid_tbl.h"
 #include "crc32_p.h"
@@ -211,3 +216,5 @@ Z_INTERNAL uint32_t crc32_copy_braid(uint32_t crc, uint8_t *dst, const uint8_t *
     memcpy(dst, src, len);
     return crc;
 }
+
+#endif /* CRC32_BRAID_FALLBACK */

--- a/arch/generic/crc32_chorba_c.c
+++ b/arch/generic/crc32_chorba_c.c
@@ -1,5 +1,8 @@
 #include "zbuild.h"
-#include "zendian.h"
+#include "arch_functions.h"
+
+#ifdef CRC32_CHORBA_FALLBACK
+
 #if defined(__EMSCRIPTEN__)
 #  include "zutil_p.h"
 #endif
@@ -7,7 +10,6 @@
 #include "crc32_chorba_p.h"
 #include "crc32_braid_p.h"
 #include "crc32_braid_tbl.h"
-#include "generic_functions.h"
 
 /* Implement Chorba algorithm from https://arxiv.org/abs/2412.16398 */
 #define bitbuffer_size_bytes (16 * 1024 * sizeof(chorba_word_t))
@@ -1273,3 +1275,5 @@ uint32_t crc32_copy_chorba(uint32_t crc, uint8_t *dst, const uint8_t *src, size_
     memcpy(dst, src, len);
     return crc;
 }
+
+#endif /* CRC32_CHORBA_FALLBACK */

--- a/arch/generic/generic_functions.h
+++ b/arch/generic/generic_functions.h
@@ -5,9 +5,6 @@
 #ifndef GENERIC_FUNCTIONS_H_
 #define GENERIC_FUNCTIONS_H_
 
-#include "zendian.h"
-#include "deflate.h"
-
 typedef uint32_t (*adler32_func)(uint32_t adler, const uint8_t *buf, size_t len);
 typedef uint32_t (*adler32_copy_func)(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len);
 typedef uint32_t (*compare256_func)(const uint8_t *src0, const uint8_t *src1);
@@ -15,50 +12,69 @@ typedef uint32_t (*crc32_func)(uint32_t crc, const uint8_t *buf, size_t len);
 typedef uint32_t (*crc32_copy_func)(uint32_t crc, uint8_t *dst, const uint8_t *src, size_t len);
 typedef void     (*slide_hash_func)(deflate_state *s);
 
-
+#ifdef ADLER32_FALLBACK
 uint32_t adler32_c(uint32_t adler, const uint8_t *buf, size_t len);
 uint32_t adler32_copy_c(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len);
-
+#endif
+#ifdef CHUNKSET_FALLBACK
 uint8_t* chunkmemset_safe_c(uint8_t *out, uint8_t *from, size_t len, size_t left);
-
-#ifdef WITH_ALL_FALLBACKS
+#endif
+#ifdef COMPARE256_FALLBACK
 uint32_t compare256_8(const uint8_t *src0, const uint8_t *src1);
 uint32_t compare256_64(const uint8_t *src0, const uint8_t *src1);
-#endif
 uint32_t compare256_c(const uint8_t *src0, const uint8_t *src1);
+#endif
 
+#ifdef CRC32_BRAID_FALLBACK
 uint32_t crc32_braid(uint32_t crc, const uint8_t *buf, size_t len);
 uint32_t crc32_copy_braid(uint32_t crc, uint8_t *dst, const uint8_t *src, size_t len);
+#endif
 
-#ifndef WITHOUT_CHORBA
+/* Chorba is available whenever braid is needed as a fallback and hasn't been disabled. */
+#if defined(CRC32_BRAID_FALLBACK) && !defined(WITHOUT_CHORBA)
+#  define CRC32_CHORBA_FALLBACK
+#endif
+
+#ifdef CRC32_CHORBA_FALLBACK
   uint32_t crc32_chorba(uint32_t crc, const uint8_t *buf, size_t len);
   uint32_t crc32_copy_chorba(uint32_t crc, uint8_t *dst, const uint8_t *src, size_t len);
 #endif
-
+#ifdef CHUNKSET_FALLBACK
 void     inflate_fast_c(PREFIX3(stream) *strm, uint32_t start);
-
+#endif
+#ifdef COMPARE256_FALLBACK
 uint32_t longest_match_c(deflate_state *const s, uint32_t cur_match);
 uint32_t longest_match_slow_c(deflate_state *const s, uint32_t cur_match);
-
+#endif
+#ifdef SLIDE_HASH_FALLBACK
 void     slide_hash_c(deflate_state *s);
+#endif
 
 #ifdef DISABLE_RUNTIME_CPU_DETECTION
-// Generic code
-#  define native_adler32 adler32_c
-#  define native_adler32_copy adler32_copy_c
-#  define native_chunkmemset_safe chunkmemset_safe_c
-#ifndef WITHOUT_CHORBA
-#  define native_crc32 crc32_chorba
-#  define native_crc32_copy crc32_copy_chorba
-#else
-#  define native_crc32 crc32_braid
-#  define native_crc32_copy crc32_copy_braid
-#endif
-#  define native_inflate_fast inflate_fast_c
-#  define native_slide_hash slide_hash_c
-#  define native_longest_match longest_match_c
-#  define native_longest_match_slow longest_match_slow_c
-#  define native_compare256 compare256_c
+// Generic fallbacks when no native implementation exists
+#  ifdef ADLER32_FALLBACK
+#    define native_adler32 adler32_c
+#    define native_adler32_copy adler32_copy_c
+#  endif
+#  ifdef CHUNKSET_FALLBACK
+#    define native_chunkmemset_safe chunkmemset_safe_c
+#    define native_inflate_fast inflate_fast_c
+#  endif
+#  ifdef COMPARE256_FALLBACK
+#    define native_compare256 compare256_c
+#    define native_longest_match longest_match_c
+#    define native_longest_match_slow longest_match_slow_c
+#  endif
+#  ifdef CRC32_CHORBA_FALLBACK
+#    define native_crc32 crc32_chorba
+#    define native_crc32_copy crc32_copy_chorba
+#  elif defined(CRC32_BRAID_FALLBACK)
+#    define native_crc32 crc32_braid
+#    define native_crc32_copy crc32_copy_braid
+#  endif
+#  ifdef SLIDE_HASH_FALLBACK
+#    define native_slide_hash slide_hash_c
+#  endif
 #endif
 
 #endif

--- a/arch/generic/slide_hash_c.c
+++ b/arch/generic/slide_hash_c.c
@@ -5,6 +5,10 @@
  */
 
 #include "zbuild.h"
+#include "arch_functions.h"
+
+#ifdef SLIDE_HASH_FALLBACK
+
 #include "deflate.h"
 
 /* ===========================================================================
@@ -50,3 +54,5 @@ Z_INTERNAL void slide_hash_c(deflate_state *s) {
     slide_hash_c_chain(s->head, HASH_SIZE, wsize);
     slide_hash_c_chain(s->prev, wsize, wsize);
 }
+
+#endif /* SLIDE_HASH_FALLBACK */

--- a/arch/loongarch/loongarch_functions.h
+++ b/arch/loongarch/loongarch_functions.h
@@ -15,6 +15,10 @@ uint32_t crc32_loongarch64(uint32_t crc, const uint8_t *buf, size_t len);
 uint32_t crc32_copy_loongarch64(uint32_t crc, uint8_t *dst, const uint8_t *src, size_t len);
 #endif
 
+#ifndef LOONGARCH_CRC_NATIVE
+#  define CRC32_BRAID_FALLBACK
+#endif
+
 #ifdef LOONGARCH_LSX
 uint32_t adler32_lsx(uint32_t adler, const uint8_t *src, size_t len);
 uint32_t adler32_copy_lsx(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len);
@@ -24,6 +28,13 @@ void inflate_fast_lsx(PREFIX3(stream) *strm, uint32_t start);
 uint32_t longest_match_lsx(deflate_state *const s, uint32_t cur_match);
 uint32_t longest_match_slow_lsx(deflate_state *const s, uint32_t cur_match);
 void slide_hash_lsx(deflate_state *s);
+#endif
+
+#ifndef LOONGARCH_LSX_NATIVE
+#  define ADLER32_FALLBACK
+#  define CHUNKSET_FALLBACK
+#  define COMPARE256_FALLBACK
+#  define SLIDE_HASH_FALLBACK
 #endif
 
 #ifdef LOONGARCH_LASX

--- a/arch/loongarch/loongarch_functions.h
+++ b/arch/loongarch/loongarch_functions.h
@@ -8,6 +8,8 @@
 #ifndef LOONGARCH_FUNCTIONS_H_
 #define LOONGARCH_FUNCTIONS_H_
 
+#include "loongarch_natives.h"
+
 #ifdef LOONGARCH_CRC
 uint32_t crc32_loongarch64(uint32_t crc, const uint8_t *buf, size_t len);
 uint32_t crc32_copy_loongarch64(uint32_t crc, uint8_t *dst, const uint8_t *src, size_t len);
@@ -36,14 +38,14 @@ void slide_hash_lasx(deflate_state *s);
 #endif
 
 #ifdef DISABLE_RUNTIME_CPU_DETECTION
-// LOONGARCH - CRC32 - All known CPUs has crc instructions
-#  if defined(LOONGARCH_CRC)
+// LOONGARCH - CRC32
+#  ifdef LOONGARCH_CRC_NATIVE
 #    undef native_crc32
 #    define native_crc32 crc32_loongarch64
 #    undef native_crc32_copy
 #    define native_crc32_copy crc32_copy_loongarch64
 #  endif
-#  if defined(LOONGARCH_LSX) && defined(__loongarch_sx)
+#  ifdef LOONGARCH_LSX_NATIVE
 #    undef native_adler32
 #    define native_adler32 adler32_lsx
 #    undef native_adler32_copy
@@ -61,7 +63,7 @@ void slide_hash_lasx(deflate_state *s);
 #    undef native_slide_hash
 #    define native_slide_hash slide_hash_lsx
 #  endif
-#  if defined(LOONGARCH_LASX) && defined(__loongarch_asx)
+#  ifdef LOONGARCH_LASX_NATIVE
 #    undef native_adler32
 #    define native_adler32 adler32_lasx
 #    undef native_adler32_copy

--- a/arch/loongarch/loongarch_functions.h
+++ b/arch/loongarch/loongarch_functions.h
@@ -51,27 +51,17 @@ void slide_hash_lasx(deflate_state *s);
 #ifdef DISABLE_RUNTIME_CPU_DETECTION
 // LOONGARCH - CRC32
 #  ifdef LOONGARCH_CRC_NATIVE
-#    undef native_crc32
 #    define native_crc32 crc32_loongarch64
-#    undef native_crc32_copy
 #    define native_crc32_copy crc32_copy_loongarch64
 #  endif
 #  ifdef LOONGARCH_LSX_NATIVE
-#    undef native_adler32
 #    define native_adler32 adler32_lsx
-#    undef native_adler32_copy
 #    define native_adler32_copy adler32_copy_lsx
-#    undef native_chunkmemset_safe
 #    define native_chunkmemset_safe chunkmemset_safe_lsx
-#    undef native_compare256
 #    define native_compare256 compare256_lsx
-#    undef native_inflate_fast
 #    define native_inflate_fast inflate_fast_lsx
-#    undef native_longest_match
 #    define native_longest_match longest_match_lsx
-#    undef native_longest_match_slow
 #    define native_longest_match_slow longest_match_slow_lsx
-#    undef native_slide_hash
 #    define native_slide_hash slide_hash_lsx
 #  endif
 #  ifdef LOONGARCH_LASX_NATIVE

--- a/arch/loongarch/loongarch_natives.h
+++ b/arch/loongarch/loongarch_natives.h
@@ -1,0 +1,26 @@
+/* loongarch_natives.h -- LoongArch compile-time feature detection macros.
+ * For conditions of distribution and use, see copyright notice in zlib.h
+ */
+
+#ifndef LOONGARCH_NATIVES_H_
+#define LOONGARCH_NATIVES_H_
+
+/* Compile-time feature detection macros */
+#if defined(__loongarch__)
+// All known CPUs have crc instructions
+#  ifdef LOONGARCH_CRC
+#    define LOONGARCH_CRC_NATIVE
+#  endif
+#endif
+#if defined(__loongarch_sx)
+#  ifdef LOONGARCH_LSX
+#    define LOONGARCH_LSX_NATIVE
+#  endif
+#endif
+#if defined(__loongarch_asx)
+#  ifdef LOONGARCH_LASX
+#    define LOONGARCH_LASX_NATIVE
+#  endif
+#endif
+
+#endif /* LOONGARCH_NATIVES_H_ */

--- a/arch/power/power_functions.h
+++ b/arch/power/power_functions.h
@@ -7,6 +7,8 @@
 #ifndef POWER_FUNCTIONS_H_
 #define POWER_FUNCTIONS_H_
 
+#include "power_natives.h"
+
 #ifdef PPC_VMX
 uint32_t adler32_vmx(uint32_t adler, const uint8_t *buf, size_t len);
 uint32_t adler32_copy_vmx(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len);
@@ -29,10 +31,9 @@ uint32_t longest_match_power9(deflate_state *const s, uint32_t cur_match);
 uint32_t longest_match_slow_power9(deflate_state *const s, uint32_t cur_match);
 #endif
 
-
 #ifdef DISABLE_RUNTIME_CPU_DETECTION
 // Power - VMX
-#  if defined(PPC_VMX) && defined(__ALTIVEC__)
+#  ifdef PPC_VMX_NATIVE
 #    undef native_adler32
 #    define native_adler32 adler32_vmx
 #    undef native_adler32_copy
@@ -41,7 +42,7 @@ uint32_t longest_match_slow_power9(deflate_state *const s, uint32_t cur_match);
 #    define native_slide_hash slide_hash_vmx
 #  endif
 // Power8 - VSX
-#  if defined(POWER8_VSX) && defined(_ARCH_PWR8) && defined(__VSX__)
+#  ifdef POWER8_VSX_NATIVE
 #    undef native_adler32
 #    define native_adler32 adler32_power8
 #    undef native_adler32_copy
@@ -53,14 +54,14 @@ uint32_t longest_match_slow_power9(deflate_state *const s, uint32_t cur_match);
 #    undef native_slide_hash
 #    define native_slide_hash slide_hash_power8
 #  endif
-#  if defined(POWER8_VSX_CRC32) && defined(_ARCH_PWR8) && defined(__VSX__)
+#  ifdef POWER8_VSX_CRC32_NATIVE
 #    undef native_crc32
 #    define native_crc32 crc32_power8
 #    undef native_crc32_copy
 #    define native_crc32_copy crc32_copy_power8
 #  endif
 // Power9
-#  if defined(POWER9) && defined(_ARCH_PWR9)
+#  ifdef POWER9_NATIVE
 #    undef native_compare256
 #    define native_compare256 compare256_power9
 #    undef native_longest_match

--- a/arch/power/power_functions.h
+++ b/arch/power/power_functions.h
@@ -25,10 +25,26 @@ void slide_hash_power8(deflate_state *s);
 void inflate_fast_power8(PREFIX3(stream) *strm, uint32_t start);
 #endif
 
+#if !defined(PPC_VMX_NATIVE) && !defined(POWER8_VSX_NATIVE)
+#  define ADLER32_FALLBACK
+#  define SLIDE_HASH_FALLBACK
+#endif
+
+#ifndef POWER8_VSX_NATIVE
+#  define CHUNKSET_FALLBACK
+#endif
+#ifndef POWER8_VSX_CRC32_NATIVE
+#  define CRC32_BRAID_FALLBACK
+#endif
+
 #ifdef POWER9
 uint32_t compare256_power9(const uint8_t *src0, const uint8_t *src1);
 uint32_t longest_match_power9(deflate_state *const s, uint32_t cur_match);
 uint32_t longest_match_slow_power9(deflate_state *const s, uint32_t cur_match);
+#endif
+
+#ifndef POWER9_NATIVE
+#  define COMPARE256_FALLBACK
 #endif
 
 #ifdef DISABLE_RUNTIME_CPU_DETECTION

--- a/arch/power/power_functions.h
+++ b/arch/power/power_functions.h
@@ -50,11 +50,8 @@ uint32_t longest_match_slow_power9(deflate_state *const s, uint32_t cur_match);
 #ifdef DISABLE_RUNTIME_CPU_DETECTION
 // Power - VMX
 #  ifdef PPC_VMX_NATIVE
-#    undef native_adler32
 #    define native_adler32 adler32_vmx
-#    undef native_adler32_copy
 #    define native_adler32_copy adler32_copy_vmx
-#    undef native_slide_hash
 #    define native_slide_hash slide_hash_vmx
 #  endif
 // Power8 - VSX
@@ -63,26 +60,19 @@ uint32_t longest_match_slow_power9(deflate_state *const s, uint32_t cur_match);
 #    define native_adler32 adler32_power8
 #    undef native_adler32_copy
 #    define native_adler32_copy adler32_copy_power8
-#    undef native_chunkmemset_safe
 #    define native_chunkmemset_safe chunkmemset_safe_power8
-#    undef native_inflate_fast
 #    define native_inflate_fast inflate_fast_power8
 #    undef native_slide_hash
 #    define native_slide_hash slide_hash_power8
 #  endif
 #  ifdef POWER8_VSX_CRC32_NATIVE
-#    undef native_crc32
 #    define native_crc32 crc32_power8
-#    undef native_crc32_copy
 #    define native_crc32_copy crc32_copy_power8
 #  endif
 // Power9
 #  ifdef POWER9_NATIVE
-#    undef native_compare256
 #    define native_compare256 compare256_power9
-#    undef native_longest_match
 #    define native_longest_match longest_match_power9
-#    undef native_longest_match_slow
 #    define native_longest_match_slow longest_match_slow_power9
 #  endif
 #endif

--- a/arch/power/power_natives.h
+++ b/arch/power/power_natives.h
@@ -1,0 +1,28 @@
+/* power_natives.h -- POWER compile-time feature detection macros.
+ * For conditions of distribution and use, see copyright notice in zlib.h
+ */
+
+#ifndef POWER_NATIVES_H_
+#define POWER_NATIVES_H_
+
+/* Compile-time feature detection macros */
+#if defined(__ALTIVEC__)
+#  ifdef PPC_VMX
+#    define PPC_VMX_NATIVE
+#  endif
+#endif
+#if defined(_ARCH_PWR8) && defined(__VSX__)
+#  ifdef POWER8_VSX
+#    define POWER8_VSX_NATIVE
+#  endif
+#  ifdef POWER8_VSX_CRC32
+#    define POWER8_VSX_CRC32_NATIVE
+#  endif
+#endif
+#if defined(_ARCH_PWR9)
+#  ifdef POWER9
+#    define POWER9_NATIVE
+#  endif
+#endif
+
+#endif /* POWER_NATIVES_H_ */

--- a/arch/riscv/riscv_functions.h
+++ b/arch/riscv/riscv_functions.h
@@ -9,6 +9,8 @@
 #ifndef RISCV_FUNCTIONS_H_
 #define RISCV_FUNCTIONS_H_
 
+#include "riscv_natives.h"
+
 #ifdef RISCV_RVV
 uint32_t adler32_rvv(uint32_t adler, const uint8_t *buf, size_t len);
 uint32_t adler32_copy_rvv(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len);
@@ -28,7 +30,7 @@ uint32_t crc32_copy_riscv64_zbc(uint32_t crc, uint8_t *dst, const uint8_t *src, 
 
 #ifdef DISABLE_RUNTIME_CPU_DETECTION
 // RISCV - RVV
-#  if defined(RISCV_RVV) && defined(__riscv_v) && defined(__linux__)
+#  ifdef RISCV_RVV_NATIVE
 #    undef native_adler32
 #    define native_adler32 adler32_rvv
 #    undef native_adler32_copy
@@ -46,9 +48,8 @@ uint32_t crc32_copy_riscv64_zbc(uint32_t crc, uint8_t *dst, const uint8_t *src, 
 #    undef native_slide_hash
 #    define native_slide_hash slide_hash_rvv
 #  endif
-
 // RISCV - CRC32
-#  if (defined(RISCV_CRC32_ZBC) && defined (__riscv_zbc))
+#  ifdef RISCV_ZBC_NATIVE
 #    undef native_crc32
 #    define native_crc32 crc32_riscv64_zbc
 #    undef native_crc32_copy

--- a/arch/riscv/riscv_functions.h
+++ b/arch/riscv/riscv_functions.h
@@ -11,6 +11,8 @@
 
 #include "riscv_natives.h"
 
+#define CRC32_BRAID_FALLBACK  /* used by crc32_zbc */
+
 #ifdef RISCV_RVV
 uint32_t adler32_rvv(uint32_t adler, const uint8_t *buf, size_t len);
 uint32_t adler32_copy_rvv(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len);
@@ -21,6 +23,13 @@ uint32_t longest_match_rvv(deflate_state *const s, uint32_t cur_match);
 uint32_t longest_match_slow_rvv(deflate_state *const s, uint32_t cur_match);
 void slide_hash_rvv(deflate_state *s);
 void inflate_fast_rvv(PREFIX3(stream) *strm, uint32_t start);
+#endif
+
+#ifndef RISCV_RVV_NATIVE
+#  define ADLER32_FALLBACK
+#  define CHUNKSET_FALLBACK
+#  define COMPARE256_FALLBACK
+#  define SLIDE_HASH_FALLBACK
 #endif
 
 #ifdef RISCV_CRC32_ZBC

--- a/arch/riscv/riscv_functions.h
+++ b/arch/riscv/riscv_functions.h
@@ -40,21 +40,13 @@ uint32_t crc32_copy_riscv64_zbc(uint32_t crc, uint8_t *dst, const uint8_t *src, 
 #ifdef DISABLE_RUNTIME_CPU_DETECTION
 // RISCV - RVV
 #  ifdef RISCV_RVV_NATIVE
-#    undef native_adler32
 #    define native_adler32 adler32_rvv
-#    undef native_adler32_copy
 #    define native_adler32_copy adler32_copy_rvv
-#    undef native_chunkmemset_safe
 #    define native_chunkmemset_safe chunkmemset_safe_rvv
-#    undef native_compare256
 #    define native_compare256 compare256_rvv
-#    undef native_inflate_fast
 #    define native_inflate_fast inflate_fast_rvv
-#    undef native_longest_match
 #    define native_longest_match longest_match_rvv
-#    undef native_longest_match_slow
 #    define native_longest_match_slow longest_match_slow_rvv
-#    undef native_slide_hash
 #    define native_slide_hash slide_hash_rvv
 #  endif
 // RISCV - CRC32

--- a/arch/riscv/riscv_natives.h
+++ b/arch/riscv/riscv_natives.h
@@ -1,0 +1,20 @@
+/* riscv_natives.h -- RISCV compile-time feature detection macros.
+ * For conditions of distribution and use, see copyright notice in zlib.h
+ */
+
+#ifndef RISCV_NATIVES_H_
+#define RISCV_NATIVES_H_
+
+/* Compile-time feature detection macros */
+#if defined(__riscv_v) && defined(__linux__)
+#  ifdef RISCV_RVV
+#    define RISCV_RVV_NATIVE
+#  endif
+#endif
+#if defined(__riscv_zbc)
+#  ifdef RISCV_CRC32_ZBC
+#    define RISCV_ZBC_NATIVE
+#  endif
+#endif
+
+#endif /* RISCV_NATIVES_H_ */

--- a/arch/s390/s390_functions.h
+++ b/arch/s390/s390_functions.h
@@ -5,6 +5,8 @@
 #ifndef S390_FUNCTIONS_H_
 #define S390_FUNCTIONS_H_
 
+#include "s390_natives.h"
+
 #ifdef S390_CRC32_VX
 uint32_t crc32_s390_vx(uint32_t crc, const uint8_t *buf, size_t len);
 uint32_t crc32_copy_s390_vx(uint32_t crc, uint8_t *dst, const uint8_t *src, size_t len);
@@ -19,7 +21,8 @@ uint32_t crc32_copy_s390_vx(uint32_t crc, uint8_t *dst, const uint8_t *src, size
 #endif
 
 #ifdef DISABLE_RUNTIME_CPU_DETECTION
-#  if defined(S390_CRC32_VX) && defined(__zarch__) && __ARCH__ >= 11 && defined(__VX__)
+// S390 - CRC32 VX
+#  ifdef S390_CRC32_VX_NATIVE
 #    undef native_crc32
 #    define native_crc32 crc32_s390_vx
 #    undef native_crc32_copy

--- a/arch/s390/s390_functions.h
+++ b/arch/s390/s390_functions.h
@@ -29,9 +29,7 @@ uint32_t crc32_copy_s390_vx(uint32_t crc, uint8_t *dst, const uint8_t *src, size
 #ifdef DISABLE_RUNTIME_CPU_DETECTION
 // S390 - CRC32 VX
 #  ifdef S390_CRC32_VX_NATIVE
-#    undef native_crc32
 #    define native_crc32 crc32_s390_vx
-#    undef native_crc32_copy
 #    define native_crc32_copy crc32_copy_s390_vx
 #  endif
 #endif

--- a/arch/s390/s390_functions.h
+++ b/arch/s390/s390_functions.h
@@ -7,6 +7,12 @@
 
 #include "s390_natives.h"
 
+#define ADLER32_FALLBACK
+#define CHUNKSET_FALLBACK
+#define COMPARE256_FALLBACK
+#define CRC32_BRAID_FALLBACK  /* used by crc32_s390_vx */
+#define SLIDE_HASH_FALLBACK
+
 #ifdef S390_CRC32_VX
 uint32_t crc32_s390_vx(uint32_t crc, const uint8_t *buf, size_t len);
 uint32_t crc32_copy_s390_vx(uint32_t crc, uint8_t *dst, const uint8_t *src, size_t len);

--- a/arch/s390/s390_natives.h
+++ b/arch/s390/s390_natives.h
@@ -1,0 +1,15 @@
+/* s390_natives.h -- s390 compile-time feature detection macros.
+ * For conditions of distribution and use, see copyright notice in zlib.h
+ */
+
+#ifndef S390_NATIVES_H_
+#define S390_NATIVES_H_
+
+/* Compile-time feature detection macros */
+#if defined(__zarch__) && __ARCH__ >= 11 && defined(__VX__)
+#  ifdef S390_CRC32_VX
+#    define S390_CRC32_VX_NATIVE
+#  endif
+#endif
+
+#endif /* S390_NATIVES_H_ */

--- a/arch/x86/crc32_chorba_sse2.c
+++ b/arch/x86/crc32_chorba_sse2.c
@@ -1,7 +1,7 @@
 #include "zbuild.h"
 #include "arch_functions.h"
 
-#if defined(X86_SSE2) && !defined(WITHOUT_CHORBA_SSE) && defined(CRC32_CHORBA_FALLBACK)
+#if defined(X86_SSE2) && defined(CRC32_CHORBA_SSE_FALLBACK)
 
 #include "crc32_chorba_p.h"
 #include "crc32_braid_p.h"

--- a/arch/x86/crc32_chorba_sse2.c
+++ b/arch/x86/crc32_chorba_sse2.c
@@ -1,12 +1,13 @@
-#if defined(X86_SSE2) && !defined(WITHOUT_CHORBA_SSE)
-
 #include "zbuild.h"
+#include "arch_functions.h"
+
+#if defined(X86_SSE2) && !defined(WITHOUT_CHORBA_SSE) && defined(CRC32_CHORBA_FALLBACK)
+
 #include "crc32_chorba_p.h"
 #include "crc32_braid_p.h"
 #include "crc32_braid_tbl.h"
 #include <emmintrin.h>
 #include "arch/x86/x86_intrins.h"
-#include "arch_functions.h"
 
 #define READ_NEXT(in, off, a, b) do { \
         a = _mm_load_si128((__m128i*)(in + off / sizeof(uint64_t))); \

--- a/arch/x86/crc32_chorba_sse41.c
+++ b/arch/x86/crc32_chorba_sse41.c
@@ -1,7 +1,7 @@
 #include "zbuild.h"
 #include "arch_functions.h"
 
-#if defined(X86_SSE41) && !defined(WITHOUT_CHORBA_SSE) && defined(CRC32_CHORBA_FALLBACK)
+#if defined(X86_SSE41) && defined(CRC32_CHORBA_SSE_FALLBACK)
 
 #include "crc32_chorba_p.h"
 #include "crc32_braid_p.h"

--- a/arch/x86/crc32_chorba_sse41.c
+++ b/arch/x86/crc32_chorba_sse41.c
@@ -1,13 +1,14 @@
-#if defined(X86_SSE41) && !defined(WITHOUT_CHORBA_SSE)
-
 #include "zbuild.h"
+#include "arch_functions.h"
+
+#if defined(X86_SSE41) && !defined(WITHOUT_CHORBA_SSE) && defined(CRC32_CHORBA_FALLBACK)
+
 #include "crc32_chorba_p.h"
 #include "crc32_braid_p.h"
 #include "crc32_braid_tbl.h"
 #include <emmintrin.h>
 #include <smmintrin.h>
 #include "arch/x86/x86_intrins.h"
-#include "arch_functions.h"
 
 #define READ_NEXT(in, off, a, b) do { \
         a = _mm_load_si128((__m128i*)(in + off / sizeof(uint64_t))); \

--- a/arch/x86/x86_functions.h
+++ b/arch/x86/x86_functions.h
@@ -6,6 +6,8 @@
 #ifndef X86_FUNCTIONS_H_
 #define X86_FUNCTIONS_H_
 
+#include "x86_natives.h"
+
 /* So great news, your compiler is broken and causes stack smashing. Rather than
  * notching out its compilation we'll just remove the assignment in the functable.
  * Further context:
@@ -80,7 +82,7 @@ uint32_t crc32_copy_vpclmulqdq(uint32_t crc, uint8_t *dst, const uint8_t *src, s
 
 #ifdef DISABLE_RUNTIME_CPU_DETECTION
 // X86 - SSE2
-#  if (defined(X86_SSE2) && defined(__SSE2__)) || (defined(ARCH_X86) && defined(ARCH_64BIT))
+#  ifdef X86_SSE2_NATIVE
 #    undef native_chunkmemset_safe
 #    define native_chunkmemset_safe chunkmemset_safe_sse2
 #    undef native_compare256
@@ -101,7 +103,7 @@ uint32_t crc32_copy_vpclmulqdq(uint32_t crc, uint8_t *dst, const uint8_t *src, s
 #    define native_slide_hash slide_hash_sse2
 #  endif
 // X86 - SSSE3
-#  if defined(X86_SSSE3) && defined(__SSSE3__)
+#  ifdef X86_SSSE3_NATIVE
 #    undef native_adler32
 #    define native_adler32 adler32_ssse3
 #    undef native_adler32_copy
@@ -112,26 +114,26 @@ uint32_t crc32_copy_vpclmulqdq(uint32_t crc, uint8_t *dst, const uint8_t *src, s
 #    define native_inflate_fast inflate_fast_ssse3
 #  endif
 // X86 - SSE4.1
-#  if defined(X86_SSE41) && defined(__SSE4_1__) && !defined(WITHOUT_CHORBA_SSE)
-#   undef native_crc32
-#   define native_crc32 crc32_chorba_sse41
-#   undef native_crc32_copy
-#   define native_crc32_copy crc32_copy_chorba_sse41
+#  if defined(X86_SSE41_NATIVE) && !defined(WITHOUT_CHORBA_SSE)
+#    undef native_crc32
+#    define native_crc32 crc32_chorba_sse41
+#    undef native_crc32_copy
+#    define native_crc32_copy crc32_copy_chorba_sse41
 #  endif
 // X86 - SSE4.2
-#  if defined(X86_SSE42) && defined(__SSE4_2__)
+#  ifdef X86_SSE42_NATIVE
 #    undef native_adler32_copy
 #    define native_adler32_copy adler32_copy_sse42
 #  endif
 // X86 - PCLMUL
-#  if defined(X86_PCLMULQDQ_CRC) && defined(__PCLMUL__)
+#  ifdef X86_PCLMULQDQ_NATIVE
 #    undef native_crc32
 #    define native_crc32 crc32_pclmulqdq
 #    undef native_crc32_copy
 #    define native_crc32_copy crc32_copy_pclmulqdq
 #  endif
 // X86 - AVX2
-#  if defined(X86_AVX2) && defined(__AVX2__)
+#  ifdef X86_AVX2_NATIVE
 #    undef native_adler32
 #    define native_adler32 adler32_avx2
 #    undef native_adler32_copy
@@ -150,7 +152,7 @@ uint32_t crc32_copy_vpclmulqdq(uint32_t crc, uint8_t *dst, const uint8_t *src, s
 #    define native_slide_hash slide_hash_avx2
 #  endif
 // X86 - AVX512 (F,DQ,BW,Vl)
-#  if defined(X86_AVX512) && defined(__AVX512F__) && defined(__AVX512DQ__) && defined(__AVX512BW__) && defined(__AVX512VL__)
+#  ifdef X86_AVX512_NATIVE
 #    undef native_adler32
 #    define native_adler32 adler32_avx512
 #    undef native_adler32_copy
@@ -166,14 +168,14 @@ uint32_t crc32_copy_vpclmulqdq(uint32_t crc, uint8_t *dst, const uint8_t *src, s
 #    undef native_longest_match_slow
 #    define native_longest_match_slow longest_match_slow_avx512
 // X86 - AVX512 (VNNI)
-#    if defined(X86_AVX512VNNI) && defined(__AVX512VNNI__)
+#    ifdef X86_AVX512VNNI_NATIVE
 #      undef native_adler32
 #      define native_adler32 adler32_avx512_vnni
 #      undef native_adler32_copy
 #      define native_adler32_copy adler32_copy_avx512_vnni
 #    endif
 // X86 - VPCLMULQDQ
-#    if defined(__PCLMUL__) && defined(__AVX512F__) && defined(__VPCLMULQDQ__)
+#    ifdef X86_VPCLMULQDQ_NATIVE
 #      undef native_crc32
 #      define native_crc32 crc32_vpclmulqdq
 #      undef native_crc32_copy

--- a/arch/x86/x86_functions.h
+++ b/arch/x86/x86_functions.h
@@ -8,12 +8,14 @@
 
 #include "x86_natives.h"
 
-/* So great news, your compiler is broken and causes stack smashing. Rather than
- * notching out its compilation we'll just remove the assignment in the functable.
- * Further context:
+#if !defined(X86_PCLMULQDQ_NATIVE) && !defined(X86_VPCLMULQDQ_NATIVE)
+#  define CRC32_BRAID_FALLBACK
+/* SSE2/SSE4.1 chorba variants need braid fallback */
+#  if !defined(WITHOUT_CHORBA) && (!defined(_MSC_VER) || _MSC_VER > 1930)
+/* Visual Studio 2019 and prior can't compile the SSE2/SSE4.1 chorba variants due to stack corruption bug.
  * https://developercommunity.visualstudio.com/t/Stack-corruption-with-v142-toolchain-whe/10853479 */
-#if defined(_MSC_VER) && defined(ARCH_32BIT) && _MSC_VER >= 1920 && _MSC_VER <= 1929
-#define NO_CHORBA_SSE
+#    define CRC32_CHORBA_SSE_FALLBACK
+#  endif
 #endif
 
 #ifdef X86_SSE2
@@ -24,7 +26,7 @@ uint32_t longest_match_sse2(deflate_state *const s, uint32_t cur_match);
 uint32_t longest_match_slow_sse2(deflate_state *const s, uint32_t cur_match);
 void slide_hash_sse2(deflate_state *s);
 
-#  if !defined(WITHOUT_CHORBA) && !defined(WITHOUT_CHORBA_SSE)
+#  ifdef CRC32_CHORBA_SSE_FALLBACK
     uint32_t crc32_chorba_sse2(uint32_t crc, const uint8_t *buf, size_t len);
     uint32_t crc32_copy_chorba_sse2(uint32_t crc, uint8_t *dst, const uint8_t *src, size_t len);
     uint32_t chorba_small_nondestructive_sse2(uint32_t crc, const uint8_t *buf, size_t len);
@@ -49,7 +51,7 @@ void inflate_fast_ssse3(PREFIX3(stream) *strm, uint32_t start);
 #endif
 
 #if defined(X86_SSE41)
-#  if !defined(WITHOUT_CHORBA) && !defined(WITHOUT_CHORBA_SSE)
+#  ifdef CRC32_CHORBA_SSE_FALLBACK
     uint32_t crc32_chorba_sse41(uint32_t crc, const uint8_t *buf, size_t len);
     uint32_t crc32_copy_chorba_sse41(uint32_t crc, uint8_t *dst, const uint8_t *src, size_t len);
 #  endif
@@ -92,10 +94,6 @@ uint32_t crc32_vpclmulqdq(uint32_t crc, const uint8_t *buf, size_t len);
 uint32_t crc32_copy_vpclmulqdq(uint32_t crc, uint8_t *dst, const uint8_t *src, size_t len);
 #endif
 
-#if !defined(X86_PCLMULQDQ_NATIVE) && !defined(X86_VPCLMULQDQ_NATIVE)
-#  define CRC32_BRAID_FALLBACK
-#endif
-
 #ifdef DISABLE_RUNTIME_CPU_DETECTION
 // X86 - SSE2
 #  ifdef X86_SSE2_NATIVE
@@ -104,7 +102,7 @@ uint32_t crc32_copy_vpclmulqdq(uint32_t crc, uint8_t *dst, const uint8_t *src, s
 #    define native_inflate_fast inflate_fast_sse2
 #    define native_longest_match longest_match_sse2
 #    define native_longest_match_slow longest_match_slow_sse2
-#    if !defined(WITHOUT_CHORBA) && !defined(WITHOUT_CHORBA_SSE)
+#    ifdef CRC32_CHORBA_SSE_FALLBACK
 #      define native_crc32 crc32_chorba_sse2
 #      define native_crc32_copy crc32_copy_chorba_sse2
 #    endif
@@ -121,7 +119,7 @@ uint32_t crc32_copy_vpclmulqdq(uint32_t crc, uint8_t *dst, const uint8_t *src, s
 #  endif
 // X86 - SSE4.1
 #  if defined(X86_SSE41_NATIVE)
-#    if !defined(WITHOUT_CHORBA) && !defined(WITHOUT_CHORBA_SSE)
+#    ifdef CRC32_CHORBA_SSE_FALLBACK
 #      undef native_crc32
 #      define native_crc32 crc32_chorba_sse41
 #      undef native_crc32_copy

--- a/arch/x86/x86_functions.h
+++ b/arch/x86/x86_functions.h
@@ -99,30 +99,20 @@ uint32_t crc32_copy_vpclmulqdq(uint32_t crc, uint8_t *dst, const uint8_t *src, s
 #ifdef DISABLE_RUNTIME_CPU_DETECTION
 // X86 - SSE2
 #  ifdef X86_SSE2_NATIVE
-#    undef native_chunkmemset_safe
 #    define native_chunkmemset_safe chunkmemset_safe_sse2
-#    undef native_compare256
 #    define native_compare256 compare256_sse2
-#    undef native_inflate_fast
 #    define native_inflate_fast inflate_fast_sse2
-#    undef native_longest_match
 #    define native_longest_match longest_match_sse2
-#    undef native_longest_match_slow
 #    define native_longest_match_slow longest_match_slow_sse2
 #    if !defined(WITHOUT_CHORBA) && !defined(WITHOUT_CHORBA_SSE)
-#      undef native_crc32
 #      define native_crc32 crc32_chorba_sse2
-#      undef native_crc32_copy
 #      define native_crc32_copy crc32_copy_chorba_sse2
 #    endif
-#    undef native_slide_hash
 #    define native_slide_hash slide_hash_sse2
 #  endif
 // X86 - SSSE3
 #  ifdef X86_SSSE3_NATIVE
-#    undef native_adler32
 #    define native_adler32 adler32_ssse3
-#    undef native_adler32_copy
 #    define native_adler32_copy adler32_copy_ssse3
 #    undef native_chunkmemset_safe
 #    define native_chunkmemset_safe chunkmemset_safe_ssse3

--- a/arch/x86/x86_functions.h
+++ b/arch/x86/x86_functions.h
@@ -24,11 +24,17 @@ uint32_t longest_match_sse2(deflate_state *const s, uint32_t cur_match);
 uint32_t longest_match_slow_sse2(deflate_state *const s, uint32_t cur_match);
 void slide_hash_sse2(deflate_state *s);
 
-#  if !defined(WITHOUT_CHORBA_SSE)
+#  if !defined(WITHOUT_CHORBA) && !defined(WITHOUT_CHORBA_SSE)
     uint32_t crc32_chorba_sse2(uint32_t crc, const uint8_t *buf, size_t len);
     uint32_t crc32_copy_chorba_sse2(uint32_t crc, uint8_t *dst, const uint8_t *src, size_t len);
     uint32_t chorba_small_nondestructive_sse2(uint32_t crc, const uint8_t *buf, size_t len);
 #  endif
+#endif
+
+#ifndef X86_SSE2_NATIVE
+#  define CHUNKSET_FALLBACK
+#  define COMPARE256_FALLBACK
+#  define SLIDE_HASH_FALLBACK
 #endif
 
 #ifdef X86_SSSE3
@@ -38,9 +44,15 @@ uint8_t* chunkmemset_safe_ssse3(uint8_t *out, uint8_t *from, size_t len, size_t 
 void inflate_fast_ssse3(PREFIX3(stream) *strm, uint32_t start);
 #endif
 
-#if defined(X86_SSE41) && !defined(WITHOUT_CHORBA_SSE)
+#ifndef X86_SSSE3_NATIVE
+#  define ADLER32_FALLBACK
+#endif
+
+#if defined(X86_SSE41)
+#  if !defined(WITHOUT_CHORBA) && !defined(WITHOUT_CHORBA_SSE)
     uint32_t crc32_chorba_sse41(uint32_t crc, const uint8_t *buf, size_t len);
     uint32_t crc32_copy_chorba_sse41(uint32_t crc, uint8_t *dst, const uint8_t *src, size_t len);
+#  endif
 #endif
 
 #ifdef X86_SSE42
@@ -80,6 +92,10 @@ uint32_t crc32_vpclmulqdq(uint32_t crc, const uint8_t *buf, size_t len);
 uint32_t crc32_copy_vpclmulqdq(uint32_t crc, uint8_t *dst, const uint8_t *src, size_t len);
 #endif
 
+#if !defined(X86_PCLMULQDQ_NATIVE) && !defined(X86_VPCLMULQDQ_NATIVE)
+#  define CRC32_BRAID_FALLBACK
+#endif
+
 #ifdef DISABLE_RUNTIME_CPU_DETECTION
 // X86 - SSE2
 #  ifdef X86_SSE2_NATIVE
@@ -93,7 +109,7 @@ uint32_t crc32_copy_vpclmulqdq(uint32_t crc, uint8_t *dst, const uint8_t *src, s
 #    define native_longest_match longest_match_sse2
 #    undef native_longest_match_slow
 #    define native_longest_match_slow longest_match_slow_sse2
-#    if !defined(WITHOUT_CHORBA_SSE)
+#    if !defined(WITHOUT_CHORBA) && !defined(WITHOUT_CHORBA_SSE)
 #      undef native_crc32
 #      define native_crc32 crc32_chorba_sse2
 #      undef native_crc32_copy
@@ -114,11 +130,13 @@ uint32_t crc32_copy_vpclmulqdq(uint32_t crc, uint8_t *dst, const uint8_t *src, s
 #    define native_inflate_fast inflate_fast_ssse3
 #  endif
 // X86 - SSE4.1
-#  if defined(X86_SSE41_NATIVE) && !defined(WITHOUT_CHORBA_SSE)
-#    undef native_crc32
-#    define native_crc32 crc32_chorba_sse41
-#    undef native_crc32_copy
-#    define native_crc32_copy crc32_copy_chorba_sse41
+#  if defined(X86_SSE41_NATIVE)
+#    if !defined(WITHOUT_CHORBA) && !defined(WITHOUT_CHORBA_SSE)
+#      undef native_crc32
+#      define native_crc32 crc32_chorba_sse41
+#      undef native_crc32_copy
+#      define native_crc32_copy crc32_copy_chorba_sse41
+#    endif
 #  endif
 // X86 - SSE4.2
 #  ifdef X86_SSE42_NATIVE

--- a/arch/x86/x86_natives.h
+++ b/arch/x86/x86_natives.h
@@ -1,0 +1,53 @@
+/* x86_natives.h -- x86 compile-time feature detection macros.
+ * For conditions of distribution and use, see copyright notice in zlib.h
+ */
+
+#ifndef X86_NATIVES_H_
+#define X86_NATIVES_H_
+
+/* Compile-time feature detection macros */
+#if defined(__SSE2__) || (defined(ARCH_X86) && defined(ARCH_64BIT))
+#  ifdef X86_SSE2
+#    define X86_SSE2_NATIVE
+#  endif
+#endif
+#if defined(__SSSE3__)
+#  ifdef X86_SSSE3
+#    define X86_SSSE3_NATIVE
+#  endif
+#endif
+#if defined(__SSE4_1__)
+#  ifdef X86_SSE41
+#    define X86_SSE41_NATIVE
+#  endif
+#endif
+#if defined(__SSE4_2__)
+#  ifdef X86_SSE42
+#    define X86_SSE42_NATIVE
+#  endif
+#endif
+#if defined(__PCLMUL__)
+#  ifdef X86_PCLMULQDQ_CRC
+#    define X86_PCLMULQDQ_NATIVE
+#  endif
+#  if defined(__AVX512F__) && defined(__VPCLMULQDQ__)
+#    define X86_VPCLMULQDQ_NATIVE
+#  endif
+#endif
+#if defined(__AVX2__)
+#  ifdef X86_AVX2
+#    define X86_AVX2_NATIVE
+#  endif
+#endif
+#if defined(__AVX512F__) && defined(__AVX512DQ__) && defined(__AVX512BW__) && defined(__AVX512VL__)
+#  ifdef X86_AVX512
+#    define X86_AVX512_NATIVE
+#  endif
+#endif
+#if defined(__AVX512VNNI__)
+#  ifdef X86_AVX512VNNI
+#    define X86_AVX512VNNI_NATIVE
+#  endif
+#endif
+
+#endif /* X86_NATIVES_H_ */

--- a/arch_functions.h
+++ b/arch_functions.h
@@ -11,8 +11,6 @@
 #include "deflate.h"
 #include "fallback_builtins.h"
 
-#include "arch/generic/generic_functions.h"
-
 #if defined(X86_FEATURES)
 #  include "arch/x86/x86_functions.h"
 #elif defined(ARM_FEATURES)
@@ -25,6 +23,34 @@
 #  include "arch/riscv/riscv_functions.h"
 #elif defined(LOONGARCH_FEATURES)
 #  include "arch/loongarch/loongarch_functions.h"
+#else
+/* No architecture detected - all fallbacks needed */
+#  ifndef WITH_ALL_FALLBACKS
+#    define WITH_ALL_FALLBACKS
+#  endif
 #endif
+
+#ifdef WITH_ALL_FALLBACKS
+#  ifndef ADLER32_FALLBACK
+#    define ADLER32_FALLBACK
+#  endif
+#  ifndef CHUNKSET_FALLBACK
+#    define CHUNKSET_FALLBACK
+#  endif
+#  ifndef COMPARE256_FALLBACK
+#    define COMPARE256_FALLBACK
+#  endif
+#  ifndef CRC32_BRAID_FALLBACK
+#    define CRC32_BRAID_FALLBACK
+#  endif
+#  if !defined(CRC32_CHORBA_FALLBACK) && !defined(WITHOUT_CHORBA)
+#    define CRC32_CHORBA_FALLBACK
+#  endif
+#  ifndef SLIDE_HASH_FALLBACK
+#    define SLIDE_HASH_FALLBACK
+#  endif
+#endif
+
+#include "arch/generic/generic_functions.h"
 
 #endif

--- a/arch_natives.h
+++ b/arch_natives.h
@@ -1,0 +1,24 @@
+/* arch_natives.h -- Compile-time feature detection macros for all architectures.
+ * For conditions of distribution and use, see copyright notice in zlib.h
+ */
+
+#ifndef ARCH_NATIVES_H_
+#define ARCH_NATIVES_H_
+
+#include "zbuild.h"
+
+#if defined(X86_FEATURES)
+#  include "arch/x86/x86_natives.h"
+#elif defined(ARM_FEATURES)
+#  include "arch/arm/arm_natives.h"
+#elif defined(PPC_FEATURES) || defined(POWER_FEATURES)
+#  include "arch/power/power_natives.h"
+#elif defined(S390_FEATURES)
+#  include "arch/s390/s390_natives.h"
+#elif defined(RISCV_FEATURES)
+#  include "arch/riscv/riscv_natives.h"
+#elif defined(LOONGARCH_FEATURES)
+#  include "arch/loongarch/loongarch_natives.h"
+#endif
+
+#endif /* ARCH_NATIVES_H_ */

--- a/functable.c
+++ b/functable.c
@@ -64,6 +64,415 @@ static int force_init_empty(void) {
     return 0;
 }
 
+/* Set up generic C code fallbacks */
+static inline void init_functable_c(struct functable_s *ft) {
+#ifndef WITH_ALL_FALLBACKS
+    // Only use necessary generic functions when no suitable simd versions are available.
+#  ifdef X86_SSE2_NATIVE
+    // x86_64 always has SSE2
+    ft->adler32 = &adler32_c;
+    ft->adler32_copy = &adler32_copy_c;
+    ft->crc32 = &crc32_braid;
+    ft->crc32_copy = &crc32_copy_braid;
+#  elif defined(ARM_NEON_NATIVE)
+#    ifndef ARM_CRC32_NATIVE
+    ft->crc32 = &crc32_braid;
+    ft->crc32_copy = &crc32_copy_braid;
+#    endif
+#  elif defined(POWER8_VSX_NATIVE)
+#    ifndef POWER9_NATIVE
+    ft->compare256 = &compare256_c;
+    ft->longest_match = &longest_match_c;
+    ft->longest_match_slow = &longest_match_slow_c;
+#    endif
+#    ifndef POWER8_VSX_CRC32_NATIVE
+    ft->crc32 = &crc32_braid;
+    ft->crc32_copy = &crc32_copy_braid;
+#    endif
+#  elif defined(LOONGARCH_LSX_NATIVE)
+#    ifndef LOONGARCH_CRC
+    ft->crc32 = &crc32_braid;
+    ft->crc32_copy = &crc32_copy_braid;
+#    endif
+#  elif defined(RISCV_RVV_NATIVE)
+#    ifndef RISCV_ZBC_NATIVE
+    ft->crc32 = &crc32_braid;
+    ft->crc32_copy = &crc32_copy_braid;
+#    endif
+#  elif defined(S390_CRC32_VX_NATIVE)
+    ft->adler32 = &adler32_c;
+    ft->adler32_copy = &adler32_copy_c;
+    ft->chunkmemset_safe = &chunkmemset_safe_c;
+    ft->compare256 = &compare256_c;
+    ft->inflate_fast = &inflate_fast_c;
+    ft->longest_match = &longest_match_c;
+    ft->longest_match_slow = &longest_match_slow_c;
+    ft->slide_hash = &slide_hash_c;
+#  endif
+#else // WITH_ALL_FALLBACKS
+    ft->adler32 = &adler32_c;
+    ft->adler32_copy = &adler32_copy_c;
+    ft->chunkmemset_safe = &chunkmemset_safe_c;
+    ft->compare256 = &compare256_c;
+    ft->crc32 = &crc32_braid;
+    ft->crc32_copy = &crc32_copy_braid;
+    ft->inflate_fast = &inflate_fast_c;
+    ft->longest_match = &longest_match_c;
+    ft->longest_match_slow = &longest_match_slow_c;
+    ft->slide_hash = &slide_hash_c;
+#endif
+
+    // Chorba generic C fallback
+#if defined(WITH_OPTIM) && !defined(WITHOUT_CHORBA)
+    ft->crc32 = &crc32_chorba;
+    ft->crc32_copy = &crc32_copy_chorba;
+#endif
+}
+
+#ifdef WITH_OPTIM
+
+#ifdef ARCH_X86
+/* X86 architecture optimized functions */
+static inline void init_functable_x86(struct functable_s *ft, struct cpu_features *cf) {
+    Z_UNUSED(ft);
+    Z_UNUSED(cf);
+
+    // X86 - SSE2
+#ifdef X86_SSE2
+#  ifndef X86_SSE2_NATIVE
+    if (cf->x86.has_sse2)
+#  endif
+    {
+#  ifndef X86_AVX2_NATIVE
+        ft->chunkmemset_safe = &chunkmemset_safe_sse2;
+        ft->compare256 = &compare256_sse2;
+        ft->inflate_fast = &inflate_fast_sse2;
+        ft->longest_match = &longest_match_sse2;
+        ft->longest_match_slow = &longest_match_slow_sse2;
+        ft->slide_hash = &slide_hash_sse2;
+#  endif
+#  if !defined(WITHOUT_CHORBA_SSE) && !defined(X86_PCLMULQDQ_NATIVE)
+        ft->crc32 = &crc32_chorba_sse2;
+        ft->crc32_copy = &crc32_copy_chorba_sse2;
+#  endif
+    }
+#endif
+    // X86 - SSSE3
+#ifdef X86_SSSE3
+#  ifndef X86_SSSE3_NATIVE
+    if (cf->x86.has_ssse3)
+#  endif
+    {
+        ft->adler32 = &adler32_ssse3;
+        ft->adler32_copy = &adler32_copy_ssse3;
+#  ifndef X86_AVX2_NATIVE
+        ft->chunkmemset_safe = &chunkmemset_safe_ssse3;
+        ft->inflate_fast = &inflate_fast_ssse3;
+#  endif
+    }
+#endif
+
+    // X86 - SSE4.1
+#if defined(X86_SSE41) && !defined(X86_PCLMULQDQ_NATIVE)
+#  ifndef X86_SSE41_NATIVE
+    if (cf->x86.has_sse41)
+#  endif
+    {
+#  ifndef WITHOUT_CHORBA_SSE
+        ft->crc32 = &crc32_chorba_sse41;
+        ft->crc32_copy = &crc32_copy_chorba_sse41;
+#  endif
+    }
+#endif
+
+    // X86 - SSE4.2
+#if defined(X86_SSE42) && !defined(X86_AVX512_NATIVE)
+#  ifndef X86_SSE42_NATIVE
+    if (cf->x86.has_sse42)
+#  endif
+    {
+        ft->adler32_copy = &adler32_copy_sse42;
+    }
+#endif
+    // X86 - PCLMUL
+#if defined(X86_PCLMULQDQ_CRC) && !defined(X86_VPCLMULQDQ_NATIVE)
+#  ifndef X86_PCLMULQDQ_NATIVE
+    if (cf->x86.has_pclmulqdq)
+#  endif
+    {
+        ft->crc32 = &crc32_pclmulqdq;
+        ft->crc32_copy = &crc32_copy_pclmulqdq;
+    }
+#endif
+    // X86 - AVX2
+#ifdef X86_AVX2
+    /* BMI2 support is all but implicit with AVX2 but let's sanity check this just in case. Enabling BMI2 allows for
+     * flagless shifts, resulting in fewer flag stalls for the pipeline, and allows us to set destination registers
+     * for the shift results as an operand, eliminating several register-register moves when the original value needs
+     * to remain intact. They also allow for a count operand that isn't the CL register, avoiding contention there */
+#  ifndef X86_AVX2_NATIVE
+    if (cf->x86.has_avx2 && cf->x86.has_bmi2)
+#  endif
+    {
+#  ifndef X86_AVX512_NATIVE
+        ft->adler32 = &adler32_avx2;
+        ft->adler32_copy = &adler32_copy_avx2;
+        ft->chunkmemset_safe = &chunkmemset_safe_avx2;
+        ft->compare256 = &compare256_avx2;
+        ft->inflate_fast = &inflate_fast_avx2;
+        ft->longest_match = &longest_match_avx2;
+        ft->longest_match_slow = &longest_match_slow_avx2;
+#  endif
+        ft->slide_hash = &slide_hash_avx2;
+    }
+#endif
+    // X86 - AVX512 (F,DQ,BW,Vl)
+#ifdef X86_AVX512
+#  ifndef X86_AVX512_NATIVE
+    if (cf->x86.has_avx512_common)
+#  endif
+    {
+#  ifndef X86_AVX512VNNI_NATIVE
+        ft->adler32 = &adler32_avx512;
+        ft->adler32_copy = &adler32_copy_avx512;
+#  endif
+        ft->chunkmemset_safe = &chunkmemset_safe_avx512;
+        ft->compare256 = &compare256_avx512;
+        ft->inflate_fast = &inflate_fast_avx512;
+        ft->longest_match = &longest_match_avx512;
+        ft->longest_match_slow = &longest_match_slow_avx512;
+    }
+#endif
+#ifdef X86_AVX512VNNI
+#  ifndef X86_AVX512VNNI_NATIVE
+    if (cf->x86.has_avx512vnni)
+#  endif
+    {
+        ft->adler32 = &adler32_avx512_vnni;
+        ft->adler32_copy = &adler32_copy_avx512_vnni;
+    }
+#endif
+    // X86 - VPCLMULQDQ
+#ifdef X86_VPCLMULQDQ_CRC
+#  ifndef X86_VPCLMULQDQ_NATIVE
+    if (cf->x86.has_pclmulqdq && cf->x86.has_avx512_common && cf->x86.has_vpclmulqdq)
+#  endif
+    {
+        ft->crc32 = &crc32_vpclmulqdq;
+        ft->crc32_copy = &crc32_copy_vpclmulqdq;
+    }
+#endif
+}
+#endif
+
+#ifdef ARCH_ARM
+/* ARM architecture optimized functions */
+static inline void init_functable_arm(struct functable_s *ft, struct cpu_features *cf) {
+    Z_UNUSED(ft);
+    Z_UNUSED(cf);
+
+    // ARM - SIMD
+#if defined(ARM_SIMD) && !defined(ARM_NEON_NATIVE)
+#  ifndef ARM_SIMD_NATIVE
+    if (cf->arm.has_simd)
+#  endif
+    {
+        ft->slide_hash = &slide_hash_armv6;
+    }
+#endif
+    // ARM - NEON
+#ifdef ARM_NEON
+#  ifndef ARM_NEON_NATIVE
+    if (cf->arm.has_neon)
+#  endif
+    {
+        ft->adler32 = &adler32_neon;
+        ft->adler32_copy = &adler32_copy_neon;
+        ft->chunkmemset_safe = &chunkmemset_safe_neon;
+        ft->compare256 = &compare256_neon;
+        ft->inflate_fast = &inflate_fast_neon;
+        ft->longest_match = &longest_match_neon;
+        ft->longest_match_slow = &longest_match_slow_neon;
+        ft->slide_hash = &slide_hash_neon;
+    }
+#endif
+    // ARM - CRC32
+#if defined(ARM_CRC32) && !defined(ARM_PMULL_EOR3_NATIVE)
+#  ifndef ARM_CRC32_NATIVE
+    if (cf->arm.has_crc32)
+#  endif
+    {
+        ft->crc32 = &crc32_armv8;
+        ft->crc32_copy = &crc32_copy_armv8;
+    }
+#endif
+    // ARM - PMULL EOR3
+#ifdef ARM_PMULL_EOR3
+#  ifndef ARM_PMULL_EOR3_NATIVE
+    if (cf->arm.has_crc32 && cf->arm.has_pmull && cf->arm.has_eor3 && cf->arm.has_fast_pmull)
+#  endif
+    {
+        ft->crc32 = &crc32_armv8_pmull_eor3;
+        ft->crc32_copy = &crc32_copy_armv8_pmull_eor3;
+    }
+#endif
+}
+#endif
+
+#ifdef ARCH_POWER
+/* Power architecture optimized functions */
+static inline void init_functable_power(struct functable_s *ft, struct cpu_features *cf) {
+    Z_UNUSED(ft);
+    Z_UNUSED(cf);
+
+    // Power - VMX
+#ifdef PPC_VMX
+#  ifndef PPC_VMX_NATIVE
+    if (cf->power.has_altivec)
+#  endif
+    {
+        ft->adler32 = &adler32_vmx;
+        ft->adler32_copy = &adler32_copy_vmx;
+        ft->slide_hash = &slide_hash_vmx;
+    }
+#endif
+    // Power8 - VSX
+#ifdef POWER8_VSX
+#  ifndef POWER8_VSX_NATIVE
+    if (cf->power.has_arch_2_07)
+#  endif
+    {
+        ft->adler32 = &adler32_power8;
+        ft->adler32_copy = &adler32_copy_power8;
+        ft->chunkmemset_safe = &chunkmemset_safe_power8;
+        ft->inflate_fast = &inflate_fast_power8;
+        ft->slide_hash = &slide_hash_power8;
+    }
+#endif
+#ifdef POWER8_VSX_CRC32
+#  ifndef POWER8_VSX_CRC32_NATIVE
+    if (cf->power.has_arch_2_07)
+#  endif
+    {
+        ft->crc32 = &crc32_power8;
+        ft->crc32_copy = &crc32_copy_power8;
+    }
+#endif
+    // Power9
+#ifdef POWER9
+#  ifndef POWER9_NATIVE
+    if (cf->power.has_arch_3_00)
+#  endif
+    {
+        ft->compare256 = &compare256_power9;
+        ft->longest_match = &longest_match_power9;
+        ft->longest_match_slow = &longest_match_slow_power9;
+    }
+#endif
+}
+#endif
+
+#ifdef ARCH_RISCV
+/* RISC-V architecture optimized functions */
+static inline void init_functable_riscv(struct functable_s *ft, struct cpu_features *cf) {
+    Z_UNUSED(ft);
+    Z_UNUSED(cf);
+
+    // RISCV - RVV
+#ifdef RISCV_RVV
+#  ifndef RISCV_RVV_NATIVE
+    if (cf->riscv.has_rvv)
+#  endif
+    {
+        ft->adler32 = &adler32_rvv;
+        ft->adler32_copy = &adler32_copy_rvv;
+        ft->chunkmemset_safe = &chunkmemset_safe_rvv;
+        ft->compare256 = &compare256_rvv;
+        ft->inflate_fast = &inflate_fast_rvv;
+        ft->longest_match = &longest_match_rvv;
+        ft->longest_match_slow = &longest_match_slow_rvv;
+        ft->slide_hash = &slide_hash_rvv;
+    }
+#endif
+
+    // RISCV - ZBC
+#ifdef RISCV_CRC32_ZBC
+#  ifndef RISCV_ZBC_NATIVE
+    if (cf->riscv.has_zbc)
+#  endif
+    {
+        ft->crc32 = &crc32_riscv64_zbc;
+        ft->crc32_copy = &crc32_copy_riscv64_zbc;
+    }
+#endif
+}
+#endif
+
+#ifdef ARCH_S390
+/* S390 architecture optimized functions */
+static inline void init_functable_s390(struct functable_s *ft, struct cpu_features *cf) {
+    Z_UNUSED(ft);
+    Z_UNUSED(cf);
+
+#ifdef S390_CRC32_VX
+#  ifndef S390_CRC32_VX_NATIVE
+    if (cf->s390.has_vx)
+#  endif
+    {
+        ft->crc32 = &crc32_s390_vx;
+        ft->crc32_copy = &crc32_copy_s390_vx;
+    }
+#endif
+}
+#endif
+
+#ifdef ARCH_LOONGARCH
+/* LoongArch architecture optimized functions */
+static inline void init_functable_loongarch(struct functable_s *ft, struct cpu_features *cf) {
+    Z_UNUSED(ft);
+    Z_UNUSED(cf);
+
+#ifdef LOONGARCH_CRC
+    if (cf->loongarch.has_crc) {
+        ft->crc32 = &crc32_loongarch64;
+        ft->crc32_copy = &crc32_copy_loongarch64;
+    }
+#endif
+#if defined(LOONGARCH_LSX) && !defined(LOONGARCH_LASX_NATIVE)
+#  ifndef LOONGARCH_LSX_NATIVE
+    if (cf->loongarch.has_lsx)
+#  endif
+    {
+        ft->adler32 = &adler32_lsx;
+        ft->adler32_copy = &adler32_copy_lsx;
+        ft->chunkmemset_safe = &chunkmemset_safe_lsx;
+        ft->compare256 = &compare256_lsx;
+        ft->inflate_fast = &inflate_fast_lsx;
+        ft->longest_match = &longest_match_lsx;
+        ft->longest_match_slow = &longest_match_slow_lsx;
+        ft->slide_hash = &slide_hash_lsx;
+    }
+#endif
+#ifdef LOONGARCH_LASX
+#  ifndef LOONGARCH_LASX_NATIVE
+    if (cf->loongarch.has_lasx)
+#  endif
+    {
+        ft->adler32 = &adler32_lasx;
+        ft->adler32_copy = &adler32_copy_lasx;
+        ft->chunkmemset_safe = &chunkmemset_safe_lasx;
+        ft->compare256 = &compare256_lasx;
+        ft->inflate_fast = &inflate_fast_lasx;
+        ft->longest_match = &longest_match_lasx;
+        ft->longest_match_slow = &longest_match_slow_lasx;
+        ft->slide_hash = &slide_hash_lasx;
+    }
+#endif
+}
+#endif
+
+#endif // WITH_OPTIM
+
 /* Functable initialization.
  * Selects the best available optimized functions appropriate for the runtime cpu.
  */
@@ -75,369 +484,28 @@ static int init_functable(void) {
     cpu_check_features(&cf);
     ft.force_init = &force_init_empty;
 
-    // Set up generic C code fallbacks
-#ifndef WITH_ALL_FALLBACKS
-    // Only use necessary generic functions when no suitable simd versions are available.
-#  ifdef X86_SSE2_NATIVE
-    // x86_64 always has SSE2
-    ft.adler32 = &adler32_c;
-    ft.adler32_copy = &adler32_copy_c;
-    ft.crc32 = &crc32_braid;
-    ft.crc32_copy = &crc32_copy_braid;
-#  elif defined(ARM_NEON_NATIVE)
-#    ifndef ARM_CRC32_NATIVE
-    ft.crc32 = &crc32_braid;
-    ft.crc32_copy = &crc32_copy_braid;
-#    endif
-#  elif defined(POWER8_VSX_NATIVE)
-#    ifndef POWER9_NATIVE
-    ft.compare256 = &compare256_c;
-    ft.longest_match = &longest_match_c;
-    ft.longest_match_slow = &longest_match_slow_c;
-#    endif
-#    ifndef POWER8_VSX_CRC32_NATIVE
-    ft.crc32 = &crc32_braid;
-    ft.crc32_copy = &crc32_copy_braid;
-#    endif
-#  elif defined(LOONGARCH_LSX_NATIVE)
-#    ifndef LOONGARCH_CRC
-    ft.crc32 = &crc32_braid;
-    ft.crc32_copy = &crc32_copy_braid;
-#    endif
-#  elif defined(RISCV_RVV_NATIVE)
-#    ifndef RISCV_ZBC_NATIVE
-    ft.crc32 = &crc32_braid;
-    ft.crc32_copy = &crc32_copy_braid;
-#    endif
-#  elif defined(S390_CRC32_VX_NATIVE)
-    ft.adler32 = &adler32_c;
-    ft.adler32_copy = &adler32_copy_c;
-    ft.chunkmemset_safe = &chunkmemset_safe_c;
-    ft.compare256 = &compare256_c;
-    ft.inflate_fast = &inflate_fast_c;
-    ft.longest_match = &longest_match_c;
-    ft.longest_match_slow = &longest_match_slow_c;
-    ft.slide_hash = &slide_hash_c;
-#  endif
-#else // WITH_ALL_FALLBACKS
-    ft.adler32 = &adler32_c;
-    ft.adler32_copy = &adler32_copy_c;
-    ft.chunkmemset_safe = &chunkmemset_safe_c;
-    ft.compare256 = &compare256_c;
-    ft.crc32 = &crc32_braid;
-    ft.crc32_copy = &crc32_copy_braid;
-    ft.inflate_fast = &inflate_fast_c;
-    ft.longest_match = &longest_match_c;
-    ft.longest_match_slow = &longest_match_slow_c;
-    ft.slide_hash = &slide_hash_c;
-#endif
+    init_functable_c(&ft);
 
-    // Select arch-optimized functions
 #ifdef WITH_OPTIM
-
-    // Chorba generic C fallback
-#ifndef WITHOUT_CHORBA
-    ft.crc32 = &crc32_chorba;
-    ft.crc32_copy = &crc32_copy_chorba;
+#  ifdef ARCH_X86
+    init_functable_x86(&ft, &cf);
+#  endif
+#  ifdef ARCH_ARM
+    init_functable_arm(&ft, &cf);
+#  endif
+#  ifdef ARCH_POWER
+    init_functable_power(&ft, &cf);
+#  endif
+#  ifdef ARCH_RISCV
+    init_functable_riscv(&ft, &cf);
+#  endif
+#  ifdef ARCH_S390
+    init_functable_s390(&ft, &cf);
+#  endif
+#  ifdef ARCH_LOONGARCH
+    init_functable_loongarch(&ft, &cf);
+#  endif
 #endif
-
-    // X86 - SSE2
-#ifdef X86_SSE2
-#  ifndef X86_SSE2_NATIVE
-    if (cf.x86.has_sse2)
-#  endif
-    {
-#  ifndef X86_AVX2_NATIVE
-        ft.chunkmemset_safe = &chunkmemset_safe_sse2;
-        ft.compare256 = &compare256_sse2;
-        ft.inflate_fast = &inflate_fast_sse2;
-        ft.longest_match = &longest_match_sse2;
-        ft.longest_match_slow = &longest_match_slow_sse2;
-        ft.slide_hash = &slide_hash_sse2;
-#  endif
-#  if !defined(WITHOUT_CHORBA_SSE) && !defined(X86_PCLMULQDQ_NATIVE)
-        ft.crc32 = &crc32_chorba_sse2;
-        ft.crc32_copy = &crc32_copy_chorba_sse2;
-#  endif
-    }
-#endif
-    // X86 - SSSE3
-#ifdef X86_SSSE3
-#  ifndef X86_SSSE3_NATIVE
-    if (cf.x86.has_ssse3)
-#  endif
-    {
-        ft.adler32 = &adler32_ssse3;
-        ft.adler32_copy = &adler32_copy_ssse3;
-#  ifndef X86_AVX2_NATIVE
-        ft.chunkmemset_safe = &chunkmemset_safe_ssse3;
-        ft.inflate_fast = &inflate_fast_ssse3;
-#  endif
-    }
-#endif
-
-    // X86 - SSE4.1
-#if defined(X86_SSE41) && !defined(X86_PCLMULQDQ_NATIVE)
-#  ifndef X86_SSE41_NATIVE
-    if (cf.x86.has_sse41)
-#  endif
-    {
-#  ifndef WITHOUT_CHORBA_SSE
-        ft.crc32 = &crc32_chorba_sse41;
-        ft.crc32_copy = &crc32_copy_chorba_sse41;
-#  endif
-    }
-#endif
-
-    // X86 - SSE4.2
-#if defined(X86_SSE42) && !defined(X86_AVX512_NATIVE)
-#  ifndef X86_SSE42_NATIVE
-    if (cf.x86.has_sse42)
-#  endif
-    {
-        ft.adler32_copy = &adler32_copy_sse42;
-    }
-#endif
-    // X86 - PCLMUL
-#if defined(X86_PCLMULQDQ_CRC) && !defined(X86_VPCLMULQDQ_NATIVE)
-#  ifndef X86_PCLMULQDQ_NATIVE
-    if (cf.x86.has_pclmulqdq)
-#  endif
-    {
-        ft.crc32 = &crc32_pclmulqdq;
-        ft.crc32_copy = &crc32_copy_pclmulqdq;
-    }
-#endif
-    // X86 - AVX2
-#ifdef X86_AVX2
-    /* BMI2 support is all but implicit with AVX2 but let's sanity check this just in case. Enabling BMI2 allows for
-     * flagless shifts, resulting in fewer flag stalls for the pipeline, and allows us to set destination registers
-     * for the shift results as an operand, eliminating several register-register moves when the original value needs
-     * to remain intact. They also allow for a count operand that isn't the CL register, avoiding contention there */
-#  ifndef X86_AVX2_NATIVE
-    if (cf.x86.has_avx2 && cf.x86.has_bmi2)
-#  endif
-    {
-#  ifndef X86_AVX512_NATIVE
-        ft.adler32 = &adler32_avx2;
-        ft.adler32_copy = &adler32_copy_avx2;
-        ft.chunkmemset_safe = &chunkmemset_safe_avx2;
-        ft.compare256 = &compare256_avx2;
-        ft.inflate_fast = &inflate_fast_avx2;
-        ft.longest_match = &longest_match_avx2;
-        ft.longest_match_slow = &longest_match_slow_avx2;
-#  endif
-        ft.slide_hash = &slide_hash_avx2;
-    }
-#endif
-    // X86 - AVX512 (F,DQ,BW,Vl)
-#ifdef X86_AVX512
-#  ifndef X86_AVX512_NATIVE
-    if (cf.x86.has_avx512_common)
-#  endif
-    {
-#  ifndef X86_AVX512VNNI_NATIVE
-        ft.adler32 = &adler32_avx512;
-        ft.adler32_copy = &adler32_copy_avx512;
-#  endif
-        ft.chunkmemset_safe = &chunkmemset_safe_avx512;
-        ft.compare256 = &compare256_avx512;
-        ft.inflate_fast = &inflate_fast_avx512;
-        ft.longest_match = &longest_match_avx512;
-        ft.longest_match_slow = &longest_match_slow_avx512;
-    }
-#endif
-#ifdef X86_AVX512VNNI
-#  ifndef X86_AVX512VNNI_NATIVE
-    if (cf.x86.has_avx512vnni)
-#  endif
-    {
-        ft.adler32 = &adler32_avx512_vnni;
-        ft.adler32_copy = &adler32_copy_avx512_vnni;
-    }
-#endif
-    // X86 - VPCLMULQDQ
-#ifdef X86_VPCLMULQDQ_CRC
-#  ifndef X86_VPCLMULQDQ_NATIVE
-    if (cf.x86.has_pclmulqdq && cf.x86.has_avx512_common && cf.x86.has_vpclmulqdq)
-#  endif
-    {
-        ft.crc32 = &crc32_vpclmulqdq;
-        ft.crc32_copy = &crc32_copy_vpclmulqdq;
-    }
-#endif
-
-
-    // ARM - SIMD
-#if defined(ARM_SIMD) && !defined(ARM_NEON_NATIVE)
-#  ifndef ARM_SIMD_NATIVE
-    if (cf.arm.has_simd)
-#  endif
-    {
-        ft.slide_hash = &slide_hash_armv6;
-    }
-#endif
-    // ARM - NEON
-#ifdef ARM_NEON
-#  ifndef ARM_NEON_NATIVE
-    if (cf.arm.has_neon)
-#  endif
-    {
-        ft.adler32 = &adler32_neon;
-        ft.adler32_copy = &adler32_copy_neon;
-        ft.chunkmemset_safe = &chunkmemset_safe_neon;
-        ft.compare256 = &compare256_neon;
-        ft.inflate_fast = &inflate_fast_neon;
-        ft.longest_match = &longest_match_neon;
-        ft.longest_match_slow = &longest_match_slow_neon;
-        ft.slide_hash = &slide_hash_neon;
-    }
-#endif
-    // ARM - CRC32
-#if defined(ARM_CRC32) && !defined(ARM_PMULL_EOR3_NATIVE)
-#  ifndef ARM_CRC32_NATIVE
-    if (cf.arm.has_crc32)
-#  endif
-    {
-        ft.crc32 = &crc32_armv8;
-        ft.crc32_copy = &crc32_copy_armv8;
-    }
-#endif
-    // ARM - PMULL EOR3
-#ifdef ARM_PMULL_EOR3
-#  ifndef ARM_PMULL_EOR3_NATIVE
-    if (cf.arm.has_crc32 && cf.arm.has_pmull && cf.arm.has_eor3 && cf.arm.has_fast_pmull)
-#  endif
-    {
-        ft.crc32 = &crc32_armv8_pmull_eor3;
-        ft.crc32_copy = &crc32_copy_armv8_pmull_eor3;
-    }
-#endif
-
-    // Power - VMX
-#ifdef PPC_VMX
-#  ifndef PPC_VMX_NATIVE
-    if (cf.power.has_altivec)
-#  endif
-    {
-        ft.adler32 = &adler32_vmx;
-        ft.adler32_copy = &adler32_copy_vmx;
-        ft.slide_hash = &slide_hash_vmx;
-    }
-#endif
-    // Power8 - VSX
-#ifdef POWER8_VSX
-#  ifndef POWER8_VSX_NATIVE
-    if (cf.power.has_arch_2_07)
-#  endif
-    {
-        ft.adler32 = &adler32_power8;
-        ft.adler32_copy = &adler32_copy_power8;
-        ft.chunkmemset_safe = &chunkmemset_safe_power8;
-        ft.inflate_fast = &inflate_fast_power8;
-        ft.slide_hash = &slide_hash_power8;
-    }
-#endif
-#ifdef POWER8_VSX_CRC32
-#  ifndef POWER8_VSX_CRC32_NATIVE
-    if (cf.power.has_arch_2_07)
-#  endif
-    {
-        ft.crc32 = &crc32_power8;
-        ft.crc32_copy = &crc32_copy_power8;
-    }
-#endif
-    // Power9
-#ifdef POWER9
-#  ifndef POWER9_NATIVE
-    if (cf.power.has_arch_3_00)
-#  endif
-    {
-        ft.compare256 = &compare256_power9;
-        ft.longest_match = &longest_match_power9;
-        ft.longest_match_slow = &longest_match_slow_power9;
-    }
-#endif
-
-
-    // RISCV - RVV
-#ifdef RISCV_RVV
-#  ifndef RISCV_RVV_NATIVE
-    if (cf.riscv.has_rvv)
-#  endif
-    {
-        ft.adler32 = &adler32_rvv;
-        ft.adler32_copy = &adler32_copy_rvv;
-        ft.chunkmemset_safe = &chunkmemset_safe_rvv;
-        ft.compare256 = &compare256_rvv;
-        ft.inflate_fast = &inflate_fast_rvv;
-        ft.longest_match = &longest_match_rvv;
-        ft.longest_match_slow = &longest_match_slow_rvv;
-        ft.slide_hash = &slide_hash_rvv;
-    }
-#endif
-
-    // RISCV - ZBC
-#ifdef RISCV_CRC32_ZBC
-#  ifndef RISCV_ZBC_NATIVE
-    if (cf.riscv.has_zbc)
-#  endif
-    {
-        ft.crc32 = &crc32_riscv64_zbc;
-        ft.crc32_copy = &crc32_copy_riscv64_zbc;
-    }
-#endif
-
-    // S390
-#ifdef S390_CRC32_VX
-#  ifndef S390_CRC32_VX_NATIVE
-    if (cf.s390.has_vx)
-#  endif
-    {
-        ft.crc32 = &crc32_s390_vx;
-        ft.crc32_copy = &crc32_copy_s390_vx;
-    }
-#endif
-
-    // LOONGARCH
-#ifdef LOONGARCH_CRC
-    if (cf.loongarch.has_crc) {
-        ft.crc32 = &crc32_loongarch64;
-        ft.crc32_copy = &crc32_copy_loongarch64;
-    }
-#endif
-#if defined(LOONGARCH_LSX) && !defined(LOONGARCH_LASX_NATIVE)
-#  ifndef LOONGARCH_LSX_NATIVE
-    if (cf.loongarch.has_lsx)
-#  endif
-    {
-        ft.adler32 = &adler32_lsx;
-        ft.adler32_copy = &adler32_copy_lsx;
-        ft.chunkmemset_safe = &chunkmemset_safe_lsx;
-        ft.compare256 = &compare256_lsx;
-        ft.inflate_fast = &inflate_fast_lsx;
-        ft.longest_match = &longest_match_lsx;
-        ft.longest_match_slow = &longest_match_slow_lsx;
-        ft.slide_hash = &slide_hash_lsx;
-    }
-#endif
-#ifdef LOONGARCH_LASX
-#  ifndef LOONGARCH_LASX_NATIVE
-    if (cf.loongarch.has_lasx)
-#  endif
-    {
-        ft.adler32 = &adler32_lasx;
-        ft.adler32_copy = &adler32_copy_lasx;
-        ft.chunkmemset_safe = &chunkmemset_safe_lasx;
-        ft.compare256 = &compare256_lasx;
-        ft.inflate_fast = &inflate_fast_lasx;
-        ft.longest_match = &longest_match_lasx;
-        ft.longest_match_slow = &longest_match_slow_lasx;
-        ft.slide_hash = &slide_hash_lasx;
-    }
-#endif
-
-#endif // WITH_OPTIM
 
     // Assign function pointers individually for atomic operation
     FUNCTABLE_ASSIGN(ft, force_init);

--- a/functable.c
+++ b/functable.c
@@ -66,64 +66,29 @@ static int force_init_empty(void) {
 
 /* Set up generic C code fallbacks */
 static inline void init_functable_c(struct functable_s *ft) {
-#ifndef WITH_ALL_FALLBACKS
-    // Only use necessary generic functions when no suitable simd versions are available.
-#  ifdef X86_SSE2_NATIVE
-    // x86_64 always has SSE2
+#ifdef ADLER32_FALLBACK
     ft->adler32 = &adler32_c;
     ft->adler32_copy = &adler32_copy_c;
-    ft->crc32 = &crc32_braid;
-    ft->crc32_copy = &crc32_copy_braid;
-#  elif defined(ARM_NEON_NATIVE)
-#    ifndef ARM_CRC32_NATIVE
-    ft->crc32 = &crc32_braid;
-    ft->crc32_copy = &crc32_copy_braid;
-#    endif
-#  elif defined(POWER8_VSX_NATIVE)
-#    ifndef POWER9_NATIVE
-    ft->compare256 = &compare256_c;
-    ft->longest_match = &longest_match_c;
-    ft->longest_match_slow = &longest_match_slow_c;
-#    endif
-#    ifndef POWER8_VSX_CRC32_NATIVE
-    ft->crc32 = &crc32_braid;
-    ft->crc32_copy = &crc32_copy_braid;
-#    endif
-#  elif defined(LOONGARCH_LSX_NATIVE)
-#    ifndef LOONGARCH_CRC
-    ft->crc32 = &crc32_braid;
-    ft->crc32_copy = &crc32_copy_braid;
-#    endif
-#  elif defined(RISCV_RVV_NATIVE)
-#    ifndef RISCV_ZBC_NATIVE
-    ft->crc32 = &crc32_braid;
-    ft->crc32_copy = &crc32_copy_braid;
-#    endif
-#  elif defined(S390_CRC32_VX_NATIVE)
-    ft->adler32 = &adler32_c;
-    ft->adler32_copy = &adler32_copy_c;
+#endif
+#ifdef CHUNKSET_FALLBACK
     ft->chunkmemset_safe = &chunkmemset_safe_c;
-    ft->compare256 = &compare256_c;
     ft->inflate_fast = &inflate_fast_c;
+#endif
+#ifdef COMPARE256_FALLBACK
+    ft->compare256 = &compare256_c;
     ft->longest_match = &longest_match_c;
     ft->longest_match_slow = &longest_match_slow_c;
-    ft->slide_hash = &slide_hash_c;
-#  endif
-#else // WITH_ALL_FALLBACKS
-    ft->adler32 = &adler32_c;
-    ft->adler32_copy = &adler32_copy_c;
-    ft->chunkmemset_safe = &chunkmemset_safe_c;
-    ft->compare256 = &compare256_c;
+#endif
+#ifdef CRC32_BRAID_FALLBACK
     ft->crc32 = &crc32_braid;
     ft->crc32_copy = &crc32_copy_braid;
-    ft->inflate_fast = &inflate_fast_c;
-    ft->longest_match = &longest_match_c;
-    ft->longest_match_slow = &longest_match_slow_c;
+#endif
+#ifdef SLIDE_HASH_FALLBACK
     ft->slide_hash = &slide_hash_c;
 #endif
 
     // Chorba generic C fallback
-#if defined(WITH_OPTIM) && !defined(WITHOUT_CHORBA)
+#if defined(WITH_OPTIM) && defined(CRC32_CHORBA_FALLBACK)
     ft->crc32 = &crc32_chorba;
     ft->crc32_copy = &crc32_copy_chorba;
 #endif
@@ -151,9 +116,11 @@ static inline void init_functable_x86(struct functable_s *ft, struct cpu_feature
         ft->longest_match_slow = &longest_match_slow_sse2;
         ft->slide_hash = &slide_hash_sse2;
 #  endif
-#  if !defined(WITHOUT_CHORBA_SSE) && !defined(X86_PCLMULQDQ_NATIVE)
+#  if !defined(X86_SSE41_NATIVE) && !defined(X86_PCLMULQDQ_NATIVE)
+#    if !defined(WITHOUT_CHORBA) && !defined(WITHOUT_CHORBA_SSE)
         ft->crc32 = &crc32_chorba_sse2;
         ft->crc32_copy = &crc32_copy_chorba_sse2;
+#    endif
 #  endif
     }
 #endif
@@ -178,7 +145,7 @@ static inline void init_functable_x86(struct functable_s *ft, struct cpu_feature
     if (cf->x86.has_sse41)
 #  endif
     {
-#  ifndef WITHOUT_CHORBA_SSE
+#  if !defined(WITHOUT_CHORBA) && !defined(WITHOUT_CHORBA_SSE)
         ft->crc32 = &crc32_chorba_sse41;
         ft->crc32_copy = &crc32_copy_chorba_sse41;
 #  endif

--- a/functable.c
+++ b/functable.c
@@ -77,12 +77,47 @@ static int init_functable(void) {
 
     // Set up generic C code fallbacks
 #ifndef WITH_ALL_FALLBACKS
-#  if defined(ARCH_X86) && defined(ARCH_64BIT) && defined(X86_SSE2)
-    // x86_64 always has SSE2, so we can use SSE2 functions as fallbacks where available.
+    // Only use necessary generic functions when no suitable simd versions are available.
+#  ifdef X86_SSE2_NATIVE
+    // x86_64 always has SSE2
     ft.adler32 = &adler32_c;
     ft.adler32_copy = &adler32_copy_c;
     ft.crc32 = &crc32_braid;
     ft.crc32_copy = &crc32_copy_braid;
+#  elif defined(ARM_NEON_NATIVE)
+#    ifndef ARM_CRC32_NATIVE
+    ft.crc32 = &crc32_braid;
+    ft.crc32_copy = &crc32_copy_braid;
+#    endif
+#  elif defined(POWER8_VSX_NATIVE)
+#    ifndef POWER9_NATIVE
+    ft.compare256 = &compare256_c;
+    ft.longest_match = &longest_match_c;
+    ft.longest_match_slow = &longest_match_slow_c;
+#    endif
+#    ifndef POWER8_VSX_CRC32_NATIVE
+    ft.crc32 = &crc32_braid;
+    ft.crc32_copy = &crc32_copy_braid;
+#    endif
+#  elif defined(LOONGARCH_LSX_NATIVE)
+#    ifndef LOONGARCH_CRC
+    ft.crc32 = &crc32_braid;
+    ft.crc32_copy = &crc32_copy_braid;
+#    endif
+#  elif defined(RISCV_RVV_NATIVE)
+#    ifndef RISCV_ZBC_NATIVE
+    ft.crc32 = &crc32_braid;
+    ft.crc32_copy = &crc32_copy_braid;
+#    endif
+#  elif defined(S390_CRC32_VX_NATIVE)
+    ft.adler32 = &adler32_c;
+    ft.adler32_copy = &adler32_copy_c;
+    ft.chunkmemset_safe = &chunkmemset_safe_c;
+    ft.compare256 = &compare256_c;
+    ft.inflate_fast = &inflate_fast_c;
+    ft.longest_match = &longest_match_c;
+    ft.longest_match_slow = &longest_match_slow_c;
+    ft.slide_hash = &slide_hash_c;
 #  endif
 #else // WITH_ALL_FALLBACKS
     ft.adler32 = &adler32_c;
@@ -108,60 +143,82 @@ static int init_functable(void) {
 
     // X86 - SSE2
 #ifdef X86_SSE2
-#  ifdef ARCH_32BIT
+#  ifndef X86_SSE2_NATIVE
     if (cf.x86.has_sse2)
 #  endif
     {
+#  ifndef X86_AVX2_NATIVE
         ft.chunkmemset_safe = &chunkmemset_safe_sse2;
         ft.compare256 = &compare256_sse2;
-#  if !defined(WITHOUT_CHORBA_SSE)
-        ft.crc32 = &crc32_chorba_sse2;
-        ft.crc32_copy = &crc32_copy_chorba_sse2;
-#  endif
         ft.inflate_fast = &inflate_fast_sse2;
         ft.longest_match = &longest_match_sse2;
         ft.longest_match_slow = &longest_match_slow_sse2;
         ft.slide_hash = &slide_hash_sse2;
+#  endif
+#  if !defined(WITHOUT_CHORBA_SSE) && !defined(X86_PCLMULQDQ_NATIVE)
+        ft.crc32 = &crc32_chorba_sse2;
+        ft.crc32_copy = &crc32_copy_chorba_sse2;
+#  endif
     }
 #endif
     // X86 - SSSE3
 #ifdef X86_SSSE3
-    if (cf.x86.has_ssse3) {
+#  ifndef X86_SSSE3_NATIVE
+    if (cf.x86.has_ssse3)
+#  endif
+    {
         ft.adler32 = &adler32_ssse3;
         ft.adler32_copy = &adler32_copy_ssse3;
+#  ifndef X86_AVX2_NATIVE
         ft.chunkmemset_safe = &chunkmemset_safe_ssse3;
         ft.inflate_fast = &inflate_fast_ssse3;
+#  endif
     }
 #endif
 
     // X86 - SSE4.1
-#if defined(X86_SSE41) && !defined(WITHOUT_CHORBA_SSE)
-    if (cf.x86.has_sse41) {
+#if defined(X86_SSE41) && !defined(X86_PCLMULQDQ_NATIVE)
+#  ifndef X86_SSE41_NATIVE
+    if (cf.x86.has_sse41)
+#  endif
+    {
+#  ifndef WITHOUT_CHORBA_SSE
         ft.crc32 = &crc32_chorba_sse41;
         ft.crc32_copy = &crc32_copy_chorba_sse41;
+#  endif
     }
 #endif
 
     // X86 - SSE4.2
-#ifdef X86_SSE42
-    if (cf.x86.has_sse42) {
+#if defined(X86_SSE42) && !defined(X86_AVX512_NATIVE)
+#  ifndef X86_SSE42_NATIVE
+    if (cf.x86.has_sse42)
+#  endif
+    {
         ft.adler32_copy = &adler32_copy_sse42;
     }
 #endif
     // X86 - PCLMUL
-#ifdef X86_PCLMULQDQ_CRC
-    if (cf.x86.has_pclmulqdq) {
+#if defined(X86_PCLMULQDQ_CRC) && !defined(X86_VPCLMULQDQ_NATIVE)
+#  ifndef X86_PCLMULQDQ_NATIVE
+    if (cf.x86.has_pclmulqdq)
+#  endif
+    {
         ft.crc32 = &crc32_pclmulqdq;
         ft.crc32_copy = &crc32_copy_pclmulqdq;
     }
 #endif
-    // X86 - AVX
+    // X86 - AVX2
 #ifdef X86_AVX2
     /* BMI2 support is all but implicit with AVX2 but let's sanity check this just in case. Enabling BMI2 allows for
      * flagless shifts, resulting in fewer flag stalls for the pipeline, and allows us to set destination registers
      * for the shift results as an operand, eliminating several register-register moves when the original value needs
      * to remain intact. They also allow for a count operand that isn't the CL register, avoiding contention there */
-    if (cf.x86.has_avx2 && cf.x86.has_bmi2) {
+#  ifndef X86_AVX2_NATIVE
+    if (cf.x86.has_avx2 && cf.x86.has_bmi2)
+#  endif
+    {
+#  ifndef X86_AVX512_NATIVE
         ft.adler32 = &adler32_avx2;
         ft.adler32_copy = &adler32_copy_avx2;
         ft.chunkmemset_safe = &chunkmemset_safe_avx2;
@@ -169,14 +226,20 @@ static int init_functable(void) {
         ft.inflate_fast = &inflate_fast_avx2;
         ft.longest_match = &longest_match_avx2;
         ft.longest_match_slow = &longest_match_slow_avx2;
+#  endif
         ft.slide_hash = &slide_hash_avx2;
     }
 #endif
     // X86 - AVX512 (F,DQ,BW,Vl)
 #ifdef X86_AVX512
-    if (cf.x86.has_avx512_common) {
+#  ifndef X86_AVX512_NATIVE
+    if (cf.x86.has_avx512_common)
+#  endif
+    {
+#  ifndef X86_AVX512VNNI_NATIVE
         ft.adler32 = &adler32_avx512;
         ft.adler32_copy = &adler32_copy_avx512;
+#  endif
         ft.chunkmemset_safe = &chunkmemset_safe_avx512;
         ft.compare256 = &compare256_avx512;
         ft.inflate_fast = &inflate_fast_avx512;
@@ -185,14 +248,20 @@ static int init_functable(void) {
     }
 #endif
 #ifdef X86_AVX512VNNI
-    if (cf.x86.has_avx512vnni) {
+#  ifndef X86_AVX512VNNI_NATIVE
+    if (cf.x86.has_avx512vnni)
+#  endif
+    {
         ft.adler32 = &adler32_avx512_vnni;
         ft.adler32_copy = &adler32_copy_avx512_vnni;
     }
 #endif
     // X86 - VPCLMULQDQ
 #ifdef X86_VPCLMULQDQ_CRC
-    if (cf.x86.has_pclmulqdq && cf.x86.has_avx512_common && cf.x86.has_vpclmulqdq) {
+#  ifndef X86_VPCLMULQDQ_NATIVE
+    if (cf.x86.has_pclmulqdq && cf.x86.has_avx512_common && cf.x86.has_vpclmulqdq)
+#  endif
+    {
         ft.crc32 = &crc32_vpclmulqdq;
         ft.crc32_copy = &crc32_copy_vpclmulqdq;
     }
@@ -200,8 +269,8 @@ static int init_functable(void) {
 
 
     // ARM - SIMD
-#ifdef ARM_SIMD
-#  ifndef ARM_NOCHECK_SIMD
+#if defined(ARM_SIMD) && !defined(ARM_NEON_NATIVE)
+#  ifndef ARM_SIMD_NATIVE
     if (cf.arm.has_simd)
 #  endif
     {
@@ -210,7 +279,7 @@ static int init_functable(void) {
 #endif
     // ARM - NEON
 #ifdef ARM_NEON
-#  ifndef ARM_NOCHECK_NEON
+#  ifndef ARM_NEON_NATIVE
     if (cf.arm.has_neon)
 #  endif
     {
@@ -225,15 +294,21 @@ static int init_functable(void) {
     }
 #endif
     // ARM - CRC32
-#ifdef ARM_CRC32
-    if (cf.arm.has_crc32) {
+#if defined(ARM_CRC32) && !defined(ARM_PMULL_EOR3_NATIVE)
+#  ifndef ARM_CRC32_NATIVE
+    if (cf.arm.has_crc32)
+#  endif
+    {
         ft.crc32 = &crc32_armv8;
         ft.crc32_copy = &crc32_copy_armv8;
     }
 #endif
     // ARM - PMULL EOR3
 #ifdef ARM_PMULL_EOR3
-    if (cf.arm.has_crc32 && cf.arm.has_pmull && cf.arm.has_eor3 && cf.arm.has_fast_pmull) {
+#  ifndef ARM_PMULL_EOR3_NATIVE
+    if (cf.arm.has_crc32 && cf.arm.has_pmull && cf.arm.has_eor3 && cf.arm.has_fast_pmull)
+#  endif
+    {
         ft.crc32 = &crc32_armv8_pmull_eor3;
         ft.crc32_copy = &crc32_copy_armv8_pmull_eor3;
     }
@@ -241,7 +316,10 @@ static int init_functable(void) {
 
     // Power - VMX
 #ifdef PPC_VMX
-    if (cf.power.has_altivec) {
+#  ifndef PPC_VMX_NATIVE
+    if (cf.power.has_altivec)
+#  endif
+    {
         ft.adler32 = &adler32_vmx;
         ft.adler32_copy = &adler32_copy_vmx;
         ft.slide_hash = &slide_hash_vmx;
@@ -249,7 +327,10 @@ static int init_functable(void) {
 #endif
     // Power8 - VSX
 #ifdef POWER8_VSX
-    if (cf.power.has_arch_2_07) {
+#  ifndef POWER8_VSX_NATIVE
+    if (cf.power.has_arch_2_07)
+#  endif
+    {
         ft.adler32 = &adler32_power8;
         ft.adler32_copy = &adler32_copy_power8;
         ft.chunkmemset_safe = &chunkmemset_safe_power8;
@@ -258,14 +339,20 @@ static int init_functable(void) {
     }
 #endif
 #ifdef POWER8_VSX_CRC32
-    if (cf.power.has_arch_2_07) {
+#  ifndef POWER8_VSX_CRC32_NATIVE
+    if (cf.power.has_arch_2_07)
+#  endif
+    {
         ft.crc32 = &crc32_power8;
         ft.crc32_copy = &crc32_copy_power8;
     }
 #endif
     // Power9
 #ifdef POWER9
-    if (cf.power.has_arch_3_00) {
+#  ifndef POWER9_NATIVE
+    if (cf.power.has_arch_3_00)
+#  endif
+    {
         ft.compare256 = &compare256_power9;
         ft.longest_match = &longest_match_power9;
         ft.longest_match_slow = &longest_match_slow_power9;
@@ -275,7 +362,10 @@ static int init_functable(void) {
 
     // RISCV - RVV
 #ifdef RISCV_RVV
-    if (cf.riscv.has_rvv) {
+#  ifndef RISCV_RVV_NATIVE
+    if (cf.riscv.has_rvv)
+#  endif
+    {
         ft.adler32 = &adler32_rvv;
         ft.adler32_copy = &adler32_copy_rvv;
         ft.chunkmemset_safe = &chunkmemset_safe_rvv;
@@ -289,7 +379,10 @@ static int init_functable(void) {
 
     // RISCV - ZBC
 #ifdef RISCV_CRC32_ZBC
-    if (cf.riscv.has_zbc) {
+#  ifndef RISCV_ZBC_NATIVE
+    if (cf.riscv.has_zbc)
+#  endif
+    {
         ft.crc32 = &crc32_riscv64_zbc;
         ft.crc32_copy = &crc32_copy_riscv64_zbc;
     }
@@ -297,7 +390,10 @@ static int init_functable(void) {
 
     // S390
 #ifdef S390_CRC32_VX
-    if (cf.s390.has_vx) {
+#  ifndef S390_CRC32_VX_NATIVE
+    if (cf.s390.has_vx)
+#  endif
+    {
         ft.crc32 = &crc32_s390_vx;
         ft.crc32_copy = &crc32_copy_s390_vx;
     }
@@ -310,8 +406,11 @@ static int init_functable(void) {
         ft.crc32_copy = &crc32_copy_loongarch64;
     }
 #endif
-#ifdef LOONGARCH_LSX
-    if (cf.loongarch.has_lsx) {
+#if defined(LOONGARCH_LSX) && !defined(LOONGARCH_LASX_NATIVE)
+#  ifndef LOONGARCH_LSX_NATIVE
+    if (cf.loongarch.has_lsx)
+#  endif
+    {
         ft.adler32 = &adler32_lsx;
         ft.adler32_copy = &adler32_copy_lsx;
         ft.chunkmemset_safe = &chunkmemset_safe_lsx;
@@ -323,7 +422,10 @@ static int init_functable(void) {
     }
 #endif
 #ifdef LOONGARCH_LASX
-    if (cf.loongarch.has_lasx) {
+#  ifndef LOONGARCH_LASX_NATIVE
+    if (cf.loongarch.has_lasx)
+#  endif
+    {
         ft.adler32 = &adler32_lasx;
         ft.adler32_copy = &adler32_copy_lasx;
         ft.chunkmemset_safe = &chunkmemset_safe_lasx;

--- a/functable.c
+++ b/functable.c
@@ -117,7 +117,7 @@ static inline void init_functable_x86(struct functable_s *ft, struct cpu_feature
         ft->slide_hash = &slide_hash_sse2;
 #  endif
 #  if !defined(X86_SSE41_NATIVE) && !defined(X86_PCLMULQDQ_NATIVE)
-#    if !defined(WITHOUT_CHORBA) && !defined(WITHOUT_CHORBA_SSE)
+#    ifdef CRC32_CHORBA_SSE_FALLBACK
         ft->crc32 = &crc32_chorba_sse2;
         ft->crc32_copy = &crc32_copy_chorba_sse2;
 #    endif
@@ -145,7 +145,7 @@ static inline void init_functable_x86(struct functable_s *ft, struct cpu_feature
     if (cf->x86.has_sse41)
 #  endif
     {
-#  if !defined(WITHOUT_CHORBA) && !defined(WITHOUT_CHORBA_SSE)
+#  ifdef CRC32_CHORBA_SSE_FALLBACK
         ft->crc32 = &crc32_chorba_sse41;
         ft->crc32_copy = &crc32_copy_chorba_sse41;
 #  endif

--- a/test/benchmarks/benchmark_adler32.cc
+++ b/test/benchmarks/benchmark_adler32.cc
@@ -77,7 +77,9 @@ public:
     BENCHMARK_ADLER32_MISALIGNED(name, hashfunc, support_flag); \
     BENCHMARK_ADLER32_ALIGNED(name, hashfunc, support_flag);
 
+#ifdef ADLER32_FALLBACK
 BENCHMARK_ADLER32(c, adler32_c, 1);
+#endif
 
 #ifdef DISABLE_RUNTIME_CPU_DETECTION
 BENCHMARK_ADLER32(native, native_adler32, 1);

--- a/test/benchmarks/benchmark_adler32_copy.cc
+++ b/test/benchmarks/benchmark_adler32_copy.cc
@@ -128,7 +128,9 @@ public:
     BENCHMARK_ADLER32_COPY_ONLY(name, copyfunc, support_flag)
 #endif
 
+#ifdef ADLER32_FALLBACK
 BENCHMARK_ADLER32_COPY(c, adler32_c, adler32_copy_c, 1);
+#endif
 
 #ifdef DISABLE_RUNTIME_CPU_DETECTION
 BENCHMARK_ADLER32_COPY(native, native_adler32, native_adler32_copy, 1);

--- a/test/benchmarks/benchmark_compare256.cc
+++ b/test/benchmarks/benchmark_compare256.cc
@@ -73,7 +73,7 @@ public:
 BENCHMARK_COMPARE256(native, native_compare256, 1);
 #else
 
-#ifdef WITH_ALL_FALLBACKS
+#ifdef COMPARE256_FALLBACK
 BENCHMARK_COMPARE256(8, compare256_8, 1);
 BENCHMARK_COMPARE256(64, compare256_64, 1);
 #endif

--- a/test/benchmarks/benchmark_crc32.cc
+++ b/test/benchmarks/benchmark_crc32.cc
@@ -88,7 +88,7 @@ BENCHMARK_CRC32(chorba_c, crc32_chorba, 1);
 BENCHMARK_CRC32(native, native_crc32, 1);
 #else
 
-#if defined(CRC32_CHORBA_FALLBACK) && !defined(WITHOUT_CHORBA_SSE)
+#ifdef CRC32_CHORBA_SSE_FALLBACK
 #   ifdef X86_SSE2
     BENCHMARK_CRC32(chorba_sse2, crc32_chorba_sse2, test_cpu_features.x86.has_sse2);
 #   endif

--- a/test/benchmarks/benchmark_crc32.cc
+++ b/test/benchmarks/benchmark_crc32.cc
@@ -77,16 +77,18 @@ public:
     BENCHMARK_CRC32_MISALIGNED(name, hashfunc, support_flag); \
     BENCHMARK_CRC32_ALIGNED(name, hashfunc, support_flag);
 
+#ifdef CRC32_BRAID_FALLBACK
 BENCHMARK_CRC32(braid, crc32_braid, 1);
+#endif
+#ifdef CRC32_CHORBA_FALLBACK
+BENCHMARK_CRC32(chorba_c, crc32_chorba, 1);
+#endif
 
 #ifdef DISABLE_RUNTIME_CPU_DETECTION
 BENCHMARK_CRC32(native, native_crc32, 1);
 #else
 
-#ifndef WITHOUT_CHORBA
-BENCHMARK_CRC32(chorba_c, crc32_chorba, 1);
-#endif
-#ifndef WITHOUT_CHORBA_SSE
+#if defined(CRC32_CHORBA_FALLBACK) && !defined(WITHOUT_CHORBA_SSE)
 #   ifdef X86_SSE2
     BENCHMARK_CRC32(chorba_sse2, crc32_chorba_sse2, test_cpu_features.x86.has_sse2);
 #   endif

--- a/test/benchmarks/benchmark_crc32_copy.cc
+++ b/test/benchmarks/benchmark_crc32_copy.cc
@@ -128,17 +128,19 @@ public:
 #endif
 
 // Base test
+#ifdef CRC32_BRAID_FALLBACK
 BENCHMARK_CRC32_COPY(braid, crc32_braid, crc32_copy_braid, 1);
+#endif
+#ifdef CRC32_CHORBA_FALLBACK
+BENCHMARK_CRC32_COPY(chorba, crc32_chorba, crc32_copy_chorba, 1)
+#endif
 
 #ifdef DISABLE_RUNTIME_CPU_DETECTION
     // Native
     BENCHMARK_CRC32_COPY(native, native_crc32, native_crc32_copy, 1)
 #else
     // Optimized functions
-#  ifndef WITHOUT_CHORBA
-    BENCHMARK_CRC32_COPY(chorba, crc32_chorba, crc32_copy_chorba, 1)
-#  endif
-#  ifndef WITHOUT_CHORBA_SSE
+#  if defined(CRC32_CHORBA_FALLBACK) && !defined(WITHOUT_CHORBA_SSE)
 #    ifdef X86_SSE2
     BENCHMARK_CRC32_COPY(chorba_sse2, crc32_chorba_sse2, crc32_copy_chorba_sse2, test_cpu_features.x86.has_sse2);
 #    endif

--- a/test/benchmarks/benchmark_crc32_copy.cc
+++ b/test/benchmarks/benchmark_crc32_copy.cc
@@ -140,7 +140,7 @@ BENCHMARK_CRC32_COPY(chorba, crc32_chorba, crc32_copy_chorba, 1)
     BENCHMARK_CRC32_COPY(native, native_crc32, native_crc32_copy, 1)
 #else
     // Optimized functions
-#  if defined(CRC32_CHORBA_FALLBACK) && !defined(WITHOUT_CHORBA_SSE)
+#  ifdef CRC32_CHORBA_SSE_FALLBACK
 #    ifdef X86_SSE2
     BENCHMARK_CRC32_COPY(chorba_sse2, crc32_chorba_sse2, crc32_copy_chorba_sse2, test_cpu_features.x86.has_sse2);
 #    endif

--- a/test/benchmarks/benchmark_slidehash.cc
+++ b/test/benchmarks/benchmark_slidehash.cc
@@ -77,7 +77,7 @@ public:
     } \
     BENCHMARK_REGISTER_F(slide_hash, name)->RangeMultiplier(2)->Range(512, MAX_RANDOM_INTS);
 
-#if defined(WITH_ALL_FALLBACKS) || !(defined(__x86_64__) || defined(_M_X64))
+#ifdef SLIDE_HASH_FALLBACK
 BENCHMARK_SLIDEHASH(c, slide_hash_c, 1);
 #endif
 

--- a/test/test_adler32.cc
+++ b/test/test_adler32.cc
@@ -36,7 +36,9 @@ INSTANTIATE_TEST_SUITE_P(adler32, adler32_variant, testing::ValuesIn(hash_tests)
         hash(GetParam(), func); \
     }
 
+#ifdef ADLER32_FALLBACK
 TEST_ADLER32(c, adler32_c, 1)
+#endif
 
 #ifdef DISABLE_RUNTIME_CPU_DETECTION
 TEST_ADLER32(native, native_adler32, 1)

--- a/test/test_adler32_copy.cc
+++ b/test/test_adler32_copy.cc
@@ -40,7 +40,9 @@ INSTANTIATE_TEST_SUITE_P(adler32_copy, adler32_copy_variant, testing::ValuesIn(h
     }
 
 // Base test
+#ifdef ADLER32_FALLBACK
 TEST_ADLER32_COPY(c, adler32_copy_c, 1)
+#endif
 
 #ifdef DISABLE_RUNTIME_CPU_DETECTION
     // Native test

--- a/test/test_compare256.cc
+++ b/test/test_compare256.cc
@@ -63,7 +63,7 @@ static inline void compare256_match_check(compare256_func compare256) {
 TEST_COMPARE256(native, native_compare256, 1)
 #else
 
-#ifdef WITH_ALL_FALLBACKS
+#ifdef COMPARE256_FALLBACK
 TEST_COMPARE256(8, compare256_8, 1)
 TEST_COMPARE256(64, compare256_64, 1)
 #endif

--- a/test/test_crc32.cc
+++ b/test/test_crc32.cc
@@ -76,7 +76,12 @@ INSTANTIATE_TEST_SUITE_P(crc32, crc32_variant, testing::ValuesIn(hash_tests));
         hash(func); \
     }
 
+#ifdef CRC32_BRAID_FALLBACK
 TEST_CRC32(braid, crc32_braid, 1)
+#endif
+#ifdef CRC32_CHORBA_FALLBACK
+TEST_CRC32(chorba_c, crc32_chorba, 1)
+#endif
 
 #ifdef DISABLE_RUNTIME_CPU_DETECTION
 TEST_CRC32(native, native_crc32, 1)
@@ -98,9 +103,6 @@ static const int align_offsets[] = {
     }
 #endif
 
-#ifndef WITHOUT_CHORBA
-TEST_CRC32(chorba_c, crc32_chorba, 1)
-#endif
 #ifdef ARM_CRC32
 INSTANTIATE_TEST_SUITE_P(crc32_alignment, crc32_align, testing::ValuesIn(align_offsets));
 TEST_CRC32(armv8, crc32_armv8, test_cpu_features.arm.has_crc32)
@@ -125,7 +127,7 @@ TEST_CRC32(pclmulqdq, crc32_pclmulqdq, test_cpu_features.x86.has_pclmulqdq)
 #ifdef X86_VPCLMULQDQ_CRC
 TEST_CRC32(vpclmulqdq, crc32_vpclmulqdq, (test_cpu_features.x86.has_pclmulqdq && test_cpu_features.x86.has_avx512_common && test_cpu_features.x86.has_vpclmulqdq))
 #endif
-#ifndef WITHOUT_CHORBA_SSE
+#if defined(CRC32_CHORBA_FALLBACK) && !defined(WITHOUT_CHORBA_SSE)
 #   ifdef X86_SSE2
     TEST_CRC32(chorba_sse2, crc32_chorba_sse2, test_cpu_features.x86.has_sse2)
 #   endif

--- a/test/test_crc32.cc
+++ b/test/test_crc32.cc
@@ -127,7 +127,7 @@ TEST_CRC32(pclmulqdq, crc32_pclmulqdq, test_cpu_features.x86.has_pclmulqdq)
 #ifdef X86_VPCLMULQDQ_CRC
 TEST_CRC32(vpclmulqdq, crc32_vpclmulqdq, (test_cpu_features.x86.has_pclmulqdq && test_cpu_features.x86.has_avx512_common && test_cpu_features.x86.has_vpclmulqdq))
 #endif
-#if defined(CRC32_CHORBA_FALLBACK) && !defined(WITHOUT_CHORBA_SSE)
+#ifdef CRC32_CHORBA_SSE_FALLBACK
 #   ifdef X86_SSE2
     TEST_CRC32(chorba_sse2, crc32_chorba_sse2, test_cpu_features.x86.has_sse2)
 #   endif

--- a/test/test_crc32_copy.cc
+++ b/test/test_crc32_copy.cc
@@ -52,7 +52,7 @@ TEST_CRC32_COPY(chorba, crc32_copy_chorba, 1)
     TEST_CRC32_COPY(native, native_crc32_copy, 1)
 #else
     // Optimized functions
-#  if defined(CRC32_CHORBA_FALLBACK) && !defined(WITHOUT_CHORBA_SSE)
+#  ifdef CRC32_CHORBA_SSE_FALLBACK
 #    ifdef X86_SSE2
     TEST_CRC32_COPY(chorba_sse2, crc32_copy_chorba_sse2, test_cpu_features.x86.has_sse2)
 #    endif

--- a/test/test_crc32_copy.cc
+++ b/test/test_crc32_copy.cc
@@ -40,17 +40,19 @@ INSTANTIATE_TEST_SUITE_P(crc32_copy, crc32_copy_variant, testing::ValuesIn(hash_
     }
 
 // Base test
+#ifdef CRC32_BRAID_FALLBACK
 TEST_CRC32_COPY(braid, crc32_copy_braid, 1)
+#endif
+#ifdef CRC32_CHORBA_FALLBACK
+TEST_CRC32_COPY(chorba, crc32_copy_chorba, 1)
+#endif
 
 #ifdef DISABLE_RUNTIME_CPU_DETECTION
     // Native test
     TEST_CRC32_COPY(native, native_crc32_copy, 1)
 #else
     // Optimized functions
-#  ifndef WITHOUT_CHORBA
-    TEST_CRC32_COPY(chorba, crc32_copy_chorba, 1)
-#  endif
-#  ifndef WITHOUT_CHORBA_SSE
+#  if defined(CRC32_CHORBA_FALLBACK) && !defined(WITHOUT_CHORBA_SSE)
 #    ifdef X86_SSE2
     TEST_CRC32_COPY(chorba_sse2, crc32_copy_chorba_sse2, test_cpu_features.x86.has_sse2)
 #    endif


### PR DESCRIPTION
The main benefit of this PR is that we no longer compile in the fallbacks when there is a better native function available. This works across all platforms and is fairly easy to follow.

We also centralize all the native #ifdef logic for native detection.

And now no need for defines `ARM_NOCHECK_NEON` and `ARM_NOCHECK_SIMD`.

~~This will need a rebase after #2128.~~

~~Relevant commits for this PR are after https://github.com/zlib-ng/zlib-ng/pull/2139/commits/551083e11141f022989b3951d249f8a643527077.~~