### PR TITLE
Unroll the slide hash loop similar to other ISAs

### DIFF
--- a/arch/power/slide_ppc_tpl.h
+++ b/arch/power/slide_ppc_tpl.h
@@ -12,15 +12,27 @@ static inline void slide_hash_chain(Pos *table, uint32_t entries, uint16_t wsize
     Pos *p = table;
 
     do {
-        vector unsigned short value, result;
+        /* Do the pointer arithmetic early to hopefully overlap the vector unit */
+        Pos *q = p;
+        p += 32;
+        vector unsigned short value0, value1, value2, value3;
+        vector unsigned short result0, result1, result2, result3;
 
-        value = vec_ld(0, p);
-        result = vec_subs(value, vmx_wsize);
-        vec_st(result, 0, p);
+        value0 = vec_ld(0, q);
+        value1 = vec_ld(16, q);
+        value2 = vec_ld(32, q);
+        value3 = vec_ld(48, q);
+        result0 = vec_subs(value0, vmx_wsize);
+        result1 = vec_subs(value1, vmx_wsize);
+        result2 = vec_subs(value2, vmx_wsize);
+        result3 = vec_subs(value3, vmx_wsize);
+        vec_st(result0, 0, q);
+        vec_st(result1, 16, q);
+        vec_st(result2, 32, q);
+        vec_st(result3, 48, q);
 
-        p += 8;
-        entries -= 8;
-   } while (entries > 0);
+        entries -= 32;
+   } while (entries);
 }
 
 void Z_INTERNAL SLIDE_PPC(deflate_state *s) {


### PR DESCRIPTION
We do this to backfill the pipeline a little bit better, particularly on the G5.  We also conveniently operate on an entire cacheline for this.

```
Comparing slide_hash/vmx (from ./benchmark_zlib_old) to slide_hash/vmx (from ./benchmark_zlib)
Benchmark                                                          Time             CPU      Time Old      Time New       CPU Old       CPU New
-----------------------------------------------------------------------------------------------------------------------------------------------
[slide_hash/vmx vs. slide_hash/vmx]/512_pvalue                   0.0022          0.0007      U Test, Repetitions: 40 vs 40
[slide_hash/vmx vs. slide_hash/vmx]/512_mean                    -0.0019         -0.0023          9667          9649          9667          9645
[slide_hash/vmx vs. slide_hash/vmx]/512_median                  -0.0038         -0.0038          9679          9642          9679          9642
[slide_hash/vmx vs. slide_hash/vmx]/512_stddev                  -0.7074         -0.8208            36            11            36             6
[slide_hash/vmx vs. slide_hash/vmx]/512_cv                      -0.7069         -0.8203             0             0             0             0
[slide_hash/vmx vs. slide_hash/vmx]/1024_pvalue                  0.1113          0.1049      U Test, Repetitions: 40 vs 40
[slide_hash/vmx vs. slide_hash/vmx]/1024_mean                   +0.0001         +0.0001          9727          9728          9726          9727
[slide_hash/vmx vs. slide_hash/vmx]/1024_median                 -0.0009         -0.0009          9739          9729          9738          9729
[slide_hash/vmx vs. slide_hash/vmx]/1024_stddev                 -0.8950         -0.8964            49             5            49             5
[slide_hash/vmx vs. slide_hash/vmx]/1024_cv                     -0.8950         -0.8964             0             0             0             0
[slide_hash/vmx vs. slide_hash/vmx]/2048_pvalue                  0.0525          0.0561      U Test, Repetitions: 40 vs 40
[slide_hash/vmx vs. slide_hash/vmx]/2048_mean                   -0.0008         -0.0008          9881          9873          9880          9873
[slide_hash/vmx vs. slide_hash/vmx]/2048_median                 -0.0022         -0.0021          9893          9872          9893          9872
[slide_hash/vmx vs. slide_hash/vmx]/2048_stddev                 -0.9132         -0.9142            49             4            49             4
[slide_hash/vmx vs. slide_hash/vmx]/2048_cv                     -0.9131         -0.9141             0             0             0             0
[slide_hash/vmx vs. slide_hash/vmx]/4096_pvalue                  0.0016          0.0016      U Test, Repetitions: 40 vs 40
[slide_hash/vmx vs. slide_hash/vmx]/4096_mean                   -0.0017         -0.0017         10189         10172         10188         10171
[slide_hash/vmx vs. slide_hash/vmx]/4096_median                 -0.0028         -0.0029         10202         10173         10201         10172
[slide_hash/vmx vs. slide_hash/vmx]/4096_stddev                 -0.8756         -0.8748            43             5            43             5
[slide_hash/vmx vs. slide_hash/vmx]/4096_cv                     -0.8754         -0.8746             0             0             0             0
[slide_hash/vmx vs. slide_hash/vmx]/8192_pvalue                  0.4162          0.4052      U Test, Repetitions: 40 vs 40
[slide_hash/vmx vs. slide_hash/vmx]/8192_mean                   +0.0004         +0.0004         10764         10769         10764         10769
[slide_hash/vmx vs. slide_hash/vmx]/8192_median                 +0.0008         +0.0008         10762         10771         10762         10771
[slide_hash/vmx vs. slide_hash/vmx]/8192_stddev                 -0.8232         -0.8221            32             6            32             6
[slide_hash/vmx vs. slide_hash/vmx]/8192_cv                     -0.8233         -0.8222             0             0             0             0
[slide_hash/vmx vs. slide_hash/vmx]/16384_pvalue                 0.0000          0.0000      U Test, Repetitions: 40 vs 40
[slide_hash/vmx vs. slide_hash/vmx]/16384_mean                  -0.0038         -0.0038         12005         11959         12005         11959
[slide_hash/vmx vs. slide_hash/vmx]/16384_median                -0.0033         -0.0033         12003         11964         12002         11963
[slide_hash/vmx vs. slide_hash/vmx]/16384_stddev                -0.7303         -0.7301            37            10            37            10
[slide_hash/vmx vs. slide_hash/vmx]/16384_cv                    -0.7292         -0.7291             0             0             0             0
[slide_hash/vmx vs. slide_hash/vmx]/32768_pvalue                 0.0000          0.0000      U Test, Repetitions: 40 vs 40
[slide_hash/vmx vs. slide_hash/vmx]/32768_mean                  -0.0082         -0.0082         14467         14348         14466         14347
[slide_hash/vmx vs. slide_hash/vmx]/32768_median                -0.0095         -0.0095         14491         14353         14490         14352
[slide_hash/vmx vs. slide_hash/vmx]/32768_stddev                -0.7200         -0.7211            55            15            55            15
[slide_hash/vmx vs. slide_hash/vmx]/32768_cv                    -0.7177         -0.7188             0             0             0             0
OVERALL_GEOMEAN                                                 -0.0023         -0.0023             0             0             0             0
```

The drop in variance is kind of impressive, even if everything else is nearly performance neutral.  I'm guessing maybe the branch predictor was steering performance pretty well until a misprediction whereas this is steering it down a more controlled path where each loop iteration is a single cacheline fetch.