### PR TITLE
Use fallback defines for Chorba Scalar/SSE

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -88,7 +88,7 @@ jobs:
             os: ubuntu-latest
             compiler: gcc
             cxx-compiler: g++
-            cmake-args: -DWITH_CHORBA=OFF
+            cmake-args: -DWITH_CRC32_CHORBA=OFF
             coverage: ubuntu_gcc_no_chorba
 
           - name: Ubuntu GCC SSE2 UBSAN

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,10 +250,6 @@ elseif(MSVC)
     if(MSVC_VERSION VERSION_LESS 1800)
         message(SEND_ERROR "Unsupported Visual Studio compiler version (requires 2013 or later).")
     endif()
-    if(MSVC_VERSION VERSION_LESS 1930)
-        message(STATUS "Old Visual Studio compiler version, disabling SSE2/SSE4.1 Chorba variants (requires 2022 or later).")
-        add_definitions(-DWITHOUT_CHORBA_SSE)
-    endif()
     # TODO. ICC can be used through MSVC. I'm not sure if we'd ever see that combination
     # (who'd use cmake from an IDE...) but checking for ICC before checking for MSVC should
     # avoid mistakes.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1298,15 +1298,12 @@ set(ZLIB_GENERIC_SRCS
     arch/generic/chunkset_c.c
     arch/generic/compare256_c.c
     arch/generic/crc32_braid_c.c
+    arch/generic/crc32_chorba_c.c
     arch/generic/slide_hash_c.c
 )
 
 if(WITH_ALL_FALLBACKS)
     add_definitions(-DWITH_ALL_FALLBACKS)
-endif()
-
-if(WITH_CRC32_CHORBA)
-    list(APPEND ZLIB_SRCS arch/generic/crc32_chorba_c.c)
 endif()
 
 if(WITH_RUNTIME_CPU_DETECTION)

--- a/Makefile.in
+++ b/Makefile.in
@@ -79,6 +79,7 @@ OBJZ = \
 	arch/generic/chunkset_c.o \
 	arch/generic/compare256_c.o \
 	arch/generic/crc32_braid_c.o \
+	arch/generic/crc32_chorba_c.o \
 	arch/generic/slide_hash_c.o \
 	adler32.o \
 	compress.o \
@@ -100,7 +101,6 @@ OBJZ = \
 	trees.o \
 	uncompr.o \
 	zutil.o \
-	arch/generic/crc32_chorba_c.o \
 	cpu_features.o \
 	$(ARCH_STATIC_OBJS)
 
@@ -117,6 +117,7 @@ PIC_OBJZ = \
 	arch/generic/chunkset_c.lo \
 	arch/generic/compare256_c.lo \
 	arch/generic/crc32_braid_c.lo \
+	arch/generic/crc32_chorba_c.lo \
 	arch/generic/slide_hash_c.lo \
 	adler32.lo \
 	compress.lo \
@@ -138,7 +139,6 @@ PIC_OBJZ = \
 	trees.lo \
 	uncompr.lo \
 	zutil.lo \
-	arch/generic/crc32_chorba_c.lo \
 	cpu_features.lo \
 	$(ARCH_SHARED_OBJS)
 

--- a/arch/x86/crc32_chorba_sse2.c
+++ b/arch/x86/crc32_chorba_sse2.c
@@ -1,7 +1,7 @@
 #include "zbuild.h"
 #include "arch_functions.h"
 
-#if defined(X86_SSE2) && !defined(WITHOUT_CHORBA_SSE) && defined(CRC32_CHORBA_FALLBACK)
+#if defined(X86_SSE2) && defined(CRC32_CHORBA_SSE_FALLBACK)
 
 #include "crc32_chorba_p.h"
 #include "crc32_braid_p.h"
@@ -328,7 +328,7 @@ Z_INTERNAL uint32_t crc32_chorba_sse2(uint32_t crc, const uint8_t *buf, size_t l
         len -= align_diff;
         buf += align_diff;
     }
-#if !defined(WITHOUT_CHORBA)
+#ifdef CRC32_CHORBA_FALLBACK
     if (len > CHORBA_LARGE_THRESHOLD)
         return crc32_chorba_118960_nondestructive(crc, buf, len);
 #endif

--- a/arch/x86/crc32_chorba_sse41.c
+++ b/arch/x86/crc32_chorba_sse41.c
@@ -1,7 +1,7 @@
 #include "zbuild.h"
 #include "arch_functions.h"
 
-#if defined(X86_SSE41) && !defined(WITHOUT_CHORBA_SSE) && defined(CRC32_CHORBA_FALLBACK)
+#if defined(X86_SSE41) && defined(CRC32_CHORBA_SSE_FALLBACK)
 
 #include "crc32_chorba_p.h"
 #include "crc32_braid_p.h"
