### PR TITLE
cmake: Fix ARCH is empty in detect-arch

### DIFF
--- a/cmake/detect-arch.cmake
+++ b/cmake/detect-arch.cmake
@@ -8,7 +8,9 @@ elseif(MSVC)
     set(ARCH ${MSVC_C_ARCHITECTURE_ID})
 elseif(EMSCRIPTEN)
     set(ARCH "wasm32")
-else()
+endif()
+
+if(NOT ARCH OR ARCH STREQUAL "")
     # Compile detect-arch.c and read the architecture name from the binary
     try_compile(
         COMPILE_RESULT


### PR DESCRIPTION
The both `CMAKE_C_COMPILER_TARGET` and `CMAKE_SYSTEM_PROCESSOR` are undefined while configuring UWP/WinRT build with Clang:
`-G Ninja -D CMAKE_SYSTEM_NAME=WindowsStore`.
These variables are undefined because `-m` is not set to Clang.

`CMAKE_C_COMPILER_ARCHITECTURE_ID` could be used, but it would cause a more significant change of the cmake script.