### PR TITLE
[CI] Force refreshing homebrew for macOS.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -786,7 +786,9 @@ jobs:
 
     - name: Install packages (macOS)
       if: runner.os == 'macOS'
-      run: brew install ninja ${{ matrix.packages }}
+      run: |
+        brew update
+        brew install ninja ${{ matrix.packages }}
       env:
         HOMEBREW_NO_INSTALL_CLEANUP: 1
 


### PR DESCRIPTION
This should allow homebrew to pick up Crystal 1.20.1, which has the build fix for Coveralls.