### PR TITLE
Cleanup crc32 chorba

### DIFF
--- a/arch/generic/crc32_chorba_c.c
+++ b/arch/generic/crc32_chorba_c.c
@@ -464,7 +464,6 @@ Z_INTERNAL uint32_t crc32_chorba_118960_nondestructive(uint32_t crc, const uint8
         next3_64 = out3;
         next4_64 = out4;
         next5_64 = out5;
-
     }
 
     memcpy(final, input_qwords + (i / sizeof(uint64_t)), len-i);

--- a/arch/generic/crc32_chorba_c.c
+++ b/arch/generic/crc32_chorba_c.c
@@ -20,6 +20,14 @@
     typedef uint64_t uint64a_t;
 #endif
 
+#define NEXT_ROUND(invec, a, b, c, d) \
+    do { \
+        a = ((invec) << 17) ^ ((invec) << 55); \
+        b = ((invec) >> 47) ^ ((invec) >> 9) ^ ((invec) << 19); \
+        c = ((invec) >> 45) ^ ((invec) << 44); \
+        d = (invec) >> 20; \
+    } while (0)
+
 /**
  * Implements the Chorba algorithm for CRC32 computation (https://arxiv.org/abs/2412.16398).
  *
@@ -428,30 +436,18 @@ Z_INTERNAL uint32_t crc32_chorba_118960_nondestructive(uint32_t crc, const uint8
         in1 = Z_U64_FROM_LE(in1) ^ next1_64;
         in2 = Z_U64_FROM_LE(in2) ^ next2_64;
 
-        a1 = (in1 << 17) ^ (in1 << 55);
-        a2 = (in1 >> 47) ^ (in1 >> 9) ^ (in1 << 19);
-        a3 = (in1 >> 45) ^ (in1 << 44);
-        a4 = (in1 >> 20);
+        NEXT_ROUND(in1, a1, a2, a3, a4);
 
-        b1 = (in2 << 17) ^ (in2 << 55);
-        b2 = (in2 >> 47) ^ (in2 >> 9) ^ (in2 << 19);
-        b3 = (in2 >> 45) ^ (in2 << 44);
-        b4 = (in2 >> 20);
+        NEXT_ROUND(in2, b1, b2, b3, b4);
 
         in3 = input_qwords[i / sizeof(uint64_t) + 2] ^ bitbuffer_qwords[(i / sizeof(uint64_t) + 2) % bitbuffer_size_qwords];
         in4 = input_qwords[i / sizeof(uint64_t) + 3] ^ bitbuffer_qwords[(i / sizeof(uint64_t) + 3) % bitbuffer_size_qwords];
         in3 = Z_U64_FROM_LE(in3) ^ next3_64 ^ a1;
         in4 = Z_U64_FROM_LE(in4) ^ next4_64 ^ a2 ^ b1;
 
-        c1 = (in3 << 17) ^ (in3 << 55);
-        c2 = (in3 >> 47) ^ (in3 >> 9) ^ (in3 << 19);
-        c3 = (in3 >> 45) ^ (in3 << 44);
-        c4 = (in3 >> 20);
+        NEXT_ROUND(in3, c1, c2, c3, c4);
 
-        d1 = (in4 << 17) ^ (in4 << 55);
-        d2 = (in4 >> 47) ^ (in4 >> 9) ^ (in4 << 19);
-        d3 = (in4 >> 45) ^ (in4 << 44);
-        d4 = (in4 >> 20);
+        NEXT_ROUND(in4, d1, d2, d3, d4);
 
         out1 = a3 ^ b2 ^ c1;
         out2 = a4 ^ b3 ^ c2 ^ d1;
@@ -580,30 +576,18 @@ Z_INTERNAL uint32_t crc32_chorba_32768_nondestructive(uint32_t crc, const uint8_
         in1 = Z_U64_FROM_LE(in1) ^ next1_64;
         in2 = Z_U64_FROM_LE(in2) ^ next2_64;
 
-        a1 = (in1 << 17) ^ (in1 << 55);
-        a2 = (in1 >> 47) ^ (in1 >> 9) ^ (in1 << 19);
-        a3 = (in1 >> 45) ^ (in1 << 44);
-        a4 = (in1 >> 20);
+        NEXT_ROUND(in1, a1, a2, a3, a4);
 
-        b1 = (in2 << 17) ^ (in2 << 55);
-        b2 = (in2 >> 47) ^ (in2 >> 9) ^ (in2 << 19);
-        b3 = (in2 >> 45) ^ (in2 << 44);
-        b4 = (in2 >> 20);
+        NEXT_ROUND(in2, b1, b2, b3, b4);
 
         in3 = input[(i + 16) / sizeof(uint64_t)] ^ bitbuffer[(i / sizeof(uint64_t) + 2)];
         in4 = input[(i + 24) / sizeof(uint64_t)] ^ bitbuffer[(i / sizeof(uint64_t) + 3)];
         in3 = Z_U64_FROM_LE(in3) ^ next3_64 ^ a1;
         in4 = Z_U64_FROM_LE(in4) ^ next4_64 ^ a2 ^ b1;
 
-        c1 = (in3 << 17) ^ (in3 << 55);
-        c2 = (in3 >> 47) ^ (in3 >> 9) ^ (in3 << 19);
-        c3 = (in3 >> 45) ^ (in3 << 44);
-        c4 = (in3 >> 20);
+        NEXT_ROUND(in3, c1, c2, c3, c4);
 
-        d1 = (in4 << 17) ^ (in4 << 55);
-        d2 = (in4 >> 47) ^ (in4 >> 9) ^ (in4 << 19);
-        d3 = (in4 >> 45) ^ (in4 << 44);
-        d4 = (in4 >> 20);
+        NEXT_ROUND(in4, d1, d2, d3, d4);
 
         out1 = a3 ^ b2 ^ c1;
         out2 = a4 ^ b3 ^ c2 ^ d1;
@@ -681,28 +665,16 @@ Z_INTERNAL uint32_t crc32_chorba_small_nondestructive(uint32_t crc, const uint8_
         in1 = Z_U64_FROM_LE(input[i / sizeof(uint64_t)]) ^ chorba3;
         in2 = Z_U64_FROM_LE(input[i / sizeof(uint64_t) + 1]) ^ chorba4 ^ chorba1;
 
-        a1 = (in1 << 17) ^ (in1 << 55);
-        a2 = (in1 >> 47) ^ (in1 >> 9) ^ (in1 << 19);
-        a3 = (in1 >> 45) ^ (in1 << 44);
-        a4 = (in1 >> 20);
+        NEXT_ROUND(in1, a1, a2, a3, a4);
 
-        b1 = (in2 << 17) ^ (in2 << 55);
-        b2 = (in2 >> 47) ^ (in2 >> 9) ^ (in2 << 19);
-        b3 = (in2 >> 45) ^ (in2 << 44);
-        b4 = (in2 >> 20);
+        NEXT_ROUND(in2, b1, b2, b3, b4);
 
         in3 = Z_U64_FROM_LE(input[i / sizeof(uint64_t) + 2]) ^ a1 ^ chorba5 ^ chorba2 ^ chorba1;
         in4 = Z_U64_FROM_LE(input[i / sizeof(uint64_t) + 3]) ^ a2 ^ b1 ^ chorba6 ^ chorba3 ^ chorba2;
 
-        c1 = (in3 << 17) ^ (in3 << 55);
-        c2 = (in3 >> 47) ^ (in3 >> 9) ^ (in3 << 19);
-        c3 = (in3 >> 45) ^ (in3 << 44);
-        c4 = (in3 >> 20);
+        NEXT_ROUND(in3, c1, c2, c3, c4);
 
-        d1 = (in4 << 17) ^ (in4 << 55);
-        d2 = (in4 >> 47) ^ (in4 >> 9) ^ (in4 << 19);
-        d3 = (in4 >> 45) ^ (in4 << 44);
-        d4 = (in4 >> 20);
+        NEXT_ROUND(in4, d1, d2, d3, d4);
 
         out1 = a3 ^ b2 ^ c1;
         out2 = a4 ^ b3 ^ c2 ^ d1;
@@ -722,28 +694,16 @@ Z_INTERNAL uint32_t crc32_chorba_small_nondestructive(uint32_t crc, const uint8_
         in1 = Z_U64_FROM_LE(input[i / sizeof(uint64_t)]) ^ next1 ^ chorba7 ^ chorba4 ^ chorba3;
         in2 = Z_U64_FROM_LE(input[i / sizeof(uint64_t) + 1]) ^ next2 ^ chorba8 ^ chorba5 ^ chorba4;
 
-        a1 = (in1 << 17) ^ (in1 << 55);
-        a2 = (in1 >> 47) ^ (in1 >> 9) ^ (in1 << 19);
-        a3 = (in1 >> 45) ^ (in1 << 44);
-        a4 = (in1 >> 20);
+        NEXT_ROUND(in1, a1, a2, a3, a4);
 
-        b1 = (in2 << 17) ^ (in2 << 55);
-        b2 = (in2 >> 47) ^ (in2 >> 9) ^ (in2 << 19);
-        b3 = (in2 >> 45) ^ (in2 << 44);
-        b4 = (in2 >> 20);
+        NEXT_ROUND(in2, b1, b2, b3, b4);
 
         in3 = Z_U64_FROM_LE(input[i / sizeof(uint64_t) + 2]) ^ next3 ^ a1 ^ chorba6 ^ chorba5;
         in4 = Z_U64_FROM_LE(input[i / sizeof(uint64_t) + 3]) ^ next4 ^ a2 ^ b1 ^ chorba7 ^ chorba6;
 
-        c1 = (in3 << 17) ^ (in3 << 55);
-        c2 = (in3 >> 47) ^ (in3 >> 9) ^ (in3 << 19);
-        c3 = (in3 >> 45) ^ (in3 << 44);
-        c4 = (in3 >> 20);
+        NEXT_ROUND(in3, c1, c2, c3, c4);
 
-        d1 = (in4 << 17) ^ (in4 << 55);
-        d2 = (in4 >> 47) ^ (in4 >> 9) ^ (in4 << 19);
-        d3 = (in4 >> 45) ^ (in4 << 44);
-        d4 = (in4 >> 20);
+        NEXT_ROUND(in4, d1, d2, d3, d4);
 
         out1 = a3 ^ b2 ^ c1;
         out2 = a4 ^ b3 ^ c2 ^ d1;
@@ -763,28 +723,16 @@ Z_INTERNAL uint32_t crc32_chorba_small_nondestructive(uint32_t crc, const uint8_
         in1 = Z_U64_FROM_LE(input[i / sizeof(uint64_t)]) ^ next1 ^ chorba8 ^ chorba7 ^ chorba1;
         in2 = Z_U64_FROM_LE(input[i / sizeof(uint64_t) + 1]) ^ next2 ^ chorba8 ^ chorba2;
 
-        a1 = (in1 << 17) ^ (in1 << 55);
-        a2 = (in1 >> 47) ^ (in1 >> 9) ^ (in1 << 19);
-        a3 = (in1 >> 45) ^ (in1 << 44);
-        a4 = (in1 >> 20);
+        NEXT_ROUND(in1, a1, a2, a3, a4);
 
-        b1 = (in2 << 17) ^ (in2 << 55);
-        b2 = (in2 >> 47) ^ (in2 >> 9) ^ (in2 << 19);
-        b3 = (in2 >> 45) ^ (in2 << 44);
-        b4 = (in2 >> 20);
+        NEXT_ROUND(in2, b1, b2, b3, b4);
 
         in3 = Z_U64_FROM_LE(input[i / sizeof(uint64_t) + 2]) ^ next3 ^ a1 ^ chorba3;
         in4 = Z_U64_FROM_LE(input[i / sizeof(uint64_t) + 3]) ^ next4 ^ a2 ^ b1 ^ chorba4;
 
-        c1 = (in3 << 17) ^ (in3 << 55);
-        c2 = (in3 >> 47) ^ (in3 >> 9) ^ (in3 << 19);
-        c3 = (in3 >> 45) ^ (in3 << 44);
-        c4 = (in3 >> 20);
+        NEXT_ROUND(in3, c1, c2, c3, c4);
 
-        d1 = (in4 << 17) ^ (in4 << 55);
-        d2 = (in4 >> 47) ^ (in4 >> 9) ^ (in4 << 19);
-        d3 = (in4 >> 45) ^ (in4 << 44);
-        d4 = (in4 >> 20);
+        NEXT_ROUND(in4, d1, d2, d3, d4);
 
         out1 = a3 ^ b2 ^ c1;
         out2 = a4 ^ b3 ^ c2 ^ d1;
@@ -804,28 +752,16 @@ Z_INTERNAL uint32_t crc32_chorba_small_nondestructive(uint32_t crc, const uint8_
         in1 = Z_U64_FROM_LE(input[i / sizeof(uint64_t)]) ^ next1 ^ chorba5 ^ chorba1;
         in2 = Z_U64_FROM_LE(input[i / sizeof(uint64_t) + 1]) ^ next2 ^ chorba6 ^ chorba2 ^ chorba1;
 
-        a1 = (in1 << 17) ^ (in1 << 55);
-        a2 = (in1 >> 47) ^ (in1 >> 9) ^ (in1 << 19);
-        a3 = (in1 >> 45) ^ (in1 << 44);
-        a4 = (in1 >> 20);
+        NEXT_ROUND(in1, a1, a2, a3, a4);
 
-        b1 = (in2 << 17) ^ (in2 << 55);
-        b2 = (in2 >> 47) ^ (in2 >> 9) ^ (in2 << 19);
-        b3 = (in2 >> 45) ^ (in2 << 44);
-        b4 = (in2 >> 20);
+        NEXT_ROUND(in2, b1, b2, b3, b4);
 
         in3 = Z_U64_FROM_LE(input[i / sizeof(uint64_t) + 2]) ^ next3 ^ a1 ^ chorba7 ^ chorba3 ^ chorba2 ^ chorba1;
         in4 = Z_U64_FROM_LE(input[i / sizeof(uint64_t) + 3]) ^ next4 ^ a2 ^ b1 ^ chorba8 ^ chorba4 ^ chorba3 ^ chorba2;
 
-        c1 = (in3 << 17) ^ (in3 << 55);
-        c2 = (in3 >> 47) ^ (in3 >> 9) ^ (in3 << 19);
-        c3 = (in3 >> 45) ^ (in3 << 44);
-        c4 = (in3 >> 20);
+        NEXT_ROUND(in3, c1, c2, c3, c4);
 
-        d1 = (in4 << 17) ^ (in4 << 55);
-        d2 = (in4 >> 47) ^ (in4 >> 9) ^ (in4 << 19);
-        d3 = (in4 >> 45) ^ (in4 << 44);
-        d4 = (in4 >> 20);
+        NEXT_ROUND(in4, d1, d2, d3, d4);
 
         out1 = a3 ^ b2 ^ c1;
         out2 = a4 ^ b3 ^ c2 ^ d1;
@@ -845,28 +781,16 @@ Z_INTERNAL uint32_t crc32_chorba_small_nondestructive(uint32_t crc, const uint8_
         in1 = Z_U64_FROM_LE(input[i / sizeof(uint64_t)]) ^ next1 ^ chorba5 ^ chorba4 ^ chorba3 ^ chorba1;
         in2 = Z_U64_FROM_LE(input[i / sizeof(uint64_t) + 1]) ^ next2 ^ chorba6 ^ chorba5 ^ chorba4 ^ chorba1 ^ chorba2;
 
-        a1 = (in1 << 17) ^ (in1 << 55);
-        a2 = (in1 >> 47) ^ (in1 >> 9) ^ (in1 << 19);
-        a3 = (in1 >> 45) ^ (in1 << 44);
-        a4 = (in1 >> 20);
+        NEXT_ROUND(in1, a1, a2, a3, a4);
 
-        b1 = (in2 << 17) ^ (in2 << 55);
-        b2 = (in2 >> 47) ^ (in2 >> 9) ^ (in2 << 19);
-        b3 = (in2 >> 45) ^ (in2 << 44);
-        b4 = (in2 >> 20);
+        NEXT_ROUND(in2, b1, b2, b3, b4);
 
         in3 = Z_U64_FROM_LE(input[i / sizeof(uint64_t) + 2]) ^ next3 ^ a1 ^ chorba7 ^ chorba6 ^ chorba5 ^ chorba2 ^ chorba3;
         in4 = Z_U64_FROM_LE(input[i / sizeof(uint64_t) + 3]) ^ next4 ^ a2 ^ b1 ^ chorba8 ^ chorba7 ^ chorba6 ^ chorba3 ^ chorba4 ^ chorba1;
 
-        c1 = (in3 << 17) ^ (in3 << 55);
-        c2 = (in3 >> 47) ^ (in3 >> 9) ^ (in3 << 19);
-        c3 = (in3 >> 45) ^ (in3 << 44);
-        c4 = (in3 >> 20);
+        NEXT_ROUND(in3, c1, c2, c3, c4);
 
-        d1 = (in4 << 17) ^ (in4 << 55);
-        d2 = (in4 >> 47) ^ (in4 >> 9) ^ (in4 << 19);
-        d3 = (in4 >> 45) ^ (in4 << 44);
-        d4 = (in4 >> 20);
+        NEXT_ROUND(in4, d1, d2, d3, d4);
 
         out1 = a3 ^ b2 ^ c1;
         out2 = a4 ^ b3 ^ c2 ^ d1;
@@ -886,28 +810,16 @@ Z_INTERNAL uint32_t crc32_chorba_small_nondestructive(uint32_t crc, const uint8_
         in1 = Z_U64_FROM_LE(input[i / sizeof(uint64_t)]) ^ next1 ^ chorba8 ^ chorba7 ^ chorba4 ^ chorba5 ^ chorba2 ^ chorba1;
         in2 = Z_U64_FROM_LE(input[i / sizeof(uint64_t) + 1]) ^ next2 ^ chorba8 ^ chorba5 ^ chorba6 ^ chorba3 ^ chorba2;
 
-        a1 = (in1 << 17) ^ (in1 << 55);
-        a2 = (in1 >> 47) ^ (in1 >> 9) ^ (in1 << 19);
-        a3 = (in1 >> 45) ^ (in1 << 44);
-        a4 = (in1 >> 20);
+        NEXT_ROUND(in1, a1, a2, a3, a4);
 
-        b1 = (in2 << 17) ^ (in2 << 55);
-        b2 = (in2 >> 47) ^ (in2 >> 9) ^ (in2 << 19);
-        b3 = (in2 >> 45) ^ (in2 << 44);
-        b4 = (in2 >> 20);
+        NEXT_ROUND(in2, b1, b2, b3, b4);
 
         in3 = Z_U64_FROM_LE(input[i / sizeof(uint64_t) + 2]) ^ next3 ^ a1 ^ chorba7 ^ chorba6 ^ chorba4 ^ chorba3 ^ chorba1;
         in4 = Z_U64_FROM_LE(input[i / sizeof(uint64_t) + 3]) ^ next4 ^ a2 ^ b1 ^ chorba8 ^ chorba7 ^ chorba5 ^ chorba4 ^ chorba2 ^ chorba1;
 
-        c1 = (in3 << 17) ^ (in3 << 55);
-        c2 = (in3 >> 47) ^ (in3 >> 9) ^ (in3 << 19);
-        c3 = (in3 >> 45) ^ (in3 << 44);
-        c4 = (in3 >> 20);
+        NEXT_ROUND(in3, c1, c2, c3, c4);
 
-        d1 = (in4 << 17) ^ (in4 << 55);
-        d2 = (in4 >> 47) ^ (in4 >> 9) ^ (in4 << 19);
-        d3 = (in4 >> 45) ^ (in4 << 44);
-        d4 = (in4 >> 20);
+        NEXT_ROUND(in4, d1, d2, d3, d4);
 
         out1 = a3 ^ b2 ^ c1;
         out2 = a4 ^ b3 ^ c2 ^ d1;
@@ -927,28 +839,16 @@ Z_INTERNAL uint32_t crc32_chorba_small_nondestructive(uint32_t crc, const uint8_
         in1 = Z_U64_FROM_LE(input[i / sizeof(uint64_t)]) ^ next1 ^ chorba8 ^ chorba6 ^ chorba5 ^ chorba3 ^ chorba2 ^ chorba1;
         in2 = Z_U64_FROM_LE(input[i / sizeof(uint64_t) + 1]) ^ next2 ^ chorba7 ^ chorba6 ^ chorba4 ^ chorba3 ^ chorba2;
 
-        a1 = (in1 << 17) ^ (in1 << 55);
-        a2 = (in1 >> 47) ^ (in1 >> 9) ^ (in1 << 19);
-        a3 = (in1 >> 45) ^ (in1 << 44);
-        a4 = (in1 >> 20);
+        NEXT_ROUND(in1, a1, a2, a3, a4);
 
-        b1 = (in2 << 17) ^ (in2 << 55);
-        b2 = (in2 >> 47) ^ (in2 >> 9) ^ (in2 << 19);
-        b3 = (in2 >> 45) ^ (in2 << 44);
-        b4 = (in2 >> 20);
+        NEXT_ROUND(in2, b1, b2, b3, b4);
 
         in3 = Z_U64_FROM_LE(input[i / sizeof(uint64_t) + 2]) ^ next3 ^ a1 ^ chorba8 ^ chorba7 ^ chorba5 ^ chorba4 ^ chorba3;
         in4 = Z_U64_FROM_LE(input[i / sizeof(uint64_t) + 3]) ^ next4 ^ a2 ^ b1 ^ chorba8 ^ chorba6 ^ chorba5 ^ chorba4;
 
-        c1 = (in3 << 17) ^ (in3 << 55);
-        c2 = (in3 >> 47) ^ (in3 >> 9) ^ (in3 << 19);
-        c3 = (in3 >> 45) ^ (in3 << 44);
-        c4 = (in3 >> 20);
+        NEXT_ROUND(in3, c1, c2, c3, c4);
 
-        d1 = (in4 << 17) ^ (in4 << 55);
-        d2 = (in4 >> 47) ^ (in4 >> 9) ^ (in4 << 19);
-        d3 = (in4 >> 45) ^ (in4 << 44);
-        d4 = (in4 >> 20);
+        NEXT_ROUND(in4, d1, d2, d3, d4);
 
         out1 = a3 ^ b2 ^ c1;
         out2 = a4 ^ b3 ^ c2 ^ d1;
@@ -968,28 +868,16 @@ Z_INTERNAL uint32_t crc32_chorba_small_nondestructive(uint32_t crc, const uint8_
         in1 = Z_U64_FROM_LE(input[i / sizeof(uint64_t)]) ^ next1 ^ chorba7 ^ chorba6 ^ chorba5;
         in2 = Z_U64_FROM_LE(input[i / sizeof(uint64_t) + 1]) ^ next2 ^ chorba8 ^ chorba7 ^ chorba6;
 
-        a1 = (in1 << 17) ^ (in1 << 55);
-        a2 = (in1 >> 47) ^ (in1 >> 9) ^ (in1 << 19);
-        a3 = (in1 >> 45) ^ (in1 << 44);
-        a4 = (in1 >> 20);
+        NEXT_ROUND(in1, a1, a2, a3, a4);
 
-        b1 = (in2 << 17) ^ (in2 << 55);
-        b2 = (in2 >> 47) ^ (in2 >> 9) ^ (in2 << 19);
-        b3 = (in2 >> 45) ^ (in2 << 44);
-        b4 = (in2 >> 20);
+        NEXT_ROUND(in2, b1, b2, b3, b4);
 
         in3 = Z_U64_FROM_LE(input[i / sizeof(uint64_t) + 2]) ^ next3 ^ a1 ^ chorba8 ^ chorba7;
         in4 = Z_U64_FROM_LE(input[i / sizeof(uint64_t) + 3]) ^ next4 ^ a2 ^ b1 ^ chorba8;
 
-        c1 = (in3 << 17) ^ (in3 << 55);
-        c2 = (in3 >> 47) ^ (in3 >> 9) ^ (in3 << 19);
-        c3 = (in3 >> 45) ^ (in3 << 44);
-        c4 = (in3 >> 20);
+        NEXT_ROUND(in3, c1, c2, c3, c4);
 
-        d1 = (in4 << 17) ^ (in4 << 55);
-        d2 = (in4 >> 47) ^ (in4 >> 9) ^ (in4 << 19);
-        d3 = (in4 >> 45) ^ (in4 << 44);
-        d4 = (in4 >> 20);
+        NEXT_ROUND(in4, d1, d2, d3, d4);
 
         out1 = a3 ^ b2 ^ c1;
         out2 = a4 ^ b3 ^ c2 ^ d1;
@@ -1023,28 +911,16 @@ Z_INTERNAL uint32_t crc32_chorba_small_nondestructive(uint32_t crc, const uint8_
         in1 = Z_U64_FROM_LE(input[i / sizeof(uint64_t)]) ^ next1;
         in2 = Z_U64_FROM_LE(input[i / sizeof(uint64_t) + 1]) ^ next2;
 
-        a1 = (in1 << 17) ^ (in1 << 55);
-        a2 = (in1 >> 47) ^ (in1 >> 9) ^ (in1 << 19);
-        a3 = (in1 >> 45) ^ (in1 << 44);
-        a4 = (in1 >> 20);
+        NEXT_ROUND(in1, a1, a2, a3, a4);
 
-        b1 = (in2 << 17) ^ (in2 << 55);
-        b2 = (in2 >> 47) ^ (in2 >> 9) ^ (in2 << 19);
-        b3 = (in2 >> 45) ^ (in2 << 44);
-        b4 = (in2 >> 20);
+        NEXT_ROUND(in2, b1, b2, b3, b4);
 
         in3 = Z_U64_FROM_LE(input[i / sizeof(uint64_t) + 2]) ^ next3 ^ a1;
         in4 = Z_U64_FROM_LE(input[i / sizeof(uint64_t) + 3]) ^ next4 ^ a2 ^ b1;
 
-        c1 = (in3 << 17) ^ (in3 << 55);
-        c2 = (in3 >> 47) ^ (in3 >> 9) ^ (in3 << 19);
-        c3 = (in3 >> 45) ^ (in3 << 44);
-        c4 = (in3 >> 20);
+        NEXT_ROUND(in3, c1, c2, c3, c4);
 
-        d1 = (in4 << 17) ^ (in4 << 55);
-        d2 = (in4 >> 47) ^ (in4 >> 9) ^ (in4 << 19);
-        d3 = (in4 >> 45) ^ (in4 << 44);
-        d4 = (in4 >> 20);
+        NEXT_ROUND(in4, d1, d2, d3, d4);
 
         out1 = a3 ^ b2 ^ c1;
         out2 = a4 ^ b3 ^ c2 ^ d1;

--- a/arch/generic/crc32_chorba_c.c
+++ b/arch/generic/crc32_chorba_c.c
@@ -28,6 +28,15 @@
         d = (invec) >> 20; \
     } while (0)
 
+#define ACCUM_ROUND(n1, n2, n3, n4, n5) \
+    do { \
+        n1 = n5 ^ (a3 ^ b2 ^ c1); \
+        n2 = a4 ^ b3 ^ c2 ^ d1; \
+        n3 = b4 ^ c3 ^ d2; \
+        n4 = c4 ^ d3; \
+        n5 = d4; \
+    } while (0)
+
 /**
  * Implements the Chorba algorithm for CRC32 computation (https://arxiv.org/abs/2412.16398).
  *
@@ -425,11 +434,6 @@ Z_INTERNAL uint32_t crc32_chorba_118960_nondestructive(uint32_t crc, const uint8
         uint64_t c1, c2, c3, c4;
         uint64_t d1, d2, d3, d4;
 
-        uint64_t out1;
-        uint64_t out2;
-        uint64_t out3;
-        uint64_t out4;
-        uint64_t out5;
 
         in1 = input_qwords[i / sizeof(uint64_t)] ^ bitbuffer_qwords[(i / sizeof(uint64_t)) % bitbuffer_size_qwords];
         in2 = input_qwords[i / sizeof(uint64_t) + 1] ^ bitbuffer_qwords[(i / sizeof(uint64_t) + 1) % bitbuffer_size_qwords];
@@ -449,17 +453,7 @@ Z_INTERNAL uint32_t crc32_chorba_118960_nondestructive(uint32_t crc, const uint8
 
         NEXT_ROUND(in4, d1, d2, d3, d4);
 
-        out1 = a3 ^ b2 ^ c1;
-        out2 = a4 ^ b3 ^ c2 ^ d1;
-        out3 = b4 ^ c3 ^ d2;
-        out4 = c4 ^ d3;
-        out5 = d4;
-
-        next1_64 = next5_64 ^ out1;
-        next2_64 = out2;
-        next3_64 = out3;
-        next4_64 = out4;
-        next5_64 = out5;
+        ACCUM_ROUND(next1_64, next2_64, next3_64, next4_64, next5_64);
     }
 
     memcpy(final, input_qwords + (i / sizeof(uint64_t)), len-i);
@@ -565,11 +559,6 @@ Z_INTERNAL uint32_t crc32_chorba_32768_nondestructive(uint32_t crc, const uint8_
         uint64_t c1, c2, c3, c4;
         uint64_t d1, d2, d3, d4;
 
-        uint64_t out1;
-        uint64_t out2;
-        uint64_t out3;
-        uint64_t out4;
-        uint64_t out5;
 
         in1 = input[i / sizeof(uint64_t)] ^ bitbuffer[(i / sizeof(uint64_t))];
         in2 = input[(i + 8) / sizeof(uint64_t)] ^ bitbuffer[(i / sizeof(uint64_t) + 1)];
@@ -589,17 +578,7 @@ Z_INTERNAL uint32_t crc32_chorba_32768_nondestructive(uint32_t crc, const uint8_
 
         NEXT_ROUND(in4, d1, d2, d3, d4);
 
-        out1 = a3 ^ b2 ^ c1;
-        out2 = a4 ^ b3 ^ c2 ^ d1;
-        out3 = b4 ^ c3 ^ d2;
-        out4 = c4 ^ d3;
-        out5 = d4;
-
-        next1_64 = next5_64 ^ out1;
-        next2_64 = out2;
-        next3_64 = out3;
-        next4_64 = out4;
-        next5_64 = out5;
+        ACCUM_ROUND(next1_64, next2_64, next3_64, next4_64, next5_64);
 
     }
 
@@ -644,11 +623,6 @@ Z_INTERNAL uint32_t crc32_chorba_small_nondestructive(uint32_t crc, const uint8_
         uint64_t c1, c2, c3, c4;
         uint64_t d1, d2, d3, d4;
 
-        uint64_t out1;
-        uint64_t out2;
-        uint64_t out3;
-        uint64_t out4;
-        uint64_t out5;
 
         uint64_t chorba1 = Z_U64_FROM_LE(input[i / sizeof(uint64_t)]) ^ next1;
         uint64_t chorba2 = Z_U64_FROM_LE(input[i / sizeof(uint64_t) + 1]) ^ next2;
@@ -676,17 +650,10 @@ Z_INTERNAL uint32_t crc32_chorba_small_nondestructive(uint32_t crc, const uint8_
 
         NEXT_ROUND(in4, d1, d2, d3, d4);
 
-        out1 = a3 ^ b2 ^ c1;
-        out2 = a4 ^ b3 ^ c2 ^ d1;
-        out3 = b4 ^ c3 ^ d2;
-        out4 = c4 ^ d3;
-        out5 = d4;
-
-        next1 = out1;
-        next2 = out2;
-        next3 = out3;
-        next4 = out4;
-        next5 = out5;
+        /* chorba5 already consumed next5, clear it so ACCUM_ROUND
+           does not xor the stale value into next1 */
+        next5 = 0;
+        ACCUM_ROUND(next1, next2, next3, next4, next5);
 
         i += 32;
 
