### PR TITLE
[zconf] Fix LFS support on Windows

### DIFF
--- a/zconf-ng.h.in
+++ b/zconf-ng.h.in
@@ -132,7 +132,7 @@ typedef PTRDIFF_TYPE ptrdiff_t;
 #  undef _LARGEFILE64_SOURCE
 #endif
 
-#if defined(Z_HAVE_UNISTD_H) || defined(_LARGEFILE64_SOURCE)
+#if defined(Z_HAVE_UNISTD_H)
 #  include <unistd.h>         /* for SEEK_*, off_t, and _LFS64_LARGEFILE */
 #  ifndef z_off_t
 #    define z_off_t off_t

--- a/zconf.h.in
+++ b/zconf.h.in
@@ -160,7 +160,7 @@ typedef PTRDIFF_TYPE ptrdiff_t;
 #  undef _LARGEFILE64_SOURCE
 #endif
 
-#if defined(Z_HAVE_UNISTD_H) || defined(_LARGEFILE64_SOURCE)
+#if defined(Z_HAVE_UNISTD_H)
 #  include <unistd.h>         /* for SEEK_*, off_t, and _LFS64_LARGEFILE */
 #  ifndef z_off_t
 #    define z_off_t off_t


### PR DESCRIPTION
* Windows doesn't have unistd.h, so z_off_t declaration only can depend on value of Z_HAVE_UNISTD_H.

Fixes #2144