### PR TITLE
CI: Use more threads and use ARM64 hosts for linux arm jobs

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -54,7 +54,7 @@ jobs:
         CI: true
 
     - name: Compile source code
-      run: cmake --build . -j2 --config Release > /dev/null
+      run: cmake --build . -j5 --config Release > /dev/null
 
   Clang:
     runs-on: ubuntu-latest
@@ -82,4 +82,4 @@ jobs:
     - name: Compile source code
       run: |
         scan-build --status-bugs \
-          cmake --build . -j2 --config Release > /dev/null
+          cmake --build . -j5 --config Release > /dev/null

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -334,8 +334,6 @@ jobs:
             ldflags: -static
             gcov-exec: ${{ github.repository == 'zlib-ng/zlib-ng' && 'gcov' || 's390x-linux-gnu-gcov' }}
             coverage: ${{ github.repository == 'zlib-ng/zlib-ng' && 'el10_gcc_s390x_dfltcc' || 'ubuntu_gcc_s390x_dfltcc' }}
-            # The dedicated z15 test VM has 4 cores
-            parallels-jobs: 4
 
           - name: ${{ github.repository == 'zlib-ng/zlib-ng' && 'EL10 Clang' || 'Ubuntu GCC' }} S390X DFLTCC ASAN
             os: ${{ github.repository == 'zlib-ng/zlib-ng' && 'z15' || 'ubuntu-latest' }}
@@ -348,8 +346,6 @@ jobs:
             asan-options: detect_leaks=0
             gcov-exec: ${{ github.repository == 'zlib-ng/zlib-ng' && 'llvm-cov gcov' || 's390x-linux-gnu-gcov' }}
             coverage: ${{ github.repository == 'zlib-ng/zlib-ng' && 'el10_clang_s390x_dfltcc_asan' || 'ubuntu_gcc_s390x_dfltcc_asan' }}
-            # The dedicated z15 test VM has 4 cores
-            parallels-jobs: 4
 
           - name: ${{ github.repository == 'zlib-ng/zlib-ng' && 'EL10 Clang' || 'Ubuntu GCC' }} S390X DFLTCC UBSAN
             os: ${{ github.repository == 'zlib-ng/zlib-ng' && 'z15' || 'ubuntu-latest' }}
@@ -361,8 +357,6 @@ jobs:
             packages: qemu-user gcc-s390x-linux-gnu g++-s390x-linux-gnu libc-dev-s390x-cross
             gcov-exec: ${{ github.repository == 'zlib-ng/zlib-ng' && 'llvm-cov gcov' || 's390x-linux-gnu-gcov' }}
             coverage: ${{ github.repository == 'zlib-ng/zlib-ng' && 'el10_clang_s390x_dfltcc_ubsan' || 'ubuntu_gcc_s390x_dfltcc_ubsan' }}
-            # The dedicated z15 test VM has 4 cores
-            parallels-jobs: 4
 
           - name: ${{ github.repository == 'zlib-ng/zlib-ng' && 'EL10' || 'Ubuntu' }} Clang S390X DFLTCC ${{ (github.repository == 'zlib-ng/zlib-ng' && 'MSAN') || 'Compat' }}
             os: ${{ github.repository == 'zlib-ng/zlib-ng' && 'z15' || 'ubuntu-latest' }}
@@ -372,8 +366,6 @@ jobs:
               ${{ github.repository == 'zlib-ng/zlib-ng' && '-GNinja -DWITH_SANITIZER=Memory' || '-DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-s390x.cmake -DZLIB_COMPAT=ON' }}
               -DWITH_DFLTCC_DEFLATE=ON -DWITH_DFLTCC_INFLATE=ON
             packages: qemu-user libc-dev-s390x-cross
-            # The dedicated z15 test VM has 4 cores
-            parallels-jobs: 4
             # Coverage disabled, causes MSAN errors
 
           - name: Ubuntu MinGW i686
@@ -384,7 +376,7 @@ jobs:
             gcov-exec: i686-w64-mingw32-gcov-posix
             coverage: ubuntu_gcc_mingw_i686
             # Limit parallel test jobs to prevent wine errors
-            parallels-jobs: 1
+            parallel-jobs: 1
 
           - name: Ubuntu MinGW x86_64
             os: ubuntu-latest
