### PR TITLE
Optimizing slide_hash for LoongArch

### DIFF
--- a/arch/loongarch/slide_hash_lasx.c
+++ b/arch/loongarch/slide_hash_lasx.c
@@ -20,17 +20,20 @@
 
 static inline void slide_hash_chain(Pos *table, uint32_t entries, const __m256i wsize) {
     table += entries;
-    table -= 16;
+    table -= 32;
 
     do {
-        __m256i value, result;
+        __m256i value1, value2, result1, result2;
 
-        value = __lasx_xvld(table, 0);
-        result = __lasx_xvssub_hu(value, wsize);
-        __lasx_xvst(result, table, 0);
+        value1 = __lasx_xvld(table, 0);
+        value2 = __lasx_xvld(table, 32);
+        result1 = __lasx_xvssub_hu(value1, wsize);
+        result2 = __lasx_xvssub_hu(value2, wsize);
+        __lasx_xvst(result1, table, 0);
+        __lasx_xvst(result2, table, 32);
 
-        table -= 16;
-        entries -= 16;
+        table -= 32;
+        entries -= 32;
     } while (entries > 0);
 }
 

--- a/arch/loongarch/slide_hash_lsx.c
+++ b/arch/loongarch/slide_hash_lsx.c
@@ -18,24 +18,15 @@
 #include <lsxintrin.h>
 #include <assert.h>
 
