### PR TITLE
Fix scan_endstr offset in longest_match slow path

### DIFF
--- a/match_tpl.h
+++ b/match_tpl.h
@@ -206,7 +206,7 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, uint32_t cur_match) {
                  * us include one more byte into hash - the byte which will be checked
                  * in main loop now, and which allows to grow match by 1.
                  */
-                scan_endstr = scan + len - (STD_MIN_MATCH+1);
+                scan_endstr = scan + len - (STD_MIN_MATCH-1);
 
                 // use update_hash_roll for deflate_slow
                 hash = update_hash_roll(0, scan_endstr[0]);
@@ -215,7 +215,7 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, uint32_t cur_match) {
 
                 pos = head[hash];
                 if (pos < cur_match) {
-                    match_offset = len - (STD_MIN_MATCH+1);
+                    match_offset = len - (STD_MIN_MATCH-1);
                     if (pos <= limit_base + match_offset)
                         goto break_matching;
                     cur_match = pos;


### PR DESCRIPTION
Fixes #2248.

`LONGEST_MATCH_SLOW` was using `len - (STD_MIN_MATCH + 1)` instead of `len - (STD_MIN_MATCH - 1)` for its end-of-string hash probe, hashing a window inside the already-matched region instead of ending one byte past the current match. See the commit message for the full analysis.

Only level 9 is affected — `deflate_slow.c` gates `longest_match_slow` on `level >= 9`.

Full benchmark results + machine specs: [gist](https://gist.github.com/nmoinvaz/b9571090d7bbcbbcf1b2ae54fcb80f1d).

**Speed** (`benchmark_zlib` deflate level 9, Apple M5, 5 repetitions):

| Input | Base | Contender | Delta |
|---|---:|---:|---:|
| 1 KiB    |   4235 ns |   4024 ns |  **-5.0%** |
| 16 KiB   |  72437 ns |  48967 ns | **-32.4%** |
| 128 KiB  | 630860 ns | 531667 ns | **-15.7%** |
| 1 MiB    |   5.15 ms |   4.58 ms | **-11.2%** |

**Compression ratio** — level 9, 58 files across `calgary`, `canterbury`,
`large`, `miscellaneous`, `neuro`, `silesia`, `snappy`, `artificial`
(~100 MB compressed):

- Net: **+334 bytes (+0.000333%)** — noise
- 6 files smaller, 2 larger, 50 unchanged
- Only `silesia/mozilla` moved more than noise: +1264 B (+0.0066%)