### PR TITLE
Optimize deflate_medium

### DIFF
--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -122,24 +122,17 @@ Z_FORCEINLINE static struct match find_best_match(deflate_state *s, uint32_t has
     return m;
 }
 
+/* fizzle_matches assumes:
+ * - current->match_length > 1
+ * - (current->match_length - 1) <= next->match_start
+ * - (current->match_length - 1) <= next->strstart
+ */
 static void fizzle_matches(deflate_state *s, struct match *current, struct match *next) {
-    unsigned char *window;
+    unsigned char *window = s->window;
     unsigned char *match, *orig;
     struct match c, n;
     int changed = 0;
     Pos limit;
-    /* step zero: sanity checks */
-
-    if (current->match_length <= 1)
-        return;
-
-    if (UNLIKELY(current->match_length > 1 + next->match_start))
-        return;
-
-    if (UNLIKELY(current->match_length > 1 + next->strstart))
-        return;
-
-    window = s->window;
 
     match = window - current->match_length + 1 + next->match_start;
     orig  = window - current->match_length + 1 + next->strstart;
@@ -176,10 +169,7 @@ static void fizzle_matches(deflate_state *s, struct match *current, struct match
         changed++;
     }
 
-    if (!changed)
-        return;
-
-    if (c.match_length <= 1 && n.match_length != 2) {
+    if (changed && c.match_length <= 1 && n.match_length != 2) {
         n.orgstart++;
         *current = c;
         *next = n;
@@ -241,8 +231,14 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
             hash_head = quick_insert_string(s, s->strstart);
 
             next_match = find_best_match(s, hash_head);
-            if (next_match.match_length >= WANT_MIN_MATCH)
+
+            uint32_t tmp_cmatch_len_sub = current_match.match_length - 1;
+            if (tmp_cmatch_len_sub
+                     && next_match.match_length >= WANT_MIN_MATCH
+                     && tmp_cmatch_len_sub <= next_match.match_start
+                     && tmp_cmatch_len_sub <= next_match.strstart) {
                 fizzle_matches(s, &current_match, &next_match);
+            }
 
             s->strstart = current_match.strstart;
         } else {

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -22,23 +22,24 @@ struct match {
 
 static int emit_match(deflate_state *s, struct match match) {
     int bflush = 0;
+    uint32_t match_len = match.match_length;
+
+    /* None of the below functions care about s->lookahead, so decrement it early */
+    s->lookahead -= match_len;
 
     /* matches that are not long enough we need to emit as literals */
-    if (match.match_length < WANT_MIN_MATCH) {
-        while (match.match_length) {
+    if (match_len < WANT_MIN_MATCH) {
+        while (match_len) {
             bflush += zng_tr_tally_lit(s, s->window[match.strstart]);
-            s->lookahead--;
+            match_len--;
             match.strstart++;
-            match.match_length--;
         }
         return bflush;
     }
 
-    check_match(s, match.strstart, match.match_start, match.match_length);
+    check_match(s, match.strstart, match.match_start, match_len);
 
-    bflush += zng_tr_tally_dist(s, match.strstart - match.match_start, match.match_length - STD_MIN_MATCH);
-
-    s->lookahead -= match.match_length;
+    bflush += zng_tr_tally_dist(s, match.strstart - match.match_start, match_len - STD_MIN_MATCH);
     return bflush;
 }
 

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -43,20 +43,21 @@ static int emit_match(deflate_state *s, struct match match) {
     return bflush;
 }
 
+/* insert_match assumes: s->lookahead > match.match_length + WANT_MIN_MATCH */
 static void insert_match(deflate_state *s, struct match match) {
-    if (UNLIKELY(s->lookahead <= (unsigned int)(match.match_length + WANT_MIN_MATCH)))
-        return;
+    uint32_t match_len = match.match_length;
+    uint32_t strstart = match.strstart;
 
     /* matches that are not long enough we need to emit as literals */
-    if (LIKELY(match.match_length < WANT_MIN_MATCH)) {
-        match.strstart++;
-        match.match_length--;
-        if (UNLIKELY(match.match_length > 0)) {
-            if (match.strstart >= match.orgstart) {
-                if (match.strstart + match.match_length - 1 >= match.orgstart) {
-                    insert_string(s, match.strstart, match.match_length);
+    if (LIKELY(match_len < WANT_MIN_MATCH)) {
+        strstart++;
+        match_len--;
+        if (UNLIKELY(match_len > 0)) {
+            if (strstart >= match.orgstart) {
+                if (strstart + match_len - 1 >= match.orgstart) {
+                    insert_string(s, strstart, match_len);
                 } else {
-                    insert_string(s, match.strstart, match.orgstart - match.strstart + 1);
+                    insert_string(s, strstart, match.orgstart - strstart + 1);
                 }
             }
         }
@@ -66,24 +67,24 @@ static void insert_match(deflate_state *s, struct match match) {
     /* Insert new strings in the hash table only if the match length
      * is not too large. This saves time but degrades compression.
      */
-    if (match.match_length <= 16 * s->max_insert_length && s->lookahead >= WANT_MIN_MATCH) {
-        match.match_length--; /* string at strstart already in table */
-        match.strstart++;
+    if (match_len <= 16 * s->max_insert_length && s->lookahead >= WANT_MIN_MATCH) {
+        match_len--; /* string at strstart already in table */
+        strstart++;
 
-        if (LIKELY(match.strstart >= match.orgstart)) {
-            if (LIKELY(match.strstart + match.match_length - 1 >= match.orgstart)) {
-                insert_string(s, match.strstart, match.match_length);
+        if (LIKELY(strstart >= match.orgstart)) {
+            if (LIKELY(strstart + match_len - 1 >= match.orgstart)) {
+                insert_string(s, strstart, match_len);
             } else {
-                insert_string(s, match.strstart, match.orgstart - match.strstart + 1);
+                insert_string(s, strstart, match.orgstart - strstart + 1);
             }
-        } else if (match.orgstart < match.strstart + match.match_length) {
-            insert_string(s, match.orgstart, match.strstart + match.match_length - match.orgstart);
+        } else if (match.orgstart < strstart + match_len) {
+            insert_string(s, match.orgstart, strstart + match_len - match.orgstart);
         }
     } else {
-        match.strstart += match.match_length;
+        strstart += match_len;
 
-        if (match.strstart >= (STD_MIN_MATCH - 2))
-            quick_insert_string(s, match.strstart + 2 - STD_MIN_MATCH);
+        if (strstart >= (STD_MIN_MATCH - 2))
+            quick_insert_string(s, strstart + 2 - STD_MIN_MATCH);
 
         /* If lookahead < WANT_MIN_MATCH, ins_h is garbage, but it does not
          * matter since it will be recomputed at next deflate call.
@@ -231,7 +232,8 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
             current_match = find_best_match(s, hash_head);
         }
 
-        insert_match(s, current_match);
+        if (LIKELY(s->lookahead > (unsigned int)(current_match.match_length + WANT_MIN_MATCH)))
+            insert_match(s, current_match);
 
         /* now, look ahead one */
         if (LIKELY(!early_exit && s->lookahead > MIN_LOOKAHEAD && (uint32_t)(current_match.strstart + current_match.match_length) < (s->window_size - MIN_LOOKAHEAD))) {

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -82,9 +82,7 @@ static void insert_match(deflate_state *s, struct match match) {
         }
     } else {
         strstart += match_len;
-
-        if (strstart >= (STD_MIN_MATCH - 2))
-            quick_insert_string(s, strstart + 2 - STD_MIN_MATCH);
+        quick_insert_string(s, strstart + 2 - STD_MIN_MATCH);
 
         /* If lookahead < WANT_MIN_MATCH, ins_h is garbage, but it does not
          * matter since it will be recomputed at next deflate call.


### PR DESCRIPTION
- emit_match()
  - Add local variable match_len in emit_match to avoid extra lookups from struct.
  - Move s->lookahead decrement to top of function, both branches of the function does it and they don't care when it is done.
- insert_match():
  - Add local variables match_len and strstart in insert_match, to avoid extra lookups from struct.
  - Move check for enough lookahead outside of function, can avoid function call instead of calling and immediately returning.
- Avoid calling fizzle_matches unless checks pass.
- Remove check that is always true (even if WANT_MIN_MATCH was reduced from 4 to 3).

PS: Easiest reviewed commit by commit.