### PR TITLE
[CI] Fix lint when using workflow_dispatch.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,4 +16,4 @@ jobs:
         BASE_SHA="${{ github.event.pull_request.base.sha }}"
         BASE_SHA="${BASE_SHA:-4b825dc642cb6eb9a060e54bf8d69288fbee4904}"
         git config core.whitespace blank-at-eol
-        git diff --color --check "$BASE_SHA" -- './*' ':!*.patch'
+        git diff --color --check "$BASE_SHA" -- './*' ':!*.patch' ':!*.pdf' ':!/test/data/'

--- a/test/abi/ignore
+++ b/test/abi/ignore
@@ -9,4 +9,3 @@
 # Size varies with version number
 [suppress_variable]
   name_regexp = z(|ng|libng)_(|v)string
-


### PR DESCRIPTION
* PDF files are binary files, so white-space is expected
* Remove trailing empty line from test/abi/ignore
* ignore all files in test/data, including test/data/lcet10.txt as it is expected to contain trailing white-space