### PR TITLE
Extend longest_match with integer-hash offset-search 

### DIFF
--- a/arch/arm/arm_functions.h
+++ b/arch/arm/arm_functions.h
@@ -14,7 +14,8 @@ uint8_t* chunkmemset_safe_neon(uint8_t *out, uint8_t *from, size_t len, size_t l
 uint32_t compare256_neon(const uint8_t *src0, const uint8_t *src1);
 void inflate_fast_neon(PREFIX3(stream) *strm, uint32_t start, int safe_mode);
 uint32_t longest_match_neon(deflate_state *const s, uint32_t cur_match);
-uint32_t longest_match_roll_neon(deflate_state *const s, uint32_t cur_match);
+uint32_t longest_match_slow_knuth_neon(deflate_state *const s, uint32_t cur_match);
+uint32_t longest_match_slow_roll_neon(deflate_state *const s, uint32_t cur_match);
 void slide_hash_neon(deflate_state *s);
 void slide_hash_head_neon(deflate_state *s);
 #endif
@@ -74,8 +75,10 @@ void slide_hash_head_armv6(deflate_state *s);
 #    define native_inflate_fast inflate_fast_neon
 #    undef native_longest_match
 #    define native_longest_match longest_match_neon
-#    undef native_longest_match_roll
-#    define native_longest_match_roll longest_match_roll_neon
+#    undef native_longest_match_slow_knuth
+#    define native_longest_match_slow_knuth longest_match_slow_knuth_neon
+#    undef native_longest_match_slow_roll
+#    define native_longest_match_slow_roll longest_match_slow_roll_neon
 #    undef native_slide_hash
 #    define native_slide_hash slide_hash_neon
 #    undef native_slide_hash_head

--- a/arch/arm/compare256_neon.c
+++ b/arch/arm/compare256_neon.c
@@ -65,8 +65,15 @@ Z_INTERNAL uint32_t compare256_neon(const uint8_t *src0, const uint8_t *src1) {
 
 #include "match_tpl.h"
 
-#define LONGEST_MATCH_ROLL
-#define LONGEST_MATCH       longest_match_roll_neon
+#define LONGEST_MATCH_SLOW
+#define LONGEST_MATCH       longest_match_slow_knuth_neon
+#define COMPARE256          compare256_neon_static
+
+#include "match_tpl.h"
+
+#define LONGEST_MATCH_SLOW
+#define LONGEST_MATCH_SLOW_ROLL
+#define LONGEST_MATCH       longest_match_slow_roll_neon
 #define COMPARE256          compare256_neon_static
 
 #include "match_tpl.h"

--- a/arch/generic/compare256_c.c
+++ b/arch/generic/compare256_c.c
@@ -80,13 +80,16 @@ Z_INTERNAL uint32_t compare256_c(const uint8_t *src0, const uint8_t *src1) {
     return COMPARE256(src0, src1);
 }
 
-// Generate longest_match_c
 #define LONGEST_MATCH       longest_match_c
 #include "match_tpl.h"
 
-// Generate longest_match_roll_c
-#define LONGEST_MATCH_ROLL
-#define LONGEST_MATCH       longest_match_roll_c
+#define LONGEST_MATCH_SLOW
+#define LONGEST_MATCH       longest_match_slow_knuth_c
+#include "match_tpl.h"
+
+#define LONGEST_MATCH_SLOW
+#define LONGEST_MATCH_SLOW_ROLL
+#define LONGEST_MATCH       longest_match_slow_roll_c
 #include "match_tpl.h"
 
 #endif /* COMPARE256_FALLBACK */

--- a/arch/generic/generic_functions.h
+++ b/arch/generic/generic_functions.h
@@ -46,7 +46,8 @@ void     inflate_fast_c(PREFIX3(stream) *strm, uint32_t start, int safe_mode);
 #endif
 #ifdef COMPARE256_FALLBACK
 uint32_t longest_match_c(deflate_state *const s, uint32_t cur_match);
-uint32_t longest_match_roll_c(deflate_state *const s, uint32_t cur_match);
+uint32_t longest_match_slow_knuth_c(deflate_state *const s, uint32_t cur_match);
+uint32_t longest_match_slow_roll_c(deflate_state *const s, uint32_t cur_match);
 #endif
 #ifdef SLIDE_HASH_FALLBACK
 void     slide_hash_c(deflate_state *s);
@@ -78,8 +79,11 @@ void     slide_hash_head_c(deflate_state *s);
 #    ifndef native_longest_match
 #      define native_longest_match longest_match_c
 #    endif
-#    ifndef native_longest_match_roll
-#      define native_longest_match_roll longest_match_roll_c
+#    ifndef native_longest_match_slow_knuth
+#      define native_longest_match_slow_knuth longest_match_slow_knuth_c
+#    endif
+#    ifndef native_longest_match_slow_roll
+#      define native_longest_match_slow_roll longest_match_slow_roll_c
 #    endif
 #  endif
 #  ifdef CRC32_CHORBA_FALLBACK

--- a/arch/loongarch/compare256_lasx.c
+++ b/arch/loongarch/compare256_lasx.c
@@ -51,8 +51,15 @@ Z_INTERNAL uint32_t compare256_lasx(const uint8_t *src0, const uint8_t *src1) {
 
 #include "match_tpl.h"
 
-#define LONGEST_MATCH_ROLL
-#define LONGEST_MATCH       longest_match_roll_lasx
+#define LONGEST_MATCH_SLOW
+#define LONGEST_MATCH       longest_match_slow_knuth_lasx
+#define COMPARE256          compare256_lasx_static
+
+#include "match_tpl.h"
+
+#define LONGEST_MATCH_SLOW
+#define LONGEST_MATCH_SLOW_ROLL
+#define LONGEST_MATCH       longest_match_slow_roll_lasx
 #define COMPARE256          compare256_lasx_static
 
 #include "match_tpl.h"

--- a/arch/loongarch/compare256_lsx.c
+++ b/arch/loongarch/compare256_lsx.c
@@ -79,8 +79,15 @@ Z_INTERNAL uint32_t compare256_lsx(const uint8_t *src0, const uint8_t *src1) {
 
 #include "match_tpl.h"
 
-#define LONGEST_MATCH_ROLL
-#define LONGEST_MATCH       longest_match_roll_lsx
+#define LONGEST_MATCH_SLOW
+#define LONGEST_MATCH       longest_match_slow_knuth_lsx
+#define COMPARE256          compare256_lsx_static
+
+#include "match_tpl.h"
+
+#define LONGEST_MATCH_SLOW
+#define LONGEST_MATCH_SLOW_ROLL
+#define LONGEST_MATCH       longest_match_slow_roll_lsx
 #define COMPARE256          compare256_lsx_static
 
 #include "match_tpl.h"

--- a/arch/loongarch/loongarch_functions.h
+++ b/arch/loongarch/loongarch_functions.h
@@ -26,7 +26,8 @@ uint8_t* chunkmemset_safe_lsx(uint8_t *out, uint8_t *from, size_t len, size_t le
 uint32_t compare256_lsx(const uint8_t *src0, const uint8_t *src1);
 void inflate_fast_lsx(PREFIX3(stream) *strm, uint32_t start, int safe_mode);
 uint32_t longest_match_lsx(deflate_state *const s, uint32_t cur_match);
-uint32_t longest_match_roll_lsx(deflate_state *const s, uint32_t cur_match);
+uint32_t longest_match_slow_knuth_lsx(deflate_state *const s, uint32_t cur_match);
+uint32_t longest_match_slow_roll_lsx(deflate_state *const s, uint32_t cur_match);
 void slide_hash_lsx(deflate_state *s);
 void slide_hash_head_lsx(deflate_state *s);
 #endif
@@ -45,7 +46,8 @@ uint8_t* chunkmemset_safe_lasx(uint8_t *out, uint8_t *from, size_t len, size_t l
 uint32_t compare256_lasx(const uint8_t *src0, const uint8_t *src1);
 void inflate_fast_lasx(PREFIX3(stream) *strm, uint32_t start, int safe_mode);
 uint32_t longest_match_lasx(deflate_state *const s, uint32_t cur_match);
-uint32_t longest_match_roll_lasx(deflate_state *const s, uint32_t cur_match);
+uint32_t longest_match_slow_knuth_lasx(deflate_state *const s, uint32_t cur_match);
+uint32_t longest_match_slow_roll_lasx(deflate_state *const s, uint32_t cur_match);
 void slide_hash_lasx(deflate_state *s);
 void slide_hash_head_lasx(deflate_state *s);
 #endif
@@ -71,8 +73,10 @@ void slide_hash_head_lasx(deflate_state *s);
 #    define native_inflate_fast inflate_fast_lsx
 #    undef native_longest_match
 #    define native_longest_match longest_match_lsx
-#    undef native_longest_match_roll
-#    define native_longest_match_roll longest_match_roll_lsx
+#    undef native_longest_match_slow_knuth
+#    define native_longest_match_slow_knuth longest_match_slow_knuth_lsx
+#    undef native_longest_match_slow_roll
+#    define native_longest_match_slow_roll longest_match_slow_roll_lsx
 #    undef native_slide_hash
 #    define native_slide_hash slide_hash_lsx
 #    undef native_slide_hash_head
@@ -91,8 +95,10 @@ void slide_hash_head_lasx(deflate_state *s);
 #    define native_inflate_fast inflate_fast_lasx
 #    undef native_longest_match
 #    define native_longest_match longest_match_lasx
-#    undef native_longest_match_roll
-#    define native_longest_match_roll longest_match_roll_lasx
+#    undef native_longest_match_slow_knuth
+#    define native_longest_match_slow_knuth longest_match_slow_knuth_lasx
+#    undef native_longest_match_slow_roll
+#    define native_longest_match_slow_roll longest_match_slow_roll_lasx
 #    undef native_slide_hash
 #    define native_slide_hash slide_hash_lasx
 #    undef native_slide_hash_head

--- a/arch/power/compare256_power9.c
+++ b/arch/power/compare256_power9.c
@@ -60,8 +60,15 @@ Z_INTERNAL uint32_t compare256_power9(const uint8_t *src0, const uint8_t *src1) 
 
 #include "match_tpl.h"
 
-#define LONGEST_MATCH_ROLL
-#define LONGEST_MATCH       longest_match_roll_power9
+#define LONGEST_MATCH_SLOW
+#define LONGEST_MATCH       longest_match_slow_knuth_power9
+#define COMPARE256          compare256_power9_static
+
+#include "match_tpl.h"
+
+#define LONGEST_MATCH_SLOW
+#define LONGEST_MATCH_SLOW_ROLL
+#define LONGEST_MATCH       longest_match_slow_roll_power9
 #define COMPARE256          compare256_power9_static
 
 #include "match_tpl.h"

--- a/arch/power/power_functions.h
+++ b/arch/power/power_functions.h
@@ -42,7 +42,8 @@ void inflate_fast_power8(PREFIX3(stream) *strm, uint32_t start, int safe_mode);
 #ifdef POWER9
 uint32_t compare256_power9(const uint8_t *src0, const uint8_t *src1);
 uint32_t longest_match_power9(deflate_state *const s, uint32_t cur_match);
-uint32_t longest_match_roll_power9(deflate_state *const s, uint32_t cur_match);
+uint32_t longest_match_slow_knuth_power9(deflate_state *const s, uint32_t cur_match);
+uint32_t longest_match_slow_roll_power9(deflate_state *const s, uint32_t cur_match);
 #endif
 
 #ifndef POWER9_NATIVE
@@ -88,8 +89,10 @@ uint32_t longest_match_roll_power9(deflate_state *const s, uint32_t cur_match);
 #    define native_compare256 compare256_power9
 #    undef native_longest_match
 #    define native_longest_match longest_match_power9
-#    undef native_longest_match_roll
-#    define native_longest_match_roll longest_match_roll_power9
+#    undef native_longest_match_slow_knuth
+#    define native_longest_match_slow_knuth longest_match_slow_knuth_power9
+#    undef native_longest_match_slow_roll
+#    define native_longest_match_slow_roll longest_match_slow_roll_power9
 #  endif
 #endif
 

--- a/arch/riscv/compare256_rvv.c
+++ b/arch/riscv/compare256_rvv.c
@@ -41,8 +41,15 @@ Z_INTERNAL uint32_t compare256_rvv(const uint8_t *src0, const uint8_t *src1) {
 
 #include "match_tpl.h"
 
-#define LONGEST_MATCH_ROLL
-#define LONGEST_MATCH       longest_match_roll_rvv
+#define LONGEST_MATCH_SLOW
+#define LONGEST_MATCH       longest_match_slow_knuth_rvv
+#define COMPARE256          compare256_rvv_static
+
+#include "match_tpl.h"
+
+#define LONGEST_MATCH_SLOW
+#define LONGEST_MATCH_SLOW_ROLL
+#define LONGEST_MATCH       longest_match_slow_roll_rvv
 #define COMPARE256          compare256_rvv_static
 
 #include "match_tpl.h"

--- a/arch/riscv/riscv_functions.h
+++ b/arch/riscv/riscv_functions.h
@@ -20,7 +20,8 @@ uint8_t* chunkmemset_safe_rvv(uint8_t *out, uint8_t *from, size_t len, size_t le
 uint32_t compare256_rvv(const uint8_t *src0, const uint8_t *src1);
 
 uint32_t longest_match_rvv(deflate_state *const s, uint32_t cur_match);
-uint32_t longest_match_roll_rvv(deflate_state *const s, uint32_t cur_match);
+uint32_t longest_match_slow_knuth_rvv(deflate_state *const s, uint32_t cur_match);
+uint32_t longest_match_slow_roll_rvv(deflate_state *const s, uint32_t cur_match);
 void slide_hash_rvv(deflate_state *s);
 void slide_hash_head_rvv(deflate_state *s);
 void inflate_fast_rvv(PREFIX3(stream) *strm, uint32_t start, int safe_mode);
@@ -53,8 +54,10 @@ uint32_t crc32_copy_riscv64_zbc(uint32_t crc, uint8_t *dst, const uint8_t *src, 
 #    define native_inflate_fast inflate_fast_rvv
 #    undef native_longest_match
 #    define native_longest_match longest_match_rvv
-#    undef native_longest_match_roll
-#    define native_longest_match_roll longest_match_roll_rvv
+#    undef native_longest_match_slow_knuth
+#    define native_longest_match_slow_knuth longest_match_slow_knuth_rvv
+#    undef native_longest_match_slow_roll
+#    define native_longest_match_slow_roll longest_match_slow_roll_rvv
 #    undef native_slide_hash
 #    define native_slide_hash slide_hash_rvv
 #    undef native_slide_hash_head

--- a/arch/x86/compare256_avx2.c
+++ b/arch/x86/compare256_avx2.c
@@ -52,8 +52,15 @@ Z_INTERNAL uint32_t compare256_avx2(const uint8_t *src0, const uint8_t *src1) {
 
 #include "match_tpl.h"
 
-#define LONGEST_MATCH_ROLL
-#define LONGEST_MATCH       longest_match_roll_avx2
+#define LONGEST_MATCH_SLOW
+#define LONGEST_MATCH       longest_match_slow_knuth_avx2
+#define COMPARE256          compare256_avx2_static
+
+#include "match_tpl.h"
+
+#define LONGEST_MATCH_SLOW
+#define LONGEST_MATCH_SLOW_ROLL
+#define LONGEST_MATCH       longest_match_slow_roll_avx2
 #define COMPARE256          compare256_avx2_static
 
 #include "match_tpl.h"

--- a/arch/x86/compare256_avx512.c
+++ b/arch/x86/compare256_avx512.c
@@ -78,8 +78,15 @@ Z_INTERNAL uint32_t compare256_avx512(const uint8_t *src0, const uint8_t *src1) 
 
 #include "match_tpl.h"
 
-#define LONGEST_MATCH_ROLL
-#define LONGEST_MATCH       longest_match_roll_avx512
+#define LONGEST_MATCH_SLOW
+#define LONGEST_MATCH       longest_match_slow_knuth_avx512
+#define COMPARE256          compare256_avx512_static
+
+#include "match_tpl.h"
+
+#define LONGEST_MATCH_SLOW
+#define LONGEST_MATCH_SLOW_ROLL
+#define LONGEST_MATCH       longest_match_slow_roll_avx512
 #define COMPARE256          compare256_avx512_static
 
 #include "match_tpl.h"

--- a/arch/x86/compare256_sse2.c
+++ b/arch/x86/compare256_sse2.c
@@ -77,8 +77,15 @@ Z_INTERNAL uint32_t compare256_sse2(const uint8_t *src0, const uint8_t *src1) {
 
 #include "match_tpl.h"
 
-#define LONGEST_MATCH_ROLL
-#define LONGEST_MATCH       longest_match_roll_sse2
+#define LONGEST_MATCH_SLOW
+#define LONGEST_MATCH       longest_match_slow_knuth_sse2
+#define COMPARE256          compare256_sse2_static
+
+#include "match_tpl.h"
+
+#define LONGEST_MATCH_SLOW
+#define LONGEST_MATCH_SLOW_ROLL
+#define LONGEST_MATCH       longest_match_slow_roll_sse2
 #define COMPARE256          compare256_sse2_static
 
 #include "match_tpl.h"

--- a/arch/x86/x86_functions.h
+++ b/arch/x86/x86_functions.h
@@ -20,7 +20,8 @@ uint8_t* chunkmemset_safe_sse2(uint8_t *out, uint8_t *from, size_t len, size_t l
 uint32_t compare256_sse2(const uint8_t *src0, const uint8_t *src1);
 void inflate_fast_sse2(PREFIX3(stream)* strm, uint32_t start, int safe_mode);
 uint32_t longest_match_sse2(deflate_state *const s, uint32_t cur_match);
-uint32_t longest_match_roll_sse2(deflate_state *const s, uint32_t cur_match);
+uint32_t longest_match_slow_knuth_sse2(deflate_state *const s, uint32_t cur_match);
+uint32_t longest_match_slow_roll_sse2(deflate_state *const s, uint32_t cur_match);
 void slide_hash_sse2(deflate_state *s);
 void slide_hash_head_sse2(deflate_state *s);
 
@@ -66,7 +67,8 @@ uint8_t* chunkmemset_safe_avx2(uint8_t *out, uint8_t *from, size_t len, size_t l
 uint32_t compare256_avx2(const uint8_t *src0, const uint8_t *src1);
 void inflate_fast_avx2(PREFIX3(stream)* strm, uint32_t start, int safe_mode);
 uint32_t longest_match_avx2(deflate_state *const s, uint32_t cur_match);
-uint32_t longest_match_roll_avx2(deflate_state *const s, uint32_t cur_match);
+uint32_t longest_match_slow_knuth_avx2(deflate_state *const s, uint32_t cur_match);
+uint32_t longest_match_slow_roll_avx2(deflate_state *const s, uint32_t cur_match);
 void slide_hash_avx2(deflate_state *s);
 void slide_hash_head_avx2(deflate_state *s);
 #endif
@@ -77,7 +79,8 @@ uint8_t* chunkmemset_safe_avx512(uint8_t *out, uint8_t *from, size_t len, size_t
 uint32_t compare256_avx512(const uint8_t *src0, const uint8_t *src1);
 void inflate_fast_avx512(PREFIX3(stream)* strm, uint32_t start, int safe_mode);
 uint32_t longest_match_avx512(deflate_state *const s, uint32_t cur_match);
-uint32_t longest_match_roll_avx512(deflate_state *const s, uint32_t cur_match);
+uint32_t longest_match_slow_knuth_avx512(deflate_state *const s, uint32_t cur_match);
+uint32_t longest_match_slow_roll_avx512(deflate_state *const s, uint32_t cur_match);
 #endif
 #ifdef X86_AVX512VNNI
 uint32_t adler32_avx512_vnni(uint32_t adler, const uint8_t *buf, size_t len);
@@ -113,8 +116,10 @@ uint32_t crc32_copy_vpclmulqdq_avx512(uint32_t crc, uint8_t *dst, const uint8_t 
 #    define native_inflate_fast inflate_fast_sse2
 #    undef native_longest_match
 #    define native_longest_match longest_match_sse2
-#    undef native_longest_match_roll
-#    define native_longest_match_roll longest_match_roll_sse2
+#    undef native_longest_match_slow_knuth
+#    define native_longest_match_slow_knuth longest_match_slow_knuth_sse2
+#    undef native_longest_match_slow_roll
+#    define native_longest_match_slow_roll longest_match_slow_roll_sse2
 #    ifdef CRC32_CHORBA_SSE_FALLBACK
 #      undef native_crc32
 #      define native_crc32 crc32_chorba_sse2
@@ -172,8 +177,10 @@ uint32_t crc32_copy_vpclmulqdq_avx512(uint32_t crc, uint8_t *dst, const uint8_t 
 #    define native_inflate_fast inflate_fast_avx2
 #    undef native_longest_match
 #    define native_longest_match longest_match_avx2
-#    undef native_longest_match_roll
-#    define native_longest_match_roll longest_match_roll_avx2
+#    undef native_longest_match_slow_knuth
+#    define native_longest_match_slow_knuth longest_match_slow_knuth_avx2
+#    undef native_longest_match_slow_roll
+#    define native_longest_match_slow_roll longest_match_slow_roll_avx2
 #    undef native_slide_hash
 #    define native_slide_hash slide_hash_avx2
 #    undef native_slide_hash_head
@@ -200,8 +207,10 @@ uint32_t crc32_copy_vpclmulqdq_avx512(uint32_t crc, uint8_t *dst, const uint8_t 
 #    define native_inflate_fast inflate_fast_avx512
 #    undef native_longest_match
 #    define native_longest_match longest_match_avx512
-#    undef native_longest_match_roll
-#    define native_longest_match_roll longest_match_roll_avx512
+#    undef native_longest_match_slow_knuth
+#    define native_longest_match_slow_knuth longest_match_slow_knuth_avx512
+#    undef native_longest_match_slow_roll
+#    define native_longest_match_slow_roll longest_match_slow_roll_avx512
 // X86 - AVX512 (VNNI)
 #    ifdef X86_AVX512VNNI_NATIVE
 #      undef native_adler32

--- a/deflate.c
+++ b/deflate.c
@@ -434,10 +434,7 @@ int32_t Z_EXPORT PREFIX(deflateSetDictionary)(PREFIX3(stream) *strm, const uint8
     if (wrap == 2 || (wrap == 1 && s->status != INIT_STATE) || s->lookahead)
         return Z_STREAM_ERROR;
 
-    if (s->level >= 9)
-        insert_batch = insert_roll_batch;
-    else
-        insert_batch = insert_knuth_batch;
+    insert_batch = s->insert_batch;
 
     /* when using zlib wrappers, compute Adler-32 for provided dictionary */
     if (wrap == 1)
@@ -1183,6 +1180,16 @@ static void lm_set_level(deflate_state *s, int level) {
     s->good_match       = configuration_table[level].good_length;
     s->nice_match       = configuration_table[level].nice_length;
     s->max_chain_length = configuration_table[level].max_chain;
+    if (level >= 9) {
+        s->longest_match = FUNCTABLE_FPTR(longest_match_slow_roll);
+        s->insert_batch  = insert_roll_batch;
+    } else {
+        s->longest_match = FUNCTABLE_FPTR(longest_match_slow_knuth);
+        if (HAVE_QUICK_STRATEGY && level == 1)
+            s->insert_batch = insert_knuth_batch_head;
+        else
+            s->insert_batch = insert_knuth_batch;
+    }
     s->level = level;
 }
 
@@ -1221,7 +1228,7 @@ static void lm_init(deflate_state *s) {
 
 void Z_INTERNAL PREFIX(fill_window)(deflate_state *s) {
     PREFIX3(stream) *strm = s->strm;
-    insert_batch_func insert_batch;
+    insert_batch_func insert_batch = s->insert_batch;
     unsigned char *window = s->window;
     unsigned n;
     unsigned int more;    /* Amount of free space at the end of the window. */
@@ -1229,13 +1236,6 @@ void Z_INTERNAL PREFIX(fill_window)(deflate_state *s) {
     int level = s->level;
 
     Assert(s->lookahead < MIN_LOOKAHEAD, "already enough lookahead");
-
-    if (level >= 9)
-        insert_batch = insert_roll_batch;
-    else if (HAVE_QUICK_STRATEGY && level == 1)
-        insert_batch = insert_knuth_batch_head;
-    else
-        insert_batch = insert_knuth_batch;
 
     do {
         more = s->window_size - s->lookahead - s->strstart;

--- a/deflate.h
+++ b/deflate.h
@@ -148,6 +148,9 @@ void         insert_knuth_batch      (deflate_state *const s, unsigned char *win
 void         insert_roll_batch       (deflate_state *const s, unsigned char *window, uint32_t str, uint32_t count);
 void         insert_knuth_batch_head (deflate_state *const s, unsigned char *window, uint32_t str, uint32_t count);
 
+/* Match function. Returns the longest match. */
+typedef uint32_t (* longest_match_func) (deflate_state *const s, uint32_t cur_match);
+
 /* Struct for memory allocation handling */
 typedef struct deflate_allocs_s {
     char            *buf_start;
@@ -332,6 +335,10 @@ struct ALIGNED_(64) internal_state {
     unsigned long compressed_len; /* total bit length of compressed file mod 2^32 */
     unsigned long bits_sent;      /* bit length of compressed data sent mod 2^32 */
 #endif
+
+    /* Level-selected function variants, set by lm_set_level() */
+    longest_match_func longest_match;
+    insert_batch_func insert_batch;
 
     /* Reserved for future use and alignment purposes */
     int32_t reserved[19];

--- a/deflate_p.h
+++ b/deflate_p.h
@@ -206,7 +206,5 @@ Z_FORCEINLINE static unsigned read_buf(PREFIX3(stream) *strm, unsigned char *buf
 
 /* Compression function. Returns the block state after the call. */
 typedef block_state (*compress_func) (deflate_state *s, int flush);
-/* Match function. Returns the longest match. */
-typedef uint32_t    (*match_func)    (deflate_state *const s, uint32_t cur_match);
 
 #endif

--- a/deflate_slow.c
+++ b/deflate_slow.c
@@ -7,7 +7,6 @@
 #include "zbuild.h"
 #include "deflate.h"
 #include "deflate_p.h"
-#include "functable.h"
 #include "insert_string_p.h"
 
 /* ===========================================================================
@@ -16,19 +15,11 @@
  * no better match at the next window position.
  */
 Z_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
-    match_func longest_match;
-    insert_batch_func insert_batch;
+    longest_match_func longest_match = s->longest_match;
+    insert_batch_func insert_batch = s->insert_batch;
     unsigned char *window = s->window;
     int bflush;              /* set if current block must be flushed */
     int level = s->level;
-
-    if (level >= 9) {
-        longest_match = FUNCTABLE_FPTR(longest_match_slow_roll);
-        insert_batch = insert_roll_batch;
-    } else {
-        longest_match = FUNCTABLE_FPTR(longest_match_slow_knuth);
-        insert_batch = insert_knuth_batch;
-    }
 
     /* Process the input block. */
     for (;;) {

--- a/deflate_slow.c
+++ b/deflate_slow.c
@@ -23,10 +23,10 @@ Z_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
     int level = s->level;
 
     if (level >= 9) {
-        longest_match = FUNCTABLE_FPTR(longest_match_roll);
+        longest_match = FUNCTABLE_FPTR(longest_match_slow_roll);
         insert_batch = insert_roll_batch;
     } else {
-        longest_match = FUNCTABLE_FPTR(longest_match);
+        longest_match = FUNCTABLE_FPTR(longest_match_slow_knuth);
         insert_batch = insert_knuth_batch;
     }
 

--- a/functable.c
+++ b/functable.c
@@ -87,7 +87,8 @@ static int init_functable(void) {
 #ifdef COMPARE256_FALLBACK
     ft.compare256 = &compare256_c;
     ft.longest_match = &longest_match_c;
-    ft.longest_match_roll = &longest_match_roll_c;
+    ft.longest_match_slow_knuth = &longest_match_slow_knuth_c;
+    ft.longest_match_slow_roll = &longest_match_slow_roll_c;
 #endif
 #ifdef CRC32_BRAID_FALLBACK
     ft.crc32 = &crc32_braid;
@@ -118,7 +119,8 @@ static int init_functable(void) {
         ft.compare256 = &compare256_sse2;
         ft.inflate_fast = &inflate_fast_sse2;
         ft.longest_match = &longest_match_sse2;
-        ft.longest_match_roll = &longest_match_roll_sse2;
+        ft.longest_match_slow_knuth = &longest_match_slow_knuth_sse2;
+        ft.longest_match_slow_roll = &longest_match_slow_roll_sse2;
         ft.slide_hash = &slide_hash_sse2;
         ft.slide_hash_head = &slide_hash_head_sse2;
 #  endif
@@ -192,7 +194,8 @@ static int init_functable(void) {
         ft.compare256 = &compare256_avx2;
         ft.inflate_fast = &inflate_fast_avx2;
         ft.longest_match = &longest_match_avx2;
-        ft.longest_match_roll = &longest_match_roll_avx2;
+        ft.longest_match_slow_knuth = &longest_match_slow_knuth_avx2;
+        ft.longest_match_slow_roll = &longest_match_slow_roll_avx2;
 #  endif
         ft.slide_hash = &slide_hash_avx2;
         ft.slide_hash_head = &slide_hash_head_avx2;
@@ -218,7 +221,8 @@ static int init_functable(void) {
         ft.compare256 = &compare256_avx512;
         ft.inflate_fast = &inflate_fast_avx512;
         ft.longest_match = &longest_match_avx512;
-        ft.longest_match_roll = &longest_match_roll_avx512;
+        ft.longest_match_slow_knuth = &longest_match_slow_knuth_avx512;
+        ft.longest_match_slow_roll = &longest_match_slow_roll_avx512;
     }
 #endif
 #ifdef X86_AVX512VNNI
@@ -274,7 +278,8 @@ static int init_functable(void) {
         ft.compare256 = &compare256_neon;
         ft.inflate_fast = &inflate_fast_neon;
         ft.longest_match = &longest_match_neon;
-        ft.longest_match_roll = &longest_match_roll_neon;
+        ft.longest_match_slow_knuth = &longest_match_slow_knuth_neon;
+        ft.longest_match_slow_roll = &longest_match_slow_roll_neon;
         ft.slide_hash = &slide_hash_neon;
         ft.slide_hash_head = &slide_hash_head_neon;
     }
@@ -353,7 +358,8 @@ static int init_functable(void) {
     {
         ft.compare256 = &compare256_power9;
         ft.longest_match = &longest_match_power9;
-        ft.longest_match_roll = &longest_match_roll_power9;
+        ft.longest_match_slow_knuth = &longest_match_slow_knuth_power9;
+        ft.longest_match_slow_roll = &longest_match_slow_roll_power9;
     }
 #endif
 
@@ -370,7 +376,8 @@ static int init_functable(void) {
         ft.compare256 = &compare256_rvv;
         ft.inflate_fast = &inflate_fast_rvv;
         ft.longest_match = &longest_match_rvv;
-        ft.longest_match_roll = &longest_match_roll_rvv;
+        ft.longest_match_slow_knuth = &longest_match_slow_knuth_rvv;
+        ft.longest_match_slow_roll = &longest_match_slow_roll_rvv;
         ft.slide_hash = &slide_hash_rvv;
         ft.slide_hash_head = &slide_hash_head_rvv;
     }
@@ -421,7 +428,8 @@ static int init_functable(void) {
         ft.compare256 = &compare256_lsx;
         ft.inflate_fast = &inflate_fast_lsx;
         ft.longest_match = &longest_match_lsx;
-        ft.longest_match_roll = &longest_match_roll_lsx;
+        ft.longest_match_slow_knuth = &longest_match_slow_knuth_lsx;
+        ft.longest_match_slow_roll = &longest_match_slow_roll_lsx;
         ft.slide_hash = &slide_hash_lsx;
         ft.slide_hash_head = &slide_hash_head_lsx;
     }
@@ -437,7 +445,8 @@ static int init_functable(void) {
         ft.compare256 = &compare256_lasx;
         ft.inflate_fast = &inflate_fast_lasx;
         ft.longest_match = &longest_match_lasx;
-        ft.longest_match_roll = &longest_match_roll_lasx;
+        ft.longest_match_slow_knuth = &longest_match_slow_knuth_lasx;
+        ft.longest_match_slow_roll = &longest_match_slow_roll_lasx;
         ft.slide_hash = &slide_hash_lasx;
         ft.slide_hash_head = &slide_hash_head_lasx;
     }
@@ -455,7 +464,8 @@ static int init_functable(void) {
     FUNCTABLE_VERIFY_ASSIGN(ft, crc32_copy);
     FUNCTABLE_VERIFY_ASSIGN(ft, inflate_fast);
     FUNCTABLE_VERIFY_ASSIGN(ft, longest_match);
-    FUNCTABLE_VERIFY_ASSIGN(ft, longest_match_roll);
+    FUNCTABLE_VERIFY_ASSIGN(ft, longest_match_slow_knuth);
+    FUNCTABLE_VERIFY_ASSIGN(ft, longest_match_slow_roll);
     FUNCTABLE_VERIFY_ASSIGN(ft, slide_hash);
     FUNCTABLE_VERIFY_ASSIGN(ft, slide_hash_head);
 
@@ -516,9 +526,14 @@ static uint32_t longest_match_stub(deflate_state* const s, uint32_t cur_match) {
     return functable.longest_match(s, cur_match);
 }
 
-static uint32_t longest_match_roll_stub(deflate_state* const s, uint32_t cur_match) {
+static uint32_t longest_match_slow_knuth_stub(deflate_state* const s, uint32_t cur_match) {
     FUNCTABLE_INIT_ABORT;
-    return functable.longest_match_roll(s, cur_match);
+    return functable.longest_match_slow_knuth(s, cur_match);
+}
+
+static uint32_t longest_match_slow_roll_stub(deflate_state* const s, uint32_t cur_match) {
+    FUNCTABLE_INIT_ABORT;
+    return functable.longest_match_slow_roll(s, cur_match);
 }
 
 static void slide_hash_stub(deflate_state* s) {
@@ -542,7 +557,8 @@ Z_INTERNAL struct functable_s functable = {
     crc32_copy_stub,
     inflate_fast_stub,
     longest_match_stub,
-    longest_match_roll_stub,
+    longest_match_slow_knuth_stub,
+    longest_match_slow_roll_stub,
     slide_hash_stub,
     slide_hash_head_stub,
 };

--- a/functable.h
+++ b/functable.h
@@ -23,18 +23,19 @@
 #else
 
 struct functable_s {
-    int      (* force_init)         (void);
-    uint32_t (* adler32)            (uint32_t adler, const uint8_t *buf, size_t len);
-    uint32_t (* adler32_copy)       (uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len);
-    uint8_t* (* chunkmemset_safe)   (uint8_t *out, uint8_t *from, size_t len, size_t left);
-    uint32_t (* compare256)         (const uint8_t *src0, const uint8_t *src1);
-    uint32_t (* crc32)              (uint32_t crc, const uint8_t *buf, size_t len);
-    uint32_t (* crc32_copy)         (uint32_t crc, uint8_t *dst, const uint8_t *src, size_t len);
-    void     (* inflate_fast)       (PREFIX3(stream) *strm, uint32_t start, int safe_mode);
-    uint32_t (* longest_match)      (deflate_state *const s, uint32_t cur_match);
-    uint32_t (* longest_match_roll) (deflate_state *const s, uint32_t cur_match);
-    void     (* slide_hash)         (deflate_state *s);
-    void     (* slide_hash_head)    (deflate_state *s);
+    int      (* force_init)               (void);
+    uint32_t (* adler32)                  (uint32_t adler, const uint8_t *buf, size_t len);
+    uint32_t (* adler32_copy)             (uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len);
+    uint8_t* (* chunkmemset_safe)         (uint8_t *out, uint8_t *from, size_t len, size_t left);
+    uint32_t (* compare256)               (const uint8_t *src0, const uint8_t *src1);
+    uint32_t (* crc32)                    (uint32_t crc, const uint8_t *buf, size_t len);
+    uint32_t (* crc32_copy)               (uint32_t crc, uint8_t *dst, const uint8_t *src, size_t len);
+    void     (* inflate_fast)             (PREFIX3(stream) *strm, uint32_t start, int safe_mode);
+    uint32_t (* longest_match)            (deflate_state *const s, uint32_t cur_match);
+    uint32_t (* longest_match_slow_knuth) (deflate_state *const s, uint32_t cur_match);
+    uint32_t (* longest_match_slow_roll)  (deflate_state *const s, uint32_t cur_match);
+    void     (* slide_hash)               (deflate_state *s);
+    void     (* slide_hash_head)          (deflate_state *s);
 };
 
 Z_INTERNAL extern struct functable_s functable;

--- a/match_tpl.h
+++ b/match_tpl.h
@@ -30,16 +30,17 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, uint32_t cur_match) {
     unsigned int strstart = s->strstart;
     const unsigned char *window = s->window;
     const Pos *prev = s->prev;
-#ifdef LONGEST_MATCH_ROLL
+#ifdef LONGEST_MATCH_SLOW_ROLL
     const Pos *head = s->head;
 #endif
     const unsigned char *scan;
     const unsigned char *mbase_start = window;
     const unsigned char *mbase_end;
     uint32_t limit;
-#ifdef LONGEST_MATCH_ROLL
+#ifdef LONGEST_MATCH_SLOW_ROLL
     uint32_t limit_base;
-#else
+#endif
+#ifndef LONGEST_MATCH_SLOW
     int32_t early_exit;
 #endif
     uint32_t chain_length = s->max_chain_length;
@@ -76,7 +77,10 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, uint32_t cur_match) {
      * we prevent matches with the string of window index 0
      */
     limit = strstart > MAX_DIST(s) ? (strstart - MAX_DIST(s)) : 0;
-#ifdef LONGEST_MATCH_ROLL
+#ifndef LONGEST_MATCH_SLOW
+    early_exit = s->level < EARLY_EXIT_TRIGGER_LEVEL;
+#endif
+#ifdef LONGEST_MATCH_SLOW_ROLL
     limit_base = limit;
     if (best_len >= STD_MIN_MATCH) {
         /* We're continuing search (lazy evaluation). */
@@ -109,8 +113,6 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, uint32_t cur_match) {
         mbase_start -= match_offset;
         mbase_end -= match_offset;
     }
-#else
-    early_exit = s->level < EARLY_EXIT_TRIGGER_LEVEL;
 #endif
     Assert((unsigned long)strstart <= s->window_size - MIN_LOOKAHEAD, "need lookahead");
     for (;;) {
@@ -194,7 +196,7 @@ short_match_accept:
 
             scan_end = zng_memread_8(scan+offset);
 
-#ifdef LONGEST_MATCH_ROLL
+#ifdef LONGEST_MATCH_SLOW_ROLL
             /* Look for a better string offset */
             if (UNLIKELY(len > STD_MIN_MATCH && match_start + len < strstart)) {
                 const unsigned char *scan_endstr;
@@ -246,7 +248,7 @@ short_match_accept:
 #endif
             mbase_end = (mbase_start+offset);
         }
-#ifndef LONGEST_MATCH_ROLL
+#ifndef LONGEST_MATCH_SLOW
         else if (UNLIKELY(early_exit)) {
             /* The probability of finding a match later if we here is pretty low, so for
              * performance it's best to outright stop here for the lower compression levels
@@ -259,5 +261,6 @@ short_match_accept:
     return best_len;
 }
 
-#undef LONGEST_MATCH_ROLL
+#undef LONGEST_MATCH_SLOW
+#undef LONGEST_MATCH_SLOW_ROLL
 #undef LONGEST_MATCH

--- a/match_tpl.h
+++ b/match_tpl.h
@@ -30,14 +30,14 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, uint32_t cur_match) {
     unsigned int strstart = s->strstart;
     const unsigned char *window = s->window;
     const Pos *prev = s->prev;
-#ifdef LONGEST_MATCH_SLOW_ROLL
+#ifdef LONGEST_MATCH_SLOW
     const Pos *head = s->head;
 #endif
     const unsigned char *scan;
     const unsigned char *mbase_start = window;
     const unsigned char *mbase_end;
     uint32_t limit;
-#ifdef LONGEST_MATCH_SLOW_ROLL
+#ifdef LONGEST_MATCH_SLOW
     uint32_t limit_base;
 #endif
 #ifndef LONGEST_MATCH_SLOW
@@ -57,6 +57,19 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, uint32_t cur_match) {
     best_len = s->prev_length ? s->prev_length : STD_MIN_MATCH-1;
     if (UNLIKELY(best_len >= lookahead))
         return lookahead;
+#ifdef LONGEST_MATCH_SLOW
+#  ifdef LONGEST_MATCH_SLOW_ROLL
+    /* Rolling-hash variant always runs the post-match offset search; the
+     * compiler folds the constant away below.
+     */
+    const int offset_search = 1;
+#  else
+    /* The post-match offset search only pays off when we entered with a
+     * prior best_len from lazy evaluation, so gate on it at function entry.
+     */
+    const int offset_search = (best_len >= STD_MIN_MATCH);
+#  endif
+#endif
 
     /* Calculate read offset which should only extend an extra byte to find the
      * next best match length. When best_len is shorter than the read width, we
@@ -80,31 +93,41 @@ Z_INTERNAL uint32_t LONGEST_MATCH(deflate_state *const s, uint32_t cur_match) {
 #ifndef LONGEST_MATCH_SLOW
     early_exit = s->level < EARLY_EXIT_TRIGGER_LEVEL;
 #endif
-#ifdef LONGEST_MATCH_SLOW_ROLL
+#ifdef LONGEST_MATCH_SLOW
     limit_base = limit;
     if (best_len >= STD_MIN_MATCH) {
-        /* We're continuing search (lazy evaluation). */
+        /* We're continuing search (lazy evaluation). Find a most distant
+         * chain by hashing substrings within the match area. We cannot use
+         * s->prev[strstart+1,...] immediately because those strings are not
+         * yet inserted into the hash table.
+         */
+#  ifdef LONGEST_MATCH_SLOW_ROLL
         uint32_t hash;
         uint32_t pos;
 
-        /* Find a most distant chain starting from scan with index=1 (index=0 corresponds
-         * to cur_match). We cannot use s->prev[strstart+1,...] immediately, because
-         * these strings are not yet inserted into the hash table.
-         */
-        // use update_hash_roll for deflate_slow
         hash = update_hash_roll(0, scan[1]);
         hash = update_hash_roll(hash, scan[2]);
 
         for (uint32_t i = 3; i <= best_len; i++) {
-            // use update_hash_roll for deflate_slow
             hash = update_hash_roll(hash, scan[i]);
-            /* If we're starting with best_len >= 3, we can use offset search. */
             pos = head[hash];
             if (UNLIKELY(pos < cur_match)) {
                 match_offset = i - 2;
                 cur_match = pos;
             }
         }
+#  else /* 4-byte Knuth hash, fresh lookup per offset */
+        for (uint32_t i = 1; i + (WANT_MIN_MATCH - 1) <= best_len; i++) {
+            uint32_t val = Z_U32_FROM_LE(zng_memread_4(scan + i));
+            uint32_t hash;
+            UPDATE_HASH_KNUTH(hash, val);
+            uint32_t pos = head[hash];
+            if (pos < cur_match) {
+                match_offset = i;
+                cur_match = pos;
+            }
+        }
+#  endif
 
         /* Update offset-dependent variables */
         limit = limit_base+match_offset;
@@ -196,9 +219,9 @@ short_match_accept:
 
             scan_end = zng_memread_8(scan+offset);
 
-#ifdef LONGEST_MATCH_SLOW_ROLL
+#ifdef LONGEST_MATCH_SLOW
             /* Look for a better string offset */
-            if (UNLIKELY(len > STD_MIN_MATCH && match_start + len < strstart)) {
+            if (UNLIKELY(offset_search && len > STD_MIN_MATCH && match_start + len < strstart)) {
                 const unsigned char *scan_endstr;
                 uint32_t hash;
                 uint32_t pos, next_pos;
@@ -207,7 +230,16 @@ short_match_accept:
                 cur_match -= match_offset;
                 match_offset = 0;
                 next_pos = cur_match;
+
+                /* Walk prev[] for positions inside the match. The bound keeps
+                 * the hash window within the match, so we follow chains that
+                 * share bytes with the current match, not data past its end.
+                 */
+#  ifdef LONGEST_MATCH_SLOW_ROLL
                 for (uint32_t i = 0; i <= len - STD_MIN_MATCH; i++) {
+#  else /* 4-byte Knuth hash needs len - 4 bound */
+                for (uint32_t i = 0; i <= len - WANT_MIN_MATCH; i++) {
+#  endif
                     pos = prev[(cur_match + i) & wmask];
                     if (UNLIKELY(pos < next_pos)) {
                         /* Hash chain is more distant, use it */
@@ -220,11 +252,11 @@ short_match_accept:
                 /* Switch cur_match to next_pos chain */
                 cur_match = next_pos;
 
-                /* Try hash head at len-(STD_MIN_MATCH-1) position to see if we could get
-                 * a better cur_match at the end of string. Using (STD_MIN_MATCH-1) lets
-                 * us include one more byte into hash - the byte which will be checked
-                 * in main loop now, and which allows to grow match by 1.
+                /* Try hash head at a window covering the tail of the current
+                 * match to find chains that extend farther back. The window
+                 * width differs per variant: 3 bytes for rolling, 4 for Knuth.
                  */
+#  ifdef LONGEST_MATCH_SLOW_ROLL
                 scan_endstr = scan + len - (STD_MIN_MATCH-1);
 
                 hash = update_hash_roll(0, scan_endstr[0]);
@@ -238,6 +270,19 @@ short_match_accept:
                         return best_len;
                     cur_match = pos;
                 }
+#  else
+                scan_endstr = scan + len - WANT_MIN_MATCH;
+                uint32_t val = Z_U32_FROM_LE(zng_memread_4(scan_endstr));
+                UPDATE_HASH_KNUTH(hash, val);
+
+                pos = head[hash];
+                if (pos < cur_match) {
+                    match_offset = len - WANT_MIN_MATCH;
+                    if (pos <= limit_base + match_offset)
+                        return best_len;
+                    cur_match = pos;
+                }
+#  endif
 
                 /* Update offset-dependent variables */
                 limit = limit_base+match_offset;


### PR DESCRIPTION
Add the fast-zlib offset-search rewinding to the lazy-evaluation match path, using the 4-byte Knuth hash that levels 1-8 already use for the hash table. Level 9 keeps its rolling-hash offset search.

Following review feedback, `longest_match` is split into three per-arch variants instead of gating the offset search at runtime in a shared function:

- `longest_match` — levels 1-6 (deflate_fast, deflate_medium). Compiled without any offset-search code, instruction-identical to develop's function, so the code-bloat slowdown measured on levels 2-6 in the earlier revision is gone by construction.
- `longest_match_slow_knuth` — deflate_slow below level 9. Runs the offset search when entered with a prior `best_len` from lazy evaluation.
- `longest_match_slow_roll` — level 9, rolling hash, unchanged behavior.

The naming follows the existing `insert_knuth`/`insert_roll` and `UPDATE_HASH_KNUTH`/`UPDATE_HASH_ROLL` terminology.

The last commit moves variant selection out of the entry points entirely. `lm_set_level()` resolves the `longest_match` and `insert_batch` pointers once into `deflate_state`, and deflate_slow, fill_window and deflateSetDictionary load them instead of re-deriving from `s->level` on every call. deflate_slow's entry selection shrinks from 14 instructions to 3, fill_window loses its three-way branch, and the level-1 dictionary insert now skips `prev[]` writes like fill_window already does.

Silesia corpus level 8 (3-rep medians, Apple M5): geomean -27.6%, with mozilla -60%, reymont -44%, nci -39% alongside +0.98% ratio, and x-ray +4.8% as the lone regression (incompressible input). Levels 1-6 and 9 produce byte-identical output. gtest passes.