### PR TITLE
Minor cleanups in deflate_rle.c and deflate_fast.c

### DIFF
--- a/deflate_fast.c
+++ b/deflate_fast.c
@@ -49,7 +49,7 @@ Z_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
             int64_t dist = (int64_t)s->strstart - hash_head;
             lc = (uint8_t)str_val;
 
-            /* Find the longest match, discarding those <= prev_length.
+            /* Find the longest match.
              * At this point we have always match length < WANT_MIN_MATCH
              */
             if (dist <= MAX_DIST(s) && dist > 0 && hash_head != 0) {

--- a/deflate_rle.c
+++ b/deflate_rle.c
@@ -45,7 +45,6 @@ Z_INTERNAL block_state deflate_rle(deflate_state *s, int flush) {
             if (scan[0] == scan[1] && scan[1] == scan[2]) {
                 match_len = compare256_rle(scan, scan+3)+2;
                 match_len = MIN(match_len, s->lookahead);
-                match_len = MIN(match_len, STD_MAX_MATCH);
             }
             Assert(scan+match_len <= s->window + s->window_size - 1, "wild scan");
         }


### PR DESCRIPTION
- An incorrect comment in deflate_fast.c, seemingly copied from deflate_slow.c where it does make sense.
- In deflate_rle: No need to check that match_len is less than 258, as compare_256_rle+2 can only be <= 258.