### PR TITLE
When using ALIGN_DOWN() macro, the signedness of types must match to avoid UBSAN triggering warning about implicit sign change during widening.

### DIFF
--- a/adler32_p.h
+++ b/adler32_p.h
@@ -136,7 +136,7 @@ Z_FORCEINLINE static uint32_t adler32_copy_tail(uint32_t adler, uint8_t *dst, co
         Z_UNUSED(MAX_LEN);
         /* Process using packed 64-bit arithmetic when source is aligned */
         while (len >= 8 && ((uintptr_t)buf & 7) == 0) {
-            size_t chunk = MIN(ALIGN_DOWN(len, 8), ADLER32_SWAR_MAX_BYTES);
+            size_t chunk = MIN(ALIGN_DOWN(len, (size_t)8), (size_t)ADLER32_SWAR_MAX_BYTES);
             adler32_swar(&adler, dst, buf, chunk, &sum2, COPY);
             buf += chunk;
             if (COPY)

--- a/arch/generic/adler32_c.c
+++ b/arch/generic/adler32_c.c
@@ -41,7 +41,7 @@ Z_INTERNAL uint32_t adler32_c(uint32_t adler, const uint8_t *buf, size_t len) {
         n = NMAX;
 
         do {
-            size_t chunk = MIN(ALIGN_DOWN(n, 8), ADLER32_SWAR_MAX_BYTES);
+            size_t chunk = MIN(ALIGN_DOWN(n, (size_t)8), (size_t)ADLER32_SWAR_MAX_BYTES);
             adler32_swar(&adler, NULL, buf, chunk, &sum2, 0);
             buf += chunk;
             n -= chunk;


### PR DESCRIPTION
Should fix #2279 