### PR TITLE
Fix building GH1235 test for 32-bit MinGW

### DIFF
--- a/test/gh1235.c
+++ b/test/gh1235.c
@@ -8,7 +8,7 @@ int main(void) {
     unsigned char compressed[130];
     PREFIX3(stream) strm;
     z_size_t bound;
-    z_size_t bytes;
+    z_uintmax_t bytes;
 
     for (int i = 0; i <= 32; i++) {
         memset(plain, 6, i);


### PR DESCRIPTION
```
C:/build/git/zlib-ng/test/gh1235.c: In function 'main':
C:/build/git/zlib-ng/test/gh1235.c:34:43: error: passing argument 2 of 'compress2' from incompatible pointer type [-Wincompatible-pointer-types]
   34 |         if (PREFIX(compress2)(compressed, &bytes, plain, i, 1) != Z_OK) return -1;
      |                                           ^~~~~~
      |                                           |
      |                                           z_size_t * {aka unsigned int *}
In file included from C:/build/git/zlib-ng/zutil.h:15,
                 from C:/build/git/zlib-ng/test/gh1235.c:4:
../zlib.h:1261:69: note: expected 'long unsigned int *' but argument is of type 'z_size_t *' {aka 'unsigned int *'}
 1261 | Z_EXTERN int Z_EXPORT compress2(unsigned char *dest, unsigned long *destLen, const unsigned char *source,
      |                                                      ~~~~~~~~~~~~~~~^~~~~~~
```