### PR TITLE
add workflow_dispatch to most of the workflow files

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -1,5 +1,5 @@
 name: Static Analysis
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,5 +1,5 @@
 name: CMake
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 env:
   TERM: xterm-256color
   GTEST_COLOR: 1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,6 +4,7 @@ on:
     branches: [ "develop" ]
   pull_request:
     branches: [ "develop" ]
+  workflow_dispatch:
   schedule:
     - cron: "27 17 * * 0"
 concurrency:

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -1,5 +1,5 @@
 name: Configure
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,6 +1,7 @@
 name: OSS-Fuzz
 on:
   pull_request:
+  workflow_dispatch:
   push:
     branches:
       - stable

--- a/.github/workflows/libpng.yml
+++ b/.github/workflows/libpng.yml
@@ -1,5 +1,5 @@
 name: Libpng
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/link.yml
+++ b/.github/workflows/link.yml
@@ -1,5 +1,5 @@
 name: Link
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,4 +16,4 @@ jobs:
         BASE_SHA="${{ github.event.pull_request.base.sha }}"
         BASE_SHA="${BASE_SHA:-4b825dc642cb6eb9a060e54bf8d69288fbee4904}"
         git config core.whitespace blank-at-eol
-        git diff --color --check "$BASE_SHA" -- './*' ':!*.patch
+        git diff --color --check "$BASE_SHA" -- './*' ':!*.patch'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,5 @@
 name: Lint
-on: [pull_request]
+on: [pull_request, workflow_dispatch]
 
 jobs:
   lint:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,5 +13,7 @@ jobs:
 
     - name: Whitespace errors
       run: |
+        BASE_SHA="${{ github.event.pull_request.base.sha }}"
+        BASE_SHA="${BASE_SHA:-4b825dc642cb6eb9a060e54bf8d69288fbee4904}"
         git config core.whitespace blank-at-eol
-        git diff --color --check ${{ github.event.pull_request.base.sha }} -- './*' ':!*.patch'
+        git diff --color --check "$BASE_SHA" -- './*' ':!*.patch

--- a/.github/workflows/osb.yml
+++ b/.github/workflows/osb.yml
@@ -1,5 +1,5 @@
 name: OSB
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/pigz.yml
+++ b/.github/workflows/pigz.yml
@@ -1,5 +1,5 @@
 name: Pigz
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/pkgcheck.yml
+++ b/.github/workflows/pkgcheck.yml
@@ -1,5 +1,5 @@
 name: Package Check
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Adding `workflow_dispatch`  makes it easier to test the pull-request triggered workflows before sending to zlib-ng/zlib-ng.