### PR TITLE
Use `__attribute__((constructor))` to initialize the functable

### DIFF
--- a/functable.c
+++ b/functable.c
@@ -472,6 +472,12 @@ static int init_functable(void) {
     return Z_OK;
 }
 
+#if !defined(_WIN32) && (defined(__GNUC__) || defined(__clang__))
+static void __attribute__((constructor)) functable_constructor(void) {
+    FUNCTABLE_INIT_ABORT;
+}
+#endif
+
 /* stub functions */
 static int force_init_stub(void) {
     return init_functable();


### PR DESCRIPTION
As i see the ClickHouse developers are concerned that the current functable pointers initialize may not be thread-safe and leads to TSAN errors (atomic read functions are not used). They are adding a patch that uses `__attribute__((constructor))` to initialize functable.

https://github.com/ClickHouse/zlib-ng/pull/18
https://github.com/ClickHouse/zlib-ng/commit/a2fbeffdc30a8b0ce6d54ee31208e2688eac4c9f

This is false positive TSAN error, but I propose adding early functable initialization to zlib-ng if the compiler supports `__attribute__((constructor))`.
