### PR TITLE
Add corpora benchmarks for deflate and inflate

### DIFF
--- a/test/benchmarks/CMakeLists.txt
+++ b/test/benchmarks/CMakeLists.txt
@@ -13,7 +13,7 @@ if(NOT DEFINED CMAKE_CXX_EXTENSIONS)
 endif()
 
 # Search for Google benchmark package
-find_package(benchmark QUIET)
+find_package(benchmark 1.9.2 QUIET)
 if(NOT benchmark_FOUND)
     # Fetch google benchmark source code from official repository
     set(BENCHMARK_ENABLE_TESTING OFF)
@@ -32,11 +32,17 @@ if(NOT benchmark_FOUND)
         ${ZNG_FetchContent_Declare_EXCLUDE_FROM_ALL})
 
     ZNG_FetchContent_MakeAvailable(benchmark)
+
+    # GCC 13+ false positive in std_function.h (google/benchmark#1973)
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+        target_compile_options(benchmark PRIVATE -Wno-maybe-uninitialized)
+    endif()
 endif()
 
 # Public API benchmarks
 set(BENCH_PUBLIC_SRCS
     benchmark_compress.cc
+    benchmark_corpora.cc
     benchmark_inflate.cc
     benchmark_inflate_chunked.cc
     benchmark_uncompress.cc
@@ -58,7 +64,9 @@ set(BENCH_INTERNAL_SRCS
 
 add_executable(benchmark_zlib ${BENCH_PUBLIC_SRCS})
 
-target_compile_definitions(benchmark_zlib PRIVATE -DBENCHMARK_STATIC_DEFINE)
+target_compile_definitions(benchmark_zlib PRIVATE
+    -DBENCHMARK_STATIC_DEFINE
+    -DTEST_DATA_DIR="${PROJECT_SOURCE_DIR}/test/data")
 target_include_directories(benchmark_zlib PRIVATE
     ${PROJECT_SOURCE_DIR}
     ${PROJECT_BINARY_DIR}

--- a/test/benchmarks/benchmark_corpora.cc
+++ b/test/benchmarks/benchmark_corpora.cc
@@ -189,7 +189,7 @@ public:
         if (!load_corpus_file(cf))
             return;
 
-        outbuff_size = PREFIX(deflateBound)(NULL, (z_uintmax_t)cf->size);
+        outbuff_size = PREFIX(deflateBound)(NULL, (unsigned long)cf->size);
         outbuff = (uint8_t *)malloc(outbuff_size);
         if (outbuff == NULL)
             return;
@@ -225,6 +225,9 @@ public:
                 break;
             }
         }
+
+        state.counters["compressed"] = benchmark::Counter(double(strm.total_out));
+        state.counters["ratio"] = benchmark::Counter(double(cf->size) / double(strm.total_out));
     }
 
     void TearDown(const benchmark::State &) override {
@@ -259,7 +262,7 @@ public:
         outbuff = (uint8_t *)malloc(cf->size);
 
         /* Pre-compress the file for inflate benchmarking */
-        z_uintmax_t comp_bound = PREFIX(deflateBound)(NULL, (z_uintmax_t)cf->size);
+        z_uintmax_t comp_bound = PREFIX(deflateBound)(NULL, (unsigned long)cf->size);
         compressed = (uint8_t *)malloc(comp_bound);
 
         if (compressed != NULL) {
@@ -312,6 +315,9 @@ public:
                 break;
             }
         }
