### PR TITLE
Rename longest_match_slow to longest_match_roll

### DIFF
--- a/arch/arm/arm_functions.h
+++ b/arch/arm/arm_functions.h
@@ -14,7 +14,7 @@ uint8_t* chunkmemset_safe_neon(uint8_t *out, uint8_t *from, size_t len, size_t l
 uint32_t compare256_neon(const uint8_t *src0, const uint8_t *src1);
 void inflate_fast_neon(PREFIX3(stream) *strm, uint32_t start);
 uint32_t longest_match_neon(deflate_state *const s, uint32_t cur_match);
-uint32_t longest_match_slow_neon(deflate_state *const s, uint32_t cur_match);
+uint32_t longest_match_roll_neon(deflate_state *const s, uint32_t cur_match);
 void slide_hash_neon(deflate_state *s);
 #endif
 
@@ -65,8 +65,8 @@ void slide_hash_armv6(deflate_state *s);
 #    define native_inflate_fast inflate_fast_neon
 #    undef native_longest_match
 #    define native_longest_match longest_match_neon
-#    undef native_longest_match_slow
-#    define native_longest_match_slow longest_match_slow_neon
+#    undef native_longest_match_roll
+#    define native_longest_match_roll longest_match_roll_neon
 #    undef native_slide_hash
 #    define native_slide_hash slide_hash_neon
 #  endif

--- a/arch/arm/compare256_neon.c
+++ b/arch/arm/compare256_neon.c
@@ -47,8 +47,8 @@ Z_INTERNAL uint32_t compare256_neon(const uint8_t *src0, const uint8_t *src1) {
 
 #include "match_tpl.h"
 
-#define LONGEST_MATCH_SLOW
-#define LONGEST_MATCH       longest_match_slow_neon
+#define LONGEST_MATCH_ROLL
+#define LONGEST_MATCH       longest_match_roll_neon
 #define COMPARE256          compare256_neon_static
 
 #include "match_tpl.h"

--- a/arch/generic/compare256_c.c
+++ b/arch/generic/compare256_c.c
@@ -84,9 +84,9 @@ Z_INTERNAL uint32_t compare256_c(const uint8_t *src0, const uint8_t *src1) {
 #define LONGEST_MATCH       longest_match_c
 #include "match_tpl.h"
 
-// Generate longest_match_slow_c
-#define LONGEST_MATCH_SLOW
-#define LONGEST_MATCH       longest_match_slow_c
+// Generate longest_match_roll_c
+#define LONGEST_MATCH_ROLL
+#define LONGEST_MATCH       longest_match_roll_c
 #include "match_tpl.h"
 
 #endif /* COMPARE256_FALLBACK */

--- a/arch/generic/generic_functions.h
+++ b/arch/generic/generic_functions.h
@@ -44,7 +44,7 @@ void     inflate_fast_c(PREFIX3(stream) *strm, uint32_t start);
 #endif
 #ifdef COMPARE256_FALLBACK
 uint32_t longest_match_c(deflate_state *const s, uint32_t cur_match);
-uint32_t longest_match_slow_c(deflate_state *const s, uint32_t cur_match);
+uint32_t longest_match_roll_c(deflate_state *const s, uint32_t cur_match);
 #endif
 #ifdef SLIDE_HASH_FALLBACK
 void     slide_hash_c(deflate_state *s);
@@ -63,7 +63,7 @@ void     slide_hash_c(deflate_state *s);
 #  ifdef COMPARE256_FALLBACK
 #    define native_compare256 compare256_c
 #    define native_longest_match longest_match_c
-#    define native_longest_match_slow longest_match_slow_c
+#    define native_longest_match_roll longest_match_roll_c
 #  endif
 #  ifdef CRC32_CHORBA_FALLBACK
 #    define native_crc32 crc32_chorba

--- a/arch/loongarch/compare256_lasx.c
+++ b/arch/loongarch/compare256_lasx.c
@@ -51,8 +51,8 @@ Z_INTERNAL uint32_t compare256_lasx(const uint8_t *src0, const uint8_t *src1) {
 
 #include "match_tpl.h"
 
-#define LONGEST_MATCH_SLOW
-#define LONGEST_MATCH       longest_match_slow_lasx
+#define LONGEST_MATCH_ROLL
+#define LONGEST_MATCH       longest_match_roll_lasx
 #define COMPARE256          compare256_lasx_static
 
 #include "match_tpl.h"

--- a/arch/loongarch/compare256_lsx.c
+++ b/arch/loongarch/compare256_lsx.c
@@ -79,8 +79,8 @@ Z_INTERNAL uint32_t compare256_lsx(const uint8_t *src0, const uint8_t *src1) {
 
 #include "match_tpl.h"
 
-#define LONGEST_MATCH_SLOW
-#define LONGEST_MATCH       longest_match_slow_lsx
+#define LONGEST_MATCH_ROLL
+#define LONGEST_MATCH       longest_match_roll_lsx
 #define COMPARE256          compare256_lsx_static
 
 #include "match_tpl.h"

--- a/arch/loongarch/loongarch_functions.h
+++ b/arch/loongarch/loongarch_functions.h
@@ -26,7 +26,7 @@ uint8_t* chunkmemset_safe_lsx(uint8_t *out, uint8_t *from, size_t len, size_t le
 uint32_t compare256_lsx(const uint8_t *src0, const uint8_t *src1);
 void inflate_fast_lsx(PREFIX3(stream) *strm, uint32_t start);
 uint32_t longest_match_lsx(deflate_state *const s, uint32_t cur_match);
-uint32_t longest_match_slow_lsx(deflate_state *const s, uint32_t cur_match);
+uint32_t longest_match_roll_lsx(deflate_state *const s, uint32_t cur_match);
 void slide_hash_lsx(deflate_state *s);
 #endif
 
@@ -44,7 +44,7 @@ uint8_t* chunkmemset_safe_lasx(uint8_t *out, uint8_t *from, size_t len, size_t l
 uint32_t compare256_lasx(const uint8_t *src0, const uint8_t *src1);
 void inflate_fast_lasx(PREFIX3(stream) *strm, uint32_t start);
 uint32_t longest_match_lasx(deflate_state *const s, uint32_t cur_match);
-uint32_t longest_match_slow_lasx(deflate_state *const s, uint32_t cur_match);
+uint32_t longest_match_roll_lasx(deflate_state *const s, uint32_t cur_match);
 void slide_hash_lasx(deflate_state *s);
 #endif
 
@@ -69,8 +69,8 @@ void slide_hash_lasx(deflate_state *s);
 #    define native_inflate_fast inflate_fast_lsx
 #    undef native_longest_match
 #    define native_longest_match longest_match_lsx
-#    undef native_longest_match_slow
-#    define native_longest_match_slow longest_match_slow_lsx
+#    undef native_longest_match_roll
+#    define native_longest_match_roll longest_match_roll_lsx
 #    undef native_slide_hash
 #    define native_slide_hash slide_hash_lsx
 #  endif
@@ -87,8 +87,8 @@ void slide_hash_lasx(deflate_state *s);
 #    define native_inflate_fast inflate_fast_lasx
 #    undef native_longest_match
 #    define native_longest_match longest_match_lasx
-#    undef native_longest_match_slow
-#    define native_longest_match_slow longest_match_slow_lasx
+#    undef native_longest_match_roll
+#    define native_longest_match_roll longest_match_roll_lasx
 #    undef native_slide_hash
 #    define native_slide_hash slide_hash_lasx
 #  endif

--- a/arch/power/compare256_power9.c
+++ b/arch/power/compare256_power9.c
@@ -59,8 +59,8 @@ Z_INTERNAL uint32_t compare256_power9(const uint8_t *src0, const uint8_t *src1) 
 
 #include "match_tpl.h"
 
-#define LONGEST_MATCH_SLOW
-#define LONGEST_MATCH       longest_match_slow_power9
+#define LONGEST_MATCH_ROLL
+#define LONGEST_MATCH       longest_match_roll_power9
 #define COMPARE256          compare256_power9_static
 
 #include "match_tpl.h"

--- a/arch/power/power_functions.h
+++ b/arch/power/power_functions.h
@@ -40,7 +40,7 @@ void inflate_fast_power8(PREFIX3(stream) *strm, uint32_t start);
 #ifdef POWER9
 uint32_t compare256_power9(const uint8_t *src0, const uint8_t *src1);
 uint32_t longest_match_power9(deflate_state *const s, uint32_t cur_match);
-uint32_t longest_match_slow_power9(deflate_state *const s, uint32_t cur_match);
+uint32_t longest_match_roll_power9(deflate_state *const s, uint32_t cur_match);
 #endif
 
 #ifndef POWER9_NATIVE
@@ -82,8 +82,8 @@ uint32_t longest_match_slow_power9(deflate_state *const s, uint32_t cur_match);
 #    define native_compare256 compare256_power9
 #    undef native_longest_match
 #    define native_longest_match longest_match_power9
-#    undef native_longest_match_slow
-#    define native_longest_match_slow longest_match_slow_power9
+#    undef native_longest_match_roll
+#    define native_longest_match_roll longest_match_roll_power9
 #  endif
 #endif
 

--- a/arch/riscv/compare256_rvv.c
+++ b/arch/riscv/compare256_rvv.c
@@ -39,8 +39,8 @@ Z_INTERNAL uint32_t compare256_rvv(const uint8_t *src0, const uint8_t *src1) {
 
 #include "match_tpl.h"
 
-#define LONGEST_MATCH_SLOW
-#define LONGEST_MATCH       longest_match_slow_rvv
+#define LONGEST_MATCH_ROLL
+#define LONGEST_MATCH       longest_match_roll_rvv
 #define COMPARE256          compare256_rvv_static
 
 #include "match_tpl.h"

--- a/arch/riscv/riscv_functions.h
+++ b/arch/riscv/riscv_functions.h
@@ -20,7 +20,7 @@ uint8_t* chunkmemset_safe_rvv(uint8_t *out, uint8_t *from, size_t len, size_t le
 uint32_t compare256_rvv(const uint8_t *src0, const uint8_t *src1);
 
 uint32_t longest_match_rvv(deflate_state *const s, uint32_t cur_match);
-uint32_t longest_match_slow_rvv(deflate_state *const s, uint32_t cur_match);
+uint32_t longest_match_roll_rvv(deflate_state *const s, uint32_t cur_match);
 void slide_hash_rvv(deflate_state *s);
 void inflate_fast_rvv(PREFIX3(stream) *strm, uint32_t start);
 #endif
@@ -52,8 +52,8 @@ uint32_t crc32_copy_riscv64_zbc(uint32_t crc, uint8_t *dst, const uint8_t *src, 
 #    define native_inflate_fast inflate_fast_rvv
 #    undef native_longest_match
 #    define native_longest_match longest_match_rvv
-#    undef native_longest_match_slow
-#    define native_longest_match_slow longest_match_slow_rvv
+#    undef native_longest_match_roll
+#    define native_longest_match_roll longest_match_roll_rvv
 #    undef native_slide_hash
 #    define native_slide_hash slide_hash_rvv
 #  endif

--- a/arch/x86/compare256_avx2.c
+++ b/arch/x86/compare256_avx2.c
@@ -52,8 +52,8 @@ Z_INTERNAL uint32_t compare256_avx2(const uint8_t *src0, const uint8_t *src1) {
 
 #include "match_tpl.h"
 
-#define LONGEST_MATCH_SLOW
-#define LONGEST_MATCH       longest_match_slow_avx2
+#define LONGEST_MATCH_ROLL
+#define LONGEST_MATCH       longest_match_roll_avx2
 #define COMPARE256          compare256_avx2_static
 
 #include "match_tpl.h"

--- a/arch/x86/compare256_avx512.c
+++ b/arch/x86/compare256_avx512.c
@@ -78,8 +78,8 @@ Z_INTERNAL uint32_t compare256_avx512(const uint8_t *src0, const uint8_t *src1) 
 
 #include "match_tpl.h"
 
-#define LONGEST_MATCH_SLOW
-#define LONGEST_MATCH       longest_match_slow_avx512
+#define LONGEST_MATCH_ROLL
+#define LONGEST_MATCH       longest_match_roll_avx512
 #define COMPARE256          compare256_avx512_static
 
 #include "match_tpl.h"

--- a/arch/x86/compare256_sse2.c
+++ b/arch/x86/compare256_sse2.c
@@ -77,8 +77,8 @@ Z_INTERNAL uint32_t compare256_sse2(const uint8_t *src0, const uint8_t *src1) {
 
 #include "match_tpl.h"
 
-#define LONGEST_MATCH_SLOW
-#define LONGEST_MATCH       longest_match_slow_sse2
+#define LONGEST_MATCH_ROLL
+#define LONGEST_MATCH       longest_match_roll_sse2
 #define COMPARE256          compare256_sse2_static
 
 #include "match_tpl.h"

--- a/arch/x86/x86_functions.h
+++ b/arch/x86/x86_functions.h
@@ -21,7 +21,7 @@ uint8_t* chunkmemset_safe_sse2(uint8_t *out, uint8_t *from, size_t len, size_t l
 uint32_t compare256_sse2(const uint8_t *src0, const uint8_t *src1);
 void inflate_fast_sse2(PREFIX3(stream)* strm, uint32_t start);
 uint32_t longest_match_sse2(deflate_state *const s, uint32_t cur_match);
-uint32_t longest_match_slow_sse2(deflate_state *const s, uint32_t cur_match);
+uint32_t longest_match_roll_sse2(deflate_state *const s, uint32_t cur_match);
 void slide_hash_sse2(deflate_state *s);
 
 #  if !defined(WITHOUT_CHORBA) && !defined(WITHOUT_CHORBA_SSE)
@@ -66,7 +66,7 @@ uint8_t* chunkmemset_safe_avx2(uint8_t *out, uint8_t *from, size_t len, size_t l
 uint32_t compare256_avx2(const uint8_t *src0, const uint8_t *src1);
 void inflate_fast_avx2(PREFIX3(stream)* strm, uint32_t start);
 uint32_t longest_match_avx2(deflate_state *const s, uint32_t cur_match);
-uint32_t longest_match_slow_avx2(deflate_state *const s, uint32_t cur_match);
+uint32_t longest_match_roll_avx2(deflate_state *const s, uint32_t cur_match);
 void slide_hash_avx2(deflate_state *s);
 #endif
 #ifdef X86_AVX512
@@ -76,7 +76,7 @@ uint8_t* chunkmemset_safe_avx512(uint8_t *out, uint8_t *from, size_t len, size_t
 uint32_t compare256_avx512(const uint8_t *src0, const uint8_t *src1);
 void inflate_fast_avx512(PREFIX3(stream)* strm, uint32_t start);
 uint32_t longest_match_avx512(deflate_state *const s, uint32_t cur_match);
-uint32_t longest_match_slow_avx512(deflate_state *const s, uint32_t cur_match);
+uint32_t longest_match_roll_avx512(deflate_state *const s, uint32_t cur_match);
 #endif
 #ifdef X86_AVX512VNNI
 uint32_t adler32_avx512_vnni(uint32_t adler, const uint8_t *buf, size_t len);
@@ -111,8 +111,8 @@ uint32_t crc32_copy_vpclmulqdq_avx512(uint32_t crc, uint8_t *dst, const uint8_t 
 #    define native_inflate_fast inflate_fast_sse2
 #    undef native_longest_match
 #    define native_longest_match longest_match_sse2
-#    undef native_longest_match_slow
-#    define native_longest_match_slow longest_match_slow_sse2
+#    undef native_longest_match_roll
+#    define native_longest_match_roll longest_match_roll_sse2
 #    if !defined(WITHOUT_CHORBA) && !defined(WITHOUT_CHORBA_SSE)
 #      undef native_crc32
 #      define native_crc32 crc32_chorba_sse2
@@ -168,8 +168,8 @@ uint32_t crc32_copy_vpclmulqdq_avx512(uint32_t crc, uint8_t *dst, const uint8_t 
 #    define native_inflate_fast inflate_fast_avx2
 #    undef native_longest_match
 #    define native_longest_match longest_match_avx2
-#    undef native_longest_match_slow
-#    define native_longest_match_slow longest_match_slow_avx2
+#    undef native_longest_match_roll
+#    define native_longest_match_roll longest_match_roll_avx2
 #    undef native_slide_hash
 #    define native_slide_hash slide_hash_avx2
 #  endif
@@ -187,8 +187,8 @@ uint32_t crc32_copy_vpclmulqdq_avx512(uint32_t crc, uint8_t *dst, const uint8_t 
 #    define native_inflate_fast inflate_fast_avx512
 #    undef native_longest_match
 #    define native_longest_match longest_match_avx512
-#    undef native_longest_match_slow
-#    define native_longest_match_slow longest_match_slow_avx512
+#    undef native_longest_match_roll
+#    define native_longest_match_roll longest_match_roll_avx512
 // X86 - AVX512 (VNNI)
 #    ifdef X86_AVX512VNNI_NATIVE
 #      undef native_adler32

--- a/deflate_slow.c
+++ b/deflate_slow.c
@@ -23,7 +23,7 @@ Z_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
     int level = s->level;
 
     if (level >= 9) {
-        longest_match = FUNCTABLE_FPTR(longest_match_slow);
+        longest_match = FUNCTABLE_FPTR(longest_match_roll);
         insert_string_func = insert_string_roll;
     } else {
         longest_match = FUNCTABLE_FPTR(longest_match);

--- a/functable.c
+++ b/functable.c
@@ -87,7 +87,7 @@ static int init_functable(void) {
 #ifdef COMPARE256_FALLBACK
     ft.compare256 = &compare256_c;
     ft.longest_match = &longest_match_c;
-    ft.longest_match_slow = &longest_match_slow_c;
+    ft.longest_match_roll = &longest_match_roll_c;
 #endif
 #ifdef CRC32_BRAID_FALLBACK
     ft.crc32 = &crc32_braid;
@@ -117,7 +117,7 @@ static int init_functable(void) {
         ft.compare256 = &compare256_sse2;
         ft.inflate_fast = &inflate_fast_sse2;
         ft.longest_match = &longest_match_sse2;
-        ft.longest_match_slow = &longest_match_slow_sse2;
+        ft.longest_match_roll = &longest_match_roll_sse2;
         ft.slide_hash = &slide_hash_sse2;
 #  endif
 #  if !defined(WITHOUT_CHORBA_SSE) && !defined(X86_PCLMULQDQ_NATIVE)
@@ -190,7 +190,7 @@ static int init_functable(void) {
         ft.compare256 = &compare256_avx2;
         ft.inflate_fast = &inflate_fast_avx2;
         ft.longest_match = &longest_match_avx2;
-        ft.longest_match_slow = &longest_match_slow_avx2;
+        ft.longest_match_roll = &longest_match_roll_avx2;
 #  endif
         ft.slide_hash = &slide_hash_avx2;
     }
@@ -209,7 +209,7 @@ static int init_functable(void) {
         ft.compare256 = &compare256_avx512;
         ft.inflate_fast = &inflate_fast_avx512;
         ft.longest_match = &longest_match_avx512;
-        ft.longest_match_slow = &longest_match_slow_avx512;
+        ft.longest_match_roll = &longest_match_roll_avx512;
     }
 #endif
 #ifdef X86_AVX512VNNI
@@ -264,7 +264,7 @@ static int init_functable(void) {
         ft.compare256 = &compare256_neon;
         ft.inflate_fast = &inflate_fast_neon;
         ft.longest_match = &longest_match_neon;
-        ft.longest_match_slow = &longest_match_slow_neon;
+        ft.longest_match_roll = &longest_match_roll_neon;
         ft.slide_hash = &slide_hash_neon;
     }
 #endif
@@ -330,7 +330,7 @@ static int init_functable(void) {
     {
         ft.compare256 = &compare256_power9;
         ft.longest_match = &longest_match_power9;
-        ft.longest_match_slow = &longest_match_slow_power9;
+        ft.longest_match_roll = &longest_match_roll_power9;
     }
 #endif
 
@@ -347,7 +347,7 @@ static int init_functable(void) {
         ft.compare256 = &compare256_rvv;
         ft.inflate_fast = &inflate_fast_rvv;
         ft.longest_match = &longest_match_rvv;
-        ft.longest_match_slow = &longest_match_slow_rvv;
+        ft.longest_match_roll = &longest_match_roll_rvv;
         ft.slide_hash = &slide_hash_rvv;
     }
 #endif
@@ -396,7 +396,7 @@ static int init_functable(void) {
         ft.compare256 = &compare256_lsx;
         ft.inflate_fast = &inflate_fast_lsx;
         ft.longest_match = &longest_match_lsx;
-        ft.longest_match_slow = &longest_match_slow_lsx;
+        ft.longest_match_roll = &longest_match_roll_lsx;
         ft.slide_hash = &slide_hash_lsx;
     }
 #endif
@@ -411,7 +411,7 @@ static int init_functable(void) {
         ft.compare256 = &compare256_lasx;
         ft.inflate_fast = &inflate_fast_lasx;
         ft.longest_match = &longest_match_lasx;
-        ft.longest_match_slow = &longest_match_slow_lasx;
+        ft.longest_match_roll = &longest_match_roll_lasx;
         ft.slide_hash = &slide_hash_lasx;
     }
 #endif
@@ -428,7 +428,7 @@ static int init_functable(void) {
     FUNCTABLE_VERIFY_ASSIGN(ft, crc32_copy);
     FUNCTABLE_VERIFY_ASSIGN(ft, inflate_fast);
     FUNCTABLE_VERIFY_ASSIGN(ft, longest_match);
-    FUNCTABLE_VERIFY_ASSIGN(ft, longest_match_slow);
+    FUNCTABLE_VERIFY_ASSIGN(ft, longest_match_roll);
     FUNCTABLE_VERIFY_ASSIGN(ft, slide_hash);
 
     // Memory barrier for weak memory order CPUs
@@ -488,9 +488,9 @@ static uint32_t longest_match_stub(deflate_state* const s, uint32_t cur_match) {
     return functable.longest_match(s, cur_match);
 }
 
-static uint32_t longest_match_slow_stub(deflate_state* const s, uint32_t cur_match) {
+static uint32_t longest_match_roll_stub(deflate_state* const s, uint32_t cur_match) {
     FUNCTABLE_INIT_ABORT;
-    return functable.longest_match_slow(s, cur_match);
+    return functable.longest_match_roll(s, cur_match);
 }
 
 static void slide_hash_stub(deflate_state* s) {
@@ -509,7 +509,7 @@ Z_INTERNAL struct functable_s functable = {
     crc32_copy_stub,
     inflate_fast_stub,
     longest_match_stub,
-    longest_match_slow_stub,
+    longest_match_roll_stub,
     slide_hash_stub,
 };
 

--- a/functable.h
+++ b/functable.h
@@ -32,7 +32,7 @@ struct functable_s {
     uint32_t (* crc32_copy)         (uint32_t crc, uint8_t *dst, const uint8_t *src, size_t len);
     void     (* inflate_fast)       (PREFIX3(stream) *strm, uint32_t start);
     uint32_t (* longest_match)      (deflate_state *const s, uint32_t cur_match);
-    uint32_t (* longest_match_slow) (deflate_state *const s, uint32_t cur_match);
+    uint32_t (* longest_match_roll) (deflate_state *const s, uint32_t cur_match);
     void     (* slide_hash)         (deflate_state *s);
 };
 

--- a/match_tpl.h
+++ b/match_tpl.h
@@ -24,23 +24,20 @@
  * IN assertions: cur_match is the head of the hash chain for the current
  * string (strstart) and its distance is <= MAX_DIST, and prev_length >=1
  * OUT assertion: the match length is not greater than s->lookahead
- *
- * The LONGEST_MATCH_SLOW variant spends more time to attempt to find longer
- * matches once a match has already been found.
  */
 Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, uint32_t cur_match) {
     const unsigned wmask = W_MASK(s);
     unsigned int strstart = s->strstart;
     const unsigned char *window = s->window;
     const Pos *prev = s->prev;
-#ifdef LONGEST_MATCH_SLOW
+#ifdef LONGEST_MATCH_ROLL
     const Pos *head = s->head;
 #endif
     const unsigned char *scan;
     const unsigned char *mbase_start = window;
     const unsigned char *mbase_end;
     uint32_t limit;
-#ifdef LONGEST_MATCH_SLOW
+#ifdef LONGEST_MATCH_ROLL
     uint32_t limit_base;
 #else
     int32_t early_exit;
@@ -81,7 +78,7 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, uint32_t cur_match) {
      * we prevent matches with the string of window index 0
      */
     limit = strstart > MAX_DIST(s) ? (strstart - MAX_DIST(s)) : 0;
-#ifdef LONGEST_MATCH_SLOW
+#ifdef LONGEST_MATCH_ROLL
     limit_base = limit;
     if (best_len >= STD_MIN_MATCH) {
         /* We're continuing search (lazy evaluation). */
@@ -177,7 +174,7 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, uint32_t cur_match) {
 
             scan_end = zng_memread_8(scan+offset);
 
-#ifdef LONGEST_MATCH_SLOW
+#ifdef LONGEST_MATCH_ROLL
             /* Look for a better string offset */
             if (UNLIKELY(len > STD_MIN_MATCH && match_start + len < strstart)) {
                 const unsigned char *scan_endstr;
@@ -230,7 +227,7 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, uint32_t cur_match) {
 #endif
             mbase_end = (mbase_start+offset);
         }
-#ifndef LONGEST_MATCH_SLOW
+#ifndef LONGEST_MATCH_ROLL
         else if (UNLIKELY(early_exit)) {
             /* The probability of finding a match later if we here is pretty low, so for
              * performance it's best to outright stop here for the lower compression levels
@@ -242,7 +239,7 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, uint32_t cur_match) {
     }
     return best_len;
 
-#ifdef LONGEST_MATCH_SLOW
+#ifdef LONGEST_MATCH_ROLL
 break_matching:
 
     if (best_len < lookahead)
@@ -252,5 +249,5 @@ break_matching:
 #endif
 }
 
-#undef LONGEST_MATCH_SLOW
+#undef LONGEST_MATCH_ROLL
 #undef LONGEST_MATCH


### PR DESCRIPTION
The "slow" variant of longest_match uses a 3-byte rolling hash to seed its offset-search lookups after a match has been found. Rename the template gate, the functable entry, and all arch-specific instantiations from *_slow to *_roll to reflect what the variant actually uses, so a separate integer-hash offset-search variant can coexist under its own name.

Pure rename, no behavior change.