### PR TITLE
Optimize CHUNKMEMSET dispatch shortcuts and trailing remainder

### DIFF
--- a/arch/arm/chunkset_neon.c
+++ b/arch/arm/chunkset_neon.c
@@ -12,11 +12,15 @@
 
 typedef uint8x16_t chunk_t;
 
+#define HAVE_CHUNKMEMSET_1
 #define HAVE_CHUNKMEMSET_2
 #define HAVE_CHUNKMEMSET_4
 #define HAVE_CHUNKMEMSET_8
 #define HAVE_CHUNK_MAG
 
+static inline void chunkmemset_1(uint8_t *from, chunk_t *chunk) {
+    *chunk = vdupq_n_u8(*from);
+}
 
 static inline void chunkmemset_2(uint8_t *from, chunk_t *chunk) {
     *chunk = vreinterpretq_u8_u16(vdupq_n_u16(zng_memread_2(from)));

--- a/arch/x86/chunkset_avx2.c
+++ b/arch/x86/chunkset_avx2.c
@@ -15,12 +15,17 @@
 typedef __m256i chunk_t;
 typedef __m128i halfchunk_t;
 
+#define HAVE_CHUNKMEMSET_1
 #define HAVE_CHUNKMEMSET_2
 #define HAVE_CHUNKMEMSET_4
 #define HAVE_CHUNKMEMSET_8
 #define HAVE_CHUNKMEMSET_16
 #define HAVE_CHUNK_MAG
 #define HAVE_HALF_CHUNK
+
+static inline void chunkmemset_1(uint8_t *from, chunk_t *chunk) {
+    *chunk = _mm256_set1_epi8(*from);
+}
 
 static inline void chunkmemset_2(uint8_t *from, chunk_t *chunk) {
     *chunk = _mm256_set1_epi16(zng_memread_2(from));

--- a/arch/x86/chunkset_avx512.c
+++ b/arch/x86/chunkset_avx512.c
@@ -16,6 +16,7 @@ typedef __m128i halfchunk_t;
 typedef __mmask32 mask_t;
 typedef __mmask16 halfmask_t;
 
+#define HAVE_CHUNKMEMSET_1
 #define HAVE_CHUNKMEMSET_2
 #define HAVE_CHUNKMEMSET_4
 #define HAVE_CHUNKMEMSET_8
@@ -32,6 +33,10 @@ static inline halfmask_t gen_half_mask(size_t len) {
 
 static inline mask_t gen_mask(size_t len) {
    return (mask_t)_bzhi_u32(0xFFFFFFFF, (unsigned)len);
+}
+
+static inline void chunkmemset_1(uint8_t *from, chunk_t *chunk) {
+    *chunk = _mm256_set1_epi8(*from);
 }
 
 static inline void chunkmemset_2(uint8_t *from, chunk_t *chunk) {

--- a/arch/x86/chunkset_avx512.c
+++ b/arch/x86/chunkset_avx512.c
@@ -68,6 +68,14 @@ static inline void storechunk(uint8_t *out, chunk_t *chunk) {
     _mm256_storeu_si256((__m256i *)out, *chunk);
 }
 
+static inline void loadchunk_masked(uint8_t const *s, chunk_t *chunk, size_t len) {
+    *chunk = _mm256_maskz_loadu_epi8(gen_mask(len), s);
+}
+
+static inline void storechunk_masked(uint8_t *out, chunk_t *chunk, size_t len) {
+    _mm256_mask_storeu_epi8(out, gen_mask(len), *chunk);
+}
+
 static inline uint8_t* CHUNKCOPY(uint8_t *out, uint8_t const *from, size_t len) {
     Assert(len > 0, "chunkcopy should never have a length 0");
 

--- a/chunkset_tpl.h
+++ b/chunkset_tpl.h
@@ -141,7 +141,7 @@ static inline uint8_t* CHUNKMEMSET(uint8_t *out, uint8_t *from, size_t len) {
     if (dist == 1) {
         memset(out, *from, len);
         return out + len;
-    } else if (dist >= sizeof(chunk_t)) {
+    } else if (dist >= len || dist >= sizeof(chunk_t)) {
         return CHUNKCOPY(out, from, len);
     }
 

--- a/chunkset_tpl.h
+++ b/chunkset_tpl.h
@@ -136,10 +136,13 @@ static inline uint8_t* CHUNKMEMSET(uint8_t *out, uint8_t *from, size_t len) {
         return out + len;
     }
 
+#ifndef HAVE_CHUNKMEMSET_1
     if (dist == 1) {
         memset(out, *from, len);
         return out + len;
-    } else if (dist >= len || dist >= sizeof(chunk_t)) {
+    } else
+#endif
+    if (dist >= len || dist >= sizeof(chunk_t)) {
         return CHUNKCOPY(out, from, len);
     }
 
@@ -151,7 +154,7 @@ static inline uint8_t* CHUNKMEMSET(uint8_t *out, uint8_t *from, size_t len) {
      * also can merge an assert and some remainder peeling behavior into the same code blocks,
      * making the code a little smaller.  */
 #ifdef HAVE_HALF_CHUNK
-    if (len <= sizeof(halfchunk_t)) {
+    if (dist > 1 && len <= sizeof(halfchunk_t)) {
         if (dist >= sizeof(halfchunk_t))
             return HALFCHUNKCOPY(out, from, len);
 
@@ -170,6 +173,12 @@ static inline uint8_t* CHUNKMEMSET(uint8_t *out, uint8_t *from, size_t len) {
     }
 #endif
 
+#ifdef HAVE_CHUNKMEMSET_1
+    /* Broadcast + chunk store beats memset on NEON/AVX2/AVX-512 */
+    if (dist == 1) {
+        chunkmemset_1(from, &chunk_load);
+    } else
+#endif
 #ifdef HAVE_CHUNKMEMSET_2
     if (dist == 2) {
         chunkmemset_2(from, &chunk_load);

--- a/chunkset_tpl.h
+++ b/chunkset_tpl.h
@@ -194,6 +194,11 @@ static inline uint8_t* CHUNKMEMSET(uint8_t *out, uint8_t *from, size_t len) {
 #endif
     chunk_load = GET_CHUNK_MAG(from, &chunk_mod, dist);
 
+    if (len <= sizeof(chunk_t)) {
+        storechunk(out, &chunk_load);
+        return out + len;
+    }
+
     adv_amount = sizeof(chunk_t) - chunk_mod;
 
     while (len >= (2 * sizeof(chunk_t))) {

--- a/chunkset_tpl.h
+++ b/chunkset_tpl.h
@@ -124,12 +124,10 @@ static inline uint8_t* CHUNKMEMSET(uint8_t *out, uint8_t *from, size_t len) {
      * dispatching to this function, more */
     if (out < from && dist < len) {
 #ifdef HAVE_MASKED_READWRITE
-        /* We can still handle this case if we can mitigate over writing _and_ we
-         * fit the entirety of the copy length with one load */
         if (len <= sizeof(chunk_t)) {
-            /* Tempting to add a goto to the block below but hopefully most compilers
-             * collapse these identical code segments as one label to jump to */
-            return CHUNKCOPY(out, from, len);
+            loadchunk_masked(from, &chunk_load, len);
+            storechunk_masked(out, &chunk_load, len);
+            return out + len;
         }
 #endif
         /* Here the memmove semantics match perfectly, as when this happens we are
@@ -195,7 +193,11 @@ static inline uint8_t* CHUNKMEMSET(uint8_t *out, uint8_t *from, size_t len) {
     chunk_load = GET_CHUNK_MAG(from, &chunk_mod, dist);
 
     if (len <= sizeof(chunk_t)) {
+#ifdef HAVE_MASKED_READWRITE
+        storechunk_masked(out, &chunk_load, len);
+#else
         storechunk(out, &chunk_load);
+#endif
         return out + len;
     }
 
@@ -222,12 +224,17 @@ static inline uint8_t* CHUNKMEMSET(uint8_t *out, uint8_t *from, size_t len) {
 rem_bytes:
 #endif
     if (len) {
+#ifdef HAVE_MASKED_READWRITE
+        storechunk_masked(out, &chunk_load, len);
+        out += len;
+#else
         uint8_t *chunk_p = (uint8_t *)&chunk_load;
         if (len & 16) { memcpy(out, chunk_p, 16); out += 16; chunk_p += 16; }
         if (len & 8) { memcpy(out, chunk_p, 8); out += 8; chunk_p += 8; }
         if (len & 4) { memcpy(out, chunk_p, 4); out += 4; chunk_p += 4; }
         if (len & 2) { memcpy(out, chunk_p, 2); out += 2; chunk_p += 2; }
         if (len & 1) { *out++ = *chunk_p; }
+#endif
     }
 
     return out;

--- a/chunkset_tpl.h
+++ b/chunkset_tpl.h
@@ -217,8 +217,12 @@ static inline uint8_t* CHUNKMEMSET(uint8_t *out, uint8_t *from, size_t len) {
 rem_bytes:
 #endif
     if (len) {
-        memcpy(out, &chunk_load, len);
-        out += len;
+        uint8_t *chunk_p = (uint8_t *)&chunk_load;
+        if (len & 16) { memcpy(out, chunk_p, 16); out += 16; chunk_p += 16; }
+        if (len & 8) { memcpy(out, chunk_p, 8); out += 8; chunk_p += 8; }
+        if (len & 4) { memcpy(out, chunk_p, 4); out += 4; chunk_p += 4; }
+        if (len & 2) { memcpy(out, chunk_p, 2); out += 2; chunk_p += 2; }
+        if (len & 1) { *out++ = *chunk_p; }
     }
 
     return out;

--- a/test/benchmarks/CMakeLists.txt
+++ b/test/benchmarks/CMakeLists.txt
@@ -53,6 +53,7 @@ set(BENCH_PUBLIC_SRCS
 set(BENCH_INTERNAL_SRCS
     benchmark_adler32.cc
     benchmark_adler32_copy.cc
+    benchmark_chunkmemset.cc
     benchmark_compare256.cc
     benchmark_compare256_rle.cc
     benchmark_crc32.cc

--- a/test/benchmarks/benchmark_chunkmemset.cc
+++ b/test/benchmarks/benchmark_chunkmemset.cc
@@ -1,0 +1,126 @@
+/* benchmark_chunkmemset.cc -- benchmark chunkmemset_safe variants
+ * Copyright (C) 2026 Nathan Moinvaziri
+ * For conditions of distribution and use, see copyright notice in zlib.h
+ */
+
+#include <benchmark/benchmark.h>
+
+extern "C" {
+#  include "zbuild.h"
+#  include "zutil_p.h"
+#  include "arch_functions.h"
+#  include "../test_cpu_features.h"
+}
+
+#define BUFSIZE        8192
+#define BENCH_MAX_DIST 64
+
+typedef uint8_t* (*chunkmemset_safe_func)(uint8_t *out, uint8_t *from, size_t len, size_t left);
+
+class chunkmemset: public benchmark::Fixture {
+private:
+    uint8_t *buf;
+
+public:
+    void SetUp(::benchmark::State& state) {
+        buf = (uint8_t *)zng_alloc_aligned(BUFSIZE, 64);
+        if (buf == NULL) {
+            state.SkipWithError("malloc failed");
+            return;
+        }
+        for (size_t i = 0; i < BUFSIZE; i++) {
+            buf[i] = (uint8_t)(i & 0xFF);
+        }
+    }
+
+    void TearDown(const ::benchmark::State&) {
+        zng_free_aligned(buf);
+    }
+
+    void Bench(benchmark::State& state, chunkmemset_safe_func chunkmemset_safe) {
+        size_t dist = (size_t)state.range(0);
+        size_t len  = (size_t)state.range(1);
+        uint8_t *out  = buf + BENCH_MAX_DIST;
+        uint8_t *from = out - dist;
+        size_t left = BUFSIZE - BENCH_MAX_DIST;
+
+        for (auto _ : state) {
+            uint8_t *result = chunkmemset_safe(out, from, len, left);
+            benchmark::DoNotOptimize(result);
+        }
+    }
+};
+
+#define CHUNKMEMSET_ARGS                                       \
+        ArgNames({"dist", "len"})                              \
+        ->Args({1,  32})    /* memset path */                  \
+        ->Args({1,  258})                                      \
+        ->Args({2,  16})    /* fast vdupq, small */            \
+        ->Args({2,  64})    /* fast vdupq, main loop */        \
+        ->Args({2,  258})                                      \
+        ->Args({3,  16})    /* magazine (TBL/PERMUTE) small */ \
+        ->Args({3,  64})                                       \
+        ->Args({3,  258})                                      \
+        ->Args({4,  16})    /* fast vdupq u32 */               \
+        ->Args({4,  258})                                      \
+        ->Args({6,  16})    /* magazine, half-chunk on AVX2 */ \
+        ->Args({6,  258})                                      \
+        ->Args({8,  16})    /* fast vdupq u64 */               \
+        ->Args({8,  258})                                      \
+        ->Args({15, 258})   /* magazine, dist near chunk */    \
+        ->Args({16, 258})   /* dist == chunk_t boundary */     \
+        ->Args({32, 64})    /* chunkcopy direct */             \
+        ->Args({32, 258})                                      \
+        ->Args({8,  3})     /* dist >= len bypass (no fold) */ \
+        ->Args({15, 8})     /* dist >= len bypass */
+
+#define BENCHMARK_CHUNKMEMSET(name, fn, support_flag)                          \
+    BENCHMARK_DEFINE_F(chunkmemset, name)(benchmark::State& state) {           \
+        if (!(support_flag)) {                                                 \
+            state.SkipWithError("CPU does not support " #name);                \
+        }                                                                      \
+        Bench(state, fn);                                                      \
+    }                                                                          \
+    BENCHMARK_REGISTER_F(chunkmemset, name)->CHUNKMEMSET_ARGS;
+
+#ifdef CHUNKSET_FALLBACK
+BENCHMARK_CHUNKMEMSET(c, chunkmemset_safe_c, 1);
+#endif
+
+#ifdef DISABLE_RUNTIME_CPU_DETECTION
+BENCHMARK_CHUNKMEMSET(native, native_chunkmemset_safe, 1);
+#else
+
+#ifdef ARM_NEON
+BENCHMARK_CHUNKMEMSET(neon, chunkmemset_safe_neon, test_cpu_features.arm.has_neon);
+#endif
+
+#ifdef X86_SSE2
+BENCHMARK_CHUNKMEMSET(sse2, chunkmemset_safe_sse2, test_cpu_features.x86.has_sse2);
+#endif
+#ifdef X86_SSSE3
+BENCHMARK_CHUNKMEMSET(ssse3, chunkmemset_safe_ssse3, test_cpu_features.x86.has_ssse3);
+#endif
+#ifdef X86_AVX2
+BENCHMARK_CHUNKMEMSET(avx2, chunkmemset_safe_avx2, test_cpu_features.x86.has_avx2);
+#endif
+#ifdef X86_AVX512
+BENCHMARK_CHUNKMEMSET(avx512, chunkmemset_safe_avx512, test_cpu_features.x86.has_avx512_common);
+#endif
+
+#ifdef POWER8_VSX
+BENCHMARK_CHUNKMEMSET(power8, chunkmemset_safe_power8, test_cpu_features.power.has_arch_2_07);
+#endif
+
+#ifdef RISCV_RVV
+BENCHMARK_CHUNKMEMSET(rvv, chunkmemset_safe_rvv, test_cpu_features.riscv.has_rvv);
+#endif
+
+#ifdef LOONGARCH_LSX
+BENCHMARK_CHUNKMEMSET(lsx, chunkmemset_safe_lsx, test_cpu_features.loongarch.has_lsx);
+#endif
+#ifdef LOONGARCH_LASX
+BENCHMARK_CHUNKMEMSET(lasx, chunkmemset_safe_lasx, test_cpu_features.loongarch.has_lasx);
+#endif
+
+#endif


### PR DESCRIPTION
## Summary

A microbenchmark plus five small optimizations to `CHUNKMEMSET`:

- **Inline tail with bit-decomposed stores** — variable-length `memcpy(out, &chunk_load, len)` lowered to a CRT call on MSVC and libc memcpy on clang for sizes the compiler couldn't statically fold. Splitting `len` into `16 + 8 + 4 + 2 + 1` lets each fixed-size copy inline as a direct store.

- **Skip the unrolled loops** when `len <= sizeof(chunk_t)` — the folded `chunk_load` already contains the correct first `sizeof(chunk_t)` output bytes; a single `storechunk` plus pointer advance produces the same result as the two while-loops + tail, and lets the compiler keep `chunk_load` in a vector register.

- **Route to `CHUNKCOPY` when `dist >= len`** — when the source span doesn't overlap the destination, no pattern repeat is required. Extends the existing `dist >= sizeof(chunk_t)` shortcut so archs with `chunk_t > 8` also catch `dist in [chunk_t/2, chunk_t-1]` with small lengths.

- **Wrap AVX-512 mask intrinsics in helpers** — adds `loadchunk_masked` / `storechunk_masked` next to `loadchunk` / `storechunk` in `chunkset_avx512.c`. CHUNKMEMSET uses them in the post-magazine bypass and the trailing remainder; the masked store writes exactly `len` bytes, so AVX-512 paths no longer require `chunk_t` bytes of output headroom.

- **Use broadcast chunk store instead of memset for `dist == 1`** on NEON / AVX2 / AVX-512 — benchmarks show broadcasting the byte into a vector register and falling through to the chunk store loop beats libc memset for the short lengths common in inflate output.