@@ -322,7 +322,7 @@ Z_INTERNAL uint32_t crc32_chorba_sse41(uint32_t crc, const uint8_t *buf, size_t 
         len -= align_diff;
         buf += align_diff;
     }
-#if !defined(WITHOUT_CHORBA)
+#ifdef CRC32_CHORBA_FALLBACK
     if (len > CHORBA_LARGE_THRESHOLD)
         return crc32_chorba_118960_nondestructive(crc, buf, len);
 #endif

--- a/arch/x86/x86_functions.h
+++ b/arch/x86/x86_functions.h
@@ -8,6 +8,13 @@
 
 #include "x86_natives.h"
 
+#if !defined(X86_PCLMULQDQ_NATIVE) && !defined(X86_VPCLMULQDQ_NATIVE)
+#  define CRC32_BRAID_FALLBACK
+#  ifndef WITHOUT_CHORBA_SSE
+#    define CRC32_CHORBA_SSE_FALLBACK
+#  endif
+#endif
+
 #ifdef X86_SSE2
 uint8_t* chunkmemset_safe_sse2(uint8_t *out, uint8_t *from, size_t len, size_t left);
 uint32_t compare256_sse2(const uint8_t *src0, const uint8_t *src1);
@@ -16,7 +23,7 @@ uint32_t longest_match_sse2(deflate_state *const s, uint32_t cur_match);
 uint32_t longest_match_roll_sse2(deflate_state *const s, uint32_t cur_match);
 void slide_hash_sse2(deflate_state *s);
 
-#  if !defined(WITHOUT_CHORBA) && !defined(WITHOUT_CHORBA_SSE)
+#  ifdef CRC32_CHORBA_SSE_FALLBACK
     uint32_t crc32_chorba_sse2(uint32_t crc, const uint8_t *buf, size_t len);
     uint32_t crc32_copy_chorba_sse2(uint32_t crc, uint8_t *dst, const uint8_t *src, size_t len);
     uint32_t chorba_small_nondestructive_sse2(uint32_t crc, const uint8_t *buf, size_t len);
@@ -41,7 +48,7 @@ void inflate_fast_ssse3(PREFIX3(stream) *strm, uint32_t start);
 #endif
 
 #if defined(X86_SSE41)
-#  if !defined(WITHOUT_CHORBA) && !defined(WITHOUT_CHORBA_SSE)
+#  ifdef CRC32_CHORBA_SSE_FALLBACK
     uint32_t crc32_chorba_sse41(uint32_t crc, const uint8_t *buf, size_t len);
     uint32_t crc32_copy_chorba_sse41(uint32_t crc, uint8_t *dst, const uint8_t *src, size_t len);
 #  endif
@@ -88,10 +95,6 @@ uint32_t crc32_vpclmulqdq_avx512(uint32_t crc, const uint8_t *buf, size_t len);
 uint32_t crc32_copy_vpclmulqdq_avx512(uint32_t crc, uint8_t *dst, const uint8_t *src, size_t len);
 #endif
 
-#if !defined(X86_PCLMULQDQ_NATIVE) && !defined(X86_VPCLMULQDQ_NATIVE)
-#  define CRC32_BRAID_FALLBACK
-#endif
-
 #ifdef DISABLE_RUNTIME_CPU_DETECTION
 // X86 - SSE2
 #  ifdef X86_SSE2_NATIVE
