### PR TITLE
Add NMAX_ALIGNED32 for 32-byte aligned NEON adler32

### DIFF
--- a/adler32_p.h
+++ b/adler32_p.h
@@ -11,6 +11,8 @@
 #define BASE 65521U     /* largest prime smaller than 65536 */
 #define NMAX 5552
 /* NMAX is the largest n such that 255n(n+1)/2 + (n+1)(BASE-1) <= 2^32-1 */
+#define NMAX_ALIGNED32 (NMAX & ~31)
+/* NMAX rounded down to a multiple of 32 is 5536 */
 
 #define ADLER_DO1(sum1, sum2, buf, i)  {(sum1) += buf[(i)]; (sum2) += (sum1);}
 #define ADLER_DO2(sum1, sum2, buf, i)  {ADLER_DO1(sum1, sum2, buf, i); ADLER_DO1(sum1, sum2, buf, i+1);}

--- a/arch/arm/adler32_neon.c
+++ b/arch/arm/adler32_neon.c
@@ -169,7 +169,7 @@ Z_FORCEINLINE static void NEON_accum32(uint32_t *s, const uint8_t *buf, size_t l
     int rem = len & 3;
 
     for (size_t i = 0; i < num_iter; ++i) {
-        uint8x16x4_t d0_d3 = vld1q_u8_x4_ex(buf, 128);
+        uint8x16x4_t d0_d3 = vld1q_u8_x4_ex(buf, 256);
 
         /* Unfortunately it doesn't look like there's a direct sum 8 bit to 32
          * bit instruction, we'll have to make due summing to 16 bits first */

--- a/arch/arm/adler32_neon.c
+++ b/arch/arm/adler32_neon.c
@@ -294,7 +294,7 @@ Z_FORCEINLINE static uint32_t adler32_copy_impl(uint32_t adler, uint8_t *dst, co
      * In the copying variant we use fallback to 4x loads and 4x stores,
      * as ld1x4 seems to block ILP when stores are in the mix */
     size_t align_diff = MIN(ALIGN_DIFF(src, 32), len);
-    size_t n = NMAX;
+    size_t n = NMAX_ALIGNED32;
     if (align_diff) {
         adler32_copy_align(&pair[0], dst, src, align_diff, &pair[1], 31, COPY);
 
@@ -302,7 +302,7 @@ Z_FORCEINLINE static uint32_t adler32_copy_impl(uint32_t adler, uint8_t *dst, co
             dst += align_diff;
         src += align_diff;
         len -= align_diff;
-        n -= align_diff;
+        n = ALIGN_DOWN(n - align_diff, 32);
     }
 
     while (len >= 16) {
@@ -321,7 +321,7 @@ Z_FORCEINLINE static uint32_t adler32_copy_impl(uint32_t adler, uint8_t *dst, co
         if (COPY)
             dst += k;
         len -= k;
-        n = NMAX;
+        n = NMAX_ALIGNED32;
     }
 
     /* Process tail (len < 16).  */


### PR DESCRIPTION
NMAX (5552) is not a multiple of 32, so the NEON adler32 implementation could lose 32-byte alignment of src after the first SIMD loop iteration. This adds NMAX_ALIGNED32 (NMAX rounded down to 32, yielding 5536) in adler32_p.h and uses it in the NEON adler32 loop. The first iteration's budget is also rounded down with ALIGN_DOWN after subtracting the alignment preamble bytes, ensuring k is always a multiple of 32 and src stays 32-byte aligned throughout.

Summary generated with Claude Code.