### PR TITLE
Expand codeql testing

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,8 +7,8 @@ on:
 
 jobs:
   analyze:
-    name: Analyze
-    runs-on: ubuntu-latest
+    name: CodeQL (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     permissions:
       actions: read
       contents: read
@@ -17,7 +17,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ cpp ]
+        # https://codeql.github.com/docs/codeql-overview/system-requirements/
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - macos-26-intel
 
     steps:
       - name: Checkout
@@ -28,13 +32,22 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
-          languages: ${{ matrix.language }}
+          languages: cpp
           queries: +security-and-quality
 
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+      - name: Build default config
+        shell: bash
+        run: |
+          cmake -B build-default -S .
+          cmake --build build-default -j4
+
+      - name: Build compat config without optim/strategies, with reduced mem
+        shell: bash
+        run: |
+          cmake -B build-compat -S . -DZLIB_COMPAT=ON -DWITH_NEW_STRATEGIES=OFF -DWITH_OPTIM=OFF -DWITH_REDUCED_MEM=ON
+          cmake --build build-compat -j4
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
         with:
-          category: "/language:${{ matrix.language }}"
+          category: "/oss:${{ matrix.os }}"


### PR DESCRIPTION
Expand codeql testing to run on multiple platforms and two configs.
Different configs and platforms expose different defines, macros and source files, improving test coverage.