@@ -395,7 +387,7 @@ jobs:
             gcov-exec: x86_64-w64-mingw32-gcov-posix
             coverage: ubuntu_gcc_mingw_x86_64
              # Limit parallel test jobs to prevent wine errors
-            parallels-jobs: 1
+            parallel-jobs: 1
 
           - name: Ubuntu Clang-15
             os: ubuntu-latest
@@ -843,7 +835,7 @@ jobs:
           -DLIBCXX_INCLUDE_BENCHMARKS=OFF \
           -DLLVM_INCLUDE_TESTS=OFF \
           -DLLVM_INCLUDE_DOCS=OFF
-        cmake --build build -j3 -- cxx cxxabi
+        cmake --build build -j5 -- cxx cxxabi
         echo "LLVM_BUILD_DIR=`pwd`/build" >> $GITHUB_ENV
       env:
         CFLAGS: -O2
@@ -869,12 +861,12 @@ jobs:
         CI: true
 
     - name: Compile source code
-      run: cmake --build . --verbose -j2 --config ${{ matrix.build-config || 'Release' }}
+      run: cmake --build . --verbose -j5 --config ${{ matrix.build-config || 'Release' }}
 
     - name: Run test cases
       # Don't run tests on Windows ARM
       if: runner.os != 'Windows' || contains(matrix.name, 'ARM') == false
-      run: ctest --verbose -C Release -E benchmark_zlib --output-on-failure --max-width 120 -j ${{ matrix.parallels-jobs || '3' }}
+      run: ctest --verbose -C Release -E benchmark_zlib --output-on-failure --max-width 120 -j ${{ matrix.parallel-jobs || '5' }}
       env:
         ASAN_OPTIONS: ${{ matrix.asan-options || 'verbosity=0' }}:abort_on_error=1:halt_on_error=1
         MSAN_OPTIONS: ${{ matrix.msan-options || 'verbosity=0' }}:abort_on_error=1:halt_on_error=1
@@ -889,7 +881,7 @@ jobs:
         python3 -u -m venv ./venv
         source ./venv/${{ runner.os == 'Windows' && 'Scripts' || 'bin' }}/activate
         python3 -u -m pip install gcovr
-        python3 -m gcovr -j 3 --gcov-ignore-parse-errors --verbose \
+        python3 -m gcovr -j 5 --gcov-ignore-parse-errors --verbose \
           --exclude '(.*/|^)(_deps|benchmarks)/.*' \
           --exclude-unreachable-branches \
           --merge-mode-functions separate \
@@ -909,7 +901,7 @@ jobs:
 
     - name: Test benchmarks (crashtest only, no coverage data collection)
       if: contains(matrix.cmake-args, '-DWITH_BENCHMARKS=ON')
-      run: ctest --verbose -C Release -R ^benchmark_zlib$ --output-on-failure --max-width 120 -j ${{ matrix.parallels-jobs || '3' }}
+      run: ctest --verbose -C Release -R ^benchmark_zlib$ --output-on-failure --max-width 120 -j ${{ matrix.parallel-jobs || '5' }}
       env:
         ASAN_OPTIONS: ${{ matrix.asan-options || 'verbosity=0' }}:abort_on_error=1:halt_on_error=1
         MSAN_OPTIONS: ${{ matrix.msan-options || 'verbosity=0' }}:abort_on_error=1:halt_on_error=1

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -136,7 +136,7 @@ jobs:
             coverage: ubuntu_gcc_compat_no_opt
 
           - name: Ubuntu GCC ARM SF ASAN
-            os: ubuntu-latest
+            os: ubuntu-24.04-arm
             cmake-args: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-arm.cmake -DWITH_SANITIZER=Address
             asan-options: detect_leaks=0
             packages: qemu-user crossbuild-essential-armel
@@ -144,14 +144,14 @@ jobs:
             coverage: ubuntu_gcc_armsf
 
           - name: Ubuntu GCC ARM SF Compat No Opt UBSAN
-            os: ubuntu-latest
+            os: ubuntu-24.04-arm
             cmake-args: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-arm.cmake -DZLIB_COMPAT=ON -DWITH_NEW_STRATEGIES=OFF -DWITH_OPTIM=OFF -DWITH_SANITIZER=Undefined
             packages: qemu-user crossbuild-essential-armel
             gcov-exec: arm-linux-gnueabi-gcov
             coverage: ubuntu_gcc_armsf_compat_no_opt
 
           - name: Ubuntu GCC ARM HF ASAN
