### PR TITLE
Add MSVC support for Z_UNREACHABLE macro

### DIFF
--- a/zbuild.h
+++ b/zbuild.h
@@ -53,7 +53,11 @@
 /* Hint to compiler that a block of code is unreachable, typically in a switch default condition */
 #ifndef Z_UNREACHABLE
 #  if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
-#    define Z_UNREACHABLE() unreachable()           // C23 approach
+#    if !defined(unreachable) && defined(_MSC_VER)
+#      define Z_UNREACHABLE() __assume(0)
+#    else
+#      define Z_UNREACHABLE() unreachable()           // C23 approach
+#    endif
 #  elif (defined(__GNUC__) && (__GNUC__ >= 5)) || defined(__clang__)
 #    define Z_UNREACHABLE() __builtin_unreachable()
 #  else


### PR DESCRIPTION
Add Z_UNREACHABLE fallback for MSVC, as the C23 unreachable macro is not yet defined in the Windows SDK's <stddef.h>.
Fixes https://github.com/zlib-ng/zlib-ng/issues/2170