### PR TITLE
CI: Stop trying to use GCC on macOS

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -602,14 +602,12 @@ jobs:
             cmake-args: -DWITH_SANITIZER=Address
             codecov: macos_clang_intel_asan
 
-          - name: macOS GCC (Intel) UBSAN
+          - name: macOS Clang (Intel) UBSAN
             os: macos-15-intel
-            compiler: gcc-13
-            cxx-compiler: g++-13
+            compiler: clang
+            cxx-compiler: clang++
             cmake-args: -DWITH_SANITIZER=Undefined
-            packages: gcc@13
-            gcov-exec: gcov-13
-            codecov: macos_gcc_intel_ubsan
+            codecov: macos_clang_intel_ubsan
 
           - name: macOS Clang (Intel) Native Instructions
             os: macos-15-intel
@@ -625,14 +623,12 @@ jobs:
             cmake-args: -DWITH_SANITIZER=Address
             codecov: macos_clang_arm64
 
-          - name: macOS GCC (ARM64) UBSAN
-            os: macos-14
-            compiler: gcc-13
-            cxx-compiler: g++-13
+          - name: macOS Clang (ARM64) UBSAN
+            os: macos-latest
+            compiler: clang
+            cxx-compiler: clang++
             cmake-args: -DWITH_SANITIZER=Undefined
-            packages: gcc@13
-            gcov-exec: gcov-13
-            codecov: macos_gcc_arm64_ubsan
+            codecov: macos_clang_arm64_ubsan
 
           - name: macOS Clang (ARM64) Native Instructions
             os: macos-latest

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -173,31 +173,27 @@ jobs:
             ldflags: -static
             emu-run: node
 
-          - name: macOS GCC (Intel)
+          - name: macOS Clang (Intel)
             os: macos-15-intel
-            compiler: gcc-11
+            compiler: clang
             configure-args: --warn
-            packages: gcc@11
 
-          - name: macOS GCC (Intel) Compat No Opt
+          - name: macOS Clang (Intel) Compat No Opt
             os: macos-15-intel
-            compiler: gcc-11
+            compiler: clang
             configure-args: --warn --zlib-compat --without-optimizations --without-new-strategies
-            packages: gcc@11
 
-          - name: macOS GCC (ARM64)
+          - name: macOS Clang (ARM64)
             os: macos-latest
-            compiler: gcc-11
+            compiler: clang
             cflags: -std=gnu11
             configure-args: --warn
-            packages: gcc@11
 
-          - name: macOS GCC (ARM64) Compat No Opt
+          - name: macOS Clang (ARM64) Compat No Opt
             os: macos-latest
-            compiler: gcc-11
+            compiler: clang
             cflags: -std=gnu11
             configure-args: --warn --zlib-compat --without-optimizations --without-new-strategies
-            packages: gcc@11
 
           - name: Ubuntu GCC RISCV64
             os: ubuntu-latest


### PR DESCRIPTION
Stop trying to use GCC on macOS.
It is apparently deprecated and keeps breaking every time github actions releases new images.
Converted to use Clang instead.