-static inline void slide_hash_chain(Pos *table0, Pos *table1, uint32_t entries0,
-                                    uint32_t entries1, const __m128i wsize) {
-    uint32_t entries;
-    Pos *table;
-    __m128i value0, value1, result0, result1;
-
-    int on_chain = 0;
-
-next_chain:
-    table = (on_chain) ? table1 : table0;
-    entries = (on_chain) ? entries1 : entries0;
-
+static inline void slide_hash_chain(Pos *table, uint32_t entries, const __m128i wsize) {
     table += entries;
     table -= 16;
 
     /* ZALLOC allocates this pointer unless the user chose a custom allocator.
      * Our alloc function is aligned to 64 byte boundaries */
     do {
+        __m128i value0, value1, result0, result1;
+
         value0 = __lsx_vld(table, 0);
         value1 = __lsx_vld(table, 16);
         result0 = __lsx_vssub_hu(value0, wsize);
@@ -46,13 +37,6 @@ next_chain:
         table -= 16;
         entries -= 16;
     } while (entries > 0);
-
-    ++on_chain;
-    if (on_chain > 1) {
-        return;
-    } else {
-        goto next_chain;
-    }
 }
 
 Z_INTERNAL void slide_hash_lsx(deflate_state *s) {
@@ -63,7 +47,8 @@ Z_INTERNAL void slide_hash_lsx(deflate_state *s) {
     assert(((uintptr_t)s->head & 15) == 0);
     assert(((uintptr_t)s->prev & 15) == 0);
 
-    slide_hash_chain(s->head, s->prev, HASH_SIZE, wsize, xmm_wsize);
+    slide_hash_chain(s->head, HASH_SIZE, xmm_wsize);
+    slide_hash_chain(s->prev, wsize, xmm_wsize);
 }
 
 #endif


### PR DESCRIPTION
Like #2136

LSX: ~3,42% faster
LASX: ~5,91% faster

```
$ ./zlib-ng-develop/build/_deps/benchmark-src/tools/compare.py benchmarks ./zlib-ng-develop/build/test/benchmarks/benchmark_zlib ./zlib-ng-loongarch64-slide_hash-1/build/test/benchmarks/benchmark_zlib --benchmark_filter=slide_hash --benchmark_repetitions=1
RUNNING: ./zlib-ng-develop/build/test/benchmarks/benchmark_zlib --benchmark_filter=slide_hash --benchmark_repetitions=1 --benchmark_out=/tmp/tmpgc1jm2d4
2026-02-23T11:16:39+00:00
Running ./zlib-ng-develop/build/test/benchmarks/benchmark_zlib
Run on (8 X 2000 MHz CPU s)
CPU Caches:
  L1 Instruction 64 KiB (x8)
  L1 Data 64 KiB (x8)
  L2 Unified 256 KiB (x8)
  L3 Unified 16384 KiB (x1)
Load Average: 0.00, 0.18, 0.26
***WARNING*** ASLR is enabled, the results may have unreproducible noise in them.
----------------------------------------------------------------
Benchmark                      Time             CPU   Iterations
----------------------------------------------------------------
slide_hash/c/512           64105 ns        63981 ns        10901
slide_hash/c/1024          70123 ns        70002 ns         9994
slide_hash/c/2048          70752 ns        70620 ns         9919
slide_hash/c/4096          73325 ns        73191 ns         9559
slide_hash/c/8192          76942 ns        76785 ns         9111
slide_hash/c/16384         86199 ns        86035 ns         8132
slide_hash/c/32768        101994 ns       101835 ns         6872
slide_hash/lsx/512          5312 ns         5301 ns       138944
slide_hash/lsx/1024         5292 ns         5281 ns       131702
slide_hash/lsx/2048         5439 ns         5429 ns       131825
slide_hash/lsx/4096         5608 ns         5598 ns       121057
slide_hash/lsx/8192         5952 ns         5942 ns       122490
slide_hash/lsx/16384        6654 ns         6641 ns       109345
slide_hash/lsx/32768        8304 ns         8289 ns        82930
slide_hash/lasx/512         4019 ns         4011 ns       174431
slide_hash/lasx/1024        4051 ns         4044 ns       173240
slide_hash/lasx/2048        4119 ns         4112 ns       170518
slide_hash/lasx/4096        4241 ns         4233 ns       165304
slide_hash/lasx/8192        4492 ns         4484 ns       156275
slide_hash/lasx/16384       4982 ns         4974 ns       140847
slide_hash/lasx/32768       6026 ns         6015 ns       115994
RUNNING: ./zlib-ng-loongarch64-slide_hash-1/build/test/benchmarks/benchmark_zlib --benchmark_filter=slide_hash --benchmark_repetitions=1 --benchmark_out=/tmp/tmpwbpxzztr
2026-02-23T11:16:58+00:00
Running ./zlib-ng-loongarch64-slide_hash-1/build/test/benchmarks/benchmark_zlib
Run on (8 X 2000 MHz CPU s)
CPU Caches:
  L1 Instruction 64 KiB (x8)
  L1 Data 64 KiB (x8)
  L2 Unified 256 KiB (x8)
  L3 Unified 16384 KiB (x1)
Load Average: 0.28, 0.23, 0.28
***WARNING*** ASLR is enabled, the results may have unreproducible noise in them.
----------------------------------------------------------------
Benchmark                      Time             CPU   Iterations
----------------------------------------------------------------
slide_hash/c/512           64018 ns        63895 ns        10919
slide_hash/c/1024          70185 ns        70052 ns         9998
slide_hash/c/2048          70636 ns        70516 ns         9921
slide_hash/c/4096          73324 ns        73201 ns         9442
slide_hash/c/8192          76894 ns        76771 ns         9113
slide_hash/c/16384         86190 ns        86048 ns         8135
slide_hash/c/32768        102248 ns       102077 ns         6846
slide_hash/lsx/512          5146 ns         5138 ns       137264
slide_hash/lsx/1024         5188 ns         5180 ns       133130
slide_hash/lsx/2048         5180 ns         5171 ns       130154
slide_hash/lsx/4096         5456 ns         5446 ns       136282
slide_hash/lsx/8192         5701 ns         5690 ns       131585
slide_hash/lsx/16384        6449 ns         6438 ns       114466
slide_hash/lsx/32768        7967 ns         7955 ns        88645
slide_hash/lasx/512         3773 ns         3767 ns       185869
slide_hash/lasx/1024        3804 ns         3797 ns       184441
slide_hash/lasx/2048        3861 ns         3854 ns       181558
slide_hash/lasx/4096        4019 ns         4011 ns       174890
slide_hash/lasx/8192        4242 ns         4234 ns       164905
slide_hash/lasx/16384       4698 ns         4690 ns       148511
slide_hash/lasx/32768       5645 ns         5635 ns       123720
Comparing ./zlib-ng-develop/build/test/benchmarks/benchmark_zlib to ./zlib-ng-loongarch64-slide_hash-1/build/test/benchmarks/benchmark_zlib
Benchmark                               Time             CPU      Time Old      Time New       CPU Old       CPU New
--------------------------------------------------------------------------------------------------------------------
slide_hash/c/512                     -0.0014         -0.0013         64105         64018         63981         63895
slide_hash/c/1024                    +0.0009         +0.0007         70123         70185         70002         70052
slide_hash/c/2048                    -0.0016         -0.0015         70752         70636         70620         70516
slide_hash/c/4096                    -0.0000         +0.0001         73325         73324         73191         73201
slide_hash/c/8192                    -0.0006         -0.0002         76942         76894         76785         76771
slide_hash/c/16384                   -0.0001         +0.0002         86199         86190         86035         86048
slide_hash/c/32768                   +0.0025         +0.0024        101994        102248        101835        102077
slide_hash/lsx/512                   -0.0313         -0.0307          5312          5146          5301          5138
slide_hash/lsx/1024                  -0.0197         -0.0192          5292          5188          5281          5180
slide_hash/lsx/2048                  -0.0477         -0.0475          5439          5180          5429          5171
slide_hash/lsx/4096                  -0.0271         -0.0271          5608          5456          5598          5446
slide_hash/lsx/8192                  -0.0422         -0.0423          5952          5701          5942          5690
slide_hash/lsx/16384                 -0.0308         -0.0305          6654          6449          6641          6438
slide_hash/lsx/32768                 -0.0405         -0.0403          8304          7967          8289          7955
slide_hash/lasx/512                  -0.0612         -0.0610          4019          3773          4011          3767
slide_hash/lasx/1024                 -0.0610         -0.0611          4051          3804          4044          3797
slide_hash/lasx/2048                 -0.0629         -0.0627          4119          3861          4112          3854
slide_hash/lasx/4096                 -0.0524         -0.0523          4241          4019          4233          4011
slide_hash/lasx/8192                 -0.0558         -0.0557          4492          4242          4484          4234
slide_hash/lasx/16384                -0.0570         -0.0571          4982          4698          4974          4690
slide_hash/lasx/32768                -0.0632         -0.0632          6026          5645          6015          5635
OVERALL_GEOMEAN                      -0.0314         -0.0313             0             0             0             0
```