-            os: ubuntu-latest
+            os: ubuntu-24.04-arm
             cmake-args: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-armhf.cmake -DWITH_SANITIZER=Address -DWITH_BENCHMARKS=ON
             cxxflags: -Wno-psabi -Wno-maybe-uninitialized
             asan-options: detect_leaks=0
@@ -160,7 +160,7 @@ jobs:
             coverage: ubuntu_gcc_armhf
 
           - name: Ubuntu GCC ARM HF No Neon No ARMv8 ASAN
-            os: ubuntu-latest
+            os: ubuntu-24.04-arm
             cmake-args: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-armhf.cmake -DWITH_NEON=OFF -DWITH_ARMV8=OFF -DWITH_SANITIZER=Address
             asan-options: detect_leaks=0
             packages: qemu-user crossbuild-essential-armhf
@@ -168,25 +168,21 @@ jobs:
             coverage: ubuntu_gcc_armhf_no_neon_no_armv8
 
           - name: Ubuntu GCC ARM HF Compat No Opt UBSAN
-            os: ubuntu-latest
+            os: ubuntu-24.04-arm
             cmake-args: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-armhf.cmake -DZLIB_COMPAT=ON -DWITH_NEW_STRATEGIES=OFF -DWITH_OPTIM=OFF -DWITH_SANITIZER=Undefined
             packages: qemu-user crossbuild-essential-armhf
             gcov-exec: arm-linux-gnueabihf-gcov
             coverage: ubuntu_gcc_armhf_compat_no_opt
 
           - name: Ubuntu GCC AARCH64 ASAN
-            os: ubuntu-22.04
-            cmake-args: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-aarch64.cmake -DWITH_SANITIZER=Address -DWITH_BENCHMARKS=ON
+            os: ubuntu-24.04-arm
+            cmake-args: -DWITH_SANITIZER=Address -DWITH_BENCHMARKS=ON
             asan-options: detect_leaks=0
-            packages: qemu-user gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libc-dev-arm64-cross
-            gcov-exec: aarch64-linux-gnu-gcov
             coverage: ubuntu_gcc_aarch64
 
           - name: Ubuntu GCC AARCH64 Compat No Opt UBSAN
-            os: ubuntu-22.04
-            cmake-args: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-aarch64.cmake -DZLIB_COMPAT=ON -DWITH_NEW_STRATEGIES=OFF -DWITH_OPTIM=OFF -DWITH_SANITIZER=Undefined
-            packages: qemu-user gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libc-dev-arm64-cross
-            gcov-exec: aarch64-linux-gnu-gcov
+            os: ubuntu-24.04-arm
+            cmake-args: -DZLIB_COMPAT=ON -DWITH_NEW_STRATEGIES=OFF -DWITH_OPTIM=OFF -DWITH_SANITIZER=Undefined
             coverage: ubuntu_gcc_aarch64_compat_no_opt
 
           - name: Ubuntu GCC MIPS

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -34,53 +34,49 @@ jobs:
             configure-args: --warn --zlib-compat --sprefix=zTest_
 
           - name: Ubuntu GCC ARM SF
-            os: ubuntu-latest
+            os: ubuntu-24.04-arm
             compiler: arm-linux-gnueabi-gcc
             configure-args: --warn
             chost: arm-linux-gnueabi
             packages: qemu-user gcc-arm-linux-gnueabi libc-dev-armel-cross
 
           - name: Ubuntu GCC ARM SF Compat No Opt No Gzfileops
-            os: ubuntu-latest
+            os: ubuntu-24.04-arm
             compiler: arm-linux-gnueabi-gcc
             configure-args: --warn --zlib-compat --without-optimizations --without-new-strategies --without-gzfileops
             chost: arm-linux-gnueabi
             packages: qemu-user gcc-arm-linux-gnueabi libc-dev-armel-cross
 
           - name: Ubuntu GCC ARM HF
-            os: ubuntu-latest
+            os: ubuntu-24.04-arm
             compiler: arm-linux-gnueabihf-gcc
             configure-args: --warn
             chost: arm-linux-gnueabihf
             packages: qemu-user gcc-arm-linux-gnueabihf libc-dev-armel-cross
 
           - name: Ubuntu GCC ARM HF No Neon No ARMv8
