### PR TITLE
Update MCST qemu-e2k

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -671,7 +671,7 @@ jobs:
 
           - name: Ubuntu LCC e2kv6
             os: ubuntu-latest
-            cmake-args: -DWITH_BENCHMARKS=OFF -DBUILD_TESTING=OFF -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-e2k-lcc.cmake -DMCST_LCC_PREFIX=/opt/mcst/lcc-1.29.12.e2k-v6.2c3.linux-6.1 -DQEMU_CPU=elbrus-v6 -DBENCHMARK_ENABLE_WERROR=OFF -DBENCHMARK_FORCE_WERROR=OFF
+            cmake-args: -DWITH_BENCHMARKS=ON -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-e2k-lcc.cmake -DMCST_LCC_PREFIX=/opt/mcst/lcc-1.29.12.e2k-v6.2c3.linux-6.1 -DQEMU_CPU=elbrus-v6 -DBENCHMARK_ENABLE_WERROR=OFF -DBENCHMARK_FORCE_WERROR=OFF
             toolchain: 1.29.12.e2k-v6.2c3.linux-6.1
             cflags: -march=elbrus-v6
             cxxflags: -march=elbrus-v6 -DBENCHMARK_HAS_NO_INLINE_ASSEMBLY
@@ -799,13 +799,13 @@ jobs:
       uses: actions/cache@v5
       with:
         path: /usr/local/bin/qemu-e2k-static
-        key: cache-qemu-e2k-static-20251226
+        key: cache-qemu-e2k-static-2026-02-24
 
     - name: Install MCST QEMU (Ubuntu)
       if: contains(matrix.name, 'e2k') && steps.cache-qemu-e2k-static.outputs.cache-hit != 'true'
       shell: bash
       run: |
-        wget -q https://dev.mcst.ru/downloads/2025-12-26/qemu-e2k-static
+        wget -q https://dev.mcst.ru/downloads/2026-02-24/qemu-e2k-static
         chmod +x qemu-e2k-static
         sudo mv qemu-e2k-static /usr/local/bin
 


### PR DESCRIPTION
- Update MCST qemu-e2k ( https://dev.mcst.ru/download/ )
- Enable benchmarks and tests on e2kv6