### PR TITLE
Fix incorrect sanitizer cflag ordering and S390x fallback compiler

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -350,14 +350,14 @@ jobs:
             gcov-exec: ${{ github.repository == 'zlib-ng/zlib-ng' && 'llvm-cov gcov' || 's390x-linux-gnu-gcov' }}
             coverage: ${{ github.repository == 'zlib-ng/zlib-ng' && 'el10_clang_s390x_dfltcc_ubsan' || 'ubuntu_gcc_s390x_dfltcc_ubsan' }}
 
-          - name: ${{ github.repository == 'zlib-ng/zlib-ng' && 'EL10' || 'Ubuntu' }} Clang S390X DFLTCC ${{ (github.repository == 'zlib-ng/zlib-ng' && 'MSAN') || 'Compat' }}
+          - name: ${{ github.repository == 'zlib-ng/zlib-ng' && 'EL10 Clang' || 'Ubuntu GCC' }} S390X DFLTCC ${{ (github.repository == 'zlib-ng/zlib-ng' && 'MSAN') || 'Compat' }}
             os: ${{ github.repository == 'zlib-ng/zlib-ng' && 'z15' || 'ubuntu-latest' }}
-            compiler: clang
-            cxx-compiler: clang++
+            compiler: ${{ github.repository == 'zlib-ng/zlib-ng' && 'clang' || 'gcc' }}
+            cxx-compiler: ${{ github.repository == 'zlib-ng/zlib-ng' && 'clang++' || 'g++' }}
             cmake-args: >-
               ${{ github.repository == 'zlib-ng/zlib-ng' && '-GNinja -DWITH_SANITIZER=Memory' || '-DCMAKE_TOOLCHAIN_FILE=cmake/toolchain-s390x.cmake -DZLIB_COMPAT=ON' }}
               -DWITH_DFLTCC_DEFLATE=ON -DWITH_DFLTCC_INFLATE=ON
-            packages: qemu-user libc-dev-s390x-cross
+            packages: qemu-user gcc-s390x-linux-gnu g++-s390x-linux-gnu libc-dev-s390x-cross
             # Coverage disabled, causes MSAN errors
 
           - name: Ubuntu MinGW i686

--- a/cmake/detect-coverage.cmake
+++ b/cmake/detect-coverage.cmake
@@ -44,7 +44,7 @@ macro(add_code_coverage)
     # Set optimization level to zero for code coverage builds
     if (WITH_CODE_COVERAGE)
         # Use CMake compiler flag variables due to add_compile_options failure on Windows GCC
-        set(CMAKE_C_FLAGS "-O0 ${CMAKE_C_FLAGS}")
-        set(CMAKE_CXX_FLAGS "-O0 ${CMAKE_CXX_FLAGS}")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0")
     endif()
 endmacro()


### PR DESCRIPTION
- Fix incorrect order of compiler flags when using sanitizers
- The S390x HW runner has Clang available, but the qemu fallback used in other repos uses a toolchain specifying gcc, therefore make sure we only install and use gcc instead.

@phprus Are you able to test this? I can't test that this fixes things for the out-of-home-repo fallbacks.

Fixes on of two problems in #2201