+
+        state.counters["compressed"] = benchmark::Counter(double(strm.total_out));
+        state.counters["ratio"] = benchmark::Counter(double(cf->size) / double(strm.total_out));
     }
 
     void TearDown(const benchmark::State &) override {
@@ -330,7 +336,7 @@ static int register_corpora_benchmarks(void) {
     if (!discover_corpora())
         return 0;
 
-    int levels[] = {1, 6, 9};
+    int levels[] = {1, 3, 6, 8, 9};
 
     size_t prefix_len = strlen(CORPORA_DIR) + 1;
 

--- a/test/benchmarks/benchmark_corpora.cc
+++ b/test/benchmarks/benchmark_corpora.cc
@@ -1,0 +1,357 @@
+/* benchmark_corpora.cc -- benchmark deflate/inflate with real-world data
+ * Copyright (C) 2026 Nathan Moinvaziri
+ * For conditions of distribution and use, see copyright notice in zlib.h
+ *
+ * Benchmarks against the zlib-ng/corpora repository which contains multiple
+ * test corpora (silesia, calgary, canterbury, large, snappy, etc.).
+ *
+ * Clone the corpora repo:
+ *   git clone https://github.com/zlib-ng/corpora test/data/corpora
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <vector>
+#include <string>
+#include <algorithm>
+#include <benchmark/benchmark.h>
+
+#ifdef _WIN32
+#  include <windows.h>
+#else
+#  include <dirent.h>
+#  include <sys/stat.h>
+#endif
+
+extern "C" {
+#  include "zbuild.h"
+#  include "zutil_p.h"
+#  if defined(ZLIB_COMPAT)
+#    include "zlib.h"
+#  else
+#    include "zlib-ng.h"
+#  endif
+}
+
+/* Absolute path defined by CMake, fallback for standalone builds */
+#ifndef TEST_DATA_DIR
+#  define TEST_DATA_DIR "test/data"
+#endif
+
+#define CORPORA_DIR TEST_DATA_DIR "/corpora"
+
+struct corpus_file {
+    std::string path;
+    uint8_t *data;
+    size_t size;
+};
+
+static std::vector<corpus_file> corpora_files;
+
+/* List regular files in a directory (non-recursive, skips dotfiles and empty files) */
+static std::vector<corpus_file> list_files(const std::string &dir) {
+    std::vector<corpus_file> files;
+
+#ifdef _WIN32
+    WIN32_FIND_DATAA ffd;
+    std::string pattern = dir + "\\*";
+    HANDLE hFind = FindFirstFileA(pattern.c_str(), &ffd);
+    if (hFind == INVALID_HANDLE_VALUE)
+        return files;
+    do {
+        if (ffd.cFileName[0] == '.')
+            continue;
+        if (ffd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+            continue;
+        LARGE_INTEGER fsize;
+        fsize.LowPart = ffd.nFileSizeLow;
+        fsize.HighPart = ffd.nFileSizeHigh;
+        if (fsize.QuadPart <= 0)
+            continue;
+        files.push_back({dir + "\\" + ffd.cFileName, NULL, (size_t)fsize.QuadPart});
+    } while (FindNextFileA(hFind, &ffd));
+    FindClose(hFind);
+#else
+    DIR *d = opendir(dir.c_str());
+    if (d == NULL)
+        return files;
+    struct dirent *ent;
+    while ((ent = readdir(d)) != NULL) {
+        if (ent->d_name[0] == '.')
+            continue;
+        std::string fullpath = dir + "/" + ent->d_name;
+        struct stat st;
+        if (stat(fullpath.c_str(), &st) == 0 && S_ISREG(st.st_mode) && st.st_size > 0)
+            files.push_back({fullpath, NULL, (size_t)st.st_size});
+    }
+    closedir(d);
+#endif
+
+    std::sort(files.begin(), files.end(),
+              [](const corpus_file &a, const corpus_file &b) { return a.path < b.path; });
+    return files;
+}
+
+/* List subdirectories in a directory (skips dotfiles) */
+static std::vector<std::string> list_subdirs(const std::string &dir) {
+    std::vector<std::string> subdirs;
+
+#ifdef _WIN32
+    WIN32_FIND_DATAA ffd;
+    std::string pattern = dir + "\\*";
+    HANDLE hFind = FindFirstFileA(pattern.c_str(), &ffd);
+    if (hFind == INVALID_HANDLE_VALUE)
+        return subdirs;
+    do {
+        if (ffd.cFileName[0] == '.')
+            continue;
+        if (ffd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+            subdirs.push_back(dir + "\\" + ffd.cFileName);
+    } while (FindNextFileA(hFind, &ffd));
+    FindClose(hFind);
+#else
+    DIR *d = opendir(dir.c_str());
+    if (d == NULL)
+        return subdirs;
+    struct dirent *ent;
+    while ((ent = readdir(d)) != NULL) {
+        if (ent->d_name[0] == '.')
+            continue;
+        std::string fullpath = dir + "/" + ent->d_name;
+        struct stat st;
+        if (stat(fullpath.c_str(), &st) == 0 && S_ISDIR(st.st_mode))
+            subdirs.push_back(fullpath);
+    }
+    closedir(d);
+#endif
+
+    std::sort(subdirs.begin(), subdirs.end());
+    return subdirs;
+}
+
+/* Load a single corpus file's data on demand */
+static bool load_corpus_file(corpus_file *cf) {
+    if (cf->data != NULL)
+        return true;
+
+    FILE *fp = fopen(cf->path.c_str(), "rb");
+    if (fp == NULL)
+        return false;
+
+    uint8_t *buf = (uint8_t *)malloc(cf->size);
+    if (buf == NULL) {
+        fclose(fp);
+        return false;
+    }
+
+    size_t bytes_read = fread(buf, 1, cf->size, fp);
+    fclose(fp);
+
+    if (bytes_read != cf->size) {
+        free(buf);
+        return false;
+    }
+
+    cf->data = buf;
+    return true;
+}
+
+/* Discover corpus files without loading their contents */
+static bool discover_corpora(void) {
+    std::vector<std::string> subdirs = list_subdirs(CORPORA_DIR);
+    if (subdirs.empty())
+        return false;
+
+    for (size_t s = 0; s < subdirs.size(); s++) {
+        std::vector<corpus_file> files = list_files(subdirs[s]);
+        corpora_files.insert(corpora_files.end(), files.begin(), files.end());
+    }
+
+    return !corpora_files.empty();
+}
+
+class deflate_corpora : public benchmark::Fixture {
+private:
+    corpus_file *cf;
+    int level;
+    uint8_t *outbuff;
+    z_uintmax_t outbuff_size;
+    PREFIX3(stream) strm;
+
+public:
+    deflate_corpora(const std::string &name, corpus_file *cf, int level)
+        : cf(cf), level(level), outbuff(NULL), outbuff_size(0), strm{} {
+        this->SetName(name);
+    }
+
+    void SetUp(const benchmark::State &) override {
+        if (!load_corpus_file(cf))
+            return;
+
+        outbuff_size = PREFIX(deflateBound)(NULL, (z_uintmax_t)cf->size);
+        outbuff = (uint8_t *)malloc(outbuff_size);
+        if (outbuff == NULL)
+            return;
+
+        memset(&strm, 0, sizeof(strm));
+
+        PREFIX(deflateInit2)(&strm, level, Z_DEFLATED, MAX_WBITS, MAX_MEM_LEVEL, Z_DEFAULT_STRATEGY);
+    }
+
+    void BenchmarkCase(benchmark::State &state) override {
+        int err;
+
+        if (cf->data == NULL || outbuff == NULL) {
+            state.SkipWithError("setup failed");
+            return;
+        }
+
+        for (auto _ : state) {
+            err = PREFIX(deflateReset)(&strm);
+            if (err != Z_OK) {
+                state.SkipWithError("deflateReset did not return Z_OK");
+                break;
+            }
+
+            strm.avail_in = (uint32_t)cf->size;
+            strm.next_in = (z_const uint8_t *)cf->data;
+            strm.next_out = outbuff;
+            strm.avail_out = (uint32_t)outbuff_size;
+
+            err = PREFIX(deflate)(&strm, Z_FINISH);
+            if (err != Z_STREAM_END) {
+                state.SkipWithError("deflate did not return Z_STREAM_END");
+                break;
+            }
+        }
+    }
+
+    void TearDown(const benchmark::State &) override {
+        if (outbuff != NULL) {
+            PREFIX(deflateEnd)(&strm);
+            free(outbuff);
+            outbuff = NULL;
+        }
+    }
+};
+
+class inflate_corpora : public benchmark::Fixture {
+private:
+    corpus_file *cf;
+    uint8_t *compressed;
+    size_t compressed_size;
+    uint8_t *outbuff;
+    PREFIX3(stream) strm;
+
+public:
+    inflate_corpora(const std::string &name, corpus_file *cf)
+        : cf(cf), compressed(NULL), compressed_size(0), outbuff(NULL), strm{} {
+        this->SetName(name);
+    }
+
+    void SetUp(const benchmark::State &) override {
+        int err;
+
+        if (!load_corpus_file(cf))
+            return;
+
+        outbuff = (uint8_t *)malloc(cf->size);
+
+        /* Pre-compress the file for inflate benchmarking */
+        z_uintmax_t comp_bound = PREFIX(deflateBound)(NULL, (z_uintmax_t)cf->size);
+        compressed = (uint8_t *)malloc(comp_bound);
+
+        if (compressed != NULL) {
+            PREFIX3(stream) dstrm;
+            memset(&dstrm, 0, sizeof(dstrm));
+
+            err = PREFIX(deflateInit2)(&dstrm, Z_BEST_COMPRESSION, Z_DEFLATED, -MAX_WBITS,
+                                       MAX_MEM_LEVEL, Z_DEFAULT_STRATEGY);
+            if (err == Z_OK) {
+                dstrm.avail_in = (uint32_t)cf->size;
+                dstrm.next_in = (z_const uint8_t *)cf->data;
+                dstrm.next_out = compressed;
+                dstrm.avail_out = (uint32_t)comp_bound;
+
+                err = PREFIX(deflate)(&dstrm, Z_FINISH);
+                if (err == Z_STREAM_END)
+                    compressed_size = dstrm.total_out;
+                PREFIX(deflateEnd)(&dstrm);
+            }
+        }
+
+        memset(&strm, 0, sizeof(strm));
+
+        PREFIX(inflateInit2)(&strm, -MAX_WBITS);
+    }
+
+    void BenchmarkCase(benchmark::State &state) override {
+        int err;
+
+        if (compressed == NULL || outbuff == NULL) {
+            state.SkipWithError("setup failed");
+            return;
+        }
+
+        for (auto _ : state) {
+            err = PREFIX(inflateReset)(&strm);
+            if (err != Z_OK) {
+                state.SkipWithError("inflateReset did not return Z_OK");
+                break;
+            }
+
+            strm.avail_in = (uint32_t)compressed_size;
+            strm.next_in = compressed;
+            strm.avail_out = (uint32_t)cf->size;
+            strm.next_out = outbuff;
+
+            err = PREFIX(inflate)(&strm, Z_FINISH);
+            if (err != Z_STREAM_END) {
+                state.SkipWithError("inflate did not return Z_STREAM_END");
+                break;
+            }
+        }
+    }
+
+    void TearDown(const benchmark::State &) override {
+        if (compressed != NULL) {
+            PREFIX(inflateEnd)(&strm);
+            free(compressed);
+            compressed = NULL;
+        }
+        free(outbuff);
+        outbuff = NULL;
+    }
+};
+
+/* Dynamic benchmark registration at static init time */
+static int register_corpora_benchmarks(void) {
+    if (!discover_corpora())
+        return 0;
+
+    int levels[] = {1, 6, 9};
+
+    size_t prefix_len = strlen(CORPORA_DIR) + 1;
+
+    for (size_t i = 0; i < corpora_files.size(); i++) {
+        corpus_file *cf = &corpora_files[i];
+        std::string label = cf->path.substr(prefix_len);
+        std::replace(label.begin(), label.end(), '\\', '/');
+
+        for (size_t l = 0; l < sizeof(levels) / sizeof(levels[0]); l++) {
+            int level = levels[l];
+            std::string name = "deflate_corpora/" + label + "/level:" + std::to_string(level);
+            benchmark::internal::RegisterBenchmarkInternal(
+                ::benchmark::internal::make_unique<deflate_corpora>(name, cf, level));
+        }
+
+        std::string name = "inflate_corpora/" + label;
+        benchmark::internal::RegisterBenchmarkInternal(
+            ::benchmark::internal::make_unique<inflate_corpora>(name, cf));
+    }
+
+    return 0;
+}
+
+static int corpora_init = register_corpora_benchmarks();

--- a/test/benchmarks/benchmark_deflate.cc
+++ b/test/benchmarks/benchmark_deflate.cc
@@ -91,6 +91,9 @@ public:
             state.SkipWithError("deflateEnd did not return Z_OK");
             return;
         }
+
+        state.counters["compressed"] = benchmark::Counter(double(strm.total_out));
+        state.counters["ratio"] = benchmark::Counter(double(size) / double(strm.total_out));
     }
 
     void TearDown(const ::benchmark::State&) {


### PR DESCRIPTION
If no corpora files are found, then no benchmarks are added.

**Usage**

```sh
git clone https://github.com/zlib-ng/corpora test/data/corpora
cmake -B build -DBUILD_TESTING=ON -DWITH_BENCHMARKS=ON -DBUILD_SHARED_LIBS=OFF
cmake --build build --target benchmark_zlib
build/test/benchmarks/benchmark_zlib --benchmark_filter='corpora/silesia'
```

So far this is a really good test against various types of data. 