### PR TITLE
Hoist strstart and lookahead to locals in deflate strategies

### DIFF
--- a/deflate_huff.c
+++ b/deflate_huff.c
@@ -16,12 +16,18 @@
 Z_INTERNAL block_state deflate_huff(deflate_state *s, int flush) {
     unsigned char *window = s->window;
     int bflush = 0;         /* set if current block must be flushed */
+    unsigned int lookahead = s->lookahead;
+    unsigned int strstart = s->strstart;
 
     for (;;) {
         /* Make sure that we have a literal to write. */
-        if (UNLIKELY(s->lookahead == 0)) {
+        if (UNLIKELY(lookahead == 0)) {
+            s->lookahead = lookahead;
+            s->strstart = strstart;
             PREFIX(fill_window)(s);
-            if (UNLIKELY(s->lookahead == 0)) {
+            lookahead = s->lookahead;
+            strstart = s->strstart;
+            if (UNLIKELY(lookahead == 0)) {
                 if (flush == Z_NO_FLUSH)
                     return need_more;
                 break;      /* flush the current block */
@@ -29,12 +35,17 @@ Z_INTERNAL block_state deflate_huff(deflate_state *s, int flush) {
         }
 
         /* Output a literal byte */
-        bflush = zng_tr_tally_lit(s, window[s->strstart]);
-        s->lookahead--;
-        s->strstart++;
-        if (bflush)
+        bflush = zng_tr_tally_lit(s, window[strstart]);
+        lookahead--;
+        strstart++;
+        if (bflush) {
+            s->lookahead = lookahead;
+            s->strstart = strstart;
             FLUSH_BLOCK(s, window, 0);
+        }
     }
+    s->lookahead = lookahead;
+    s->strstart = strstart;
     s->insert = 0;
     if (flush == Z_FINISH) {
         FLUSH_BLOCK(s, window, 1);

--- a/deflate_quick.c
+++ b/deflate_quick.c
@@ -28,46 +28,43 @@
 extern const ct_data static_ltree[L_CODES+2];
 extern const ct_data static_dtree[D_CODES];
 
-Z_FORCEINLINE static void quick_start_block(deflate_state *s, int last) {
+Z_FORCEINLINE static void quick_start_block(deflate_state *s, uint32_t strstart, int last) {
     zng_tr_emit_tree(s, STATIC_TREES, last);
     s->block_open = 1 + last;
-    s->block_start = (int)s->strstart;
+    s->block_start = (int)strstart;
 }
 
-Z_FORCEINLINE static int quick_end_block(deflate_state *s, int last) {
+Z_FORCEINLINE static int quick_end_block(deflate_state *s, uint32_t strstart, int last) {
     if (s->block_open) {
         zng_tr_emit_end_block(s, static_ltree, last);
         s->block_open = 0;
-        s->block_start = (int)s->strstart;
+        s->block_start = (int)strstart;
         PREFIX(flush_pending)(s->strm);
         return (s->strm->avail_out == 0);
     }
     return 0;
 }
 
-Z_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
+Z_FORCEINLINE static block_state deflate_quick_impl(deflate_state *s, int flush,
+                                                   uint32_t strstart, uint32_t lookahead) {
     unsigned char *window;
     unsigned last = (flush == Z_FINISH) ? 1 : 0;
-    unsigned int lookahead = s->lookahead;
-    unsigned int strstart = s->strstart;
 
     if (UNLIKELY(last && s->block_open != 2)) {
         /* Emit end of previous block */
-        if (quick_end_block(s, 0))
+        if (quick_end_block(s, strstart, 0))
             return need_more;
         /* Emit start of last block */
-        quick_start_block(s, last);
+        quick_start_block(s, strstart, last);
     } else if (UNLIKELY(s->block_open == 0 && lookahead > 0)) {
         /* Start new block only when we have lookahead data, so that if no
            input data is given an empty block will not be written */
-        quick_start_block(s, last);
+        quick_start_block(s, strstart, last);
     }
 
     window = s->window;
 
     for (;;) {
-        uint8_t lc;
-
         if (UNLIKELY(s->pending + ((BIT_BUF_SIZE + 7) >> 3) >= s->pending_buf_size)) {
             PREFIX(flush_pending)(s->strm);
             if (s->strm->avail_out == 0) {
@@ -91,23 +88,23 @@ Z_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
             if (UNLIKELY(s->block_open == 0)) {
                 /* Start new block when we have lookahead data, so that if no
                    input data is given an empty block will not be written */
-                quick_start_block(s, last);
+                quick_start_block(s, strstart, last);
             }
         }
 
+        uint32_t str_val = Z_U32_FROM_LE(zng_memread_4(window + strstart));
+
         if (LIKELY(lookahead >= WANT_MIN_MATCH)) {
-            uint32_t str_val = Z_U32_FROM_LE(zng_memread_4(window + strstart));
             uint32_t hash_head = quick_insert_value(s, strstart, str_val);
             int64_t dist = (int64_t)strstart - hash_head;
-            lc = (uint8_t)str_val;
 
             if (dist <= MAX_DIST(s) && dist > 0) {
                 const uint8_t *match_start = window + hash_head;
                 uint32_t match_val = Z_U32_FROM_LE(zng_memread_4(match_start));
 
                 if (str_val == match_val) {
-                    const uint8_t *str_start = window + strstart;
-                    uint32_t match_len = FUNCTABLE_CALL(compare256)(str_start+2, match_start+2) + 2;
+                    const uint8_t *scan_start = window + strstart;
+                    uint32_t match_len = FUNCTABLE_CALL(compare256)(scan_start+2, match_start+2) + 2;
 
                     if (match_len >= WANT_MIN_MATCH) {
                         if (UNLIKELY(match_len > lookahead))
@@ -124,10 +121,9 @@ Z_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
                     }
                 }
             }
-        } else {
-            lc = window[strstart];
         }
-        zng_tr_emit_lit(s, static_ltree, lc);
+
+        zng_tr_emit_lit(s, static_ltree, (uint8_t)str_val);
         strstart++;
         lookahead--;
     }
@@ -136,12 +132,16 @@ Z_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
     s->strstart = strstart;
     s->insert = strstart < (STD_MIN_MATCH - 1) ? strstart : (STD_MIN_MATCH - 1);
     if (UNLIKELY(last)) {
-        if (quick_end_block(s, 1))
+        if (quick_end_block(s, strstart, 1))
             return finish_started;
         return finish_done;
     }
 
-    if (quick_end_block(s, 0))
+    if (quick_end_block(s, strstart, 0))
         return need_more;
     return block_done;
+}
+
+Z_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
+    return deflate_quick_impl(s, flush, s->strstart, s->lookahead);
 }

--- a/deflate_quick.c
+++ b/deflate_quick.c
@@ -48,6 +48,8 @@ Z_FORCEINLINE static int quick_end_block(deflate_state *s, int last) {
 Z_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
     unsigned char *window;
     unsigned last = (flush == Z_FINISH) ? 1 : 0;
+    unsigned int lookahead = s->lookahead;
+    unsigned int strstart = s->strstart;
 
     if (UNLIKELY(last && s->block_open != 2)) {
         /* Emit end of previous block */
@@ -55,7 +57,7 @@ Z_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
             return need_more;
         /* Emit start of last block */
         quick_start_block(s, last);
-    } else if (UNLIKELY(s->block_open == 0 && s->lookahead > 0)) {
+    } else if (UNLIKELY(s->block_open == 0 && lookahead > 0)) {
         /* Start new block only when we have lookahead data, so that if no
            input data is given an empty block will not be written */
         quick_start_block(s, last);
@@ -69,16 +71,21 @@ Z_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
         if (UNLIKELY(s->pending + ((BIT_BUF_SIZE + 7) >> 3) >= s->pending_buf_size)) {
             PREFIX(flush_pending)(s->strm);
             if (s->strm->avail_out == 0) {
+                s->lookahead = lookahead;
+                s->strstart = strstart;
                 return (last && s->strm->avail_in == 0 && s->bi_valid == 0 && s->block_open == 0) ? finish_started : need_more;
             }
         }
 
-        if (UNLIKELY(s->lookahead < MIN_LOOKAHEAD)) {
+        if (UNLIKELY(lookahead < MIN_LOOKAHEAD)) {
+            s->lookahead = lookahead;
+            s->strstart = strstart;
             PREFIX(fill_window)(s);
-            if (UNLIKELY(s->lookahead < MIN_LOOKAHEAD && flush == Z_NO_FLUSH)) {
+            lookahead = s->lookahead;
+            strstart = s->strstart;
+            if (UNLIKELY(lookahead < MIN_LOOKAHEAD && flush == Z_NO_FLUSH))
                 return need_more;
-            }
-            if (UNLIKELY(s->lookahead == 0))
+            if (UNLIKELY(lookahead == 0))
                 break;
 
             if (UNLIKELY(s->block_open == 0)) {
@@ -88,10 +95,10 @@ Z_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
             }
         }
 
-        if (LIKELY(s->lookahead >= WANT_MIN_MATCH)) {
-            uint32_t str_val = Z_U32_FROM_LE(zng_memread_4(window + s->strstart));
-            uint32_t hash_head = quick_insert_value(s, s->strstart, str_val);
-            int64_t dist = (int64_t)s->strstart - hash_head;
+        if (LIKELY(lookahead >= WANT_MIN_MATCH)) {
+            uint32_t str_val = Z_U32_FROM_LE(zng_memread_4(window + strstart));
+            uint32_t hash_head = quick_insert_value(s, strstart, str_val);
+            int64_t dist = (int64_t)strstart - hash_head;
             lc = (uint8_t)str_val;
 
             if (dist <= MAX_DIST(s) && dist > 0) {
@@ -99,33 +106,35 @@ Z_INTERNAL block_state deflate_quick(deflate_state *s, int flush) {
                 uint32_t match_val = Z_U32_FROM_LE(zng_memread_4(match_start));
 
                 if (str_val == match_val) {
-                    const uint8_t *str_start = window + s->strstart;
+                    const uint8_t *str_start = window + strstart;
                     uint32_t match_len = FUNCTABLE_CALL(compare256)(str_start+2, match_start+2) + 2;
 
                     if (match_len >= WANT_MIN_MATCH) {
-                        if (UNLIKELY(match_len > s->lookahead))
-                            match_len = s->lookahead;
+                        if (UNLIKELY(match_len > lookahead))
+                            match_len = lookahead;
 
                         Assert(match_len <= STD_MAX_MATCH, "match too long");
-                        Assert(s->strstart <= UINT16_MAX, "strstart should fit in uint16_t");
-                        check_match(s, s->strstart, hash_head, match_len);
+                        Assert(strstart <= UINT16_MAX, "strstart should fit in uint16_t");
+                        check_match(s, strstart, hash_head, match_len);
 
                         zng_tr_emit_dist(s, static_ltree, static_dtree, match_len - STD_MIN_MATCH, (uint32_t)dist);
-                        s->lookahead -= match_len;
-                        s->strstart += match_len;
+                        lookahead -= match_len;
+                        strstart += match_len;
                         continue;
                     }
                 }
             }
         } else {
-            lc = window[s->strstart];
+            lc = window[strstart];
         }
         zng_tr_emit_lit(s, static_ltree, lc);
-        s->strstart++;
-        s->lookahead--;
+        strstart++;
+        lookahead--;
     }
 
-    s->insert = s->strstart < (STD_MIN_MATCH - 1) ? s->strstart : (STD_MIN_MATCH - 1);
+    s->lookahead = lookahead;
+    s->strstart = strstart;
+    s->insert = strstart < (STD_MIN_MATCH - 1) ? strstart : (STD_MIN_MATCH - 1);
     if (UNLIKELY(last)) {
         if (quick_end_block(s, 1))
             return finish_started;

--- a/deflate_rle.c
+++ b/deflate_rle.c
@@ -26,49 +26,60 @@ Z_INTERNAL block_state deflate_rle(deflate_state *s, int flush) {
     unsigned char *scan;            /* scan goes up to strend for length of run */
     int bflush = 0;                 /* set if current block must be flushed */
     uint32_t match_len = 0;
+    unsigned int lookahead = s->lookahead;
+    unsigned int strstart = s->strstart;
 
     for (;;) {
         /* Make sure that we always have enough lookahead, except
          * at the end of the input file. We need STD_MAX_MATCH bytes
          * for the longest run, plus one for the unrolled loop.
          */
-        if (UNLIKELY(s->lookahead <= STD_MAX_MATCH)) {
+        if (UNLIKELY(lookahead <= STD_MAX_MATCH)) {
+            s->lookahead = lookahead;
+            s->strstart = strstart;
             PREFIX(fill_window)(s);
-            if (UNLIKELY(s->lookahead <= STD_MAX_MATCH && flush == Z_NO_FLUSH))
+            lookahead = s->lookahead;
+            strstart = s->strstart;
+            if (UNLIKELY(lookahead <= STD_MAX_MATCH && flush == Z_NO_FLUSH))
                 return need_more;
-            if (UNLIKELY(s->lookahead == 0))
+            if (UNLIKELY(lookahead == 0))
                 break; /* flush the current block */
         }
 
         /* See how many times the previous byte repeats */
-        if (LIKELY(s->lookahead >= STD_MIN_MATCH && s->strstart > 0)) {
-            scan = window + s->strstart - 1;
+        if (LIKELY(lookahead >= STD_MIN_MATCH && strstart > 0)) {
+            scan = window + strstart - 1;
             if (scan[0] == scan[1] && scan[1] == scan[2]) {
                 match_len = compare256_rle(scan, scan+3)+2;
-                match_len = MIN(match_len, s->lookahead);
+                match_len = MIN(match_len, lookahead);
             }
             Assert(scan+match_len <= window + s->window_size - 1, "wild scan");
         }
 
         /* Emit match if have run of STD_MIN_MATCH or longer, else emit literal */
         if (match_len >= STD_MIN_MATCH) {
-            Assert(s->strstart <= UINT16_MAX, "strstart should fit in uint16_t");
-            check_match(s, s->strstart, s->strstart - 1, match_len);
+            Assert(strstart <= UINT16_MAX, "strstart should fit in uint16_t");
+            check_match(s, strstart, strstart - 1, match_len);
 
             bflush = zng_tr_tally_dist(s, 1, match_len - STD_MIN_MATCH);
 
-            s->lookahead -= match_len;
-            s->strstart += match_len;
+            lookahead -= match_len;
+            strstart += match_len;
             match_len = 0;
         } else {
             /* No match, output a literal byte */
-            bflush = zng_tr_tally_lit(s, window[s->strstart]);
-            s->lookahead--;
-            s->strstart++;
+            bflush = zng_tr_tally_lit(s, window[strstart]);
+            lookahead--;
+            strstart++;
         }
-        if (bflush)
+        if (bflush) {
+            s->lookahead = lookahead;
+            s->strstart = strstart;
             FLUSH_BLOCK(s, window, 0);
+        }
     }
+    s->lookahead = lookahead;
+    s->strstart = strstart;
     s->insert = 0;
     if (flush == Z_FINISH) {
         FLUSH_BLOCK(s, window, 1);


### PR DESCRIPTION
Lift s->strstart and s->lookahead into function locals across the deflate strategies (deflate_medium is left alone — its helpers already mediate strstart through a local struct match). The locals sync back to s before any external call that reads or mutates them and reload on the way out.

Writes through window[strstart] no longer make the compiler treat strstart and lookahead as aliased, so the cursor and remaining-input counter stay in registers across the inner loop. On AArch64 the deflate_quick body shrinks ~11% with 21 fewer loads/stores in the function.

Benchmarks on Apple M5, levels 1/3/6/9 over 128K and 1MB inputs, `--benchmark_repetitions=5 --benchmark_cooldown=5`, vs upstream/develop.

**AArch64**

| Strategy | Level | Size | Δ wall | Δ CPU |
|---|---|---|---|---|
| deflate_quick | 1 | 128K | **-10.95%** | -11.12% |
| deflate_quick | 1 | 1M | **-10.46%** | -10.31% |
| deflate_fast | 3 | 128K | -0.17% | -0.13% |
| deflate_fast | 3 | 1M | -0.67% | -0.59% |
| deflate_medium | 6 | 128K | +0.76% | +0.79% |
| deflate_medium | 6 | 1M | -0.18% | -0.81% |
| deflate_slow | 9 | 128K | **-2.23%** | -2.03% |
| deflate_slow | 9 | 1M | **-2.07%** | -2.03% |
| Geomean | | | **-3.35%** | |

**x86_64 (via Rosetta 2)**

| Strategy | Level | Size | Δ wall | Δ CPU |
|---|---|---|---|---|
| deflate_quick | 1 | 128K | **-10.47%** | -10.06% |
| deflate_quick | 1 | 1M | -6.93% | -6.65% |
| deflate_fast | 3 | 128K | **-6.01%** | -5.59% |
| deflate_fast | 3 | 1M | **-5.75%** | -5.68% |
| deflate_medium | 6 | 128K | -3.77% | -2.74% |
| deflate_medium | 6 | 1M | -2.91% | -2.13% |
| deflate_slow | 9 | 128K | -1.34% | -0.92% |
| deflate_slow | 9 | 1M | -1.39% | -1.15% |
| Geomean | | | **-4.87%** | |

Compression ratio is identical across all levels and sizes.


**AArch64 — Z_HUFFMAN_ONLY and Z_RLE strategies (1MB input)**

| Strategy | Level | Δ wall | Δ CPU |
|---|---|---|---|
| deflate_huff (Z_HUFFMAN_ONLY) | 1 | **-35.70%** | -35.03% |
| deflate_huff | 6 | **-35.38%** | -35.14% |
| deflate_huff | 9 | **-33.94%** | -34.01% |
| deflate_rle (Z_RLE) | 1 | **-33.05%** | -33.09% |
| deflate_rle | 6 | **-33.26%** | -33.26% |
| deflate_rle | 9 | **-33.42%** | -33.45% |
| Geomean | | **-34.13%** | |

These two strategies have the tightest inner loops (one literal or one fixed-distance match per iteration). Without the hoist, every iteration reloaded `s->strstart` and `s->lookahead` after the `window[]` write because of char-aliasing. The hoist keeps them in registers throughout, eliminating most of the per-iteration memory traffic.