@@ -705,17 +672,7 @@ Z_INTERNAL uint32_t crc32_chorba_small_nondestructive(uint32_t crc, const uint8_
 
         NEXT_ROUND(in4, d1, d2, d3, d4);
 
-        out1 = a3 ^ b2 ^ c1;
-        out2 = a4 ^ b3 ^ c2 ^ d1;
-        out3 = b4 ^ c3 ^ d2;
-        out4 = c4 ^ d3;
-        out5 = d4;
-
-        next1 = next5 ^ out1;
-        next2 = out2;
-        next3 = out3;
-        next4 = out4;
-        next5 = out5;
+        ACCUM_ROUND(next1, next2, next3, next4, next5);
 
         i += 32;
 
@@ -734,17 +691,7 @@ Z_INTERNAL uint32_t crc32_chorba_small_nondestructive(uint32_t crc, const uint8_
 
         NEXT_ROUND(in4, d1, d2, d3, d4);
 
-        out1 = a3 ^ b2 ^ c1;
-        out2 = a4 ^ b3 ^ c2 ^ d1;
-        out3 = b4 ^ c3 ^ d2;
-        out4 = c4 ^ d3;
-        out5 = d4;
-
-        next1 = next5 ^ out1;
-        next2 = out2;
-        next3 = out3;
-        next4 = out4;
-        next5 = out5;
+        ACCUM_ROUND(next1, next2, next3, next4, next5);
 
         i += 32;
 
@@ -763,17 +710,7 @@ Z_INTERNAL uint32_t crc32_chorba_small_nondestructive(uint32_t crc, const uint8_
 
         NEXT_ROUND(in4, d1, d2, d3, d4);
 
-        out1 = a3 ^ b2 ^ c1;
-        out2 = a4 ^ b3 ^ c2 ^ d1;
-        out3 = b4 ^ c3 ^ d2;
-        out4 = c4 ^ d3;
-        out5 = d4;
-
-        next1 = next5 ^ out1;
-        next2 = out2;
-        next3 = out3;
-        next4 = out4;
-        next5 = out5;
+        ACCUM_ROUND(next1, next2, next3, next4, next5);
 
         i += 32;
 
@@ -792,17 +729,7 @@ Z_INTERNAL uint32_t crc32_chorba_small_nondestructive(uint32_t crc, const uint8_
 
         NEXT_ROUND(in4, d1, d2, d3, d4);
 
-        out1 = a3 ^ b2 ^ c1;
-        out2 = a4 ^ b3 ^ c2 ^ d1;
-        out3 = b4 ^ c3 ^ d2;
-        out4 = c4 ^ d3;
-        out5 = d4;
-
-        next1 = next5 ^ out1;
-        next2 = out2;
-        next3 = out3;
-        next4 = out4;
-        next5 = out5;
+        ACCUM_ROUND(next1, next2, next3, next4, next5);
 
         i += 32;
 
@@ -821,17 +748,7 @@ Z_INTERNAL uint32_t crc32_chorba_small_nondestructive(uint32_t crc, const uint8_
 
         NEXT_ROUND(in4, d1, d2, d3, d4);
 
-        out1 = a3 ^ b2 ^ c1;
-        out2 = a4 ^ b3 ^ c2 ^ d1;
-        out3 = b4 ^ c3 ^ d2;
-        out4 = c4 ^ d3;
-        out5 = d4;
-
-        next1 = next5 ^ out1;
-        next2 = out2;
-        next3 = out3;
-        next4 = out4;
-        next5 = out5;
+        ACCUM_ROUND(next1, next2, next3, next4, next5);
 
         i += 32;
 
@@ -850,17 +767,7 @@ Z_INTERNAL uint32_t crc32_chorba_small_nondestructive(uint32_t crc, const uint8_
 
         NEXT_ROUND(in4, d1, d2, d3, d4);
 
-        out1 = a3 ^ b2 ^ c1;
-        out2 = a4 ^ b3 ^ c2 ^ d1;
-        out3 = b4 ^ c3 ^ d2;
-        out4 = c4 ^ d3;
-        out5 = d4;
-
-        next1 = next5 ^ out1;
-        next2 = out2;
-        next3 = out3;
-        next4 = out4;
-        next5 = out5;
+        ACCUM_ROUND(next1, next2, next3, next4, next5);
 
         i += 32;
 
@@ -879,17 +786,7 @@ Z_INTERNAL uint32_t crc32_chorba_small_nondestructive(uint32_t crc, const uint8_
 
         NEXT_ROUND(in4, d1, d2, d3, d4);
 
-        out1 = a3 ^ b2 ^ c1;
-        out2 = a4 ^ b3 ^ c2 ^ d1;
-        out3 = b4 ^ c3 ^ d2;
-        out4 = c4 ^ d3;
-        out5 = d4;
-
-        next1 = next5 ^ out1;
-        next2 = out2;
-        next3 = out3;
-        next4 = out4;
-        next5 = out5;
+        ACCUM_ROUND(next1, next2, next3, next4, next5);
     }
 
     for (; (i + 40 + 32) < len; i += 32) {
@@ -902,11 +799,6 @@ Z_INTERNAL uint32_t crc32_chorba_small_nondestructive(uint32_t crc, const uint8_
         uint64_t c1, c2, c3, c4;
         uint64_t d1, d2, d3, d4;
 
-        uint64_t out1;
-        uint64_t out2;
-        uint64_t out3;
-        uint64_t out4;
-        uint64_t out5;
 
         in1 = Z_U64_FROM_LE(input[i / sizeof(uint64_t)]) ^ next1;
         in2 = Z_U64_FROM_LE(input[i / sizeof(uint64_t) + 1]) ^ next2;
@@ -922,17 +814,7 @@ Z_INTERNAL uint32_t crc32_chorba_small_nondestructive(uint32_t crc, const uint8_
 
         NEXT_ROUND(in4, d1, d2, d3, d4);
 
-        out1 = a3 ^ b2 ^ c1;
-        out2 = a4 ^ b3 ^ c2 ^ d1;
-        out3 = b4 ^ c3 ^ d2;
-        out4 = c4 ^ d3;
-        out5 = d4;
-
-        next1 = next5 ^ out1;
-        next2 = out2;
-        next3 = out3;
-        next4 = out4;
-        next5 = out5;
+        ACCUM_ROUND(next1, next2, next3, next4, next5);
     }
 
     memcpy(final, input+(i / sizeof(uint64_t)), len-i);

--- a/arch/x86/crc32_chorba_sse2.c
+++ b/arch/x86/crc32_chorba_sse2.c
@@ -8,17 +8,19 @@
 #include "arch/x86/x86_intrins.h"
 #include "arch_functions.h"
 
-#define READ_NEXT(in, off, a, b) do { \
+#define READ_NEXT(in, off, a, b) \
+    do { \
         a = _mm_load_si128((__m128i*)(in + off / sizeof(uint64_t))); \
         b = _mm_load_si128((__m128i*)(in + off / sizeof(uint64_t) + 2)); \
-        } while (0);
+    } while (0);
 
-#define NEXT_ROUND(invec, a, b, c, d) do { \
+#define NEXT_ROUND(invec, a, b, c, d) \
+    do { \
         a = _mm_xor_si128(_mm_slli_epi64(invec, 17), _mm_slli_epi64(invec, 55)); \
         b = _mm_xor_si128(_mm_xor_si128(_mm_srli_epi64(invec, 47), _mm_srli_epi64(invec, 9)), _mm_slli_epi64(invec, 19)); \
         c = _mm_xor_si128(_mm_srli_epi64(invec, 45), _mm_slli_epi64(invec, 44)); \
         d  = _mm_srli_epi64(invec, 20); \
-        } while (0);
+    } while (0);
 
 Z_INTERNAL uint32_t chorba_small_nondestructive_sse2(uint32_t crc, const uint8_t *buf, size_t len) {
     /* The calling function ensured that this is aligned correctly */
@@ -42,17 +44,6 @@ Z_INTERNAL uint32_t chorba_small_nondestructive_sse2(uint32_t crc, const uint8_t
     for (; (i + 256 + 40 + 32 + 32) < len; i += 32) {
         __m128i in1in2, in3in4;
 
-        /*
-        uint64_t chorba1 = input[i / sizeof(uint64_t)];
-        uint64_t chorba2 = input[i / sizeof(uint64_t) + 1];
-        uint64_t chorba3 = input[i / sizeof(uint64_t) + 2];
-        uint64_t chorba4 = input[i / sizeof(uint64_t) + 3];
-        uint64_t chorba5 = input[i / sizeof(uint64_t) + 4];
-        uint64_t chorba6 = input[i / sizeof(uint64_t) + 5];
-        uint64_t chorba7 = input[i / sizeof(uint64_t) + 6];
-        uint64_t chorba8 = input[i / sizeof(uint64_t) + 7];
-        */
-
         const uint64_t *input_ptr = input + (i / sizeof(uint64_t));
         const __m128i *input_ptr_128 = (__m128i*)input_ptr;
         __m128i chorba12 = _mm_load_si128(input_ptr_128++);
@@ -67,41 +58,16 @@ Z_INTERNAL uint32_t chorba_small_nondestructive_sse2(uint32_t crc, const uint8_t
         __m128i chorba45 = _mm_castpd_si128(_mm_shuffle_pd(_mm_castsi128_pd(chorba34), _mm_castsi128_pd(chorba56), 1));
         __m128i chorba23 = _mm_castpd_si128(_mm_shuffle_pd(_mm_castsi128_pd(chorba12),
                                                            _mm_castsi128_pd(chorba34), 1));
-        /*
-        chorba1 ^= next1;
-        chorba2 ^= next2;
-        chorba3 ^= next3;
-        chorba4 ^= next4;
-        chorba5 ^= next5;
-        chorba7 ^= chorba1;
-        chorba8 ^= chorba2;
-        */
+ 
         i += 8 * 8;
 
         /* 0-3 */
-        /*in1 = input[i / sizeof(uint64_t)];
-        in2 = input[i / sizeof(uint64_t) + 1];*/
         READ_NEXT(input, i, in1in2, in3in4);
+
         __m128i chorba34xor = _mm_xor_si128(chorba34, _mm_unpacklo_epi64(_mm_setzero_si128(), chorba12));
         in1in2 = _mm_xor_si128(in1in2, chorba34xor);
-        /*
-        in1 ^= chorba3;
-        in2 ^= chorba4 ^ chorba1;
-        */
 
         NEXT_ROUND(in1in2, ab1, ab2, ab3, ab4);
-        /*
-        a1 = (in1 << 17) ^ (in1 << 55);
-        a2 = (in1 >> 47) ^ (in1 >> 9) ^ (in1 << 19);
-        a3 = (in1 >> 45) ^ (in1 << 44);
-        a4 = (in1 >> 20);
-
-        b1 = (in2 << 17) ^ (in2 << 55);
-        b2 = (in2 >> 47) ^ (in2 >> 9) ^ (in2 << 19);
-        b3 = (in2 >> 45) ^ (in2 << 44);
-        b4 = (in2 >> 20);
-
-        */
 
         in3in4 = _mm_xor_si128(in3in4, ab1);
         /* _hopefully_ we don't get a huge domain switching penalty for this. This seems to be the best sequence */
@@ -111,22 +77,6 @@ Z_INTERNAL uint32_t chorba_small_nondestructive_sse2(uint32_t crc, const uint8_t
         in3in4 = _mm_xor_si128(in3in4, chorba12);
 
         NEXT_ROUND(in3in4, cd1, cd2, cd3, cd4);
-        /*
-        in3 = input[i / sizeof(uint64_t) + 2];
-        in4 = input[i / sizeof(uint64_t) + 3];
-        in3 ^= a1 ^ chorba5 ^ chorba2 ^ chorba1;
-        in4 ^= b1 ^a2 ^ chorba6 ^ chorba3 ^ chorba2;
-
-        c1 = (in3 << 17) ^ (in3 << 55);
-        c2 = (in3 >> 47) ^ (in3 >> 9) ^ (in3 << 19);
-        c3 = (in3 >> 45) ^ (in3 << 44);
-        c4 = (in3 >> 20);
-
-        d1 = (in4 << 17) ^ (in4 << 55);
-        d2 = (in4 >> 47) ^ (in4 >> 9) ^ (in4 << 19);
-        d3 = (in4 >> 45) ^ (in4 << 44);
-        d4 = (in4 >> 20);
-        */
 
         __m128i b2c2 = _mm_castpd_si128(_mm_shuffle_pd(_mm_castsi128_pd(ab2), _mm_castsi128_pd(cd2), 1));
         __m128i a4_ = _mm_unpacklo_epi64(_mm_setzero_si128(), ab4);
@@ -137,29 +87,12 @@ Z_INTERNAL uint32_t chorba_small_nondestructive_sse2(uint32_t crc, const uint8_t
         __m128i d2_ = _mm_unpackhi_epi64(cd2, _mm_setzero_si128());
         __m128i b4c4 = _mm_castpd_si128(_mm_shuffle_pd(_mm_castsi128_pd(ab4), _mm_castsi128_pd(cd4), 1));
 
-        /*out1 = a3 ^ b2 ^ c1;
-        out2 = b3 ^ c2 ^ d1 ^ a4;*/
         next34 = _mm_xor_si128(cd3, _mm_xor_si128(b4c4, d2_));
         next56 = _mm_unpackhi_epi64(cd4, _mm_setzero_si128());
-
-        //out3 = b4 ^ c3 ^ d2;
-        //out4 = c4 ^ d3;
-
-        //out5 = d4;
-
-        /*
-        next1 = out1;
-        next2 = out2;
-        next3 = out3;
-        next4 = out4;
-        next5 = out5;
-        */
 
         i += 32;
 
         /* 4-7 */
-        /*in1 = input[i / sizeof(uint64_t)];
-        in2 = input[i / sizeof(uint64_t) + 1];*/
         READ_NEXT(input, i, in1in2, in3in4);
 
         in1in2 = _mm_xor_si128(in1in2, next12);
@@ -167,53 +100,16 @@ Z_INTERNAL uint32_t chorba_small_nondestructive_sse2(uint32_t crc, const uint8_t
         in1in2 = _mm_xor_si128(in1in2, chorba45);
         in1in2 = _mm_xor_si128(in1in2, chorba34);
 
-        /*
-        in1 ^= next1 ^ chorba7 ^ chorba4 ^ chorba3;
-        in2 ^= next2 ^ chorba8 ^ chorba5 ^ chorba4;
-        */
-
-        /*
-        a1 = (in1 << 17) ^ (in1 << 55);
-        a2 = (in1 >> 47) ^ (in1 >> 9) ^ (in1 << 19);
-        a3 = (in1 >> 45) ^ (in1 << 44);
-        a4 = (in1 >> 20);
-
-        b1 = (in2 << 17) ^ (in2 << 55);
-        b2 = (in2 >> 47) ^ (in2 >> 9) ^ (in2 << 19);
-        b3 = (in2 >> 45) ^ (in2 << 44);
-        b4 = (in2 >> 20);
-        */
-
         NEXT_ROUND(in1in2, ab1, ab2, ab3, ab4);
 
-        /*
-        in3 = input[i / sizeof(uint64_t) + 2];
-        in4 = input[i / sizeof(uint64_t) + 3];
-
-        in3 ^= next3 ^ a1 ^ chorba6 ^ chorba5;
-        in4 ^= next4 ^ b1 ^ a2  ^ chorba7 ^ chorba6;
-        */
         in3in4 = _mm_xor_si128(in3in4, next34);
         in3in4 = _mm_xor_si128(in3in4, ab1);
         in3in4 = _mm_xor_si128(in3in4, chorba56);
         __m128i chorba67 = _mm_castpd_si128(_mm_shuffle_pd(_mm_castsi128_pd(chorba56), _mm_castsi128_pd(chorba78), 1));
         in3in4 = _mm_xor_si128(in3in4, _mm_xor_si128(chorba67, _mm_unpacklo_epi64(_mm_setzero_si128(), ab2)));
 
-        /*
-        c1 = (in3 << 17) ^ (in3 << 55);
-        c2 = (in3 >> 47) ^ (in3 >> 9) ^ (in3 << 19);
-        c3 = (in3 >> 45) ^ (in3 << 44);
-        c4 = (in3 >> 20);
-
-        d1 = (in4 << 17) ^ (in4 << 55);
-        d2 = (in4 >> 47) ^ (in4 >> 9) ^ (in4 << 19);
-        d3 = (in4 >> 45) ^ (in4 << 44);
-        d4 = (in4 >> 20);
-        */
-
         NEXT_ROUND(in3in4, cd1, cd2, cd3, cd4);
 
-        ///*
         b2c2 = _mm_castpd_si128(_mm_shuffle_pd(_mm_castsi128_pd(ab2), _mm_castsi128_pd(cd2), 1));
         a4_ = _mm_unpacklo_epi64(_mm_setzero_si128(), ab4);
         a4_ = _mm_xor_si128(b2c2, a4_);
@@ -226,32 +122,10 @@ Z_INTERNAL uint32_t chorba_small_nondestructive_sse2(uint32_t crc, const uint8_t
         d2_ = _mm_unpackhi_epi64(cd2, _mm_setzero_si128());
         next34 = _mm_xor_si128(next34, d2_);
         next56 = _mm_unpackhi_epi64(cd4, _mm_setzero_si128());
-        //*/
-
-        /*
-        out1 = a3 ^ b2 ^ c1;
-        out2 = b3 ^ c2 ^ d1 ^ a4;
-        out3 = b4 ^ c3 ^ d2;
-        out4 = c4 ^ d3;
-        out5 = d4;
-
-        next1 = next5 ^ out1;
-        next2 = out2;
-        next3 = out3;
-        next4 = out4;
-        next5 = out5;
-        */
 
         i += 32;
 
         /* 8-11 */
-        /*
-        in1 = input[i / sizeof(uint64_t)];
-        in2 = input[i / sizeof(uint64_t) + 1];
-        in1 ^= next1 ^ chorba8 ^ chorba7 ^ chorba1;
-        in2 ^= next2 ^ chorba8 ^ chorba2;
-        */
-
         READ_NEXT(input, i, in1in2, in3in4);
 
         __m128i chorba80 = _mm_unpackhi_epi64(chorba78, _mm_setzero_si128());
@@ -262,41 +136,11 @@ Z_INTERNAL uint32_t chorba_small_nondestructive_sse2(uint32_t crc, const uint8_t
 
         NEXT_ROUND(in1in2, ab1, ab2, ab3, ab4);
 
-        /*
-        a1 = (in1 << 17) ^ (in1 << 55);
-        a2 = (in1 >> 47) ^ (in1 >> 9) ^ (in1 << 19);
-        a3 = (in1 >> 45) ^ (in1 << 44);
-        a4 = (in1 >> 20);
-
-        b1 = (in2 << 17) ^ (in2 << 55);
-        b2 = (in2 >> 47) ^ (in2 >> 9) ^ (in2 << 19);
-        b3 = (in2 >> 45) ^ (in2 << 44);
-        b4 = (in2 >> 20);
-        */
-
-        /*in3 = input[i / sizeof(uint64_t) + 2];
-        in4 = input[i / sizeof(uint64_t) + 3];*/
         in3in4 = _mm_xor_si128(next34, in3in4);
         in3in4 = _mm_xor_si128(in3in4, ab1);
         __m128i a2_ = _mm_unpacklo_epi64(_mm_setzero_si128(), ab2);
         in3in4 = _mm_xor_si128(in3in4, chorba34);
         in3in4 = _mm_xor_si128(in3in4, a2_);
-
-        /*
-        in3 ^= next3 ^ a1 ^ chorba3;
-        in4 ^= next4 ^ a2 ^ b1 ^ chorba4;
-
-        c1 = (in3 << 17) ^ (in3 << 55);
-        c2 = (in3 >> 47) ^ (in3 >> 9) ^ (in3 << 19);
-        c3 = (in3 >> 45) ^ (in3 << 44);
-        c4 = (in3 >> 20);
-
-        d1 = (in4 << 17) ^ (in4 << 55);
-        d2 = (in4 >> 47) ^ (in4 >> 9) ^ (in4 << 19);
-        d3 = (in4 >> 45) ^ (in4 << 44);
-        d4 = (in4 >> 20);
-        */
-
 
         NEXT_ROUND(in3in4, cd1, cd2, cd3, cd4);
 
@@ -311,79 +155,26 @@ Z_INTERNAL uint32_t chorba_small_nondestructive_sse2(uint32_t crc, const uint8_t
         next34 = _mm_xor_si128(next34, d2_);
         next56 = _mm_unpackhi_epi64(cd4, _mm_setzero_si128());
 
-        /*
-        out1 =      a3 ^ b2 ^ c1;
-        out2 = a4 ^ b3 ^ c2 ^ d1;
-        out3 = b4 ^ c3 ^ d2;
-        out4 = c4 ^ d3;
-        out5 = d4;
-
-        next1 = next5 ^ out1;
-        next2 = out2;
-        next3 = out3;
-        next4 = out4;
-        next5 = out5;
-        */
-
         i += 32;
 
         /* 12-15 */
-        /*
-        in1 = input[i / sizeof(uint64_t)];
-        in2 = input[i / sizeof(uint64_t) + 1];
-        */
         READ_NEXT(input, i, in1in2, in3in4);
+
         in1in2 = _mm_xor_si128(in1in2, next12);
         __m128i chorb56xorchorb12 = _mm_xor_si128(chorba56, chorba12);
         in1in2 = _mm_xor_si128(in1in2, chorb56xorchorb12);
         __m128i chorb1_ = _mm_unpacklo_epi64(_mm_setzero_si128(), chorba12);
         in1in2 = _mm_xor_si128(in1in2, chorb1_);
 
-
-        /*
-        in1 ^= next1 ^ chorba5 ^ chorba1;
-        in2 ^= next2 ^ chorba6 ^ chorba2 ^ chorba1;
-
-        a1 = (in1 << 17) ^ (in1 << 55);
-        a2 = (in1 >> 47) ^ (in1 >> 9) ^ (in1 << 19);
-        a3 = (in1 >> 45) ^ (in1 << 44);
-        a4 = (in1 >> 20);
-
-        b1 = (in2 << 17) ^ (in2 << 55);
-        b2 = (in2 >> 47) ^ (in2 >> 9) ^ (in2 << 19);
-        b3 = (in2 >> 45) ^ (in2 << 44);
-        b4 = (in2 >> 20);
-        */
-
         NEXT_ROUND(in1in2, ab1, ab2, ab3, ab4);
-
-        /*
-        in3 = input[i / sizeof(uint64_t) + 2];
-        in4 = input[i / sizeof(uint64_t) + 3];
-        in3 ^= next3 ^ a1 ^ chorba7 ^ chorba3 ^ chorba2 ^ chorba1;
-        in4 ^= next4 ^ a2 ^ b1 ^ chorba8 ^ chorba4 ^ chorba3 ^ chorba2;
-        */
 
         in3in4 = _mm_xor_si128(next34, in3in4);
         in3in4 = _mm_xor_si128(in3in4, _mm_xor_si128(ab1, chorba78));
         in3in4 = _mm_xor_si128(in3in4, _mm_xor_si128(chorba34, chorba12));
         in3in4 = _mm_xor_si128(in3in4, _mm_xor_si128(chorba23, _mm_unpacklo_epi64(_mm_setzero_si128(), ab2)));
+
         NEXT_ROUND(in3in4, cd1, cd2, cd3, cd4);
 
-        /*
-
-        c1 = (in3 << 17) ^ (in3 << 55);
-        c2 = (in3 >> 47) ^ (in3 >> 9) ^ (in3 << 19);
-        c3 = (in3 >> 45) ^ (in3 << 44);
-        c4 = (in3 >> 20);
-
-        d1 = (in4 << 17) ^ (in4 << 55);
-        d2 = (in4 >> 47) ^ (in4 >> 9) ^ (in4 << 19);
-        d3 = (in4 >> 45) ^ (in4 << 44);
-        d4 = (in4 >> 20);
-        */
-
-        ///*
         a4_ = _mm_unpacklo_epi64(next56, ab4);
         next12 = _mm_xor_si128(_mm_xor_si128(a4_, ab3), cd1);
         b2c2 = _mm_castpd_si128(_mm_shuffle_pd(_mm_castsi128_pd(ab2), _mm_castsi128_pd(cd2), 1));
@@ -393,82 +184,27 @@ Z_INTERNAL uint32_t chorba_small_nondestructive_sse2(uint32_t crc, const uint8_t
         next34 = _mm_xor_si128(b4c4, cd3);
         next34 = _mm_xor_si128(next34, d2_);
         next56 = _mm_unpackhi_epi64(cd4, _mm_setzero_si128());
-        //*/
-
-        /*
-        out1 =      a3 ^ b2 ^ c1;
-        out2 = a4 ^ b3 ^ c2 ^ d1;
-        out3 = b4 ^ c3 ^ d2;
-        out4 = c4 ^ d3;
-        out5 = d4;
-
-        next1 = next5 ^ out1;
-        next2 = out2;
-        next3 = out3;
-        next4 = out4;
-        next5 = out5;
-        */
 
         i += 32;
 
         /* 16-19 */
-        /*
-        in1 = input[i / sizeof(uint64_t)];
-        in2 = input[i / sizeof(uint64_t) + 1];
-        in1 ^= next1 ^ chorba5 ^ chorba4 ^ chorba3 ^ chorba1;
-        in2 ^= next2 ^ chorba6 ^ chorba5 ^ chorba4 ^ chorba1 ^ chorba2;
-        */
-        ///*
         READ_NEXT(input, i, in1in2, in3in4);
+
         __m128i chorba1_ = _mm_unpacklo_epi64(_mm_setzero_si128(), chorba12);
         in1in2 = _mm_xor_si128(_mm_xor_si128(next12, in1in2), _mm_xor_si128(chorba56, chorba45));
         in1in2 = _mm_xor_si128(in1in2, _mm_xor_si128(chorba12, chorba34));
         in1in2 = _mm_xor_si128(chorba1_, in1in2);
 
         NEXT_ROUND(in1in2, ab1, ab2, ab3, ab4);
-        //*/
 
-        /*
-        a1 = (in1 << 17) ^ (in1 << 55);
-        a2 = (in1 >> 47) ^ (in1 >> 9) ^ (in1 << 19);
-        a3 = (in1 >> 45) ^ (in1 << 44);
-        a4 = (in1 >> 20);
-
-        b1 = (in2 << 17) ^ (in2 << 55);
-        b2 = (in2 >> 47) ^ (in2 >> 9) ^ (in2 << 19);
-        b3 = (in2 >> 45) ^ (in2 << 44);
-        b4 = (in2 >> 20);
-        */
-
-        /*
-        in3 = input[i / sizeof(uint64_t) + 2];
-        in4 = input[i / sizeof(uint64_t) + 3];
-        */
-        ///*
         a2_ = _mm_unpacklo_epi64(_mm_setzero_si128(), ab2);
         in3in4 = _mm_xor_si128(in3in4, _mm_xor_si128(ab1, chorba78));
         in3in4 = _mm_xor_si128(in3in4, _mm_xor_si128(chorba56, chorba34));
         in3in4 = _mm_xor_si128(in3in4, _mm_xor_si128(chorba23, chorba67));
         in3in4 = _mm_xor_si128(in3in4, _mm_xor_si128(chorba1_, a2_));
         in3in4 = _mm_xor_si128(in3in4, next34);
-        //*/
-        /*
-        in3 ^= next3 ^ a1 ^ chorba7 ^ chorba6 ^ chorba5 ^ chorba2 ^ chorba3;
-        in4 ^= next4 ^ a2 ^ b1 ^ chorba8 ^ chorba7 ^ chorba6 ^ chorba3 ^ chorba4 ^ chorba1;
-        */
+
         NEXT_ROUND(in3in4, cd1, cd2, cd3, cd4);
-
-        /*
-        c1 = (in3 << 17) ^ (in3 << 55);
-        c2 = (in3 >> 47) ^ (in3 >> 9) ^ (in3 << 19);
-        c3 = (in3 >> 45) ^ (in3 << 44);
-        c4 = (in3 >> 20);
-
-        d1 = (in4 << 17) ^ (in4 << 55);
-        d2 = (in4 >> 47) ^ (in4 >> 9) ^ (in4 << 19);
-        d3 = (in4 >> 45) ^ (in4 << 44);
-        d4 = (in4 >> 20);
-        */
 
         a4_ = _mm_unpacklo_epi64(next56, ab4);
         next12 = _mm_xor_si128(_mm_xor_si128(a4_, ab3), cd1);
@@ -480,88 +216,26 @@ Z_INTERNAL uint32_t chorba_small_nondestructive_sse2(uint32_t crc, const uint8_t
         next34 = _mm_xor_si128(next34, d2_);
         next56 = _mm_unpackhi_epi64(cd4, _mm_setzero_si128());
 
-        /*
-        out1 =      a3 ^ b2 ^ c1;
-        out2 = a4 ^ b3 ^ c2 ^ d1;
-        out3 = b4 ^ c3 ^ d2;
-        out4 = c4 ^ d3;
-        out5 = d4;
-
-        next1 = next5 ^ out1;
-        next2 = out2;
-        next3 = out3;
-        next4 = out4;
-        next5 = out5;
-        */
-
         i += 32;
 
         /* 20-23 */
-        /*
-        in1 = input[i / sizeof(uint64_t)];
-        in2 = input[i / sizeof(uint64_t) + 1];
-        in1 ^= next1 ^ chorba8 ^ chorba7 ^ chorba4 ^ chorba5 ^ chorba2 ^ chorba1;
-        in2 ^= next2 ^ chorba8 ^ chorba5 ^ chorba6 ^ chorba3 ^ chorba2;
-        */
-
         READ_NEXT(input, i, in1in2, in3in4);
+
         in1in2 = _mm_xor_si128(in1in2, _mm_xor_si128(next12, chorba78));
         in1in2 = _mm_xor_si128(in1in2, _mm_xor_si128(chorba45, chorba56));
         in1in2 = _mm_xor_si128(in1in2, _mm_xor_si128(chorba23, chorba12));
         in1in2 = _mm_xor_si128(in1in2, chorba80);
+
         NEXT_ROUND(in1in2, ab1, ab2, ab3, ab4);
 
-        /*
-        a1 = (in1 << 17) ^ (in1 << 55);
-        a2 = (in1 >> 47) ^ (in1 >> 9) ^ (in1 << 19);
-        a3 = (in1 >> 45) ^ (in1 << 44);
-        a4 = (in1 >> 20);
-
-        b1 = (in2 << 17) ^ (in2 << 55);
-        b2 = (in2 >> 47) ^ (in2 >> 9) ^ (in2 << 19);
-        b3 = (in2 >> 45) ^ (in2 << 44);
-        b4 = (in2 >> 20);
-        */
-
-        /*
-        in3 = input[i / sizeof(uint64_t) + 2];
-        in4 = input[i / sizeof(uint64_t) + 3];
-        in3 ^= next3 ^ a1 ^ chorba7 ^ chorba6 ^ chorba4 ^ chorba3 ^ chorba1;
-        in4 ^= next4 ^ a2 ^ b1 ^ chorba8 ^ chorba7 ^ chorba5 ^ chorba4 ^ chorba2 ^ chorba1;
-        */
         a2_ = _mm_unpacklo_epi64(_mm_setzero_si128(), ab2);
         in3in4 = _mm_xor_si128(in3in4, _mm_xor_si128(next34, ab1));
         in3in4 = _mm_xor_si128(in3in4, _mm_xor_si128(chorba78, chorba67));
         in3in4 = _mm_xor_si128(in3in4, _mm_xor_si128(chorba45, chorba34));
         in3in4 = _mm_xor_si128(in3in4, _mm_xor_si128(chorba1_, a2_));
         in3in4 = _mm_xor_si128(in3in4, chorba12);
+
         NEXT_ROUND(in3in4, cd1, cd2, cd3, cd4);
-
-        /*
-        c1 = (in3 << 17) ^ (in3 << 55);
-        c2 = (in3 >> 47) ^ (in3 >> 9) ^ (in3 << 19);
-        c3 = (in3 >> 45) ^ (in3 << 44);
-        c4 = (in3 >> 20);
-
-        d1 = (in4 << 17) ^ (in4 << 55);
-        d2 = (in4 >> 47) ^ (in4 >> 9) ^ (in4 << 19);
-        d3 = (in4 >> 45) ^ (in4 << 44);
-        d4 = (in4 >> 20);
-        */
-
-        /*
-        out1 =      a3 ^ b2 ^ c1;
-        out2 = a4 ^ b3 ^ c2 ^ d1;
-        out3 = b4 ^ c3 ^ d2;
-        out4 = c4 ^ d3;
-        out5 = d4;
-
-        next1 = next5 ^ out1;
-        next2 = out2;
-        next3 = out3;
-        next4 = out4;
-        next5 = out5;
-        */
 
         a4_ = _mm_unpacklo_epi64(next56, ab4);
         next12 = _mm_xor_si128(_mm_xor_si128(a4_, ab3), cd1);
@@ -576,52 +250,21 @@ Z_INTERNAL uint32_t chorba_small_nondestructive_sse2(uint32_t crc, const uint8_t
         i += 32;
 
         /* 24-27 */
-        /*
-        in1 = input[i / sizeof(uint64_t)];
-        in2 = input[i / sizeof(uint64_t) + 1];
-        in1 ^= next1 ^ chorba8 ^ chorba6 ^ chorba5 ^ chorba3 ^ chorba2 ^ chorba1;
-        in2 ^= next2 ^ chorba7 ^ chorba6 ^ chorba4 ^ chorba3 ^ chorba2;
-        */
-
         READ_NEXT(input, i, in1in2, in3in4);
+
         in1in2 = _mm_xor_si128(in1in2, _mm_xor_si128(next12, chorba67));
         in1in2 = _mm_xor_si128(in1in2, _mm_xor_si128(chorba56, chorba34));
         in1in2 = _mm_xor_si128(in1in2, _mm_xor_si128(chorba23, chorba12));
         in1in2 = _mm_xor_si128(in1in2, chorba80);
+
         NEXT_ROUND(in1in2, ab1, ab2, ab3, ab4);
 
-        /*
-        a1 = (in1 << 17) ^ (in1 << 55);
-        a2 = (in1 >> 47) ^ (in1 >> 9) ^ (in1 << 19);
-        a3 = (in1 >> 45) ^ (in1 << 44);
-        a4 = (in1 >> 20);
-
-        b1 = (in2 << 17) ^ (in2 << 55);
-        b2 = (in2 >> 47) ^ (in2 >> 9) ^ (in2 << 19);
-        b3 = (in2 >> 45) ^ (in2 << 44);
-        b4 = (in2 >> 20);
-        */
-
-        /*in3 = input[i / sizeof(uint64_t) + 2];
-        in4 = input[i / sizeof(uint64_t) + 3];
-        in3 ^= next3 ^ a1 ^ chorba8 ^ chorba7 ^ chorba5 ^ chorba4 ^ chorba3;
-        in4 ^= next4 ^ a2 ^ b1 ^ chorba8 ^ chorba6 ^ chorba5 ^ chorba4;
-
-        c1 = (in3 << 17) ^ (in3 << 55);
-        c2 = (in3 >> 47) ^ (in3 >> 9) ^ (in3 << 19);
-        c3 = (in3 >> 45) ^ (in3 << 44);
-        c4 = (in3 >> 20);
-
-        d1 = (in4 << 17) ^ (in4 << 55);
-        d2 = (in4 >> 47) ^ (in4 >> 9) ^ (in4 << 19);
-        d3 = (in4 >> 45) ^ (in4 << 44);
-        d4 = (in4 >> 20);
-        */
         a2_ = _mm_unpacklo_epi64(_mm_setzero_si128(), ab2);
         in3in4 = _mm_xor_si128(in3in4, _mm_xor_si128(next34, ab1));
         in3in4 = _mm_xor_si128(in3in4, _mm_xor_si128(chorba78, chorba56));
         in3in4 = _mm_xor_si128(in3in4, _mm_xor_si128(chorba45, chorba34));
         in3in4 = _mm_xor_si128(in3in4, _mm_xor_si128(chorba80, a2_));
+
         NEXT_ROUND(in3in4, cd1, cd2, cd3, cd4);
 
         a4_ = _mm_unpacklo_epi64(next56, ab4);
@@ -634,82 +277,22 @@ Z_INTERNAL uint32_t chorba_small_nondestructive_sse2(uint32_t crc, const uint8_t
         next34 = _mm_xor_si128(next34, d2_);
         next56 = _mm_unpackhi_epi64(cd4, _mm_setzero_si128());
 
-        /*
-        out1 =      a3 ^ b2 ^ c1;
-        out2 = a4 ^ b3 ^ c2 ^ d1;
-        out3 = b4 ^ c3 ^ d2;
-        out4 = c4 ^ d3;
-        out5 = d4;
-
-        next1 = next5 ^ out1;
-        next2 = out2;
-        next3 = out3;
-        next4 = out4;
-        next5 = out5;
-        */
         i += 32;
 
         /* 28-31 */
-        /*
-        in1 = input[i / sizeof(uint64_t)];
-        in2 = input[i / sizeof(uint64_t) + 1];
-        in1 ^= next1 ^ chorba7 ^ chorba6 ^ chorba5;
-        in2 ^= next2 ^ chorba8 ^ chorba7 ^ chorba6;
-        */
         READ_NEXT(input, i, in1in2, in3in4);
+
         in1in2 = _mm_xor_si128(in1in2, _mm_xor_si128(next12, chorba78));
         in1in2 = _mm_xor_si128(in1in2, _mm_xor_si128(chorba67, chorba56));
+
         NEXT_ROUND(in1in2, ab1, ab2, ab3, ab4);
 
-        /*
-        a1 = (in1 << 17) ^ (in1 << 55);
-        a2 = (in1 >> 47) ^ (in1 >> 9) ^ (in1 << 19);
-        a3 = (in1 >> 45) ^ (in1 << 44);
-        a4 = (in1 >> 20);
-
-        b1 = (in2 << 17) ^ (in2 << 55);
-        b2 = (in2 >> 47) ^ (in2 >> 9) ^ (in2 << 19);
-        b3 = (in2 >> 45) ^ (in2 << 44);
-        b4 = (in2 >> 20);
-        */
-
-        /*
-        in3 = input[i / sizeof(uint64_t) + 2];
-        in4 = input[i / sizeof(uint64_t) + 3];
-        in3 ^= next3 ^ a1 ^ chorba8 ^ chorba7;
-        in4 ^= next4 ^ a2 ^ b1 ^ chorba8;
-
-        c1 = (in3 << 17) ^ (in3 << 55);
-        c2 = (in3 >> 47) ^ (in3 >> 9) ^ (in3 << 19);
-        c3 = (in3 >> 45) ^ (in3 << 44);
-        c4 = (in3 >> 20);
-
-        d1 = (in4 << 17) ^ (in4 << 55);
-        d2 = (in4 >> 47) ^ (in4 >> 9) ^ (in4 << 19);
-        d3 = (in4 >> 45) ^ (in4 << 44);
-        d4 = (in4 >> 20);
-        */
         a2_ = _mm_unpacklo_epi64(_mm_setzero_si128(), ab2);
         in3in4 = _mm_xor_si128(in3in4, _mm_xor_si128(next34, ab1));
         in3in4 = _mm_xor_si128(in3in4, _mm_xor_si128(chorba78, chorba80));
         in3in4 = _mm_xor_si128(a2_, in3in4);
+
         NEXT_ROUND(in3in4, cd1, cd2, cd3, cd4);
-
-        /*
-        out1 =      a3 ^ b2 ^ c1;
-        out2 = a4 ^ b3 ^ c2 ^ d1;
-        out3 = b4 ^ c3 ^ d2;
-        out4 = c4 ^ d3;
-        out5 = d4;
-        */
-
-        /*
-        next1 = next5 ^ out1;
-        next2 = out2;
-        next3 = out3;
-        next4 = out4;
-        next5 = out5;
-        */
 
         a4_ = _mm_unpacklo_epi64(next56, ab4);
         next12 = _mm_xor_si128(_mm_xor_si128(a4_, ab3), cd1);
@@ -725,67 +308,18 @@ Z_INTERNAL uint32_t chorba_small_nondestructive_sse2(uint32_t crc, const uint8_t
     for (; (i + 40 + 32) < len; i += 32) {
         __m128i in1in2, in3in4;
 
-        /*in1 = input[i / sizeof(uint64_t)];
-        in2 = input[i / sizeof(uint64_t) + 1];*/
-        //READ_NEXT_UNALIGNED(input, i, in1in2, in3in4);
         READ_NEXT(input, i, in1in2, in3in4);
+
         in1in2 = _mm_xor_si128(in1in2, next12);
 
-        /*
-        in1 ^=next1;
-        in2 ^=next2;
-        */
-
         NEXT_ROUND(in1in2, ab1, ab2, ab3, ab4);
-        /*
-        a1 = (in1 << 17) ^ (in1 << 55);
-        a2 = (in1 >> 47) ^ (in1 >> 9) ^ (in1 << 19);
-        a3 = (in1 >> 45) ^ (in1 << 44);
-        a4 = (in1 >> 20);
-
-        b1 = (in2 << 17) ^ (in2 << 55);
-        b2 = (in2 >> 47) ^ (in2 >> 9) ^ (in2 << 19);
-        b3 = (in2 >> 45) ^ (in2 << 44);
-        b4 = (in2 >> 20);
-        */
-
-        /*
-        in3 = input[i / sizeof(uint64_t) + 2];
-        in4 = input[i / sizeof(uint64_t) + 3];
-        in3 ^= next3 ^ a1;
-        in4 ^= next4 ^ a2 ^ b1;
-
-        c1 = (in3 << 17) ^ (in3 << 55);
-        c2 = (in3 >> 47) ^ (in3 >> 9) ^ (in3 << 19);
-        c3 = (in3 >> 45) ^ (in3 << 44);
-        c4 = (in3 >> 20);
-
-        d1 = (in4 << 17) ^ (in4 << 55);
-        d2 = (in4 >> 47) ^ (in4 >> 9) ^ (in4 << 19);
-        d3 = (in4 >> 45) ^ (in4 << 44);
-        d4 = (in4 >> 20);
-        */
 
         __m128i a2_ = _mm_unpacklo_epi64(_mm_setzero_si128(), ab2);
         __m128i ab1_next34 = _mm_xor_si128(next34, ab1);
         in3in4 = _mm_xor_si128(in3in4, ab1_next34);
         in3in4 = _mm_xor_si128(a2_, in3in4);
+
         NEXT_ROUND(in3in4, cd1, cd2, cd3, cd4);
-
-        /*
-
-        out1 = a3 ^ b2 ^ c1;
-        out2 = a4 ^ b3 ^ c2 ^ d1;
-        out3 = b4 ^ c3 ^ d2;
-        out4 = c4 ^ d3;
-        out5 = d4;
-
-        next1 = next5 ^ out1;
-        next2 = out2;
-        next3 = out3;
-        next4 = out4;
-        next5 = out5;
-        */
 
         __m128i b2c2 = _mm_castpd_si128(_mm_shuffle_pd(_mm_castsi128_pd(ab2), _mm_castsi128_pd(cd2), 1));
         __m128i a4_ = _mm_unpacklo_epi64(_mm_setzero_si128(), ab4);
@@ -809,13 +343,13 @@ Z_INTERNAL uint32_t chorba_small_nondestructive_sse2(uint32_t crc, const uint8_t
     /* Skip the call to memcpy */
     size_t copy_len = len - i;
     __m128i *final128 = (__m128i*)final;
-    __m128i *input128 = (__m128i*)(input + i/ sizeof(uint64_t));
+    __m128i *input128 = (__m128i*)(input + (i / sizeof(uint64_t)));
     while (copy_len >= 64) {
         _mm_store_si128(final128++, _mm_load_si128(input128++));
         _mm_store_si128(final128++, _mm_load_si128(input128++));
         _mm_store_si128(final128++, _mm_load_si128(input128++));
         _mm_store_si128(final128++, _mm_load_si128(input128++));
-         copy_len -= 64;
+        copy_len -= 64;
     }
 
     while (copy_len >= 16) {

--- a/arch/x86/crc32_chorba_sse2.c
+++ b/arch/x86/crc32_chorba_sse2.c
@@ -8,19 +8,36 @@
 #include "arch/x86/x86_intrins.h"
 #include "arch_functions.h"
 
+#define LSHIFT_QWORD(x)     _mm_unpacklo_epi64(_mm_setzero_si128(), (x))
+#define RSHIFT_QWORD(x)     _mm_unpackhi_epi64((x), _mm_setzero_si128())
+#define ALIGNR_QWORD(a, b)  _mm_castpd_si128(_mm_shuffle_pd(_mm_castsi128_pd(a), _mm_castsi128_pd(b), 1))
+
 #define READ_NEXT(in, off, a, b) \
     do { \
         a = _mm_load_si128((__m128i*)(in + off / sizeof(uint64_t))); \
         b = _mm_load_si128((__m128i*)(in + off / sizeof(uint64_t) + 2)); \
-    } while (0);
+    } while (0)
 
 #define NEXT_ROUND(invec, a, b, c, d) \
     do { \
         a = _mm_xor_si128(_mm_slli_epi64(invec, 17), _mm_slli_epi64(invec, 55)); \
         b = _mm_xor_si128(_mm_xor_si128(_mm_srli_epi64(invec, 47), _mm_srli_epi64(invec, 9)), _mm_slli_epi64(invec, 19)); \
         c = _mm_xor_si128(_mm_srli_epi64(invec, 45), _mm_slli_epi64(invec, 44)); \
-        d  = _mm_srli_epi64(invec, 20); \
-    } while (0);
+        d = _mm_srli_epi64(invec, 20); \
+    } while (0)
+
+#define ACCUM_ROUND() \
+    do { \
+        __m128i a4_ = _mm_unpacklo_epi64(next56, ab4); \
+        __m128i b2c2 = ALIGNR_QWORD(ab2, cd2); \
+        __m128i b4c4 = ALIGNR_QWORD(ab4, cd4); \
+        __m128i d2_ = RSHIFT_QWORD(cd2); \
+        next12 = _mm_xor_si128(_mm_xor_si128(a4_, ab3), cd1); \
+        next12 = _mm_xor_si128(next12, b2c2); \
+        next34 = _mm_xor_si128(b4c4, cd3); \
+        next34 = _mm_xor_si128(next34, d2_); \
+        next56 = RSHIFT_QWORD(cd4); \
+    } while (0)
 
 Z_INTERNAL uint32_t chorba_small_nondestructive_sse2(uint32_t crc, const uint8_t *buf, size_t len) {
     /* The calling function ensured that this is aligned correctly */
@@ -28,10 +45,7 @@ Z_INTERNAL uint32_t chorba_small_nondestructive_sse2(uint32_t crc, const uint8_t
     ALIGNED_(16) uint64_t final[9] = {0};
     uint64_t next1 = ~crc;
     crc = 0;
-    uint64_t next2 = 0;
-    uint64_t next3 = 0;
-    uint64_t next4 = 0;
-    uint64_t next5 = 0;
+    uint64_t next2, next3, next4, next5;
 
     __m128i next12 = _mm_cvtsi64_si128(next1);
     __m128i next34 = _mm_setzero_si128();
@@ -55,40 +69,32 @@ Z_INTERNAL uint32_t chorba_small_nondestructive_sse2(uint32_t crc, const uint8_t
         chorba34 = _mm_xor_si128(chorba34, next34);
         chorba56 = _mm_xor_si128(chorba56, next56);
         chorba78 = _mm_xor_si128(chorba78, chorba12);
-        __m128i chorba45 = _mm_castpd_si128(_mm_shuffle_pd(_mm_castsi128_pd(chorba34), _mm_castsi128_pd(chorba56), 1));
-        __m128i chorba23 = _mm_castpd_si128(_mm_shuffle_pd(_mm_castsi128_pd(chorba12),
-                                                           _mm_castsi128_pd(chorba34), 1));
- 
+        __m128i chorba45 = ALIGNR_QWORD(chorba34, chorba56);
+        __m128i chorba23 = ALIGNR_QWORD(chorba12, chorba34);
+
         i += 8 * 8;
 
         /* 0-3 */
         READ_NEXT(input, i, in1in2, in3in4);
 
-        __m128i chorba34xor = _mm_xor_si128(chorba34, _mm_unpacklo_epi64(_mm_setzero_si128(), chorba12));
+        __m128i chorba34xor = _mm_xor_si128(chorba34, LSHIFT_QWORD(chorba12));
         in1in2 = _mm_xor_si128(in1in2, chorba34xor);
 
         NEXT_ROUND(in1in2, ab1, ab2, ab3, ab4);
 
         in3in4 = _mm_xor_si128(in3in4, ab1);
         /* _hopefully_ we don't get a huge domain switching penalty for this. This seems to be the best sequence */
-        __m128i chorba56xor = _mm_xor_si128(chorba56, _mm_unpacklo_epi64(_mm_setzero_si128(), ab2));
+        __m128i chorba56xor = _mm_xor_si128(chorba56, LSHIFT_QWORD(ab2));
 
         in3in4 = _mm_xor_si128(in3in4, _mm_xor_si128(chorba56xor, chorba23));
         in3in4 = _mm_xor_si128(in3in4, chorba12);
 
         NEXT_ROUND(in3in4, cd1, cd2, cd3, cd4);
 
-        __m128i b2c2 = _mm_castpd_si128(_mm_shuffle_pd(_mm_castsi128_pd(ab2), _mm_castsi128_pd(cd2), 1));
-        __m128i a4_ = _mm_unpacklo_epi64(_mm_setzero_si128(), ab4);
-        a4_ = _mm_xor_si128(b2c2, a4_);
-        next12 = _mm_xor_si128(ab3, a4_);
-        next12 = _mm_xor_si128(next12, cd1);
-
-        __m128i d2_ = _mm_unpackhi_epi64(cd2, _mm_setzero_si128());
-        __m128i b4c4 = _mm_castpd_si128(_mm_shuffle_pd(_mm_castsi128_pd(ab4), _mm_castsi128_pd(cd4), 1));
-
-        next34 = _mm_xor_si128(cd3, _mm_xor_si128(b4c4, d2_));
-        next56 = _mm_unpackhi_epi64(cd4, _mm_setzero_si128());
+        /* chorba56 already consumed next56, clear it so ACCUM_ROUND
+           does not xor the stale value into next12 */
+        next56 = _mm_setzero_si128();
+        ACCUM_ROUND();
 
         i += 32;
 
@@ -105,30 +111,19 @@ Z_INTERNAL uint32_t chorba_small_nondestructive_sse2(uint32_t crc, const uint8_t
         in3in4 = _mm_xor_si128(in3in4, next34);
         in3in4 = _mm_xor_si128(in3in4, ab1);
         in3in4 = _mm_xor_si128(in3in4, chorba56);
-        __m128i chorba67 = _mm_castpd_si128(_mm_shuffle_pd(_mm_castsi128_pd(chorba56), _mm_castsi128_pd(chorba78), 1));
-        in3in4 = _mm_xor_si128(in3in4, _mm_xor_si128(chorba67, _mm_unpacklo_epi64(_mm_setzero_si128(), ab2)));
+        __m128i chorba67 = ALIGNR_QWORD(chorba56, chorba78);
+        in3in4 = _mm_xor_si128(in3in4, _mm_xor_si128(chorba67, LSHIFT_QWORD(ab2)));
 
         NEXT_ROUND(in3in4, cd1, cd2, cd3, cd4);
 
-        b2c2 = _mm_castpd_si128(_mm_shuffle_pd(_mm_castsi128_pd(ab2), _mm_castsi128_pd(cd2), 1));
-        a4_ = _mm_unpacklo_epi64(_mm_setzero_si128(), ab4);
-        a4_ = _mm_xor_si128(b2c2, a4_);
-        next12 = _mm_xor_si128(ab3, cd1);
-
-        next12 = _mm_xor_si128(next12, a4_);
-        next12 = _mm_xor_si128(next12, next56);
-        b4c4 = _mm_castpd_si128(_mm_shuffle_pd(_mm_castsi128_pd(ab4), _mm_castsi128_pd(cd4), 1));
-        next34 = _mm_xor_si128(b4c4, cd3);
-        d2_ = _mm_unpackhi_epi64(cd2, _mm_setzero_si128());
-        next34 = _mm_xor_si128(next34, d2_);
-        next56 = _mm_unpackhi_epi64(cd4, _mm_setzero_si128());
+        ACCUM_ROUND();
 
         i += 32;
 
         /* 8-11 */
         READ_NEXT(input, i, in1in2, in3in4);
 
-        __m128i chorba80 = _mm_unpackhi_epi64(chorba78, _mm_setzero_si128());
+        __m128i chorba80 = RSHIFT_QWORD(chorba78);
         __m128i next12_chorba12 = _mm_xor_si128(next12, chorba12);
         in1in2 = _mm_xor_si128(in1in2, chorba80);
         in1in2 = _mm_xor_si128(in1in2, chorba78);
@@ -138,22 +133,13 @@ Z_INTERNAL uint32_t chorba_small_nondestructive_sse2(uint32_t crc, const uint8_t
 
         in3in4 = _mm_xor_si128(next34, in3in4);
         in3in4 = _mm_xor_si128(in3in4, ab1);
-        __m128i a2_ = _mm_unpacklo_epi64(_mm_setzero_si128(), ab2);
+        __m128i a2_ = LSHIFT_QWORD(ab2);
         in3in4 = _mm_xor_si128(in3in4, chorba34);
         in3in4 = _mm_xor_si128(in3in4, a2_);
 
         NEXT_ROUND(in3in4, cd1, cd2, cd3, cd4);
 
-        a4_ = _mm_unpacklo_epi64(next56, ab4);
-        next12 = _mm_xor_si128(a4_, ab3);
-        next12 = _mm_xor_si128(next12, cd1);
-        b2c2 = _mm_castpd_si128(_mm_shuffle_pd(_mm_castsi128_pd(ab2), _mm_castsi128_pd(cd2), 1));
-        b4c4 = _mm_castpd_si128(_mm_shuffle_pd(_mm_castsi128_pd(ab4), _mm_castsi128_pd(cd4), 1));
-        d2_ = _mm_unpackhi_epi64(cd2, _mm_setzero_si128());
-        next12 = _mm_xor_si128(next12, b2c2);
-        next34 = _mm_xor_si128(b4c4, cd3);
-        next34 = _mm_xor_si128(next34, d2_);
-        next56 = _mm_unpackhi_epi64(cd4, _mm_setzero_si128());
+        ACCUM_ROUND();
 
         i += 32;
 
@@ -163,7 +149,7 @@ Z_INTERNAL uint32_t chorba_small_nondestructive_sse2(uint32_t crc, const uint8_t
         in1in2 = _mm_xor_si128(in1in2, next12);
         __m128i chorb56xorchorb12 = _mm_xor_si128(chorba56, chorba12);
         in1in2 = _mm_xor_si128(in1in2, chorb56xorchorb12);
-        __m128i chorb1_ = _mm_unpacklo_epi64(_mm_setzero_si128(), chorba12);
+        __m128i chorb1_ = LSHIFT_QWORD(chorba12);
         in1in2 = _mm_xor_si128(in1in2, chorb1_);
 
         NEXT_ROUND(in1in2, ab1, ab2, ab3, ab4);
@@ -171,33 +157,25 @@ Z_INTERNAL uint32_t chorba_small_nondestructive_sse2(uint32_t crc, const uint8_t
         in3in4 = _mm_xor_si128(next34, in3in4);
         in3in4 = _mm_xor_si128(in3in4, _mm_xor_si128(ab1, chorba78));
         in3in4 = _mm_xor_si128(in3in4, _mm_xor_si128(chorba34, chorba12));
-        in3in4 = _mm_xor_si128(in3in4, _mm_xor_si128(chorba23, _mm_unpacklo_epi64(_mm_setzero_si128(), ab2)));
+        in3in4 = _mm_xor_si128(in3in4, _mm_xor_si128(chorba23, LSHIFT_QWORD(ab2)));
 
         NEXT_ROUND(in3in4, cd1, cd2, cd3, cd4);
 
-        a4_ = _mm_unpacklo_epi64(next56, ab4);
-        next12 = _mm_xor_si128(_mm_xor_si128(a4_, ab3), cd1);
-        b2c2 = _mm_castpd_si128(_mm_shuffle_pd(_mm_castsi128_pd(ab2), _mm_castsi128_pd(cd2), 1));
-        b4c4 = _mm_castpd_si128(_mm_shuffle_pd(_mm_castsi128_pd(ab4), _mm_castsi128_pd(cd4), 1));
-        d2_ = _mm_unpackhi_epi64(cd2, _mm_setzero_si128());
-        next12 = _mm_xor_si128(next12, b2c2);
-        next34 = _mm_xor_si128(b4c4, cd3);
-        next34 = _mm_xor_si128(next34, d2_);
-        next56 = _mm_unpackhi_epi64(cd4, _mm_setzero_si128());
+        ACCUM_ROUND();
 
         i += 32;
 
         /* 16-19 */
         READ_NEXT(input, i, in1in2, in3in4);
 
-        __m128i chorba1_ = _mm_unpacklo_epi64(_mm_setzero_si128(), chorba12);
+        __m128i chorba1_ = LSHIFT_QWORD(chorba12);
         in1in2 = _mm_xor_si128(_mm_xor_si128(next12, in1in2), _mm_xor_si128(chorba56, chorba45));
         in1in2 = _mm_xor_si128(in1in2, _mm_xor_si128(chorba12, chorba34));
         in1in2 = _mm_xor_si128(chorba1_, in1in2);
 
         NEXT_ROUND(in1in2, ab1, ab2, ab3, ab4);
 
-        a2_ = _mm_unpacklo_epi64(_mm_setzero_si128(), ab2);
+        a2_ = LSHIFT_QWORD(ab2);
         in3in4 = _mm_xor_si128(in3in4, _mm_xor_si128(ab1, chorba78));
         in3in4 = _mm_xor_si128(in3in4, _mm_xor_si128(chorba56, chorba34));
         in3in4 = _mm_xor_si128(in3in4, _mm_xor_si128(chorba23, chorba67));
@@ -206,15 +184,7 @@ Z_INTERNAL uint32_t chorba_small_nondestructive_sse2(uint32_t crc, const uint8_t
 
         NEXT_ROUND(in3in4, cd1, cd2, cd3, cd4);
 
-        a4_ = _mm_unpacklo_epi64(next56, ab4);
-        next12 = _mm_xor_si128(_mm_xor_si128(a4_, ab3), cd1);
-        b2c2 = _mm_castpd_si128(_mm_shuffle_pd(_mm_castsi128_pd(ab2), _mm_castsi128_pd(cd2), 1));
-        b4c4 = _mm_castpd_si128(_mm_shuffle_pd(_mm_castsi128_pd(ab4), _mm_castsi128_pd(cd4), 1));
-        d2_ = _mm_unpackhi_epi64(cd2, _mm_setzero_si128());
-        next12 = _mm_xor_si128(next12, b2c2);
-        next34 = _mm_xor_si128(b4c4, cd3);
-        next34 = _mm_xor_si128(next34, d2_);
-        next56 = _mm_unpackhi_epi64(cd4, _mm_setzero_si128());
+        ACCUM_ROUND();
 
         i += 32;
 
@@ -228,7 +198,7 @@ Z_INTERNAL uint32_t chorba_small_nondestructive_sse2(uint32_t crc, const uint8_t
 
         NEXT_ROUND(in1in2, ab1, ab2, ab3, ab4);
 
-        a2_ = _mm_unpacklo_epi64(_mm_setzero_si128(), ab2);
+        a2_ = LSHIFT_QWORD(ab2);
         in3in4 = _mm_xor_si128(in3in4, _mm_xor_si128(next34, ab1));
         in3in4 = _mm_xor_si128(in3in4, _mm_xor_si128(chorba78, chorba67));
         in3in4 = _mm_xor_si128(in3in4, _mm_xor_si128(chorba45, chorba34));
@@ -237,15 +207,7 @@ Z_INTERNAL uint32_t chorba_small_nondestructive_sse2(uint32_t crc, const uint8_t
 
         NEXT_ROUND(in3in4, cd1, cd2, cd3, cd4);
 
-        a4_ = _mm_unpacklo_epi64(next56, ab4);
-        next12 = _mm_xor_si128(_mm_xor_si128(a4_, ab3), cd1);
-        b2c2 = _mm_castpd_si128(_mm_shuffle_pd(_mm_castsi128_pd(ab2), _mm_castsi128_pd(cd2), 1));
-        b4c4 = _mm_castpd_si128(_mm_shuffle_pd(_mm_castsi128_pd(ab4), _mm_castsi128_pd(cd4), 1));
-        d2_ = _mm_unpackhi_epi64(cd2, _mm_setzero_si128());
-        next12 = _mm_xor_si128(next12, b2c2);
-        next34 = _mm_xor_si128(b4c4, cd3);
-        next34 = _mm_xor_si128(next34, d2_);
-        next56 = _mm_unpackhi_epi64(cd4, _mm_setzero_si128());
+        ACCUM_ROUND();
 
         i += 32;
 
@@ -259,7 +221,7 @@ Z_INTERNAL uint32_t chorba_small_nondestructive_sse2(uint32_t crc, const uint8_t
 
         NEXT_ROUND(in1in2, ab1, ab2, ab3, ab4);
 
-        a2_ = _mm_unpacklo_epi64(_mm_setzero_si128(), ab2);
+        a2_ = LSHIFT_QWORD(ab2);
         in3in4 = _mm_xor_si128(in3in4, _mm_xor_si128(next34, ab1));
         in3in4 = _mm_xor_si128(in3in4, _mm_xor_si128(chorba78, chorba56));
         in3in4 = _mm_xor_si128(in3in4, _mm_xor_si128(chorba45, chorba34));
@@ -267,15 +229,7 @@ Z_INTERNAL uint32_t chorba_small_nondestructive_sse2(uint32_t crc, const uint8_t
 
         NEXT_ROUND(in3in4, cd1, cd2, cd3, cd4);
 
-        a4_ = _mm_unpacklo_epi64(next56, ab4);
-        next12 = _mm_xor_si128(_mm_xor_si128(a4_, ab3), cd1);
-        b2c2 = _mm_castpd_si128(_mm_shuffle_pd(_mm_castsi128_pd(ab2), _mm_castsi128_pd(cd2), 1));
-        b4c4 = _mm_castpd_si128(_mm_shuffle_pd(_mm_castsi128_pd(ab4), _mm_castsi128_pd(cd4), 1));
-        d2_ = _mm_unpackhi_epi64(cd2, _mm_setzero_si128());
-        next12 = _mm_xor_si128(next12, b2c2);
-        next34 = _mm_xor_si128(b4c4, cd3);
-        next34 = _mm_xor_si128(next34, d2_);
-        next56 = _mm_unpackhi_epi64(cd4, _mm_setzero_si128());
+        ACCUM_ROUND();
 
         i += 32;
 
@@ -287,22 +241,14 @@ Z_INTERNAL uint32_t chorba_small_nondestructive_sse2(uint32_t crc, const uint8_t
 
         NEXT_ROUND(in1in2, ab1, ab2, ab3, ab4);
 
-        a2_ = _mm_unpacklo_epi64(_mm_setzero_si128(), ab2);
+        a2_ = LSHIFT_QWORD(ab2);
         in3in4 = _mm_xor_si128(in3in4, _mm_xor_si128(next34, ab1));
         in3in4 = _mm_xor_si128(in3in4, _mm_xor_si128(chorba78, chorba80));
         in3in4 = _mm_xor_si128(a2_, in3in4);
 
         NEXT_ROUND(in3in4, cd1, cd2, cd3, cd4);
 
-        a4_ = _mm_unpacklo_epi64(next56, ab4);
-        next12 = _mm_xor_si128(_mm_xor_si128(a4_, ab3), cd1);
-        b2c2 = _mm_castpd_si128(_mm_shuffle_pd(_mm_castsi128_pd(ab2), _mm_castsi128_pd(cd2), 1));
-        b4c4 = _mm_castpd_si128(_mm_shuffle_pd(_mm_castsi128_pd(ab4), _mm_castsi128_pd(cd4), 1));
-        d2_ = _mm_unpackhi_epi64(cd2, _mm_setzero_si128());
-        next12 = _mm_xor_si128(next12, b2c2);
-        next34 = _mm_xor_si128(b4c4, cd3);
-        next34 = _mm_xor_si128(next34, d2_);
-        next56 = _mm_unpackhi_epi64(cd4, _mm_setzero_si128());
+        ACCUM_ROUND();
     }
 
     for (; (i + 40 + 32) < len; i += 32) {
@@ -314,24 +260,14 @@ Z_INTERNAL uint32_t chorba_small_nondestructive_sse2(uint32_t crc, const uint8_t
 
         NEXT_ROUND(in1in2, ab1, ab2, ab3, ab4);
 
-        __m128i a2_ = _mm_unpacklo_epi64(_mm_setzero_si128(), ab2);
+        __m128i a2_ = LSHIFT_QWORD(ab2);
         __m128i ab1_next34 = _mm_xor_si128(next34, ab1);
         in3in4 = _mm_xor_si128(in3in4, ab1_next34);
         in3in4 = _mm_xor_si128(a2_, in3in4);
 
         NEXT_ROUND(in3in4, cd1, cd2, cd3, cd4);
 
-        __m128i b2c2 = _mm_castpd_si128(_mm_shuffle_pd(_mm_castsi128_pd(ab2), _mm_castsi128_pd(cd2), 1));
-        __m128i a4_ = _mm_unpacklo_epi64(_mm_setzero_si128(), ab4);
-        a4_ = _mm_xor_si128(b2c2, a4_);
-        next12 = _mm_xor_si128(ab3, a4_);
-        next12 = _mm_xor_si128(next12, cd1);
-
-        __m128i d2_ = _mm_unpackhi_epi64(cd2, _mm_setzero_si128());
-        __m128i b4c4 = _mm_castpd_si128(_mm_shuffle_pd(_mm_castsi128_pd(ab4), _mm_castsi128_pd(cd4), 1));
-        next12 = _mm_xor_si128(next12, next56);
-        next34 = _mm_xor_si128(cd3, _mm_xor_si128(b4c4, d2_));
-        next56 = _mm_unpackhi_epi64(cd4, _mm_setzero_si128());
+        ACCUM_ROUND();
     }
 
     next1 = _mm_cvtsi128_si64(next12);

--- a/arch/x86/crc32_chorba_sse41.c
+++ b/arch/x86/crc32_chorba_sse41.c
@@ -9,47 +9,53 @@
 #include "arch/x86/x86_intrins.h"
 #include "arch_functions.h"
 
-#define READ_NEXT(in, off, a, b) do { \
+#define READ_NEXT(in, off, a, b) \
+    do { \
         a = _mm_load_si128((__m128i*)(in + off / sizeof(uint64_t))); \
         b = _mm_load_si128((__m128i*)(in + off / sizeof(uint64_t) + 2)); \
-        } while (0);
+    } while (0)
 
-#define NEXT_ROUND(invec, a, b, c, d) do { \
+#define NEXT_ROUND(invec, a, b, c, d) \
+    do { \
         a = _mm_xor_si128(_mm_slli_epi64(invec, 17), _mm_slli_epi64(invec, 55)); \
         b = _mm_xor_si128(_mm_xor_si128(_mm_srli_epi64(invec, 47), _mm_srli_epi64(invec, 9)), _mm_slli_epi64(invec, 19)); \
         c = _mm_xor_si128(_mm_srli_epi64(invec, 45), _mm_slli_epi64(invec, 44)); \
         d  = _mm_srli_epi64(invec, 20); \
-        } while (0);
+    } while (0)
 
-#define REALIGN_CHORBA(in0, in1, in2, in3, out0, out1, out2, out3, out4, shift) do { \
+#define REALIGN_CHORBA(in0, in1, in2, in3, out0, out1, out2, out3, out4, shift) \
+    do { \
         out0 = _mm_slli_si128(in0, shift); \
         out1 = _mm_alignr_epi8(in1, in0, shift); \
         out2 = _mm_alignr_epi8(in2, in1, shift); \
         out3 = _mm_alignr_epi8(in3, in2, shift); \
         out4 = _mm_srli_si128(in3, shift); \
-        } while (0)
+    } while (0)
 
-#define STORE4(out0, out1, out2, out3, out) do { \
+#define STORE4(out0, out1, out2, out3, out) \
+    do { \
         _mm_store_si128(out++, out0); \
         _mm_store_si128(out++, out1); \
         _mm_store_si128(out++, out2); \
         _mm_store_si128(out++, out3); \
     } while (0)
 
-#define READ4(out0, out1, out2, out3, in) do { \
-    out0 = _mm_load_si128(in++); \
-    out1 = _mm_load_si128(in++); \
-    out2 = _mm_load_si128(in++); \
-    out3 = _mm_load_si128(in++); \
+#define READ4(out0, out1, out2, out3, in) \
+    do { \
+        out0 = _mm_load_si128(in++); \
+        out1 = _mm_load_si128(in++); \
+        out2 = _mm_load_si128(in++); \
+        out3 = _mm_load_si128(in++); \
     } while (0)
 
 /* This is intentionally shifted one down to compensate for the deferred store from
  * the last iteration */
-#define READ4_WITHXOR(out0, out1, out2, out3, xor0, xor1, xor2, xor3, in) do { \
-    out0 = _mm_xor_si128(in[1], xor0); \
-    out1 = _mm_xor_si128(in[2], xor1); \
-    out2 = _mm_xor_si128(in[3], xor2); \
-    out3 = _mm_xor_si128(in[4], xor3); \
+#define READ4_WITHXOR(out0, out1, out2, out3, xor0, xor1, xor2, xor3, in) \
+    do { \
+        out0 = _mm_xor_si128(in[1], xor0); \
+        out1 = _mm_xor_si128(in[2], xor1); \
+        out2 = _mm_xor_si128(in[3], xor2); \
+        out3 = _mm_xor_si128(in[4], xor3); \
     } while (0)
 
 Z_FORCEINLINE static uint32_t crc32_chorba_32768_nondestructive_sse41(uint32_t crc, const uint8_t *buf, size_t len) {


### PR DESCRIPTION
This should reduce the number of CodeQL warnings in "Security and quality" on GitHub menu. 

This also helps reduce code duplication. About -773 lines.