### PR TITLE
Fix data race on functable reads

### DIFF
--- a/adler32.c
+++ b/adler32.c
@@ -55,22 +55,22 @@ Z_INTERNAL uint32_t adler32_c(uint32_t adler, const uint8_t *buf, size_t len) {
 
 #ifdef ZLIB_COMPAT
 unsigned long Z_EXPORT PREFIX(adler32_z)(unsigned long adler, const unsigned char *buf, size_t len) {
-    return (unsigned long)functable.adler32((uint32_t)adler, buf, len);
+    return (unsigned long)FUNCTABLE_READ(adler32)((uint32_t)adler, buf, len);
 }
 #else
 uint32_t Z_EXPORT PREFIX(adler32_z)(uint32_t adler, const unsigned char *buf, size_t len) {
-    return functable.adler32(adler, buf, len);
+    return FUNCTABLE_READ(adler32)(adler, buf, len);
 }
 #endif
 
 /* ========================================================================= */
 #ifdef ZLIB_COMPAT
 unsigned long Z_EXPORT PREFIX(adler32)(unsigned long adler, const unsigned char *buf, unsigned int len) {
-    return (unsigned long)functable.adler32((uint32_t)adler, buf, len);
+    return (unsigned long)FUNCTABLE_READ(adler32)((uint32_t)adler, buf, len);
 }
 #else
 uint32_t Z_EXPORT PREFIX(adler32)(uint32_t adler, const unsigned char *buf, uint32_t len) {
-    return functable.adler32(adler, buf, len);
+    return FUNCTABLE_READ(adler32)(adler, buf, len);
 }
 #endif
 

--- a/adler32_fold.c
+++ b/adler32_fold.c
@@ -10,7 +10,7 @@
 #include <limits.h>
 
 Z_INTERNAL uint32_t adler32_fold_copy_c(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len) {
-    adler = functable.adler32(adler, src, len);
+    adler = FUNCTABLE_READ(adler32)(adler, src, len);
     memcpy(dst, src, len);
     return adler;
 }

--- a/crc32_braid.c
+++ b/crc32_braid.c
@@ -23,13 +23,13 @@ const uint32_t * Z_EXPORT PREFIX(get_crc_table)(void) {
 unsigned long Z_EXPORT PREFIX(crc32_z)(unsigned long crc, const unsigned char *buf, size_t len) {
     if (buf == NULL) return 0;
 
-    return (unsigned long)functable.crc32((uint32_t)crc, buf, len);
+    return (unsigned long)FUNCTABLE_READ(crc32)((uint32_t)crc, buf, len);
 }
 #else
 uint32_t Z_EXPORT PREFIX(crc32_z)(uint32_t crc, const unsigned char *buf, size_t len) {
     if (buf == NULL) return 0;
 
-    return functable.crc32(crc, buf, len);
+    return FUNCTABLE_READ(crc32)(crc, buf, len);
 }
 #endif
 

--- a/crc32_fold.c
+++ b/crc32_fold.c
@@ -15,7 +15,7 @@ Z_INTERNAL uint32_t crc32_fold_reset_c(crc32_fold *crc) {
 }
 
 Z_INTERNAL void crc32_fold_copy_c(crc32_fold *crc, uint8_t *dst, const uint8_t *src, size_t len) {
-    crc->value = functable.crc32(crc->value, src, len);
+    crc->value = FUNCTABLE_READ(crc32)(crc->value, src, len);
     memcpy(dst, src, len);
 }
 
@@ -25,7 +25,7 @@ Z_INTERNAL void crc32_fold_c(crc32_fold *crc, const uint8_t *src, size_t len, ui
      * same arguments for the versions that _do_ do a folding CRC but we don't want a copy. The
      * init_crc is an unused argument in this context */
     Z_UNUSED(init_crc);
-    crc->value = functable.crc32(crc->value, src, len);
+    crc->value = FUNCTABLE_READ(crc32)(crc->value, src, len);
 }
 
 Z_INTERNAL uint32_t crc32_fold_final_c(crc32_fold *crc) {

--- a/deflate.c
+++ b/deflate.c
@@ -195,7 +195,7 @@ int32_t ZNG_CONDEXPORT PREFIX(deflateInit2)(PREFIX3(stream) *strm, int32_t level
     int wrap = 1;
 
     /* Force initialization functable, because deflate captures function pointers from functable. */
-    functable.force_init();
+    FUNCTABLE_READ(force_init)();
 
     if (strm == NULL)
         return Z_STREAM_ERROR;
@@ -370,7 +370,7 @@ int32_t Z_EXPORT PREFIX(deflateSetDictionary)(PREFIX3(stream) *strm, const uint8
 
     /* when using zlib wrappers, compute Adler-32 for provided dictionary */
     if (wrap == 1)
-        strm->adler = functable.adler32(strm->adler, dictionary, dictLength);
+        strm->adler = FUNCTABLE_READ(adler32)(strm->adler, dictionary, dictLength);
     DEFLATE_SET_DICTIONARY_HOOK(strm, dictionary, dictLength);  /* hook for IBM Z DFLTCC */
     s->wrap = 0;                    /* avoid computing Adler-32 in read_buf */
 
@@ -457,7 +457,7 @@ int32_t Z_EXPORT PREFIX(deflateResetKeep)(PREFIX3(stream) *strm) {
 
 #ifdef GZIP
     if (s->wrap == 2) {
-        strm->adler = functable.crc32_fold_reset(&s->crc_fold);
+        strm->adler = FUNCTABLE_READ(crc32_fold_reset)(&s->crc_fold);
     } else
 #endif
         strm->adler = ADLER32_INITIAL_VALUE;
@@ -555,7 +555,7 @@ int32_t Z_EXPORT PREFIX(deflateParams)(PREFIX3(stream) *strm, int32_t level, int
     if (s->level != level) {
         if (s->level == 0 && s->matches != 0) {
             if (s->matches == 1) {
-                functable.slide_hash(s);
+                FUNCTABLE_READ(slide_hash)(s);
             } else {
                 CLEAR_HASH(s);
             }
@@ -794,7 +794,7 @@ int32_t Z_EXPORT PREFIX(deflate)(PREFIX3(stream) *strm, int32_t flush) {
 #ifdef GZIP
     if (s->status == GZIP_STATE) {
         /* gzip header */
-        functable.crc32_fold_reset(&s->crc_fold);
+        FUNCTABLE_READ(crc32_fold_reset)(&s->crc_fold);
         put_byte(s, 31);
         put_byte(s, 139);
         put_byte(s, 8);
@@ -911,7 +911,7 @@ int32_t Z_EXPORT PREFIX(deflate)(PREFIX3(stream) *strm, int32_t flush) {
                 }
             }
             put_short(s, (uint16_t)strm->adler);
-            functable.crc32_fold_reset(&s->crc_fold);
+            FUNCTABLE_READ(crc32_fold_reset)(&s->crc_fold);
         }
         s->status = BUSY_STATE;
 
@@ -982,7 +982,7 @@ int32_t Z_EXPORT PREFIX(deflate)(PREFIX3(stream) *strm, int32_t flush) {
     /* Write the trailer */
 #ifdef GZIP
     if (s->wrap == 2) {
-        strm->adler = functable.crc32_fold_final(&s->crc_fold);
+        strm->adler = FUNCTABLE_READ(crc32_fold_final)(&s->crc_fold);
 
         put_uint32(s, strm->adler);
         put_uint32(s, (uint32_t)strm->total_in);
@@ -1095,10 +1095,10 @@ Z_INTERNAL unsigned PREFIX(read_buf)(PREFIX3(stream) *strm, unsigned char *buf, 
         memcpy(buf, strm->next_in, len);
 #ifdef GZIP
     } else if (strm->state->wrap == 2) {
-        functable.crc32_fold_copy(&strm->state->crc_fold, buf, strm->next_in, len);
+        FUNCTABLE_READ(crc32_fold_copy)(&strm->state->crc_fold, buf, strm->next_in, len);
 #endif
     } else if (strm->state->wrap == 1) {
-        strm->adler = functable.adler32_fold_copy(strm->adler, buf, strm->next_in, len);
+        strm->adler = FUNCTABLE_READ(adler32_fold_copy)(strm->adler, buf, strm->next_in, len);
     } else {
         memcpy(buf, strm->next_in, len);
     }
@@ -1125,9 +1125,9 @@ static void lm_set_level(deflate_state *s, int level) {
         s->insert_string = &insert_string_roll;
         s->quick_insert_string = &quick_insert_string_roll;
     } else {
-        s->update_hash = functable.update_hash;
-        s->insert_string = functable.insert_string;
-        s->quick_insert_string = functable.quick_insert_string;
+        s->update_hash = FUNCTABLE_READ(update_hash);
+        s->insert_string = FUNCTABLE_READ(insert_string);
+        s->quick_insert_string = FUNCTABLE_READ(quick_insert_string);
     }
 
     s->level = level;
@@ -1191,7 +1191,7 @@ void Z_INTERNAL PREFIX(fill_window)(deflate_state *s) {
             s->block_start -= (int)wsize;
             if (s->insert > s->strstart)
                 s->insert = s->strstart;
-            functable.slide_hash(s);
+            FUNCTABLE_READ(slide_hash)(s);
             more += wsize;
         }
         if (s->strm->avail_in == 0)

--- a/deflate_fast.c
+++ b/deflate_fast.c
@@ -41,7 +41,7 @@ Z_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
          * dictionary, and set hash_head to the head of the hash chain:
          */
         if (s->lookahead >= WANT_MIN_MATCH) {
-            hash_head = functable.quick_insert_string(s, s->strstart);
+            hash_head = FUNCTABLE_READ(quick_insert_string)(s, s->strstart);
             dist = (int64_t)s->strstart - hash_head;
 
             /* Find the longest match, discarding those <= prev_length.
@@ -52,7 +52,7 @@ Z_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
                  * of window index 0 (in particular we have to avoid a match
                  * of the string with itself at the start of the input file).
                  */
-                match_len = functable.longest_match(s, hash_head);
+                match_len = FUNCTABLE_READ(longest_match)(s, hash_head);
                 /* longest_match() sets match_start */
             }
         }
@@ -71,11 +71,11 @@ Z_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
                 match_len--; /* string at strstart already in table */
                 s->strstart++;
 
-                functable.insert_string(s, s->strstart, match_len);
+                FUNCTABLE_READ(insert_string)(s, s->strstart, match_len);
                 s->strstart += match_len;
             } else {
                 s->strstart += match_len;
-                functable.quick_insert_string(s, s->strstart + 2 - STD_MIN_MATCH);
+                FUNCTABLE_READ(quick_insert_string)(s, s->strstart + 2 - STD_MIN_MATCH);
 
                 /* If lookahead < STD_MIN_MATCH, ins_h is garbage, but it does not
                  * matter since it will be recomputed at next deflate call.

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -52,9 +52,9 @@ static void insert_match(deflate_state *s, struct match match) {
         if (UNLIKELY(match.match_length > 0)) {
             if (match.strstart >= match.orgstart) {
                 if (match.strstart + match.match_length - 1 >= match.orgstart) {
-                    functable.insert_string(s, match.strstart, match.match_length);
+                    FUNCTABLE_READ(insert_string)(s, match.strstart, match.match_length);
                 } else {
-                    functable.insert_string(s, match.strstart, match.orgstart - match.strstart + 1);
+                    FUNCTABLE_READ(insert_string)(s, match.strstart, match.orgstart - match.strstart + 1);
                 }
                 match.strstart += match.match_length;
                 match.match_length = 0;
@@ -72,12 +72,12 @@ static void insert_match(deflate_state *s, struct match match) {
 
         if (LIKELY(match.strstart >= match.orgstart)) {
             if (LIKELY(match.strstart + match.match_length - 1 >= match.orgstart)) {
-                functable.insert_string(s, match.strstart, match.match_length);
+                FUNCTABLE_READ(insert_string)(s, match.strstart, match.match_length);
             } else {
-                functable.insert_string(s, match.strstart, match.orgstart - match.strstart + 1);
+                FUNCTABLE_READ(insert_string)(s, match.strstart, match.orgstart - match.strstart + 1);
             }
         } else if (match.orgstart < match.strstart + match.match_length) {
-            functable.insert_string(s, match.orgstart, match.strstart + match.match_length - match.orgstart);
+            FUNCTABLE_READ(insert_string)(s, match.orgstart, match.strstart + match.match_length - match.orgstart);
         }
         match.strstart += match.match_length;
         match.match_length = 0;
@@ -86,7 +86,7 @@ static void insert_match(deflate_state *s, struct match match) {
         match.match_length = 0;
 
         if (match.strstart >= (STD_MIN_MATCH - 2))
-            functable.quick_insert_string(s, match.strstart + 2 - STD_MIN_MATCH);
+            FUNCTABLE_READ(quick_insert_string)(s, match.strstart + 2 - STD_MIN_MATCH);
 
         /* If lookahead < WANT_MIN_MATCH, ins_h is garbage, but it does not
          * matter since it will be recomputed at next deflate call.
@@ -199,7 +199,7 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
         } else {
             hash_head = 0;
             if (s->lookahead >= WANT_MIN_MATCH) {
-                hash_head = functable.quick_insert_string(s, s->strstart);
+                hash_head = FUNCTABLE_READ(quick_insert_string)(s, s->strstart);
             }
 
             current_match.strstart = (uint16_t)s->strstart;
@@ -215,7 +215,7 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
                  * of window index 0 (in particular we have to avoid a match
                  * of the string with itself at the start of the input file).
                  */
-                current_match.match_length = (uint16_t)functable.longest_match(s, hash_head);
+                current_match.match_length = (uint16_t)FUNCTABLE_READ(longest_match)(s, hash_head);
                 current_match.match_start = (uint16_t)s->match_start;
                 if (UNLIKELY(current_match.match_length < WANT_MIN_MATCH))
                     current_match.match_length = 1;
@@ -235,7 +235,7 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
         /* now, look ahead one */
         if (LIKELY(!early_exit && s->lookahead > MIN_LOOKAHEAD && (uint32_t)(current_match.strstart + current_match.match_length) < (s->window_size - MIN_LOOKAHEAD))) {
             s->strstart = current_match.strstart + current_match.match_length;
-            hash_head = functable.quick_insert_string(s, s->strstart);
+            hash_head = FUNCTABLE_READ(quick_insert_string)(s, s->strstart);
 
             next_match.strstart = (uint16_t)s->strstart;
             next_match.orgstart = next_match.strstart;
@@ -250,7 +250,7 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
                  * of window index 0 (in particular we have to avoid a match
                  * of the string with itself at the start of the input file).
                  */
-                next_match.match_length = (uint16_t)functable.longest_match(s, hash_head);
+                next_match.match_length = (uint16_t)FUNCTABLE_READ(longest_match)(s, hash_head);
                 next_match.match_start = (uint16_t)s->match_start;
                 if (UNLIKELY(next_match.match_start >= next_match.strstart)) {
                     /* this can happen due to some restarts */

--- a/deflate_quick.c
+++ b/deflate_quick.c
@@ -86,7 +86,7 @@ Z_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
         }
 
         if (LIKELY(s->lookahead >= WANT_MIN_MATCH)) {
-            hash_head = functable.quick_insert_string(s, s->strstart);
+            hash_head = FUNCTABLE_READ(quick_insert_string)(s, s->strstart);
             dist = (int64_t)s->strstart - hash_head;
 
             if (dist <= MAX_DIST(s) && dist > 0) {
@@ -94,7 +94,7 @@ Z_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
                 const uint8_t *match_start = s->window + hash_head;
 
                 if (zng_memcmp_2(str_start, match_start) == 0) {
-                    match_len = functable.compare256(str_start+2, match_start+2) + 2;
+                    match_len = FUNCTABLE_READ(compare256)(str_start+2, match_start+2) + 2;
 
                     if (match_len >= WANT_MIN_MATCH) {
                         if (UNLIKELY(match_len > s->lookahead))

--- a/deflate_slow.c
+++ b/deflate_slow.c
@@ -19,12 +19,12 @@ Z_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
     int bflush;              /* set if current block must be flushed */
     int64_t dist;
     uint32_t match_len;
-    match_func *longest_match;
+    match_func longest_match_fn;
 
     if (s->max_chain_length <= 1024)
-        longest_match = &functable.longest_match;
+        longest_match_fn = FUNCTABLE_READ(longest_match);
     else
-        longest_match = &functable.longest_match_slow;
+        longest_match_fn = FUNCTABLE_READ(longest_match_slow);
 
     /* Process the input block. */
     for (;;) {
@@ -61,7 +61,7 @@ Z_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
              * of window index 0 (in particular we have to avoid a match
              * of the string with itself at the start of the input file).
              */
-            match_len = (*longest_match)(s, hash_head);
+            match_len = longest_match_fn(s, hash_head);
             /* longest_match() sets match_start */
 
             if (match_len <= 5 && (s->strategy == Z_FILTERED)) {

--- a/functable.c
+++ b/functable.c
@@ -297,87 +297,87 @@ static void force_init_stub(void) {
 
 static uint32_t adler32_stub(uint32_t adler, const uint8_t* buf, size_t len) {
     init_functable();
-    return functable.adler32(adler, buf, len);
+    return FUNCTABLE_READ(adler32)(adler, buf, len);
 }
 
 static uint32_t adler32_fold_copy_stub(uint32_t adler, uint8_t* dst, const uint8_t* src, size_t len) {
     init_functable();
-    return functable.adler32_fold_copy(adler, dst, src, len);
+    return FUNCTABLE_READ(adler32_fold_copy)(adler, dst, src, len);
 }
 
 static uint8_t* chunkmemset_safe_stub(uint8_t* out, unsigned dist, unsigned len, unsigned left) {
     init_functable();
-    return functable.chunkmemset_safe(out, dist, len, left);
+    return FUNCTABLE_READ(chunkmemset_safe)(out, dist, len, left);
 }
 
 static uint32_t chunksize_stub(void) {
     init_functable();
-    return functable.chunksize();
+    return FUNCTABLE_READ(chunksize)();
 }
 
 static uint32_t compare256_stub(const uint8_t* src0, const uint8_t* src1) {
     init_functable();
-    return functable.compare256(src0, src1);
+    return FUNCTABLE_READ(compare256)(src0, src1);
 }
 
 static uint32_t crc32_stub(uint32_t crc, const uint8_t* buf, size_t len) {
     init_functable();
-    return functable.crc32(crc, buf, len);
+    return FUNCTABLE_READ(crc32)(crc, buf, len);
 }
 
 static void crc32_fold_stub(crc32_fold* crc, const uint8_t* src, size_t len, uint32_t init_crc) {
     init_functable();
-    functable.crc32_fold(crc, src, len, init_crc);
+    FUNCTABLE_READ(crc32_fold)(crc, src, len, init_crc);
 }
 
 static void crc32_fold_copy_stub(crc32_fold* crc, uint8_t* dst, const uint8_t* src, size_t len) {
     init_functable();
-    functable.crc32_fold_copy(crc, dst, src, len);
+    FUNCTABLE_READ(crc32_fold_copy)(crc, dst, src, len);
 }
 
 static uint32_t crc32_fold_final_stub(crc32_fold* crc) {
     init_functable();
-    return functable.crc32_fold_final(crc);
+    return FUNCTABLE_READ(crc32_fold_final)(crc);
 }
 
 static uint32_t crc32_fold_reset_stub(crc32_fold* crc) {
     init_functable();
-    return functable.crc32_fold_reset(crc);
+    return FUNCTABLE_READ(crc32_fold_reset)(crc);
 }
 
 static void inflate_fast_stub(PREFIX3(stream) *strm, uint32_t start) {
     init_functable();
-    functable.inflate_fast(strm, start);
+    FUNCTABLE_READ(inflate_fast)(strm, start);
 }
 
 static void insert_string_stub(deflate_state* const s, uint32_t str, uint32_t count) {
     init_functable();
-    functable.insert_string(s, str, count);
+    FUNCTABLE_READ(insert_string)(s, str, count);
 }
 
 static uint32_t longest_match_stub(deflate_state* const s, Pos cur_match) {
     init_functable();
-    return functable.longest_match(s, cur_match);
+    return FUNCTABLE_READ(longest_match)(s, cur_match);
 }
 
 static uint32_t longest_match_slow_stub(deflate_state* const s, Pos cur_match) {
     init_functable();
-    return functable.longest_match_slow(s, cur_match);
+    return FUNCTABLE_READ(longest_match_slow)(s, cur_match);
 }
 
 static Pos quick_insert_string_stub(deflate_state* const s, const uint32_t str) {
     init_functable();
-    return functable.quick_insert_string(s, str);
+    return FUNCTABLE_READ(quick_insert_string)(s, str);
 }
 
 static void slide_hash_stub(deflate_state* s) {
     init_functable();
-    functable.slide_hash(s);
+    FUNCTABLE_READ(slide_hash)(s);
 }
 
 static uint32_t update_hash_stub(deflate_state* const s, uint32_t h, uint32_t val) {
     init_functable();
-    return functable.update_hash(s, h, val);
+    return FUNCTABLE_READ(update_hash)(s, h, val);
 }
 
 /* functable init */

--- a/functable.h
+++ b/functable.h
@@ -10,6 +10,10 @@
 #include "crc32_fold.h"
 #include "adler32_fold.h"
 
+#if defined(_MSC_VER)
+#  include <intrin.h>
+#endif
+
 #ifdef ZLIB_COMPAT
 typedef struct z_stream_s z_stream;
 #else
@@ -38,5 +42,30 @@ struct functable_s {
 };
 
 Z_INTERNAL extern struct functable_s functable;
+
+/* Relaxed atomic read from the functable, matching the atomic stores
+ * in FUNCTABLE_ASSIGN (functable.c).  Using relaxed ordering is
+ * sufficient: the values written are deterministic per CPU, so any
+ * value we read (stale stub or final pointer) is safe to call.
+ *
+ * GCC/Clang: use __atomic_load_n with __ATOMIC_RELAXED.
+ * MSVC: _InterlockedCompareExchangePointer(ptr, NULL, NULL) performs
+ *   an atomic compare-and-swap that never modifies a non-NULL pointer
+ *   (functable members are always non-NULL — initialized to stubs).
+ *   The intrinsic acts as a full compiler barrier, so the subsequent
+ *   member access (which preserves the correct function-pointer type)
+ *   is guaranteed to reload from memory.
+ * Other: plain read (matching the FUNCTABLE_ASSIGN fallback warning). */
+#if defined(__GNUC__) || defined(__clang__)
+#  define FUNCTABLE_READ(FUNC_NAME) \
+       __atomic_load_n(&(functable.FUNC_NAME), __ATOMIC_RELAXED)
+#elif defined(_MSC_VER)
+#  define FUNCTABLE_READ(FUNC_NAME) ( \
+       _InterlockedCompareExchangePointer( \
+           (void * volatile *)&(functable.FUNC_NAME), NULL, NULL), \
+       functable.FUNC_NAME)
+#else
+#  define FUNCTABLE_READ(FUNC_NAME) functable.FUNC_NAME
+#endif
 
 #endif

--- a/infback.c
+++ b/infback.c
@@ -55,7 +55,7 @@ int32_t ZNG_CONDEXPORT PREFIX(inflateBackInit)(PREFIX3(stream) *strm, int32_t wi
     state->wnext = 0;
     state->whave = 0;
     state->sane = 1;
-    state->chunksize = functable.chunksize();
+    state->chunksize = FUNCTABLE_READ(chunksize)();
     return Z_OK;
 }
 
@@ -357,7 +357,7 @@ int32_t Z_EXPORT PREFIX(inflateBack)(PREFIX3(stream) *strm, in_func in, void *in
                 RESTORE();
                 if (state->whave < state->wsize)
                     state->whave = state->wsize - left;
-                functable.inflate_fast(strm, state->wsize);
+                FUNCTABLE_READ(inflate_fast)(strm, state->wsize);
                 LOAD();
                 break;
             }

--- a/inflate.c
+++ b/inflate.c
@@ -28,11 +28,11 @@ static inline void inf_chksum_cpy(PREFIX3(stream) *strm, uint8_t *dst,
     struct inflate_state *state = (struct inflate_state*)strm->state;
 #ifdef GUNZIP
     if (state->flags) {
-        functable.crc32_fold_copy(&state->crc_fold, dst, src, copy);
+        FUNCTABLE_READ(crc32_fold_copy)(&state->crc_fold, dst, src, copy);
     } else
 #endif
     {
-        strm->adler = state->check = functable.adler32_fold_copy(state->check, dst, src, copy);
+        strm->adler = state->check = FUNCTABLE_READ(adler32_fold_copy)(state->check, dst, src, copy);
     }
 }
 
@@ -40,11 +40,11 @@ static inline void inf_chksum(PREFIX3(stream) *strm, const uint8_t *src, uint32_
     struct inflate_state *state = (struct inflate_state*)strm->state;
 #ifdef GUNZIP
     if (state->flags) {
-        functable.crc32_fold(&state->crc_fold, src, len, 0);
+        FUNCTABLE_READ(crc32_fold)(&state->crc_fold, src, len, 0);
     } else
 #endif
     {
-        strm->adler = state->check = functable.adler32(state->check, src, len);
+        strm->adler = state->check = FUNCTABLE_READ(adler32)(state->check, src, len);
     }
 }
 
@@ -140,7 +140,7 @@ int32_t ZNG_CONDEXPORT PREFIX(inflateInit2)(PREFIX3(stream) *strm, int32_t windo
     struct inflate_state *state;
 
     /* Initialize functable earlier. */
-    functable.force_init();
+    FUNCTABLE_READ(force_init)();
 
     if (strm == NULL)
         return Z_STREAM_ERROR;
@@ -159,7 +159,7 @@ int32_t ZNG_CONDEXPORT PREFIX(inflateInit2)(PREFIX3(stream) *strm, int32_t windo
     state->strm = strm;
     state->window = NULL;
     state->mode = HEAD;     /* to pass state test in inflateReset2() */
-    state->chunksize = functable.chunksize();
+    state->chunksize = FUNCTABLE_READ(chunksize)();
     ret = PREFIX(inflateReset2)(strm, windowBits);
     if (ret != Z_OK) {
         ZFREE_STATE(strm, state);
@@ -636,7 +636,7 @@ int32_t Z_EXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int32_t flush) {
             }
             /* compute crc32 checksum if not in raw mode */
             if ((state->wrap & 4) && state->flags)
-                strm->adler = state->check = functable.crc32_fold_reset(&state->crc_fold);
+                strm->adler = state->check = FUNCTABLE_READ(crc32_fold_reset)(&state->crc_fold);
             state->mode = TYPE;
             break;
 #endif
@@ -867,7 +867,7 @@ int32_t Z_EXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int32_t flush) {
             /* use inflate_fast() if we have enough input and output */
             if (have >= INFLATE_FAST_MIN_HAVE && left >= INFLATE_FAST_MIN_LEFT) {
                 RESTORE();
-                functable.inflate_fast(strm, out);
+                FUNCTABLE_READ(inflate_fast)(strm, out);
                 LOAD();
                 if (state->mode == TYPE)
                     state->back = -1;
@@ -1026,7 +1026,7 @@ int32_t Z_EXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int32_t flush) {
             } else {
                 copy = MIN(state->length, left);
 
-                put = functable.chunkmemset_safe(put, state->offset, copy, left);
+                put = FUNCTABLE_READ(chunkmemset_safe)(put, state->offset, copy, left);
             }
             left -= copy;
             state->length -= copy;
@@ -1056,7 +1056,7 @@ int32_t Z_EXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int32_t flush) {
                     }
 #ifdef GUNZIP
                     if (state->flags)
-                        strm->adler = state->check = functable.crc32_fold_final(&state->crc_fold);
+                        strm->adler = state->check = FUNCTABLE_READ(crc32_fold_final)(&state->crc_fold);
 #endif
                 }
                 out = left;
@@ -1190,7 +1190,7 @@ int32_t Z_EXPORT PREFIX(inflateSetDictionary)(PREFIX3(stream) *strm, const uint8
 
     /* check for correct dictionary identifier */
     if (state->mode == DICT) {
-        dictid = functable.adler32(ADLER32_INITIAL_VALUE, dictionary, dictLength);
+        dictid = FUNCTABLE_READ(adler32)(ADLER32_INITIAL_VALUE, dictionary, dictLength);
         if (dictid != state->check)
             return Z_DATA_ERROR;
     }

--- a/inflate_p.h
+++ b/inflate_p.h
@@ -46,9 +46,9 @@
 /* check function to use adler32() for zlib or crc32() for gzip */
 #ifdef GUNZIP
 #  define UPDATE(check, buf, len) \
-    (state->flags ? PREFIX(crc32)(check, buf, len) : functable.adler32(check, buf, len))
+    (state->flags ? PREFIX(crc32)(check, buf, len) : FUNCTABLE_READ(adler32)(check, buf, len))
 #else
-#  define UPDATE(check, buf, len) functable.adler32(check, buf, len)
+#  define UPDATE(check, buf, len) FUNCTABLE_READ(adler32)(check, buf, len)
 #endif
 
 /* check macros for header crc */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -243,7 +243,7 @@ if(WITH_GTEST)
 
         find_package(Threads)
         if(Threads_FOUND AND NOT BASEARCH_WASM32_FOUND)
-            target_sources(gtest_zlib PRIVATE test_deflate_concurrency.cc)
+            target_sources(gtest_zlib PRIVATE test_deflate_concurrency.cc test_functable_thread_safety.cc)
             if(UNIX AND NOT APPLE)
                 # On Linux, use a workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=52590
                 target_link_libraries(gtest_zlib -Wl,--whole-archive -lpthread -Wl,--no-whole-archive)

--- a/test/test_functable_thread_safety.cc
+++ b/test/test_functable_thread_safety.cc
@@ -1,0 +1,33 @@
+/* test_functable_thread_safety.cc -- verify concurrent functable initialization.
+ *
+ * For conditions of distribution and use, see copyright notice in zlib.h
+ */
+
+#include "zbuild.h"
+#ifdef ZLIB_COMPAT
+#include "zlib.h"
+#else
+#include "zlib-ng.h"
+#endif
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <thread>
+
+TEST(functable, thread_safety) {
+    uint8_t byte = 0;
+    std::atomic<int> barrier{0};
+
+    std::thread t([&]() {
+        barrier.fetch_add(1, std::memory_order_relaxed);
+        while (barrier.load(std::memory_order_relaxed) < 2) {}
+        PREFIX(adler32)(0, &byte, 1);
+    });
+
+    barrier.fetch_add(1, std::memory_order_relaxed);
+    while (barrier.load(std::memory_order_relaxed) < 2) {}
+    PREFIX(crc32)(0, &byte, 1);
+
+    t.join();
+}


### PR DESCRIPTION
FUNCTABLE_ASSIGN (added in #1609) writes functable members with atomic stores, but callers read them with non-atomic loads. When init_functable() runs concurrently with a reader, this is a data race. Per [C11 5.1.2.4p25](https://port70.net/~nsz/c/c11/n1570.html#5.1.2.4p25), any such data race is undefined behavior. In practice, this causes TSAN violation reports.

Add FUNCTABLE_READ() to perform matching (relaxed) atomic loads, closing the race.

To reproduce (on the parent commit, before the fix):

```
mkdir build && cd build
cmake .. -DWITH_GTEST=ON -DZLIBNG_ENABLE_TESTS=ON \
    -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
    -DCMAKE_C_FLAGS="-fsanitize=thread" \
    -DCMAKE_CXX_FLAGS="-fsanitize=thread" \
    -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=thread" \
    -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=thread"
make -j$(nproc) gtest_zlib
./gtest_zlib --gtest_filter='functable.thread_safety'
```

```
WARNING: ThreadSanitizer: data race
  Atomic write of size 8 by thread T1:
    #0 init_functable functable.c
    #1 adler32_stub functable.c
    #2 zng_adler32
  Previous read of size 8 by main thread:
    #0 zng_crc32
  Location is global 'functable' of size 144
SUMMARY: ThreadSanitizer: data race functable.c in init_functable
```

With this fix, the same test reports zero warnings.