### PR TITLE
Make orchestrator the parent of most workflows, handle cancellations

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -1,5 +1,5 @@
 name: Static Analysis
-on: [push, pull_request, workflow_dispatch]
+on: [workflow_call, workflow_dispatch]
 jobs:
   static-analysis:
     name: GCC-14

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,12 +1,10 @@
-name: "CodeQL"
+name: CodeQL
 on:
-  push:
-    branches: [ "develop" ]
-  pull_request:
-    branches: [ "develop" ]
+  workflow_call:
   workflow_dispatch:
   schedule:
     - cron: "27 17 * * 0"
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -1,5 +1,5 @@
 name: Configure
-on: [push, pull_request, workflow_dispatch]
+on: [workflow_call, workflow_dispatch]
 jobs:
   configure:
     name: ${{ matrix.name }}

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -10,6 +10,12 @@ on:
       - '2.*'
     tags:
       - '*'
+concurrency:
+  # Group by workflow name and branch/PR to only cancel runs on the same branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Only cancels in-progress runs if the branch is not 'stable' or 'develop'
+  cancel-in-progress: ${{ !contains(fromJSON('["refs/heads/stable", "refs/heads/develop"]'), github.ref) }}
+
 jobs:
   fuzzing:
     name: Fuzzing

--- a/.github/workflows/libpng.yml
+++ b/.github/workflows/libpng.yml
@@ -1,5 +1,5 @@
 name: Libpng
-on: [push, pull_request, workflow_dispatch]
+on: [workflow_call, workflow_dispatch]
 jobs:
   libpng:
     name: Ubuntu Clang

--- a/.github/workflows/link.yml
+++ b/.github/workflows/link.yml
@@ -1,5 +1,5 @@
 name: Link
-on: [push, pull_request, workflow_dispatch]
+on: [workflow_call, workflow_dispatch]
 jobs:
   zlib:
     name: Link zlib

--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -1,16 +1,60 @@
 name: Orchestrator
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
+concurrency:
+  # Group by workflow name and branch/PR to only cancel runs on the same branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Only cancels in-progress runs if the branch is not 'stable' or 'develop'
+  cancel-in-progress: ${{ !contains(fromJSON('["refs/heads/stable", "refs/heads/develop"]'), github.ref) }}
 
 jobs:
+  # Workflows not handled here: fuzz, lint, release
+
+  analyze:
+    name: Static Analysis
+    uses: ./.github/workflows/analyze.yml
+    secrets: inherit
+
   cmake:
+    name: CMake
     uses: ./.github/workflows/cmake.yml
     secrets: inherit
 
+  codeql:
+    name: CodeQL
+    uses: ./.github/workflows/codeql.yml
+    secrets: inherit
+
+  configure:
+    name: Configure
+    uses: ./.github/workflows/configure.yml
+    secrets: inherit
+
+  libpng:
+    name: Libpng
+    uses: ./.github/workflows/libpng.yml
+    secrets: inherit
+
+  link:
+    name: Link
+    uses: ./.github/workflows/link.yml
+    secrets: inherit
+
+  osb:
+    name: OSB
+    uses: ./.github/workflows/osb.yml
+    secrets: inherit
+
   pigz:
+    name: Pigz
     uses: ./.github/workflows/pigz.yml
     secrets: inherit
 
-  # This job only starts if ALL reusable workflows above succeed
+  pkgcheck:
+    name: Package Check
+    uses: ./.github/workflows/pkgcheck.yml
+    secrets: inherit
+
+  # This job only starts if both cmake and pigz workflows above succeed
   final-upload:
     needs: [cmake, pigz]
     runs-on: ubuntu-slim

--- a/.github/workflows/osb.yml
+++ b/.github/workflows/osb.yml
@@ -1,5 +1,5 @@
 name: OSB
-on: [push, pull_request, workflow_dispatch]
+on: [workflow_call, workflow_dispatch]
 jobs:
   cmake:
     name: ${{ matrix.name }}

--- a/.github/workflows/pkgcheck.yml
+++ b/.github/workflows/pkgcheck.yml
@@ -1,5 +1,5 @@
 name: Package Check
-on: [push, pull_request, workflow_dispatch]
+on: [workflow_call, workflow_dispatch]
 jobs:
   pkgcheck:
     name: ${{ matrix.name }}


### PR DESCRIPTION
Make orchestrator the parent of most workflows, and let it handle
all automatic cancellations of workflows when new commits are pushed.