### PR TITLE
Replace python3 with python in GitHub Actions workflows

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -908,10 +908,10 @@ jobs:
       if: matrix.coverage
       shell: bash
       run: |
-        python3 -u -m venv ./venv
+        python -u -m venv ./venv
         source ./venv/${{ runner.os == 'Windows' && 'Scripts' || 'bin' }}/activate
-        python3 -u -m pip install gcovr
-        python3 -m gcovr -j 5 --gcov-ignore-parse-errors --verbose \
+        python -u -m pip install gcovr
+        python -m gcovr -j 5 --gcov-ignore-parse-errors --verbose \
           --exclude '(.*/|^)(_deps|benchmarks)/.*' \
           --exclude-unreachable-branches \
           --merge-mode-functions separate \

--- a/.github/workflows/pigz.yml
+++ b/.github/workflows/pigz.yml
@@ -99,9 +99,10 @@ jobs:
 
     - name: Generate coverage report
       if: matrix.coverage
+      shell: bash
       run: |
-        python3 -u -m pip install gcovr
-        python3 -m gcovr -j 5 --gcov-ignore-parse-errors --verbose \
+        python -u -m pip install gcovr
+        python -m gcovr -j 5 --gcov-ignore-parse-errors --verbose \
           --exclude '(.*/|^)(_deps|benchmarks)/.*' \
           --exclude-unreachable-branches \
           --merge-mode-functions separate \


### PR DESCRIPTION
Using python command prevents it from using a different python installation that may exist on the machine. setup-python should redirect python command for us.