### PR TITLE
[CI] Retain CMake configure log if configuring fails

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -913,6 +913,7 @@ jobs:
       with:
         name: ${{ matrix.name }} (cmake)
         path: |
+          **/CMakeFiles/CMakeConfigureLog.yaml
           **/CMakeFiles/CMakeOutput.log
           **/CMakeFiles/CMakeError.log
           **/Testing/Temporary/*


### PR DESCRIPTION
* We need to add CMakeConfigureLog.yaml to build artifacts to diagnose configuration failures

See #2157 for rationale