-            os: ubuntu-latest
+            os: ubuntu-24.04-arm
             compiler: arm-linux-gnueabihf-gcc
             configure-args: --warn --without-neon --without-armv8
             chost: arm-linux-gnueabihf
             packages: qemu-user gcc-arm-linux-gnueabihf libc-dev-armel-cross
 
           - name: Ubuntu GCC ARM HF Compat No Opt
-            os: ubuntu-latest
+            os: ubuntu-24.04-arm
             compiler: arm-linux-gnueabihf-gcc
             configure-args: --warn --zlib-compat --without-optimizations --without-new-strategies
             chost: arm-linux-gnueabihf
             packages: qemu-user gcc-arm-linux-gnueabihf libc-dev-armel-cross
 
           - name: Ubuntu GCC AARCH64
-            os: ubuntu-latest
-            compiler: aarch64-linux-gnu-gcc
+            os: ubuntu-24.04-arm
+            compiler: gcc
             configure-args: --warn
-            chost: aarch64-linux-gnu
-            packages: qemu-user gcc-aarch64-linux-gnu libc-dev-arm64-cross
 
           - name: Ubuntu GCC AARCH64 Compat No Opt
-            os: ubuntu-latest
-            compiler: aarch64-linux-gnu-gcc
+            os: ubuntu-24.04-arm
+            compiler: gcc
             configure-args: --warn --zlib-compat --without-optimizations --without-new-strategies
-            chost: aarch64-linux-gnu
-            packages: qemu-user gcc-aarch64-linux-gnu libc-dev-arm64-cross
 
           - name: Ubuntu GCC MIPS
             os: ubuntu-latest

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -278,7 +278,7 @@ jobs:
         CI: true
 
     - name: Compile source code
-      run: make -j2
+      run: make -j5
       working-directory: ${{ matrix.build-dir }}
 
     - name: Run test cases

--- a/.github/workflows/libpng.yml
+++ b/.github/workflows/libpng.yml
@@ -26,7 +26,7 @@ jobs:
         CI: true
 
     - name: Compile source code (zlib-ng)
-      run: cmake --build . -j2 --config Release
+      run: cmake --build . -j5 --config Release
 
     - name: Checkout repository (libpng)
       uses: actions/checkout@v6
@@ -49,9 +49,9 @@ jobs:
         CI: true
 
     - name: Compile source code (libpng)
-      run: cmake --build . -j2 --config Release
+      run: cmake --build . -j5 --config Release
       working-directory: libpng
 
     - name: Run test cases (libpng)
-      run: ctest -j2 -C Release --output-on-failure --max-width 120
+      run: ctest -j5 -C Release --output-on-failure --max-width 120
       working-directory: libpng

--- a/.github/workflows/link.yml
+++ b/.github/workflows/link.yml
@@ -24,13 +24,13 @@ jobs:
       run: cmake -S zlib -B zlib/build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF
 
     - name: Compile source code (zlib)
-      run: cmake --build zlib/build -j2 --config Release
+      run: cmake --build zlib/build -j5 --config Release
 
     - name: Generate project files (native)
       run: cmake -S . -B native -DZLIB_COMPAT=OFF -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DZLIB_LIBRARIES=../zlib/build/libz.a -DZLIB_INCLUDE_DIR="../zlib/build;../zlib"
 
     - name: Compile source code (native)
-      run: cmake --build native -j2 --config Release
+      run: cmake --build native -j5 --config Release
 
     - name: Upload build errors
       uses: actions/upload-artifact@v7
@@ -55,13 +55,13 @@ jobs:
       run: cmake -S . -B compat -DZLIB_COMPAT=ON -DZLIB_ENABLE_TESTS=OFF -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DWITH_MAINTAINER_WARNINGS=ON
 
     - name: Compile source code (compat)
-      run: cmake --build compat -j2 --config Release
+      run: cmake --build compat -j5 --config Release
 
     - name: Generate project files (native)
       run: cmake -S . -B native -DZLIB_COMPAT=OFF -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DZLIB_LIBRARIES=../compat/libz.a -DZLIB_INCLUDE_DIR=../compat
 
     - name: Compile source code (native)
-      run: cmake --build native -j2 --config Release
+      run: cmake --build native -j5 --config Release
 
     - name: Upload build errors
       uses: actions/upload-artifact@v7

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6

--- a/.github/workflows/osb.yml
+++ b/.github/workflows/osb.yml
@@ -50,10 +50,10 @@ jobs:
         CI: true
 
     - name: Compile source code
