### PR TITLE
Fix building with C23 support

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -712,7 +712,9 @@ unsigned long Z_EXPORT PREFIX(deflateBound)(PREFIX3(stream) *strm, unsigned long
 #endif
     default:                                /* for compiler happiness */
         Z_UNREACHABLE();
+#if !defined(__STDC_VERSION__) || __STDC_VERSION__ < 202311L
         wraplen = ZLIB_WRAPLEN;
+#endif
     }
 
     /* if not default parameters, return conservative bound */

--- a/gzread.c
+++ b/gzread.c
@@ -233,7 +233,9 @@ static int gz_fetch(gz_state *state) {
             continue;
         default:    // Can't happen
             Z_UNREACHABLE();
+#if !defined(__STDC_VERSION__) || __STDC_VERSION__ < 202311L
             return -1;
+#endif
         }
     } while (state->x.have == 0 && (!state->eof || strm->avail_in));
     return 0;


### PR DESCRIPTION
* Z_UNREACHABLE() macro can't be followed by any code in same block scope