### PR TITLE
Clean up dead assignments in insert_match

### DIFF
--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -57,8 +57,6 @@ static void insert_match(deflate_state *s, struct match match) {
                 } else {
                     insert_string(s, match.strstart, match.orgstart - match.strstart + 1);
                 }
-                match.strstart += match.match_length;
-                match.match_length = 0;
             }
         }
         return;
@@ -80,11 +78,8 @@ static void insert_match(deflate_state *s, struct match match) {
         } else if (match.orgstart < match.strstart + match.match_length) {
             insert_string(s, match.orgstart, match.strstart + match.match_length - match.orgstart);
         }
-        match.strstart += match.match_length;
-        match.match_length = 0;
     } else {
         match.strstart += match.match_length;
-        match.match_length = 0;
 
         if (match.strstart >= (STD_MIN_MATCH - 2))
             quick_insert_string(s, match.strstart + 2 - STD_MIN_MATCH);


### PR DESCRIPTION
When 56d3d985 was reverted in b85cfdf9, it restored dead stores to `match.strstart` and `match.match_length` in `insert_match()` that have no effect since `match` is passed by value. The compiler already eliminated them via dead store elimination, verified by comparing assembly output before and after. This removes them from source to keep the code consistent with what the compiler actually emits.

Summary generated with Claude Code.