### PR TITLE
Short-circuit longest_match on short candidates via XOR and ctz

### DIFF
--- a/arch/arm/compare256_neon.c
+++ b/arch/arm/compare256_neon.c
@@ -11,15 +11,33 @@
 #if defined(ARM_NEON)
 #include "neon_intrins.h"
 
+#if defined(ARCH_ARM) && defined(ARCH_64BIT) && (!defined(_MSC_VER) || defined(__clang__))
+#  define COMPARE256_NEON_POSTINDEX
+#endif
+
 Z_FORCEINLINE static uint32_t compare256_neon_static(const uint8_t *src0, const uint8_t *src1) {
     uint32_t len = 0;
+#ifdef COMPARE256_NEON_POSTINDEX
+    intptr_t offset = (intptr_t)src0 - (intptr_t)src1;
+#endif
 
     do {
         uint8x16_t a, b, cmp;
         uint64_t lane;
 
+        /* Force post-indexed loads; the inlined longest_match loop otherwise emits a
+         * separate add per iteration. */
+#ifdef COMPARE256_NEON_POSTINDEX
+        __asm__("ldr %q0, [%2, %3]\n\t"
+                "ldr %q1, [%2], #16"
+                : "=w"(a), "=w"(b), "+r"(src1)
+                : "r"(offset)
+                : "memory");
+#else
         a = vld1q_u8(src0);
         b = vld1q_u8(src1);
+        src0 += 16, src1 += 16;
+#endif
 
         cmp = veorq_u8(a, b);
 
@@ -31,12 +49,12 @@ Z_FORCEINLINE static uint32_t compare256_neon_static(const uint8_t *src0, const 
         if (lane)
             return len + zng_first_diff_byte64(lane);
         len += 8;
-
-        src0 += 16, src1 += 16;
     } while (len < 256);
 
     return 256;
 }
+
+#undef COMPARE256_NEON_POSTINDEX
 
 Z_INTERNAL uint32_t compare256_neon(const uint8_t *src0, const uint8_t *src1) {
     return compare256_neon_static(src0, src1);

--- a/arch/power/compare256_power9.c
+++ b/arch/power/compare256_power9.c
@@ -6,9 +6,10 @@
 #ifdef POWER9
 
 #include "zbuild.h"
+#include "zendian.h"
 #include "zmemory.h"
 #include "deflate.h"
-#include "zendian.h"
+#include "fallback_builtins.h"
 
 #include <altivec.h>
 

--- a/arch/riscv/compare256_rvv.c
+++ b/arch/riscv/compare256_rvv.c
@@ -7,8 +7,10 @@
 #ifdef RISCV_RVV
 
 #include "zbuild.h"
+#include "zendian.h"
 #include "zmemory.h"
 #include "deflate.h"
+#include "fallback_builtins.h"
 
 #include <riscv_vector.h>
 

--- a/fallback_builtins.h
+++ b/fallback_builtins.h
@@ -130,6 +130,14 @@ Z_FORCEINLINE static uint32_t zng_clz64(uint64_t value) {
 #  define zng_first_diff_byte64(diff) (zng_ctz64(diff) / 8)
 #endif
 
+/* Builds a mask of the first n bytes (1..8) so an XOR diff can be tested for
+ * a leading n-byte match with a single AND. */
+#if BYTE_ORDER == BIG_ENDIAN
+#  define zng_first_bytes_mask64(n) (UINT64_MAX << ((8 - (n)) * 8))
+#else
+#  define zng_first_bytes_mask64(n) (UINT64_MAX >> ((8 - (n)) * 8))
+#endif
+
 Z_FORCEINLINE static uint16_t zng_bitreverse16(uint16_t value) {
 #if __has_builtin(__builtin_bitreverse16)
     return (uint16_t)__builtin_bitreverse16(value);

--- a/match_tpl.h
+++ b/match_tpl.h
@@ -131,10 +131,14 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, uint32_t cur_match) {
                 /* Peel the first candidate out of the loop. A full 8-byte match falls straight
                  * through to compare256, and single-candidate chains (barely-compressible data)
                  * run with no loop overhead. */
+                uint64_t first_mask = zng_first_bytes_mask64(best_len + 1);
                 uint64_t diff = scan_start ^ cand_start;
-                len = zng_first_diff_byte64(diff);
-                if (len > best_len)
+                /* A candidate beats best_len only when its first best_len+1 bytes match, i.e.
+                 * those bytes of the XOR are zero. The masked test rejects without running ctz. */
+                if (UNLIKELY((diff & first_mask) == 0)) {
+                    len = zng_first_diff_byte64(diff);
                     goto short_match_accept;
+                }
                 if (--chain_length == 0 || (cur_match = prev[cur_match & wmask]) <= limit)
                     return best_len;
                 cand_start = zng_memread_8(mbase_start + cur_match);
@@ -142,9 +146,10 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, uint32_t cur_match) {
                     /* Walk the remaining candidates with the chain advance kept inline. */
                     for (;;) {
                         diff = scan_start ^ cand_start;
-                        len = zng_first_diff_byte64(diff);
-                        if (len > best_len)
+                        if (UNLIKELY((diff & first_mask) == 0)) {
+                            len = zng_first_diff_byte64(diff);
                             goto short_match_accept;
+                        }
                         if (--chain_length == 0 || (cur_match = prev[cur_match & wmask]) <= limit)
                             return best_len;
                         cand_start = zng_memread_8(mbase_start + cur_match);

--- a/match_tpl.h
+++ b/match_tpl.h
@@ -128,12 +128,30 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, uint32_t cur_match) {
         if (best_len < sizeof(uint64_t)) {
             uint64_t cand_start = zng_memread_8(mbase_start + cur_match);
             if (scan_start != cand_start) {
+                /* Peel the first candidate out of the loop. A full 8-byte match falls straight
+                 * through to compare256, and single-candidate chains (barely-compressible data)
+                 * run with no loop overhead. */
                 uint64_t diff = scan_start ^ cand_start;
                 len = zng_first_diff_byte64(diff);
-                if (len <= best_len) {
-                    GOTO_NEXT_CHAIN;
+                if (len > best_len)
+                    goto short_match_accept;
+                if (--chain_length == 0 || (cur_match = prev[cur_match & wmask]) <= limit)
+                    return best_len;
+                cand_start = zng_memread_8(mbase_start + cur_match);
+                if (scan_start != cand_start) {
+                    /* Walk the remaining candidates with the chain advance kept inline. */
+                    for (;;) {
+                        diff = scan_start ^ cand_start;
+                        len = zng_first_diff_byte64(diff);
+                        if (len > best_len)
+                            goto short_match_accept;
+                        if (--chain_length == 0 || (cur_match = prev[cur_match & wmask]) <= limit)
+                            return best_len;
+                        cand_start = zng_memread_8(mbase_start + cur_match);
+                        if (scan_start == cand_start)
+                            break;
+                    }
                 }
-                goto short_match_accept;
             }
             /* All 8 bytes match, fallthrough to compare256 for the tail. */
         } else {

--- a/match_tpl.h
+++ b/match_tpl.h
@@ -57,15 +57,11 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, uint32_t cur_match) {
     if (UNLIKELY(best_len >= lookahead))
         return lookahead;
 
-    /* Calculate read offset which should only extend an extra byte
-     * to find the next best match length.
+    /* Calculate read offset which should only extend an extra byte to find the
+     * next best match length. When best_len is shorter than the read width, we
+     * diff the mismatched bytes instead.
      */
-    offset = best_len-1;
-    if (UNLIKELY(best_len >= sizeof(uint32_t))) {
-        offset -= 2;
-        if (best_len >= sizeof(uint64_t))
-            offset -= 4;
-    }
+    offset = best_len >= sizeof(uint64_t) ? best_len - 7 : 0;
 
     scan = window + strstart;
     scan_start = zng_memread_8(scan);
@@ -128,32 +124,36 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, uint32_t cur_match) {
          * that depend on those values. However the length of the match is limited to the
          * lookahead, so the output of deflate is not affected by the uninitialized values.
          */
-        if (best_len < sizeof(uint32_t)) {
-            for (;;) {
-                if (zng_memcmp_2(mbase_end+cur_match, &scan_end) == 0 &&
-                    zng_memcmp_2(mbase_start+cur_match, &scan_start) == 0)
-                    break;
-                GOTO_NEXT_CHAIN;
+        uint32_t len;
+        if (best_len < sizeof(uint64_t)) {
+            uint64_t cand_start = zng_memread_8(mbase_start + cur_match);
+            if (scan_start != cand_start) {
+                uint64_t diff = scan_start ^ cand_start;
+                len = zng_first_diff_byte64(diff);
+                if (len <= best_len) {
+                    GOTO_NEXT_CHAIN;
+                }
+                goto short_match_accept;
             }
-        } else if (best_len >= sizeof(uint64_t)) {
+            /* All 8 bytes match, fallthrough to compare256 for the tail. */
+        } else {
+            /* Pre-filter the candidate on the start and end sentinels before compare256 using
+             * simple 8-byte comparison since best_len >= 8. */
             for (;;) {
+                /* First check the end of the candidate at best_len+1 due to the higher
+                 * likelihood of a mismatch. */
                 if (zng_memcmp_8(mbase_end+cur_match, &scan_end) == 0 &&
                     zng_memcmp_8(mbase_start+cur_match, &scan_start) == 0)
                     break;
                 GOTO_NEXT_CHAIN;
             }
-        } else {
-            for (;;) {
-                if (zng_memcmp_4(mbase_end+cur_match, &scan_end) == 0 &&
-                    zng_memcmp_4(mbase_start+cur_match, &scan_start) == 0)
-                    break;
-                GOTO_NEXT_CHAIN;
-            }
         }
-        uint32_t len = COMPARE256(scan+2, mbase_start+cur_match+2) + 2;
+        len = COMPARE256(scan+2, mbase_start+cur_match+2) + 2;
         Assert(scan+len <= window+(unsigned)(s->window_size-1), "wild scan");
 
-        if (len > best_len) {
+        if (len > best_len)
+short_match_accept:
+        {
             uint32_t match_start = cur_match - match_offset;
             s->match_start = match_start;
 
@@ -167,12 +167,7 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, uint32_t cur_match) {
 
             best_len = len;
 
-            offset = best_len-1;
-            if (LIKELY(best_len >= sizeof(uint32_t))) {
-                offset -= 2;
-                if (best_len >= sizeof(uint64_t))
-                    offset -= 4;
-            }
+            offset = best_len >= sizeof(uint64_t) ? best_len - 7 : 0;
 
             scan_end = zng_memread_8(scan+offset);
 


### PR DESCRIPTION
## Summary

- When `best_len` is under 8, the whole candidate match fits in the first 8 bytes, so a single 8-byte load XORed against `scan_start` and run through `ctz` gives the exact match length with no `COMPARE256` call and no separate tail sentinel.
- The `best_len`-to-offset mapping collapses to a single subtract since the graduated `sizeof(uint32_t)` / `sizeof(uint64_t)` brackets no longer cover anything distinct.
- Benefits every deflate strategy that calls `longest_match` (fast, medium, slow).

## Benchmark results

Apple M-series, 5 repetitions, `--benchmark_cooldown=3`, median change vs `develop`:

| level | 1 KB | 16 KB | 128 KB | 1 MB |
|-------|------|-------|--------|------|
| 1     | -3.3% | -1.3% |  -1.3% |  -1.5% |
| 3     | -1.6% | -1.4% | **-10.6%** | **-11.9%** |
| 6     | -0.9% | -0.7% |  -0.6% |  -1.5% |
| 7     | -1.3% | -3.0% |  -1.0% |  -1.7% |
| 9     | -1.3% | +1.0% |  +0.7% |  +0.7% |

Level 3 shows the largest win because `deflate_medium` (max_lazy_match=4) keeps most candidates on the short-match path, where the new code skips `COMPARE256` entirely. Level 9 is neutral because long matches hit the existing `>= 8` branch.

## Ratio

Byte-identical compressed output across the Silesia and Calgary corpora at all levels.

## Correctness

- `gtest_zlib` (2166 tests) passes.
- Round-trip passes at levels 1, 3, 6, 7, 9.
