### PR TITLE
Bump Google Benchmark to v1.9.5

### DIFF
--- a/test/benchmarks/CMakeLists.txt
+++ b/test/benchmarks/CMakeLists.txt
@@ -23,7 +23,7 @@ if(NOT benchmark_FOUND)
         set(GBENCHMARK_REPOSITORY https://github.com/google/benchmark.git)
     endif()
     if(NOT DEFINED GBENCHMARK_TAG)
-        set(GBENCHMARK_TAG v1.9.4)
+        set(GBENCHMARK_TAG v1.9.5)
     endif()
 
     FetchContent_Declare(benchmark


### PR DESCRIPTION
* Google Benchmark v1.9.4 fails to compile with recent versions of clang and Visual C++ if warnings are treated as errors