-      run: cmake --build ${{ matrix.build-dir || '.' }} --verbose -j2
+      run: cmake --build ${{ matrix.build-dir || '.' }} --verbose -j5
 
     - name: Run test cases
-      run: ctest --verbose -C Release --output-on-failure --max-width 120 -j 3
+      run: ctest --verbose -C Release --output-on-failure --max-width 120 -j 5
       working-directory: ${{ matrix.build-dir || '.' }}
 
     - name: Make source tree writable

--- a/.github/workflows/pigz.yml
+++ b/.github/workflows/pigz.yml
@@ -95,18 +95,18 @@ jobs:
         CI: true
 
     - name: Compile source code
-      run: cmake --build . -j2 --config ${{ matrix.build-config || 'Release' }}
+      run: cmake --build . -j5 --config ${{ matrix.build-config || 'Release' }}
       working-directory: test/pigz
 
     - name: Run test cases
-      run: ctest --verbose -C Release --output-on-failure --max-width 120 -j ${{ matrix.parallels-jobs || '3' }}
+      run: ctest --verbose -C Release --output-on-failure --max-width 120 -j ${{ matrix.parallel-jobs || '5' }}
       working-directory: test/pigz
 
     - name: Generate coverage report
       if: matrix.coverage
       run: |
         python3 -u -m pip install gcovr
-        python3 -m gcovr -j 3 --gcov-ignore-parse-errors --verbose \
+        python3 -m gcovr -j 5 --gcov-ignore-parse-errors --verbose \
           --exclude '(.*/|^)(_deps|benchmarks)/.*' \
           --exclude-unreachable-branches \
           --merge-mode-functions separate \

--- a/.github/workflows/pigz.yml
+++ b/.github/workflows/pigz.yml
@@ -47,9 +47,7 @@ jobs:
             cmake-args: -DWITH_THREADS=OFF -DPIGZ_VERSION=v2.6
 
           - name: Ubuntu GCC AARCH64
-            os: ubuntu-latest
-            cmake-args: -DCMAKE_TOOLCHAIN_FILE=../../cmake/toolchain-aarch64.cmake
-            packages: qemu-user gcc-aarch64-linux-gnu libc-dev-arm64-cross
+            os: ubuntu-24.04-arm
             coverage: ubuntu_gcc_pigz_aarch64
 
     steps:

--- a/.github/workflows/pkgcheck.yml
+++ b/.github/workflows/pkgcheck.yml
@@ -27,7 +27,7 @@ jobs:
             ldflags: -m32
 
           - name: Ubuntu GCC ARM HF
-            os: ubuntu-latest
+            os: ubuntu-24.04-arm
             chost: arm-linux-gnueabihf
             compiler: arm-linux-gnueabihf-gcc
             cxx-compiler: arm-linux-gnueabihf-g++
@@ -35,12 +35,9 @@ jobs:
             packages: qemu-user gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf libc6-dev-armhf-cross
 
           - name: Ubuntu GCC AARCH64
-            os: ubuntu-latest
-            chost: aarch64-linux-gnu
-            compiler: aarch64-linux-gnu-gcc
-            cxx-compiler: aarch64-linux-gnu-g++
-            cmake-args: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-aarch64.cmake
-            packages: qemu-user gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libc6-dev-arm64-cross
+            os: ubuntu-24.04-arm
+            compiler: gcc
+            cxx-compiler: g++
 
           - name: Ubuntu GCC MIPS
             os: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
         CI: true
 
     - name: Compile source code
-      run: cmake --build . -j2 --config Release --target install
+      run: cmake --build . -j5 --config Release --target install
 
     - name: Package release (Windows)
       if: runner.os == 'Windows'


### PR DESCRIPTION
- Github workers have been increased from 2 to 4 cores, increase concurrency.
- Use ARM64 runners for all ARM-based builds
- Run lint in ubuntu-slim, a lightweight actions runner

Github workers have been upgraded from 2 cpus to 4 cpus, lets utilize those extra cores to speed up compilation and testing.
ARM-based runners have also been added, so lets utilize those for ARM-jobs, this avoids qemu for Aarch64 and I'd guess qemu of ARM on Aarch64 should be better than on X86-64.
Run lint in a ubuntu-slim container, this is not a full VM and only has a single core.