### PR TITLE
Unify and expand on usage of local variables in deflate strategies

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -452,7 +452,7 @@ int32_t Z_EXPORT PREFIX(deflateSetDictionary)(PREFIX3(stream) *strm, const uint8
     while (s->lookahead >= STD_MIN_MATCH) {
         str = s->strstart;
         n = s->lookahead - (STD_MIN_MATCH - 1);
-        insert_string_func(s, str, n);
+        insert_string_func(s, s->window, str, n);
         s->strstart = str + n;
         s->lookahead = STD_MIN_MATCH - 1;
         PREFIX(fill_window)(s);
@@ -1226,14 +1226,14 @@ void Z_INTERNAL PREFIX(fill_window)(deflate_state *s) {
             if (UNLIKELY(level >= 9)) {
                 s->ins_h = update_hash_roll(window[str], window[str+1]);
             } else if (str >= 1) {
-                quick_insert_string(s, str + 2 - STD_MIN_MATCH);
+                quick_insert_string(s, window, str + 2 - STD_MIN_MATCH);
             }
             unsigned int count = s->insert;
             if (UNLIKELY(s->lookahead == 1)) {
                 count -= 1;
             }
             if (count > 0) {
-                insert_string_func(s, str, count);
+                insert_string_func(s, window, str, count);
                 s->insert -= count;
             }
         }

--- a/deflate.h
+++ b/deflate.h
@@ -120,9 +120,9 @@ typedef uint16_t Pos;
 /* Type definitions for hash callbacks */
 typedef struct internal_state deflate_state;
 
-typedef void     (* insert_string_cb)      (deflate_state *const s, uint32_t str, uint32_t count);
-void     insert_string           (deflate_state *const s, uint32_t str, uint32_t count);
-void     insert_string_roll      (deflate_state *const s, uint32_t str, uint32_t count);
+typedef void    (* insert_string_cb)    (deflate_state *const s, unsigned char *window, uint32_t str, uint32_t count);
+void            insert_string           (deflate_state *const s, unsigned char *window, uint32_t str, uint32_t count);
+void            insert_string_roll      (deflate_state *const s, unsigned char *window, uint32_t str, uint32_t count);
 
 /* Struct for memory allocation handling */
 typedef struct deflate_allocs_s {

--- a/deflate_fast.c
+++ b/deflate_fast.c
@@ -80,11 +80,11 @@ Z_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
                 match_len--; /* string at strstart already in table */
                 s->strstart++;
 
-                insert_string_static(s, s->strstart, match_len);
+                insert_string_static(s, window, s->strstart, match_len);
                 s->strstart += match_len;
             } else {
                 s->strstart += match_len;
-                quick_insert_string(s, s->strstart + 2 - STD_MIN_MATCH);
+                quick_insert_string(s, window, s->strstart + 2 - STD_MIN_MATCH);
 
                 /* If lookahead < STD_MIN_MATCH, ins_h is garbage, but it does not
                  * matter since it will be recomputed at next deflate call.

--- a/deflate_fast.c
+++ b/deflate_fast.c
@@ -98,15 +98,15 @@ Z_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
             s->strstart++;
         }
         if (UNLIKELY(bflush))
-            FLUSH_BLOCK(s, 0);
+            FLUSH_BLOCK(s, window, 0);
     }
     s->insert = s->strstart < (STD_MIN_MATCH - 1) ? s->strstart : (STD_MIN_MATCH - 1);
 
     if (UNLIKELY(flush == Z_FINISH)) {
-        FLUSH_BLOCK(s, 1);
+        FLUSH_BLOCK(s, window, 1);
         return finish_done;
     }
     if (UNLIKELY(s->sym_next))
-        FLUSH_BLOCK(s, 0);
+        FLUSH_BLOCK(s, window, 0);
     return block_done;
 }

--- a/deflate_huff.c
+++ b/deflate_huff.c
@@ -14,6 +14,7 @@
  * (It will be regenerated if this run of deflate switches away from Huffman.)
  */
 Z_INTERNAL block_state deflate_huff(deflate_state *s, int flush) {
+    unsigned char *window = s->window;
     int bflush = 0;         /* set if current block must be flushed */
 
     for (;;) {
@@ -28,18 +29,18 @@ Z_INTERNAL block_state deflate_huff(deflate_state *s, int flush) {
         }
 
         /* Output a literal byte */
-        bflush = zng_tr_tally_lit(s, s->window[s->strstart]);
+        bflush = zng_tr_tally_lit(s, window[s->strstart]);
         s->lookahead--;
         s->strstart++;
         if (bflush)
-            FLUSH_BLOCK(s, 0);
+            FLUSH_BLOCK(s, window, 0);
     }
     s->insert = 0;
     if (flush == Z_FINISH) {
-        FLUSH_BLOCK(s, 1);
+        FLUSH_BLOCK(s, window, 1);
         return finish_done;
     }
     if (s->sym_next)
-        FLUSH_BLOCK(s, 0);
+        FLUSH_BLOCK(s, window, 0);
     return block_done;
 }

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -44,7 +44,7 @@ static int emit_match(deflate_state *s, unsigned char *window, struct match matc
 }
 
 /* insert_match assumes: s->lookahead > match.match_length + WANT_MIN_MATCH */
-static void insert_match(deflate_state *s, struct match match) {
+static void insert_match(deflate_state *s, unsigned char *window, struct match match) {
     uint32_t match_len = match.match_length;
     uint32_t strstart = match.strstart;
 
@@ -55,9 +55,9 @@ static void insert_match(deflate_state *s, struct match match) {
         if (UNLIKELY(match_len > 0)) {
             if (strstart >= match.orgstart) {
                 if (strstart + match_len - 1 >= match.orgstart) {
-                    insert_string(s, strstart, match_len);
+                    insert_string(s, window, strstart, match_len);
                 } else {
-                    insert_string(s, strstart, match.orgstart - strstart + 1);
+                    insert_string(s, window, strstart, match.orgstart - strstart + 1);
                 }
             }
         }
@@ -73,16 +73,16 @@ static void insert_match(deflate_state *s, struct match match) {
 
         if (LIKELY(strstart >= match.orgstart)) {
             if (LIKELY(strstart + match_len - 1 >= match.orgstart)) {
-                insert_string(s, strstart, match_len);
+                insert_string(s, window, strstart, match_len);
             } else {
-                insert_string(s, strstart, match.orgstart - strstart + 1);
+                insert_string(s, window, strstart, match.orgstart - strstart + 1);
             }
         } else if (match.orgstart < strstart + match_len) {
-            insert_string(s, match.orgstart, strstart + match_len - match.orgstart);
+            insert_string(s, window, match.orgstart, strstart + match_len - match.orgstart);
         }
     } else {
         strstart += match_len;
-        quick_insert_string(s, strstart + 2 - STD_MIN_MATCH);
+        quick_insert_string(s, window, strstart + 2 - STD_MIN_MATCH);
 
         /* If lookahead < WANT_MIN_MATCH, ins_h is garbage, but it does not
          * matter since it will be recomputed at next deflate call.
@@ -214,19 +214,19 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
         } else {
             hash_head = 0;
             if (s->lookahead >= WANT_MIN_MATCH) {
-                hash_head = quick_insert_string(s, s->strstart);
+                hash_head = quick_insert_string(s, window, s->strstart);
             }
 
             current_match = find_best_match(s, hash_head);
         }
 
         if (LIKELY(s->lookahead > (unsigned int)(current_match.match_length + WANT_MIN_MATCH)))
-            insert_match(s, current_match);
+            insert_match(s, window, current_match);
 
         /* now, look ahead one */
         if (LIKELY(!early_exit && s->lookahead > MIN_LOOKAHEAD && (uint32_t)(current_match.strstart + current_match.match_length) < (s->window_size - MIN_LOOKAHEAD))) {
             s->strstart = current_match.strstart + current_match.match_length;
-            hash_head = quick_insert_string(s, s->strstart);
+            hash_head = quick_insert_string(s, window, s->strstart);
 
             next_match = find_best_match(s, hash_head);
 

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -20,7 +20,7 @@ struct match {
     uint16_t orgstart;
 };
 
-static int emit_match(deflate_state *s, struct match match) {
+static int emit_match(deflate_state *s, unsigned char *window, struct match match) {
     int bflush = 0;
     uint32_t match_len = match.match_length;
 
@@ -30,7 +30,7 @@ static int emit_match(deflate_state *s, struct match match) {
     /* matches that are not long enough we need to emit as literals */
     if (match_len < WANT_MIN_MATCH) {
         while (match_len) {
-            bflush += zng_tr_tally_lit(s, s->window[match.strstart]);
+            bflush += zng_tr_tally_lit(s, window[match.strstart]);
             match_len--;
             match.strstart++;
         }
@@ -125,8 +125,7 @@ Z_FORCEINLINE static struct match find_best_match(deflate_state *s, uint32_t has
  * - (current->match_length - 1) <= next->match_start
  * - (current->match_length - 1) <= next->strstart
  */
-static void fizzle_matches(deflate_state *s, struct match *current, struct match *next) {
-    unsigned char *window = s->window;
+static void fizzle_matches(deflate_state *s, unsigned char *window, struct match *current, struct match *next) {
     unsigned char *match, *orig;
     struct match c, n;
     int changed = 0;
@@ -180,6 +179,7 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
     /* Align the first struct to start on a new cacheline, this allows us to fit both structs in one cacheline */
     ALIGNED_(16) struct match current_match = {0};
                  struct match next_match = {0};
+    unsigned char *window = s->window;
 
     /* For levels below 5, don't check the next position for a better match */
     int early_exit = s->level < 5;
@@ -235,7 +235,7 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
                      && next_match.match_length >= WANT_MIN_MATCH
                      && tmp_cmatch_len_sub <= next_match.match_start
                      && tmp_cmatch_len_sub <= next_match.strstart) {
-                fizzle_matches(s, &current_match, &next_match);
+                fizzle_matches(s, window, &current_match, &next_match);
             }
 
             s->strstart = current_match.strstart;
@@ -244,21 +244,21 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
         }
 
         /* now emit the current match */
-        bflush = emit_match(s, current_match);
+        bflush = emit_match(s, window, current_match);
 
         /* move the "cursor" forward */
         s->strstart += current_match.match_length;
 
         if (UNLIKELY(bflush))
-            FLUSH_BLOCK(s, 0);
+            FLUSH_BLOCK(s, window, 0);
     }
     s->insert = s->strstart < (STD_MIN_MATCH - 1) ? s->strstart : (STD_MIN_MATCH - 1);
     if (flush == Z_FINISH) {
-        FLUSH_BLOCK(s, 1);
+        FLUSH_BLOCK(s, window, 1);
         return finish_done;
     }
     if (UNLIKELY(s->sym_next))
-        FLUSH_BLOCK(s, 0);
+        FLUSH_BLOCK(s, window, 0);
 
     return block_done;
 }

--- a/deflate_p.h
+++ b/deflate_p.h
@@ -185,19 +185,20 @@ Z_FORCEINLINE static unsigned read_buf(PREFIX3(stream) *strm, unsigned char *buf
  * Flush the current block, with given end-of-file flag.
  * IN assertion: strstart is set to the end of the current match.
  */
-#define FLUSH_BLOCK_ONLY(s, last) { \
-    zng_tr_flush_block(s, (s->block_start >= 0 ? \
-                   &s->window[(unsigned)s->block_start] : \
+#define FLUSH_BLOCK_ONLY(s, window, last) { \
+    int block_start = s->block_start; \
+    zng_tr_flush_block(s, (block_start >= 0 ? \
+                   &window[(unsigned)block_start] : \
                    NULL), \
-                   (uint32_t)((int)s->strstart - s->block_start), \
+                   (uint32_t)((int)s->strstart - block_start), \
                    (last)); \
     s->block_start = (int)s->strstart; \
     PREFIX(flush_pending)(s->strm); \
 }
 
 /* Same but force premature exit if necessary. */
-#define FLUSH_BLOCK(s, last) { \
-    FLUSH_BLOCK_ONLY(s, last); \
+#define FLUSH_BLOCK(s, window, last) { \
+    FLUSH_BLOCK_ONLY(s, window, last); \
     if (s->strm->avail_out == 0) return (last) ? finish_started : need_more; \
 }
 

--- a/deflate_rle.c
+++ b/deflate_rle.c
@@ -22,8 +22,9 @@
  * deflate switches away from Z_RLE.)
  */
 Z_INTERNAL block_state deflate_rle(deflate_state *s, int flush) {
-    int bflush = 0;                 /* set if current block must be flushed */
+    unsigned char *window = s->window;
     unsigned char *scan;            /* scan goes up to strend for length of run */
+    int bflush = 0;                 /* set if current block must be flushed */
     uint32_t match_len = 0;
 
     for (;;) {
@@ -41,12 +42,12 @@ Z_INTERNAL block_state deflate_rle(deflate_state *s, int flush) {
 
         /* See how many times the previous byte repeats */
         if (s->lookahead >= STD_MIN_MATCH && s->strstart > 0) {
-            scan = s->window + s->strstart - 1;
+            scan = window + s->strstart - 1;
             if (scan[0] == scan[1] && scan[1] == scan[2]) {
                 match_len = compare256_rle(scan, scan+3)+2;
                 match_len = MIN(match_len, s->lookahead);
             }
-            Assert(scan+match_len <= s->window + s->window_size - 1, "wild scan");
+            Assert(scan+match_len <= window + s->window_size - 1, "wild scan");
         }
 
         /* Emit match if have run of STD_MIN_MATCH or longer, else emit literal */
@@ -61,19 +62,19 @@ Z_INTERNAL block_state deflate_rle(deflate_state *s, int flush) {
             match_len = 0;
         } else {
             /* No match, output a literal byte */
-            bflush = zng_tr_tally_lit(s, s->window[s->strstart]);
+            bflush = zng_tr_tally_lit(s, window[s->strstart]);
             s->lookahead--;
             s->strstart++;
         }
         if (bflush)
-            FLUSH_BLOCK(s, 0);
+            FLUSH_BLOCK(s, window, 0);
     }
     s->insert = 0;
     if (flush == Z_FINISH) {
-        FLUSH_BLOCK(s, 1);
+        FLUSH_BLOCK(s, window, 1);
         return finish_done;
     }
     if (s->sym_next)
-        FLUSH_BLOCK(s, 0);
+        FLUSH_BLOCK(s, window, 0);
     return block_done;
 }

--- a/deflate_slow.c
+++ b/deflate_slow.c
@@ -52,9 +52,9 @@ Z_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
         uint32_t hash_head = 0;
         if (LIKELY(s->lookahead >= WANT_MIN_MATCH)) {
             if (level >= 9)
-                hash_head = quick_insert_string_roll(s, s->strstart);
+                hash_head = quick_insert_string_roll(s, window, s->strstart);
             else
-                hash_head = quick_insert_string(s, s->strstart);
+                hash_head = quick_insert_string(s, window, s->strstart);
         }
 
         /* Find the longest match, discarding those <= prev_length.
@@ -103,7 +103,7 @@ Z_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
                 unsigned int insert_cnt = mov_fwd;
                 if (UNLIKELY(insert_cnt > max_insert - s->strstart))
                     insert_cnt = max_insert - s->strstart;
-                insert_string_func(s, s->strstart + 1, insert_cnt);
+                insert_string_func(s, window, s->strstart + 1, insert_cnt);
             }
             s->prev_length = 0;
             s->match_available = 0;

--- a/deflate_slow.c
+++ b/deflate_slow.c
@@ -110,7 +110,7 @@ Z_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
             s->strstart += mov_fwd + 1;
 
             if (UNLIKELY(bflush))
-                FLUSH_BLOCK(s, 0);
+                FLUSH_BLOCK(s, window, 0);
 
         } else if (s->match_available) {
             /* If there was no match at the previous position, output a
@@ -119,7 +119,7 @@ Z_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
              */
             bflush = zng_tr_tally_lit(s, window[s->strstart-1]);
             if (UNLIKELY(bflush))
-                FLUSH_BLOCK_ONLY(s, 0);
+                FLUSH_BLOCK_ONLY(s, window, 0);
             s->prev_length = match_len;
             s->strstart++;
             s->lookahead--;
@@ -142,10 +142,10 @@ Z_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
     }
     s->insert = s->strstart < (STD_MIN_MATCH - 1) ? s->strstart : (STD_MIN_MATCH - 1);
     if (UNLIKELY(flush == Z_FINISH)) {
-        FLUSH_BLOCK(s, 1);
+        FLUSH_BLOCK(s, window, 1);
         return finish_done;
     }
     if (UNLIKELY(s->sym_next))
-        FLUSH_BLOCK(s, 0);
+        FLUSH_BLOCK(s, window, 0);
     return block_done;
 }

--- a/deflate_stored.c
+++ b/deflate_stored.c
@@ -25,6 +25,7 @@
  * maximizes the opportunities to have a single copy from next_in to next_out.
  */
 Z_INTERNAL block_state deflate_stored(deflate_state *s, int flush) {
+    unsigned char *window = s->window;
     /* Smallest worthy block size when not flushing or finishing. By default
      * this is 32K. This can be as small as 507 bytes for memLevel == 1. For
      * large input and output buffers, the stored block size will be larger.
@@ -83,7 +84,7 @@ Z_INTERNAL block_state deflate_stored(deflate_state *s, int flush) {
         /* Copy uncompressed bytes from the window to next_out. */
         if (left) {
             left = MIN(left, len);
-            memcpy(s->strm->next_out, s->window + s->block_start, left);
+            memcpy(s->strm->next_out, window + s->block_start, left);
             s->strm->next_out += left;
             s->strm->avail_out -= left;
             s->strm->total_out += left;
@@ -115,19 +116,19 @@ Z_INTERNAL block_state deflate_stored(deflate_state *s, int flush) {
          */
         if (used >= w_size) {    /* supplant the previous history */
             s->matches = 2;         /* clear hash */
-            memcpy(s->window, s->strm->next_in - w_size, w_size);
+            memcpy(window, s->strm->next_in - w_size, w_size);
             s->strstart = w_size;
             s->insert = s->strstart;
         } else {
             if (s->window_size - s->strstart <= used) {
                 /* Slide the window down. */
                 s->strstart -= w_size;
-                memcpy(s->window, s->window + w_size, s->strstart);
+                memcpy(window, window + w_size, s->strstart);
                 if (s->matches < 2)
                     s->matches++;   /* add a pending slide_hash() */
                 s->insert = MIN(s->insert, s->strstart);
             }
-            memcpy(s->window + s->strstart, s->strm->next_in - used, used);
+            memcpy(window + s->strstart, s->strm->next_in - used, used);
             s->strstart += used;
             s->insert += MIN(used, w_size - s->insert);
         }
@@ -149,7 +150,7 @@ Z_INTERNAL block_state deflate_stored(deflate_state *s, int flush) {
         /* Slide the window down. */
         s->block_start -= (int)w_size;
         s->strstart -= w_size;
-        memcpy(s->window, s->window + w_size, s->strstart);
+        memcpy(window, window + w_size, s->strstart);
         if (s->matches < 2)
             s->matches++;           /* add a pending slide_hash() */
         have += w_size;          /* more space now */
@@ -158,7 +159,7 @@ Z_INTERNAL block_state deflate_stored(deflate_state *s, int flush) {
 
     have = MIN(have, s->strm->avail_in);
     if (have) {
-        read_buf(s->strm, s->window + s->strstart, have);
+        read_buf(s->strm, window + s->strstart, have);
         s->strstart += have;
         s->insert += MIN(have, w_size - s->insert);
     }
@@ -177,7 +178,7 @@ Z_INTERNAL block_state deflate_stored(deflate_state *s, int flush) {
     if (left >= min_block || ((left || flush == Z_FINISH) && flush != Z_NO_FLUSH && s->strm->avail_in == 0 && left <= have)) {
         len = MIN(left, have);
         last = flush == Z_FINISH && s->strm->avail_in == 0 && len == left ? 1 : 0;
-        zng_tr_stored_block(s, s->window + s->block_start, len, last);
+        zng_tr_stored_block(s, window + s->block_start, len, last);
         s->block_start += (int)len;
         PREFIX(flush_pending)(s->strm);
     }

--- a/insert_string.c
+++ b/insert_string.c
@@ -9,10 +9,10 @@
 #include "deflate.h"
 #include "insert_string_p.h"
 
-void insert_string(deflate_state *const s, uint32_t str, uint32_t count) {
-    insert_string_static(s, str, count);
+Z_INTERNAL void insert_string(deflate_state *const s, unsigned char *window, uint32_t str, uint32_t count) {
+    insert_string_static(s, window, str, count);
 }
 
-void insert_string_roll(deflate_state *const s, uint32_t str, uint32_t count) {
-    insert_string_roll_static(s, str, count);
+Z_INTERNAL void insert_string_roll(deflate_state *const s, unsigned char *window, uint32_t str, uint32_t count) {
+    insert_string_roll_static(s, window, str, count);
 }

--- a/insert_string_tpl.h
+++ b/insert_string_tpl.h
@@ -60,8 +60,8 @@ Z_FORCEINLINE static uint32_t QUICK_INSERT_VALUE(deflate_state *const s, uint32_
  * of the hash chain (the most recent string with same hash key). Return
  * the previous length of the hash chain.
  */
-Z_FORCEINLINE static uint32_t QUICK_INSERT_STRING(deflate_state *const s, uint32_t str) {
-    uint8_t *strstart = s->window + str + HASH_CALC_OFFSET;
+Z_FORCEINLINE static uint32_t QUICK_INSERT_STRING(deflate_state *const s, unsigned char *window, uint32_t str) {
+    uint8_t *strstart = window + str + HASH_CALC_OFFSET;
     uint32_t val, hm, head;
 
     HASH_CALC_VAR_INIT;
@@ -86,8 +86,8 @@ Z_FORCEINLINE static uint32_t QUICK_INSERT_STRING(deflate_state *const s, uint32
  *    input characters and the first STD_MIN_MATCH bytes of str are valid
  *    (except for the last STD_MIN_MATCH-1 bytes of the input file).
  */
-Z_FORCEINLINE static void INSERT_STRING(deflate_state *const s, uint32_t str, uint32_t count) {
-    uint8_t *strstart = s->window + str + HASH_CALC_OFFSET;
+Z_FORCEINLINE static void INSERT_STRING(deflate_state *const s, unsigned char *window, uint32_t str, uint32_t count) {
+    uint8_t *strstart = window + str + HASH_CALC_OFFSET;
     uint8_t *strend = strstart + count;
 
     /* Local pointers to avoid indirection */

--- a/test/benchmarks/benchmark_insert_string.cc
+++ b/test/benchmarks/benchmark_insert_string.cc
@@ -19,12 +19,13 @@ extern "C" {
 #define MAX_WSIZE 32768
 #define TEST_WINDOW_SIZE (MAX_WSIZE * 2)
 
-typedef uint32_t (* quick_insert_string_cb)(deflate_state *const s, uint32_t str);
+typedef uint32_t (* quick_insert_string_cb)(deflate_state *const s, unsigned char *window, uint32_t str);
 
 // Base class with common setup/teardown for both insert_string benchmarks
 class insert_string_base: public benchmark::Fixture {
 protected:
     deflate_state *s;
+    unsigned char *window;
 
 public:
     void SetUp(const ::benchmark::State&) {
@@ -37,6 +38,7 @@ public:
 
         // Allocate window
         s->window = (uint8_t*)zng_alloc_aligned(TEST_WINDOW_SIZE, 64);
+        window = s->window;
 
         // Allocate hash tables
         s->head = (Pos*)zng_alloc_aligned(HASH_SIZE * sizeof(Pos), 64);
@@ -52,7 +54,7 @@ public:
         // Fill window with deterministic data patterns
         for (size_t i = 0; i < TEST_WINDOW_SIZE; i++) {
             // Create patterns that will exercise the hash function well
-            s->window[i] = (uint8_t)((i * 17 + (i >> 4) * 31 + (i >> 8) * 13) & 0xFF);
+            window[i] = (uint8_t)((i * 17 + (i >> 4) * 31 + (i >> 8) * 13) & 0xFF);
         }
     }
 
@@ -87,7 +89,7 @@ public:
             state.ResumeTiming();
 
             // Benchmark the insert_string function
-            insert_func(s, str_pos, count);
+            insert_func(s, window, str_pos, count);
         }
     }
 };
@@ -140,7 +142,7 @@ public:
 
             // Benchmark quick_insert_string (single insertions)
             for (uint32_t i = 0; i < count; i++) {
-                uint32_t result = quick_insert_func(s, start_pos + i);
+                uint32_t result = quick_insert_func(s, window, start_pos + i);
                 benchmark::DoNotOptimize(result);
             }
         }


### PR DESCRIPTION
- Use local `window` variable in all deflate strategies (`deflate_stored`, `deflate_rle` were completely missing this)
- Pass `window` to `FLUSH_BLOCK` and `FLUSH_BLOCK_ONCE` macros
- Store `block_start` in temp var in `FLUSH_BLOCK` macro
- `deflate_medium` now passes `window` to its static functions
- Pass `window` to `insert_string` function variants.