### PR TITLE
[CI] Build MSVC 2026 C23 with benchmarks.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -483,7 +483,7 @@ jobs:
           - name: Windows MSVC 2026 v145 Win64 C23
             os: windows-2025-vs2026
             compiler: cl
-            cmake-args: -G "Visual Studio 18 2026" -A x64 -T v145 -DCMAKE_C_STANDARD=23
+            cmake-args: -G "Visual Studio 18 2026" -A x64 -T v145 -DCMAKE_C_STANDARD=23 -DWITH_BENCHMARKS=ON
             # Coverage disabled for msvc
 
           - name: Windows MSVC 2022 v143 Win32


### PR DESCRIPTION
* Google Benchmark version 1.9.2 introduced code that will conflict with preprocessor macros in `windows.h`, so enable building benchmarks to catch any issues in new files, as requested by @nmoinvaz