### PR TITLE
Test building with ClangCl for Windows ARM64

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -546,6 +546,11 @@ jobs:
             cmake-args: -A ARM64EC
             # Coverage disabled for msvc
 
+          - name: Windows ClangCl ARM64
+            os: windows-11-arm
+            cmake-args: -T ClangCl -A ARM64
+            # Coverage disabled for clangcl
+
           - name: Windows ClangCl Win32
             os: windows-latest
             cmake-args: -T ClangCl -A Win32

--- a/arch/arm/acle_intrins.h
+++ b/arch/arm/acle_intrins.h
@@ -2,7 +2,7 @@
 #define ARM_ACLE_INTRINS_H
 
 #include <stdint.h>
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
 #  include <intrin.h>
 #elif defined(HAVE_ARM_ACLE_H)
 #  include <arm_acle.h>

--- a/arch/arm/crc32_armv8_pmull_eor3.c
+++ b/arch/arm/crc32_armv8_pmull_eor3.c
@@ -17,7 +17,7 @@
 
 /* Carryless multiply low 64 bits: a[0] * b[0] */
 static inline uint64x2_t clmul_lo(uint64x2_t a, uint64x2_t b) {
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
     return vreinterpretq_u64_p128(vmull_p64(
         vget_low_p64(vreinterpret_p64_u64(a)),
         vget_low_p64(vreinterpret_p64_u64(b))));
@@ -35,7 +35,7 @@ static inline uint64x2_t clmul_hi(uint64x2_t a, uint64x2_t b) {
 
 /* Carryless multiply of two 32-bit scalars: a * b (returns 64-bit result in 128-bit vector) */
 static inline uint64x2_t clmul_scalar(uint32_t a, uint32_t b) {
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
     return vreinterpretq_u64_p128(vmull_p64(vdup_n_p64((poly64_t)a), vdup_n_p64((poly64_t)b)));
 #else
     return vreinterpretq_u64_p128(vmull_p64((poly64_t)a, (poly64_t)b));

--- a/arch/arm/neon_intrins.h
+++ b/arch/arm/neon_intrins.h
@@ -1,7 +1,7 @@
 #ifndef ARM_NEON_INTRINS_H
 #define ARM_NEON_INTRINS_H
 
-#if defined(_MSC_VER) && defined(ARCH_ARM) && defined(ARCH_64BIT)
+#if defined(_MSC_VER) && !defined(__clang__) && defined(ARCH_ARM) && defined(ARCH_64BIT)
 /* arm64_neon.h is MSVC specific */
 #  include <arm64_neon.h>
 #else
@@ -63,12 +63,12 @@ static inline void vst1q_u16_x4(uint16_t *p, uint16x8x4_t a) {
 }
 #  endif // HASLD4 check
 
-#  ifndef _MSC_VER
+#  if !defined(_MSC_VER) || defined(__clang__)
 #    define vld1_u8_ex(p, align) vld1_u8(HINT_ALIGNED((p), (align)/8))
 #    define vld1q_u8_ex(p, align) vld1q_u8(HINT_ALIGNED((p), (align)/8))
 #    define vld1q_u64_ex(p, align) vld1q_u64(HINT_ALIGNED((p), (align)/8))
 #  endif
-#  if !defined(_MSC_VER) || !defined(ARM_NEON_HASLD4)
+#  if !defined(_MSC_VER) || !defined(ARM_NEON_HASLD4) || defined(__clang__)
 #    define vld1q_u8_x4_ex(p, align) vld1q_u8_x4(HINT_ALIGNED((p), (align)/8))
 #    define vld1q_u16_x4_ex(p, align) vld1q_u16_x4(HINT_ALIGNED((p), (align)/8))
 #    define vst1q_u16_x4_ex(p, a, align) vst1q_u16_x4(HINT_ALIGNED((p), (align)/8), a)

--- a/cmake/detect-intrinsics.cmake
+++ b/cmake/detect-intrinsics.cmake
@@ -42,7 +42,7 @@ macro(check_armv8_compiler_flag)
     )
     # Check whether compiler supports ARMv8 intrinsics
     check_c_source_compiles(
-        "#if defined(_MSC_VER)
+        "#if defined(_MSC_VER) && !defined(__clang__)
         #include <intrin.h>
         #else
         #include <arm_acle.h>
@@ -73,12 +73,12 @@ macro(check_armv8_pmull_eor3_compiler_flag)
     # Check whether compiler supports ARMv8 PMULL + EOR3 intrinsics
     set(CMAKE_REQUIRED_FLAGS "${PMULLEOR3FLAG} ${NATIVEFLAG} ${ZNOLTOFLAG}")
     check_c_source_compiles(
-        "#if defined(_MSC_VER) && (defined(_M_ARM64) || defined(_M_ARM64EC))
+        "#if defined(_MSC_VER) && !defined(__clang__) && (defined(_M_ARM64) || defined(_M_ARM64EC))
         #  include <arm64_neon.h>
         #else
         #  include <arm_neon.h>
         #endif
-        #ifdef _MSC_VER
+        #if defined(_MSC_VER) && !defined(__clang__)
         __n128 f(__n64 a, __n64 b) {
         #else
         poly128_t f(poly64_t a, poly64_t b) {
@@ -260,7 +260,7 @@ macro(check_neon_compiler_flag)
     # Check whether compiler supports NEON flag
     set(CMAKE_REQUIRED_FLAGS "${NEONFLAG} ${NATIVEFLAG} ${ZNOLTOFLAG}")
     check_c_source_compiles(
-        "#if defined(_M_ARM64) || defined(_M_ARM64EC)
+        "#if defined(_MSC_VER) && !defined(__clang__) && (defined(_M_ARM64) || defined(_M_ARM64EC))
         #  include <arm64_neon.h>
         #else
         #  include <arm_neon.h>
@@ -323,7 +323,7 @@ macro(check_neon_ld4_intrinsics)
     # Check whether compiler supports loading 4 neon vecs into a register range
     set(CMAKE_REQUIRED_FLAGS "${NEONFLAG} ${NATIVEFLAG} ${ZNOLTOFLAG}")
     check_c_source_compiles(
-        "#if defined(_MSC_VER) && (defined(_M_ARM64) || defined(_M_ARM64EC))
+        "#if defined(_MSC_VER) && !defined(__clang__) && (defined(_M_ARM64) || defined(_M_ARM64EC))
         #  include <arm64_neon.h>
         #else
         #  include <arm_neon.h>


### PR DESCRIPTION
Clang and ClangCl don't have `arm64_neon.h` so trying to include it will cause mysterious compiler and linker errors when the header from Visual C++ is found instead. The intrinsic names are different between the compilers but both define `_MSC_VER`.

Fixes #2273