### PR TITLE
Allow /delta on fork pull requests

### DIFF
--- a/.github/workflows/delta.yml
+++ b/.github/workflows/delta.yml
@@ -81,13 +81,6 @@ jobs:
           BASE_SHA=$(echo "$pr_json" | jq -r .base.sha)
           HEAD_BRANCH=$(echo "$pr_json" | jq -r .head.ref)
           HEAD_SHA=$(echo "$pr_json" | jq -r .head.sha)
-          BASE_REPO_ID=$(echo "$pr_json" | jq -r .base.repo.id)
-          HEAD_REPO_ID=$(echo "$pr_json" | jq -r '.head.repo.id // empty')
-
-          if [ "$HEAD_REPO_ID" != "$BASE_REPO_ID" ]; then
-            echo "::error::/delta is not supported on pull requests from forks"
-            exit 1
-          fi
 
           if [ "$OFFSET" = "0" ]; then
             HEAD_REF="$HEAD_SHA"


### PR DESCRIPTION
## Summary

The `/delta` workflow rejects fork PRs even though the `author_association` gate already restricts triggers to `OWNER`, `MEMBER`, or `COLLABORATOR`. A maintainer typing `/delta` on a fork PR is the same trust model as checking the PR out locally to benchmark it, so the extra fork check is friction without a clear safety benefit.

This drops the rejection and the now-unused base/head repo id parsing. `actions/checkout` resolves the fork's head SHA via `refs/pull/N/head` in the base repo, so no other plumbing is needed.