### PR TITLE
Increase inflate lenbits from 10 to 11

### DIFF
--- a/inffast_tpl.h
+++ b/inffast_tpl.h
@@ -144,9 +144,10 @@ void Z_INTERNAL INFLATE_FAST(PREFIX3(stream) *strm, uint32_t start, int safe_mod
     do {
         /* This lookup needs bits >= MAX_LEN_ROOT_BITS, which every path here
            guarantees: each refill leaves bits >= 56, the literal-only paths
-           loop after consuming at most 35 bits, and the distance path refills
-           to at least MAX_BITS + MAX_DIST_EXTRA_BITS + MAX_LEN_ROOT_BITS
-           before consuming at most MAX_BITS + MAX_DIST_EXTRA_BITS. */
+           loop after consuming at most 2*MAX_LEN_ROOT_BITS + MAX_BITS bits, and
+           the distance path refills to at least MAX_BITS + MAX_DIST_EXTRA_BITS
+           + MAX_LEN_ROOT_BITS before consuming at most MAX_BITS +
+           MAX_DIST_EXTRA_BITS. */
         here = lcode[hold & lmask];
         Z_TOUCH(here);
         /* No-op on the first iteration: the pre-loop refill already filled hold

--- a/inftrees.c
+++ b/inftrees.c
@@ -26,6 +26,10 @@ const char PREFIX(inflate_copyright)[] = " inflate 1.3.1 Copyright 1995-2024 Mar
   copyright string in the executable of your product.
  */
 
+/* Share of the 2^MAX_BITS code space that must sit above MAX_LEN_ROOT_BITS-1 bits before the
+   larger literal/length root table is worth building. */
+#define ROOT_GROW_MIN_SPACE ((1U << MAX_BITS) / 256)
+
 /* Count number of codes for each code length. */
 static inline void count_lengths(uint16_t *lens, int codes, uint16_t *count) {
     /* IBM...made some weird choices for VSX/VMX. Basically vec_ld has an inherent
@@ -231,6 +235,17 @@ int Z_INTERNAL zng_inflate_table(codetype type, uint16_t *lens, unsigned codes,
     for (min = 1; min < max; min++)
         if (count[min] != 0) break;
     root = MAX(root, min);
+
+    /* Growing root doubles the table build and its footprint, a cost paid once per block, but it
+       only pays off on the symbols that exceed the smaller root. Weighting count[] by the code
+       space each length occupies estimates how often that happens, without decoding the block. */
+    if (type == LENS && root == MAX_LEN_ROOT_BITS) {
+        unsigned space = 0;
+        for (len = root; len <= MAX_BITS; len++)
+            space += (unsigned)count[len] << (MAX_BITS - len);
+        if (space < ROOT_GROW_MIN_SPACE)
+            root--;
+    }
 
     /* check for an over-subscribed or incomplete set of lengths */
     left = 1;

--- a/inftrees.h
+++ b/inftrees.h
@@ -39,17 +39,17 @@ typedef struct {
  */
 
 /* Maximum size of the dynamic table.  The maximum number of code structures is
-   1924, which is the sum of 1332 for literal/length codes and 592 for distance
+   2932, which is the sum of 2340 for literal/length codes and 592 for distance
    codes.  These values were found by exhaustive searches using the program
    examples/enough.c found in the zlib distributions.  The arguments to that
    program are the number of symbols, the initial root table size, and the
-   maximum bit length of a code.  "enough 286 10 15" for literal/length codes
-   returns 1332, and "enough 30 9 15" for distance codes returns 592.
-   The initial root table size (10 or 9) is found in the fifth argument of the
-   inflate_table() calls in inflate.c and infback.c.  If the root table size is
+   maximum bit length of a code.  "enough 286 11 15" for literal/length codes
+   returns 2340, and "enough 30 9 15" for distance codes returns 592.
+   The initial root table size (11 or 9) is MAX_LEN_ROOT_BITS in zutil.h and the
+   distbits assignment in inflate.c and infback.c.  If the root table size is
    changed, then these maximum sizes would be need to be recalculated and
    updated. */
-#define ENOUGH_LENS 1332
+#define ENOUGH_LENS 2340
 #define ENOUGH_DISTS 592
 #define ENOUGH (ENOUGH_LENS+ENOUGH_DISTS)
 

--- a/zutil.h
+++ b/zutil.h
@@ -40,7 +40,7 @@ extern z_const char * const PREFIX(z_errmsg)[10]; /* indexed by 2-zlib_error */
 /* all codes must not exceed MAX_BITS bits */
 #define MAX_DIST_EXTRA_BITS 13
 /* maximum number of extra distance bits */
-#define MAX_LEN_ROOT_BITS 10
+#define MAX_LEN_ROOT_BITS 11
 /* maximum number of index bits for the first-level length code table
    (the largest value assigned to state->lenbits) */
 


### PR DESCRIPTION
## Summary

- Increases lenbits from 10 to 11, eliminating secondary Huffman table lookups for 11-bit codes
- Adds an adaptive path that checks the code-length alphabet to determine whether long codes are possible before allocating the larger table -- **This is optional if we decide we don't want it**
- The inflate_state struct size is unchanged; an extended buffer is allocated lazily only when needed and reused across blocks

## Background

The deflate format uses Huffman codes up to 15 bits. The inflate root table provides single-lookup decoding for codes up to `lenbits` bits; longer codes require a secondary lookup. With lenbits=10, 11-bit codes (common in data with flat byte distributions) always need two lookups.

The code-length alphabet (decoded in the LENLENS stage) reveals whether any code length > 10 is possible. If symbols 11-15 all have zero code lengths, no literal/length code can exceed 10 bits. This O(1) check avoids scanning all code lengths. When the check is negative, the code path is identical to baseline with no performance impact.

Based on madler/zlib#793 and zlib-ng/zlib-ng#1332.

## Benchmarks

Silesia corpus, Apple M4 Pro, lowpowermode=1, `--benchmark_cooldown=3`, 5 repetitions, A-B-A-B interleaved runs averaged:

| File | Change |
|------|--------|
| osdb | **-9.4%** |
| mr | **-5.7%** |
| mozilla | -1.9% |
| nci | -1.4% |

All other files are within noise. Data that does not benefit from lenbits=11 takes the same code path as before with no performance impact.