### PR TITLE
CI: Fix coveralls uploads for retried jobs

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -1,8 +1,5 @@
 name: Static Analysis
 on: [push, pull_request, workflow_dispatch]
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
 jobs:
   static-analysis:
     name: GCC-14

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,5 +1,5 @@
 name: CMake
-on: [push, pull_request, workflow_dispatch]
+on: [workflow_call, workflow_dispatch]
 env:
   TERM: xterm-256color
   GTEST_COLOR: 1
@@ -899,13 +899,16 @@ jobs:
 
     - name: Upload job coverage report to coveralls
       uses: coverallsapp/github-action@v2
-      if: (matrix.coverage && !contains(matrix.os, 'z15') && (env.COVERALLS_REPO_TOKEN != '' || github.repository == 'zlib-ng/zlib-ng'))
+      env:
+        COVERALLS_REPO_TOKEN: "${{ secrets.COVERALLS_REPO_TOKEN }}"
+      if: |
+        matrix.codecov
+        && !contains(matrix.os, 'z15')
+        && (env.COVERALLS_REPO_TOKEN != '' || github.repository == 'zlib-ng/zlib-ng')
       with:
         file: ${{ matrix.coverage }}.xml
         flag-name: "${{ matrix.name }}-${{ github.event_name }}"
         parallel: true
-      env:
-        COVERALLS_REPO_TOKEN: "${{ secrets.COVERALLS_REPO_TOKEN }}"
 
     - name: Test benchmarks (crashtest only, no coverage data collection)
       if: contains(matrix.cmake-args, '-DWITH_BENCHMARKS=ON')
@@ -929,17 +932,3 @@ jobs:
           **/Testing/Temporary/*
           ${{ matrix.coverage }}.xml
         retention-days: 30
-
-  coverage:
-    name: Upload Coverage Reports
-    runs-on: ubuntu-latest
-    needs: cmake
-    if: cancelled() == false
-    steps:
-    - name: Upload to Coveralls - Final
-      uses: coverallsapp/github-action@v2
-      if: (env.COVERALLS_REPO_TOKEN != '' || github.repository == 'zlib-ng/zlib-ng')
-      with:
-        parallel-finished: true
-      env:
-        COVERALLS_REPO_TOKEN: "${{ secrets.COVERALLS_REPO_TOKEN }}"

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -3,10 +3,6 @@ on: [workflow_call, workflow_dispatch]
 env:
   TERM: xterm-256color
   GTEST_COLOR: 1
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  # Don't abort on push to avoid incomplete coverage uploads
-  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 jobs:
   cmake:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,9 +7,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "27 17 * * 0"
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -1,8 +1,5 @@
 name: Configure
 on: [push, pull_request, workflow_dispatch]
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
 jobs:
   configure:
     name: ${{ matrix.name }}

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -10,9 +10,6 @@ on:
       - '2.*'
     tags:
       - '*'
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
 jobs:
   fuzzing:
     name: Fuzzing

--- a/.github/workflows/libpng.yml
+++ b/.github/workflows/libpng.yml
@@ -1,8 +1,5 @@
 name: Libpng
 on: [push, pull_request, workflow_dispatch]
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
 jobs:
   libpng:
     name: Ubuntu Clang

--- a/.github/workflows/link.yml
+++ b/.github/workflows/link.yml
@@ -1,8 +1,5 @@
 name: Link
 on: [push, pull_request, workflow_dispatch]
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
 jobs:
   zlib:
     name: Link zlib

--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -1,0 +1,25 @@
+name: Orchestrator
+on: [push, pull_request]
+
+jobs:
+  cmake:
+    uses: ./.github/workflows/cmake.yml
+    secrets: inherit
+
+  pigz:
+    uses: ./.github/workflows/pigz.yml
+    secrets: inherit
+
+  # This job only starts if ALL reusable workflows above succeed
+  final-upload:
+    needs: [cmake, pigz]
+    runs-on: ubuntu-slim
+    if: success()
+    steps:
+      - name: Coveralls - Finalize
+        uses: coverallsapp/github-action@v2
+        if: (env.COVERALLS_REPO_TOKEN != '' || github.repository == 'zlib-ng/zlib-ng')
+        with:
+          parallel-finished: true
+        env:
+          COVERALLS_REPO_TOKEN: "${{ secrets.COVERALLS_REPO_TOKEN }}"

--- a/.github/workflows/osb.yml
+++ b/.github/workflows/osb.yml
@@ -1,8 +1,5 @@
 name: OSB
 on: [push, pull_request, workflow_dispatch]
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
 jobs:
   cmake:
     name: ${{ matrix.name }}

--- a/.github/workflows/pigz.yml
+++ b/.github/workflows/pigz.yml
@@ -1,5 +1,5 @@
 name: Pigz
-on: [push, pull_request, workflow_dispatch]
+on: [workflow_call, workflow_dispatch]
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -114,6 +114,18 @@ jobs:
           --gcov-executable "${{ matrix.gcov-exec || 'gcov' }}" \
           --root . \
           --xml --output ${{ matrix.coverage }}.xml
+
+    - name: Upload job coverage report to coveralls
+      uses: coverallsapp/github-action@v2
+      env:
+        COVERALLS_REPO_TOKEN: "${{ secrets.COVERALLS_REPO_TOKEN }}"
+      if: |
+        matrix.codecov
+        && (env.COVERALLS_REPO_TOKEN != '' || github.repository == 'zlib-ng/zlib-ng')
+      with:
+        file: ${{ matrix.codecov }}.xml
+        flag-name: "${{ matrix.name }}-${{ github.event_name }}"
+        parallel: true
 
     - name: Upload build errors
       uses: actions/upload-artifact@v7

--- a/.github/workflows/pigz.yml
+++ b/.github/workflows/pigz.yml
@@ -1,8 +1,5 @@
 name: Pigz
 on: [workflow_call, workflow_dispatch]
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
 jobs:
   pigz:
     name: ${{ matrix.name }}

--- a/.github/workflows/pkgcheck.yml
+++ b/.github/workflows/pkgcheck.yml
@@ -1,8 +1,5 @@
 name: Package Check
 on: [push, pull_request, workflow_dispatch]
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
 jobs:
   pkgcheck:
     name: ${{ matrix.name }}


### PR DESCRIPTION
Make sure coveralls uploads are not finalized until all jobs are successful,
as doing that blocks further uploads from retried builds.