@@ -105,7 +108,7 @@ uint32_t crc32_copy_vpclmulqdq_avx512(uint32_t crc, uint8_t *dst, const uint8_t 
 #    define native_longest_match longest_match_sse2
 #    undef native_longest_match_roll
 #    define native_longest_match_roll longest_match_roll_sse2
-#    if !defined(WITHOUT_CHORBA) && !defined(WITHOUT_CHORBA_SSE)
+#    ifdef CRC32_CHORBA_SSE_FALLBACK
 #      undef native_crc32
 #      define native_crc32 crc32_chorba_sse2
 #      undef native_crc32_copy
@@ -127,7 +130,7 @@ uint32_t crc32_copy_vpclmulqdq_avx512(uint32_t crc, uint8_t *dst, const uint8_t 
 #  endif
 // X86 - SSE4.1
 #  if defined(X86_SSE41_NATIVE)
-#    if !defined(WITHOUT_CHORBA) && !defined(WITHOUT_CHORBA_SSE)
+#    ifdef CRC32_CHORBA_SSE_FALLBACK
 #      undef native_crc32
 #      define native_crc32 crc32_chorba_sse41
 #      undef native_crc32_copy

--- a/arch/x86/x86_functions.h
+++ b/arch/x86/x86_functions.h
@@ -8,14 +8,6 @@
 
 #include "x86_natives.h"
 
-/* So great news, your compiler is broken and causes stack smashing. Rather than
- * notching out its compilation we'll just remove the assignment in the functable.
- * Further context:
- * https://developercommunity.visualstudio.com/t/Stack-corruption-with-v142-toolchain-whe/10853479 */
-#if defined(_MSC_VER) && defined(ARCH_32BIT) && _MSC_VER >= 1920 && _MSC_VER <= 1929
-#define NO_CHORBA_SSE
-#endif
-
 #ifdef X86_SSE2
 uint8_t* chunkmemset_safe_sse2(uint8_t *out, uint8_t *from, size_t len, size_t left);
 uint32_t compare256_sse2(const uint8_t *src0, const uint8_t *src1);

--- a/arch/x86/x86_intrins.h
+++ b/arch/x86/x86_intrins.h
@@ -100,25 +100,15 @@ static inline __m512i _mm512_zextsi128_si512(__m128i a) {
  * corruption. _mm_loadl_epi64 compiles to a single MOVQ xmm,m64 that
  * bypasses the buggy synthesis path. Fixed in VS 2022 17.11 (v143).
  *
- * MSVC only defines _mm_cvtsi64_si128 / _mm_cvtsi128_si64 on 64-bit, so the
- * 32-bit polyfills below are also needed for basic compilation.
+ * GCC and MSVC only define _mm_cvtsi64_si128 / _mm_cvtsi128_si64 on 64-bit,
+ * so the 32-bit polyfills below are also needed for basic compilation.
  *
  * https://developercommunity.visualstudio.com/t/10853479
  */
-#if defined(_MSC_VER) && !defined(__clang__) && defined(ARCH_32BIT)
+#if !defined(__clang__) && defined(ARCH_32BIT)
+#ifdef _MSC_VER
 #include <intrin.h>
-static inline int64_t _mm_cvtsi128_si64(__m128i a) {
-    union { __m128i v; int64_t i; } u;
-    u.v = a;
-    return u.i;
-}
-
-static inline __m128i _mm_cvtsi64_si128(int64_t a) {
-    return _mm_loadl_epi64((const __m128i*)&a);
-}
 #endif
-
-#if defined(__GNUC__) && !defined(__clang__) && defined(ARCH_32BIT)
 static inline int64_t _mm_cvtsi128_si64(__m128i a) {
     union { __m128i v; int64_t i; } u;
     u.v = a;

--- a/arch/x86/x86_intrins.h
+++ b/arch/x86/x86_intrins.h
@@ -94,14 +94,19 @@ static inline __m512i _mm512_zextsi128_si512(__m128i a) {
 #  define _mm512_extracti32x4_epi32(v1, e1) _mm512_maskz_extracti32x4_epi32(UINT8_MAX, v1, e1)
 #endif
 
-#if defined(_MSC_VER) && !defined(__clang__)
+/* Workaround for MSVC v142 (Visual Studio 2019, and VS 2022 pre-17.11) bug:
+ * v142 miscompiles _mm_set_epi64x(0, a) on 32-bit by routing part of the
+ * synthesis through a GPR, clobbering live register data and causing stack
+ * corruption. _mm_loadl_epi64 compiles to a single MOVQ xmm,m64 that
+ * bypasses the buggy synthesis path. Fixed in VS 2022 17.11 (v143).
+ *
+ * MSVC only defines _mm_cvtsi64_si128 / _mm_cvtsi128_si64 on 64-bit, so the
+ * 32-bit polyfills below are also needed for basic compilation.
+ *
+ * https://developercommunity.visualstudio.com/t/10853479
+ */
+#if defined(_MSC_VER) && !defined(__clang__) && defined(ARCH_32BIT)
 #include <intrin.h>
-/* For whatever reason this intrinsic is 64 bit only with MSVC?
- * While we don't have 64 bit GPRs, it should at least be able to move it to stack
- * or shuffle it over 2 registers */
-#ifdef ARCH_32BIT
-/* So, while we can't move directly to a GPR, hopefully this move to
- * a stack resident variable doesn't equate to something awful */
 static inline int64_t _mm_cvtsi128_si64(__m128i a) {
     union { __m128i v; int64_t i; } u;
     u.v = a;
@@ -109,18 +114,20 @@ static inline int64_t _mm_cvtsi128_si64(__m128i a) {
 }
 
 static inline __m128i _mm_cvtsi64_si128(int64_t a) {
-   return _mm_set_epi64x(0, a);
+    return _mm_loadl_epi64((const __m128i*)&a);
 }
 #endif
-#endif
 
-#if defined(__GNUC__) && defined(ARCH_X86) && defined(ARCH_32BIT) && !defined(__clang__)
+#if defined(__GNUC__) && !defined(__clang__) && defined(ARCH_32BIT)
 static inline int64_t _mm_cvtsi128_si64(__m128i a) {
     union { __m128i v; int64_t i; } u;
     u.v = a;
     return u.i;
 }
-#define _mm_cvtsi64_si128(a) _mm_set_epi64x(0, a)
+
+static inline __m128i _mm_cvtsi64_si128(int64_t a) {
+    return _mm_loadl_epi64((const __m128i*)&a);
+}
 #endif
 
 #endif // include guard X86_INTRINS_H

--- a/functable.c
+++ b/functable.c
@@ -120,7 +120,7 @@ static int init_functable(void) {
         ft.longest_match_roll = &longest_match_roll_sse2;
         ft.slide_hash = &slide_hash_sse2;
 #  endif
-#  if !defined(WITHOUT_CHORBA_SSE) && !defined(X86_PCLMULQDQ_NATIVE)
+#  if defined(CRC32_CHORBA_SSE_FALLBACK) && !defined(X86_SSE41_NATIVE) && !defined(X86_PCLMULQDQ_NATIVE)
         ft.crc32 = &crc32_chorba_sse2;
         ft.crc32_copy = &crc32_copy_chorba_sse2;
 #  endif
@@ -147,7 +147,7 @@ static int init_functable(void) {
     if (cf.x86.has_sse41)
 #  endif
     {
-#  ifndef WITHOUT_CHORBA_SSE
+#  ifdef CRC32_CHORBA_SSE_FALLBACK
         ft.crc32 = &crc32_chorba_sse41;
         ft.crc32_copy = &crc32_copy_chorba_sse41;
 #  endif

--- a/test/benchmarks/benchmark_crc32.cc
+++ b/test/benchmarks/benchmark_crc32.cc
@@ -88,7 +88,7 @@ BENCHMARK_CRC32(chorba_c, crc32_chorba, 1);
 BENCHMARK_CRC32(native, native_crc32, 1);
 #else
 
-#if defined(CRC32_CHORBA_FALLBACK) && !defined(WITHOUT_CHORBA_SSE)
+#ifdef CRC32_CHORBA_SSE_FALLBACK
 #   ifdef X86_SSE2
     BENCHMARK_CRC32(chorba_sse2, crc32_chorba_sse2, test_cpu_features.x86.has_sse2);
 #   endif

--- a/test/benchmarks/benchmark_crc32_copy.cc
+++ b/test/benchmarks/benchmark_crc32_copy.cc
@@ -140,7 +140,7 @@ BENCHMARK_CRC32_COPY(chorba, crc32_chorba, crc32_copy_chorba, 1)
     BENCHMARK_CRC32_COPY(native, native_crc32, native_crc32_copy, 1)
 #else
     // Optimized functions
-#  if defined(CRC32_CHORBA_FALLBACK) && !defined(WITHOUT_CHORBA_SSE)
+#  ifdef CRC32_CHORBA_SSE_FALLBACK
 #    ifdef X86_SSE2
     BENCHMARK_CRC32_COPY(chorba_sse2, crc32_chorba_sse2, crc32_copy_chorba_sse2, test_cpu_features.x86.has_sse2);
 #    endif

--- a/test/test_crc32.cc
+++ b/test/test_crc32.cc
@@ -131,7 +131,7 @@ TEST_CRC32(vpclmulqdq_avx2, crc32_vpclmulqdq_avx2, (test_cpu_features.x86.has_pc
 #ifdef X86_VPCLMULQDQ_AVX512
 TEST_CRC32(vpclmulqdq_avx512, crc32_vpclmulqdq_avx512, (test_cpu_features.x86.has_pclmulqdq && test_cpu_features.x86.has_avx512_common && test_cpu_features.x86.has_vpclmulqdq))
 #endif
-#if defined(CRC32_CHORBA_FALLBACK) && !defined(WITHOUT_CHORBA_SSE)
+#ifdef CRC32_CHORBA_SSE_FALLBACK
 #   ifdef X86_SSE2
     TEST_CRC32(chorba_sse2, crc32_chorba_sse2, test_cpu_features.x86.has_sse2)
 #   endif

--- a/test/test_crc32_copy.cc
+++ b/test/test_crc32_copy.cc
@@ -52,7 +52,7 @@ TEST_CRC32_COPY(chorba, crc32_copy_chorba, 1)
     TEST_CRC32_COPY(native, native_crc32_copy, 1)
 #else
     // Optimized functions
-#  if defined(CRC32_CHORBA_FALLBACK) && !defined(WITHOUT_CHORBA_SSE)
+#  ifdef CRC32_CHORBA_SSE_FALLBACK
 #    ifdef X86_SSE2
     TEST_CRC32_COPY(chorba_sse2, crc32_copy_chorba_sse2, test_cpu_features.x86.has_sse2)
 #    endif


### PR DESCRIPTION
This is part deux of the fallback builtin simplifications specifically dealing with the Chorba fallbacks.