### PR TITLE
Remove ptrdiff_t configure/cmake detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -636,32 +636,6 @@ if(HAVE_BUILTIN_ASSUME_ALIGNED)
 endif()
 set(CMAKE_REQUIRED_FLAGS)
 
-#
-# check for ptrdiff_t support
-#
-check_c_source_compiles(
-    "#include <stddef.h>
-     int main() {
-         ptrdiff_t *a;
-         (void)a;
-         return 0;
-    }"
-    HAVE_PTRDIFF_T
-)
-if(NOT HAVE_PTRDIFF_T)
-    set(NEED_PTRDIFF_T 1)
-
-    check_type_size("void *" SIZEOF_DATA_PTR)
-    message(STATUS "sizeof(void *) is ${SIZEOF_DATA_PTR} bytes")
-
-    if(${SIZEOF_DATA_PTR} MATCHES "4")
-        set(PTRDIFF_TYPE "uint32_t")
-    elseif(${SIZEOF_DATA_PTR} MATCHES "8")
-        set(PTRDIFF_TYPE "uint64_t")
-    else()
-        message(FATAL_ERROR "sizeof(void *) is neither 32 nor 64 bit")
-    endif()
-endif()
 
 add_compile_options($<$<CONFIG:Debug>:-DZLIB_DEBUG>)
 
@@ -1163,10 +1137,6 @@ macro(generate_cmakein input output)
     file(STRINGS ${input} _lines)
     foreach(_line IN LISTS _lines)
         string(REGEX REPLACE "#ifdef HAVE_UNISTD_H.*" "@ZCONF_UNISTD_LINE@" _line "${_line}")
-        string(REGEX REPLACE "#ifdef NEED_PTRDIFF_T.*" "@ZCONF_PTRDIFF_LINE@" _line "${_line}")
-        if(NEED_PTRDIFF_T)
-            string(REGEX REPLACE "typedef PTRDIFF_TYPE" "typedef @PTRDIFF_TYPE@" _line "${_line}")
-        endif()
         file(APPEND ${output} "${_line}\n")
     endforeach()
 endmacro(generate_cmakein)
@@ -1444,11 +1414,6 @@ if(HAVE_UNISTD_H)
   SET(ZCONF_UNISTD_LINE "#if 1    /* was set to #if 1 by configure/cmake/etc */")
 else()
   SET(ZCONF_UNISTD_LINE "#if 0    /* was set to #if 0 by configure/cmake/etc */")
-endif()
-if(NEED_PTRDIFF_T)
-    SET(ZCONF_PTRDIFF_LINE "#if 1    /* was set to #if 1 by configure/cmake/etc */")
-else()
-    SET(ZCONF_PTRDIFF_LINE "#ifdef NEED_PTRDIFF_T    /* may be set to #if 1 by configure/cmake/etc */")
 endif()
 
 set(ZLIB_PC ${CMAKE_CURRENT_BINARY_DIR}/zlib${SUFFIX}.pc)

--- a/configure
+++ b/configure
@@ -938,45 +938,6 @@ fi
 echo >> configure.log
 
 
-# check for ptrdiff_t and save result in zconf.h
-printf "Checking for ptrdiff_t... " | tee -a configure.log
-cat > $test.c <<EOF
-#include <stddef.h>
-int fun(ptrdiff_t *a) { (void)a; return 0; }
-EOF
-if try $CC -c $CFLAGS $test.c; then
-  echo "Yes." | tee -a configure.log
-else
-    echo "No." | tee -a configure.log
-    sed < zconf${SUFFIX}.h "/^#ifdef NEED_PTRDIFF_T.* may be/s/def NEED_PTRDIFF_T\(.*\) may be/ 1\1 was/" > zconf${SUFFIX}.temp.h
-    mv zconf${SUFFIX}.temp.h zconf${SUFFIX}.h
-
-    printf "Checking for sizeof(void *)... " | tee -a configure.log
-    cat > $test.c <<EOF
-#include <stdint.h>
-#define COMPILE_TIME_ASSERT(pred) struct s { int x: (pred) ? 1 : -1; }
-COMPILE_TIME_ASSERT(sizeof(int32_t) == sizeof(void *));
-EOF
-    if try $CC -c $CFLAGS $test.c; then
-        echo "sizeof(int32_t)." | tee -a configure.log
-        sed < zconf${SUFFIX}.h "s/^typedef PTRDIFF_TYPE ptrdiff_t;/typedef int32_t ptrdiff_t;/g" > zconf${SUFFIX}.temp.h
-        mv zconf${SUFFIX}.temp.h zconf${SUFFIX}.h
-    else
-        cat > $test.c <<EOF
-#include <stdint.h>
-#define COMPILE_TIME_ASSERT(pred) struct s { int x: (pred) ? 1 : -1; }
-COMPILE_TIME_ASSERT(sizeof(int64_t) == sizeof(void *));
-EOF
-        if try $CC -c $CFLAGS $test.c; then
-            echo "sizeof(int64_t)." | tee -a configure.log
-            sed < zconf${SUFFIX}.h "s/^typedef PTRDIFF_TYPE ptrdiff_t;/typedef int64_t ptrdiff_t;/g" > zconf${SUFFIX}.temp.h
-            mv zconf${SUFFIX}.temp.h zconf${SUFFIX}.h
-        else
-            echo "unknown." | tee -a configure.log
-            exit 1
-        fi
-    fi
-fi
 
 # if --zlib-compat was requested
 if test $compat -eq 1; then

--- a/zconf-ng.h.in
+++ b/zconf-ng.h.in
@@ -114,10 +114,6 @@ typedef void       *voidp;
 #  define Z_HAVE_UNISTD_H
 #endif
 
-#ifdef NEED_PTRDIFF_T    /* may be set to #if 1 by configure/cmake/etc */
-typedef PTRDIFF_TYPE ptrdiff_t;
-#endif
-
 #include <sys/types.h>      /* for off_t */
 
 #include <stddef.h>         /* for wchar_t and NULL */

--- a/zconf.h.in
+++ b/zconf.h.in
@@ -142,10 +142,6 @@ typedef unsigned int z_crc_t;
 #  define Z_HAVE_UNISTD_H
 #endif
 
-#ifdef NEED_PTRDIFF_T    /* may be set to #if 1 by configure/cmake/etc */
-typedef PTRDIFF_TYPE ptrdiff_t;
-#endif
-
 #include <sys/types.h>      /* for off_t */
 
 #include <stddef.h>         /* for wchar_t and NULL */


### PR DESCRIPTION
## Summary

Remove the ptrdiff_t configure/cmake detection. `ptrdiff_t` is defined in `<stddef.h>` since C89 and is guaranteed on any C99+ compiler, making the build-time check and the fallback typedef in the zconf headers unnecessary.