### PR TITLE
Hoist rolling hash state to a local in INSERT_STRING

### DIFF
--- a/insert_string_p.h
+++ b/insert_string_p.h
@@ -15,6 +15,7 @@
 #define HASH_CALC_MASK       HASH_MASK
 #define HASH_CALC_VAR        h
 #define HASH_CALC_VAR_INIT   uint32_t h
+#define HASH_CALC_VAR_STORE
 #define HASH_CALC_OFFSET     0
 
 #define UPDATE_HASH          update_hash
@@ -28,8 +29,9 @@
 #define HASH_SLIDE           5
 
 #define HASH_CALC(h, val)    h = ((h << HASH_SLIDE) ^ ((uint8_t)val))
-#define HASH_CALC_VAR        s->ins_h
-#define HASH_CALC_VAR_INIT
+#define HASH_CALC_VAR        h
+#define HASH_CALC_VAR_INIT   uint32_t h = s->ins_h
+#define HASH_CALC_VAR_STORE  s->ins_h = h
 #define HASH_CALC_READ       val = strstart[0]
 #define HASH_CALC_MASK       (32768u - 1u)
 #define HASH_CALC_OFFSET     (STD_MIN_MATCH-1)

--- a/insert_string_tpl.h
+++ b/insert_string_tpl.h
@@ -46,6 +46,7 @@ Z_FORCEINLINE static uint32_t QUICK_INSERT_VALUE(deflate_state *const s, uint32_
     HASH_CALC(HASH_CALC_VAR, val);
     HASH_CALC_VAR &= HASH_CALC_MASK;
     hm = HASH_CALC_VAR;
+    HASH_CALC_VAR_STORE;
 
     head = s->head[hm];
     if (LIKELY(head != str)) {
@@ -69,6 +70,7 @@ Z_FORCEINLINE static uint32_t QUICK_INSERT_STRING(deflate_state *const s, uint32
     HASH_CALC(HASH_CALC_VAR, val);
     HASH_CALC_VAR &= HASH_CALC_MASK;
     hm = HASH_CALC_VAR;
+    HASH_CALC_VAR_STORE;
 
     head = s->head[hm];
     if (LIKELY(head != str)) {
@@ -95,10 +97,11 @@ Z_FORCEINLINE static void INSERT_STRING(deflate_state *const s, uint32_t str, ui
     Pos *prevp = s->prev;
     const unsigned int w_mask = W_MASK(s);
 
+    HASH_CALC_VAR_INIT;
+
     for (uint32_t idx = str; strstart < strend; idx++, strstart++) {
         uint32_t val, hm, head;
 
-        HASH_CALC_VAR_INIT;
         HASH_CALC_READ;
         HASH_CALC(HASH_CALC_VAR, val);
         HASH_CALC_VAR &= HASH_CALC_MASK;
@@ -110,6 +113,8 @@ Z_FORCEINLINE static void INSERT_STRING(deflate_state *const s, uint32_t str, ui
             headp[hm] = (Pos)idx;
         }
     }
+
+    HASH_CALC_VAR_STORE;
 }
 
 // Cleanup
@@ -120,6 +125,7 @@ Z_FORCEINLINE static void INSERT_STRING(deflate_state *const s, uint32_t str, ui
 #undef HASH_CALC_OFFSET
 #undef HASH_CALC_VAR
 #undef HASH_CALC_VAR_INIT
+#undef HASH_CALC_VAR_STORE
 #undef UPDATE_HASH
 #undef INSERT_STRING
 #undef QUICK_INSERT_STRING


### PR DESCRIPTION
## Summary

The rolling-hash variant of `INSERT_STRING` (level 9) configured `HASH_CALC_VAR` as `s->ins_h`, so the inner loop wrote through `s->ins_h` on every byte. Indirect stores via `prev[]`/`head[]` (both `Pos*`) prevented the compiler from caching the running hash in a register — it couldn't prove those writes don't alias the integer field, so it kept committing `s->ins_h` to memory each iteration.

This change lifts the running hash to a stack local. The local has no address taken, so the compiler trusts there's no aliasing and keeps it register-resident across the loop. `s->ins_h` is loaded once on entry and stored once on exit.

The non-rolling variant (levels 1–8) already used a local `h`, so it's unaffected; the assembly for `_insert_string` is byte-identical.

## Benchmark

`insert_string_bench/rolling_hash` on Apple M5, 10 reps, geomean **−3.55%**:

| count | Δ time |
| ----- | ------ |
| 100/4   | −1.60% |
| 100/5   | −0.84% |
| 100/7   | −4.38% |
| 100/14  | −4.87% |
| 100/32  | −5.99% |
| 100/127 | −5.96% |
| 100/255 | −6.81% |