### PR TITLE
Native API changes: Remove adler32_z and crc32_z, add symver.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -633,8 +633,21 @@ if (UNIX AND NOT ZLIB_COMPAT AND NOT APPLE AND NOT CMAKE_SYSTEM_NAME STREQUAL AI
             return 0;
         }"
         HAVE_ATTRIBUTE_SYMVER FAIL_REGEX "symver")
+
+    check_c_source_compiles(
+        "
+        void foo(void);
+        void foo(void) {}
+        __asm__(\".symver foo, foo@VERS_1.0\");
+        int main(void) {
+            return 0;
+        }"
+        HAVE_ASM_SYMVER FAIL_REGEX "symver")
+
     if(HAVE_ATTRIBUTE_SYMVER)
         add_definitions(-DHAVE_ATTRIBUTE_SYMVER)
+    elseif(HAVE_ASM_SYMVER)
+        add_definitions(-DHAVE_ASM_SYMVER)
     else()
         message(WARNING "Unable to provide support for deprecated functions without '__attribute__((__symver__(x)))'")
     endif()
@@ -668,7 +681,7 @@ if(MSVC)
 endif()
 
 # Linker maps need to exclude duplicates if symver is not supported
-if(HAVE_ATTRIBUTE_SYMVER)
+if(HAVE_ATTRIBUTE_SYMVER OR HAVE_ASM_SYMVER)
     set(COMMENT_IF_NO_SYMVER "")
 else()
     set(COMMENT_IF_NO_SYMVER "#")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -622,6 +622,25 @@ if(HAVE_ATTRIBUTE_ALIGNED)
 endif()
 
 #
+# Check for __attribute__((__symver__(x))) support in the compiler
+#
+if (UNIX AND NOT ZLIB_COMPAT AND NOT APPLE AND NOT CMAKE_SYSTEM_NAME STREQUAL AIX)
+    check_c_source_compiles(
+        "
+        void foo(void);
+        __attribute__((__symver__(\"foo@VERS_1.0\"))) void foo(void) {}
+        int main(void) {
+            return 0;
+        }"
+        HAVE_ATTRIBUTE_SYMVER FAIL_REGEX "symver")
+    if(HAVE_ATTRIBUTE_SYMVER)
+        add_definitions(-DHAVE_ATTRIBUTE_SYMVER)
+    else()
+        message(WARNING "Unable to provide support for deprecated functions without '__attribute__((__symver__(x)))'")
+    endif()
+endif()
+
+#
 # Check for __builtin_assume_aligned(x,n) support in the compiler
 #
 set(CMAKE_REQUIRED_FLAGS ${ZNOLTOFLAG})
@@ -646,6 +665,13 @@ if(MSVC)
     set(CMAKE_DEBUG_POSTFIX "d")
     add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
     add_definitions(-D_CRT_NONSTDC_NO_DEPRECATE)
+endif()
+
+# Linker maps need to exclude duplicates if symver is not supported
+if(HAVE_ATTRIBUTE_SYMVER)
+    set(COMMENT_IF_NO_SYMVER "")
+else()
+    set(COMMENT_IF_NO_SYMVER "#")
 endif()
 
 #
@@ -1411,9 +1437,6 @@ if(NOT DEFINED BUILD_SHARED_LIBS OR BUILD_SHARED_LIBS)
             set_target_properties(zlib-ng PROPERTIES COMPILE_FLAGS "-fno-semantic-interposition")
         endif()
         if(NOT APPLE AND NOT CMAKE_SYSTEM_NAME STREQUAL AIX)
-            if(NOT ZLIB_COMPAT)
-                add_definitions(-DHAVE_SYMVER)
-            endif()
             configure_file(${CMAKE_CURRENT_SOURCE_DIR}/zlib${SUFFIX}.map.in
                 ${CMAKE_CURRENT_BINARY_DIR}/zlib${SUFFIX}.map @ONLY)
             set_target_properties(zlib-ng PROPERTIES LINK_FLAGS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -632,8 +632,21 @@ if (UNIX AND NOT ZLIB_COMPAT AND NOT APPLE AND NOT CMAKE_SYSTEM_NAME STREQUAL AI
             return 0;
         }"
         HAVE_ATTRIBUTE_SYMVER FAIL_REGEX "symver")
+
+    check_c_source_compiles(
+        "
+        void foo(void);
+        void foo(void) {}
+        __asm__(\".symver foo, foo@VERS_1.0\");
+        int main(void) {
+            return 0;
+        }"
+        HAVE_ASM_SYMVER FAIL_REGEX "symver")
+
     if(HAVE_ATTRIBUTE_SYMVER)
         add_definitions(-DHAVE_ATTRIBUTE_SYMVER)
+    elseif(HAVE_ASM_SYMVER)
+        add_definitions(-DHAVE_ASM_SYMVER)
     else()
         message(WARNING "Unable to provide support for deprecated functions without '__attribute__((__symver__(x)))'")
     endif()
@@ -667,7 +680,7 @@ if(MSVC)
 endif()
 
 # Linker maps need to exclude duplicates if symver is not supported
-if(HAVE_ATTRIBUTE_SYMVER)
+if(HAVE_ATTRIBUTE_SYMVER OR HAVE_ASM_SYMVER)
     set(COMMENT_IF_NO_SYMVER "")
 else()
     set(COMMENT_IF_NO_SYMVER "#")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -621,6 +621,25 @@ if(HAVE_ATTRIBUTE_ALIGNED)
 endif()
 
 #
+# Check for __attribute__((__symver__(x))) support in the compiler
+#
+if (UNIX AND NOT ZLIB_COMPAT AND NOT APPLE AND NOT CMAKE_SYSTEM_NAME STREQUAL AIX)
+    check_c_source_compiles(
+        "
+        void foo(void);
+        __attribute__((__symver__(\"foo@VERS_1.0\"))) void foo(void) {}
+        int main(void) {
+            return 0;
+        }"
+        HAVE_ATTRIBUTE_SYMVER FAIL_REGEX "symver")
+    if(HAVE_ATTRIBUTE_SYMVER)
+        add_definitions(-DHAVE_ATTRIBUTE_SYMVER)
+    else()
+        message(WARNING "Unable to provide support for deprecated functions without '__attribute__((__symver__(x)))'")
+    endif()
+endif()
+
+#
 # Check for __builtin_assume_aligned(x,n) support in the compiler
 #
 set(CMAKE_REQUIRED_FLAGS ${ZNOLTOFLAG})
@@ -645,6 +664,13 @@ if(MSVC)
     set(CMAKE_DEBUG_POSTFIX "d")
     add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
     add_definitions(-D_CRT_NONSTDC_NO_DEPRECATE)
+endif()
+
+# Linker maps need to exclude duplicates if symver is not supported
+if(HAVE_ATTRIBUTE_SYMVER)
+    set(COMMENT_IF_NO_SYMVER "")
+else()
+    set(COMMENT_IF_NO_SYMVER "#")
 endif()
 
 #
@@ -1398,9 +1424,6 @@ if(NOT DEFINED BUILD_SHARED_LIBS OR BUILD_SHARED_LIBS)
             set_target_properties(zlib-ng PROPERTIES COMPILE_FLAGS "-fno-semantic-interposition")
         endif()
         if(NOT APPLE AND NOT CMAKE_SYSTEM_NAME STREQUAL AIX)
-            if(NOT ZLIB_COMPAT)
-                add_definitions(-DHAVE_SYMVER)
-            endif()
             configure_file(${CMAKE_CURRENT_SOURCE_DIR}/zlib${SUFFIX}.map.in
                 ${CMAKE_CURRENT_BINARY_DIR}/zlib${SUFFIX}.map @ONLY)
             set_target_properties(zlib-ng PROPERTIES LINK_FLAGS

--- a/adler32.c
+++ b/adler32.c
@@ -8,28 +8,49 @@
 #include "adler32_p.h"
 
 #ifdef ZLIB_COMPAT
-unsigned long Z_EXPORT PREFIX(adler32_z)(unsigned long adler, const unsigned char *buf, size_t len) {
+unsigned long Z_EXPORT adler32_z(unsigned long adler, const unsigned char *buf, size_t len) {
     if (buf == NULL)
         return ADLER32_INITIAL_VALUE;
     return (unsigned long)FUNCTABLE_CALL(adler32)((uint32_t)adler, buf, len);
 }
-#else
-uint32_t Z_EXPORT PREFIX(adler32_z)(uint32_t adler, const unsigned char *buf, size_t len) {
+unsigned long Z_EXPORT adler32(unsigned long adler, const unsigned char *buf, unsigned int len) {
+    if (buf == NULL)
+        return ADLER32_INITIAL_VALUE;
+    return (unsigned long)FUNCTABLE_CALL(adler32)((uint32_t)adler, buf, len);
+}
+#endif
+
+#ifndef ZLIB_COMPAT
+#  if defined(HAVE_SYMVER)
+// Preferred function
+ZSYMVER_DEF(zng_adler32_sizet, zng_adler32, "ZLIB_NG_2.4.0")
+uint32_t Z_EXPORT zng_adler32_sizet(uint32_t adler, const unsigned char *buf, size_t len) {
     if (buf == NULL)
         return ADLER32_INITIAL_VALUE;
     return FUNCTABLE_CALL(adler32)(adler, buf, len);
 }
-#endif
-
-/* ========================================================================= */
-#ifdef ZLIB_COMPAT
-unsigned long Z_EXPORT PREFIX(adler32)(unsigned long adler, const unsigned char *buf, unsigned int len) {
+// Deprecated function
+ZSYMVER(zng_adler32_uint32, zng_adler32, "ZLIB_NG_2.0.0")
+uint32_t Z_EXPORT zng_adler32_uint32(uint32_t adler, const unsigned char *buf, uint32_t len) {
     if (buf == NULL)
         return ADLER32_INITIAL_VALUE;
-    return (unsigned long)FUNCTABLE_CALL(adler32)((uint32_t)adler, buf, len);
+    return FUNCTABLE_CALL(adler32)(adler, buf, len);
 }
-#else
-uint32_t Z_EXPORT PREFIX(adler32)(uint32_t adler, const unsigned char *buf, uint32_t len) {
+
+#  else
+//Fallback to preferred function
+uint32_t Z_EXPORT zng_adler32(uint32_t adler, const unsigned char *buf, size_t len) {
+    if (buf == NULL)
+        return ADLER32_INITIAL_VALUE;
+    return FUNCTABLE_CALL(adler32)(adler, buf, len);
+}
+#  endif
+
+#    ifdef zng_adler32_z
+#      undef zng_adler32_z
+#    endif
+// Deprecated function
+uint32_t Z_EXPORT zng_adler32_z(uint32_t adler, const unsigned char *buf, size_t len) {
     if (buf == NULL)
         return ADLER32_INITIAL_VALUE;
     return FUNCTABLE_CALL(adler32)(adler, buf, len);

--- a/configure
+++ b/configure
@@ -634,22 +634,6 @@ else
   esac
 fi
 
-# Symbol versioning
-case "$uname" in
-  CYGWIN* | Cygwin* | cygwin* | MINGW* | mingw* | MSYS* | msys* | Darwin* | darwin*)
-    echo "Checking for Symbol versioning... No."
-  ;;
-  *)
-    if test $shared -eq 1; then
-      echo "Checking for Symbol versioning... Yes."
-      CFLAGS="${CFLAGS} -DHAVE_SYMVER"
-      SFLAGS="${SFLAGS} -DHAVE_SYMVER"
-    else
-      echo "Checking for Symbol versioning... No."
-    fi
-  ;;
-esac
-
 # Simplify some later conditionals
 LINUX=0
 FREEBSD=0
@@ -784,30 +768,6 @@ if $cc $CFLAGS -Werror=unused-command-line-argument -c $test.c >> configure.log 
 else
   echo "Checking for -Werror=unused-command-line-argument... No." | tee -a configure.log
 fi
-
-# check for version script support
-cat > $test.c <<EOF
-int foo(void) { return 0; }
-EOF
-cat > $test.map <<EOF
-{
-  global:
-    foo;
-  local:
-    *;
-};
-EOF
-if test $shared -eq 1; then
-  sed < $SRCDIR/zlib${SUFFIX}.map.in "s/@ZLIB_SYMBOL_PREFIX@/$symbol_prefix/g" > zlib${SUFFIX}.map
-  LDVERSIONSCRIPT="-Wl,--version-script,$BUILDDIR/$MAPNAME"
-  if try $CC -c $SFLAGS $test.c && try $LDSHARED $LDVERSIONSCRIPT $LDSHAREDFLAGS $LDFLAGS -o $test$shared_ext $test.o $LDSHAREDLIBC; then
-    echo "Checking for version script support... $LDVERSIONSCRIPT." | tee -a configure.log
-  else
-    echo "Checking for version script support... No." | tee -a configure.log
-    LDVERSIONSCRIPT=""
-  fi
-fi
-echo >> configure.log
 
 # check for cpuid support: GNU extensions
 cat > $test.c <<EOF
@@ -1099,6 +1059,25 @@ else
     echo "Checking for attribute(aligned) ... No." | tee -a configure.log
 fi
 
+# Check for attribute(symver) support in compiler
+cat > $test.c << EOF
+void foo(void);
+__attribute__((__symver__("foo@VERS_1.0"))) void foo(void) {}
+int main(void) {
+    return 0;
+}
+EOF
+if try ${CC} ${CFLAGS} $test.c $LDSHAREDLIBC; then
+    echo "Checking for attribute(symver) ... Yes." | tee -a configure.log
+    CFLAGS="$CFLAGS -DHAVE_ATTRIBUTE_SYMVER"
+    SFLAGS="$SFLAGS -DHAVE_ATTRIBUTE_SYMVER"
+    SYMVER_PREFIX=""
+else
+    echo "Checking for attribute(symver) ... No." | tee -a configure.log
+    echo "Warning: Unable to provide support for deprecated functions without '__attribute__((__symver__(x)))'" | tee -a configure.log
+    SYMVER_PREFIX="#"
+fi
+
 # Check for __builtin_assume_aligned(x,n) support in compiler
 cat > $test.c << EOF
 char *test(char *buffer) {
@@ -1116,6 +1095,31 @@ if try ${CC} ${CFLAGS} $test.c $LDSHAREDLIBC; then
 else
     echo "Checking for __builtin_assume_aligned() ... No." | tee -a configure.log
 fi
+
+# check for version script support
+cat > $test.c <<EOF
+int foo(void) { return 0; }
+EOF
+cat > $test.map <<EOF
+{
+  global:
+    foo;
+  local:
+    *;
+};
+EOF
+if test $shared -eq 1; then
+  sed < $SRCDIR/zlib${SUFFIX}.map.in "s/@ZLIB_SYMBOL_PREFIX@/$symbol_prefix/g" > zlib${SUFFIX}.map
+  sed < $SRCDIR/zlib${SUFFIX}.map.in "s/@COMMENT_IF_NO_SYMVER@/$SYMVER_PREFIX/g" > zlib${SUFFIX}.map
+  LDVERSIONSCRIPT="-Wl,--version-script,$BUILDDIR/$MAPNAME"
+  if try $CC -c $SFLAGS $test.c && try $LDSHARED $LDVERSIONSCRIPT $LDSHAREDFLAGS $LDFLAGS -o $test$shared_ext $test.o $LDSHAREDLIBC; then
+    echo "Checking for version script support... $LDVERSIONSCRIPT." | tee -a configure.log
+  else
+    echo "Checking for version script support... No." | tee -a configure.log
+    LDVERSIONSCRIPT=""
+  fi
+fi
+echo >> configure.log
 
 check_avx2_intrinsics() {
     # Check whether compiler supports AVX2 intrinsics

--- a/configure
+++ b/configure
@@ -1059,22 +1059,50 @@ else
     echo "Checking for attribute(aligned) ... No." | tee -a configure.log
 fi
 
-# Check for attribute(symver) support in compiler
-cat > $test.c << EOF
+case "$uname" in
+    CYGWIN* | Cygwin* | cygwin* | MSYS* | msys* | MINGW* | mingw* | Darwin* | darwin* | AIX*)
+        with_symver=0 ;;
+    *)
+        with_symver=1 ;;
+esac
+if test $compat -eq 0 -a $with_symver -eq 1; then
+    # Check for attribute(symver) support in compiler
+    cat > $test.c << EOF
 void foo(void);
 __attribute__((__symver__("foo@VERS_1.0"))) void foo(void) {}
 int main(void) {
     return 0;
 }
 EOF
-if try ${CC} ${CFLAGS} $test.c $LDSHAREDLIBC; then
-    echo "Checking for attribute(symver) ... Yes." | tee -a configure.log
-    CFLAGS="$CFLAGS -DHAVE_ATTRIBUTE_SYMVER"
-    SFLAGS="$SFLAGS -DHAVE_ATTRIBUTE_SYMVER"
-    SYMVER_PREFIX=""
+    if try ${CC} ${CFLAGS} $test.c $LDSHAREDLIBC; then
+        echo "Checking for attribute(symver) ... Yes." | tee -a configure.log
+        CFLAGS="$CFLAGS -DHAVE_ATTRIBUTE_SYMVER"
+        SFLAGS="$SFLAGS -DHAVE_ATTRIBUTE_SYMVER"
+        SYMVER_PREFIX=""
+    else
+        echo "Checking for attribute(symver) ... No." | tee -a configure.log
+
+        # Check for asm .symver support in compiler
+        cat > $test.c << EOF
+void foo(void);
+__asm__(".symver foo, foo@VERS_1.0");
+void foo(void) {}
+int main(void) {
+    return 0;
+}
+EOF
+        if try ${CC} ${CFLAGS} $test.c $LDSHAREDLIBC; then
+            echo "Checking for asm .symver ... Yes." | tee -a configure.log
+            CFLAGS="$CFLAGS -DHAVE_ASM_SYMVER"
+            SFLAGS="$SFLAGS -DHAVE_ASM_SYMVER"
+        else
+            echo "Checking for asm .symver ... No." | tee -a configure.log
+
+            echo "Warning: Unable to provide support for deprecated functions without '__attribute__((__symver__(x)))' or '__asm__(".symver foo, foo@VERS_1.0")'" | tee -a configure.log
+            SYMVER_PREFIX="#"
+        fi
+    fi
 else
-    echo "Checking for attribute(symver) ... No." | tee -a configure.log
-    echo "Warning: Unable to provide support for deprecated functions without '__attribute__((__symver__(x)))'" | tee -a configure.log
     SYMVER_PREFIX="#"
 fi
 
@@ -1109,8 +1137,9 @@ cat > $test.map <<EOF
 };
 EOF
 if test $shared -eq 1; then
-  sed < $SRCDIR/zlib${SUFFIX}.map.in "s/@ZLIB_SYMBOL_PREFIX@/$symbol_prefix/g" > zlib${SUFFIX}.map
-  sed < $SRCDIR/zlib${SUFFIX}.map.in "s/@COMMENT_IF_NO_SYMVER@/$SYMVER_PREFIX/g" > zlib${SUFFIX}.map
+  sed < $SRCDIR/zlib${SUFFIX}.map.in -e "s/@ZLIB_SYMBOL_PREFIX@/$symbol_prefix/g"   \
+                                     -e "s/@COMMENT_IF_NO_SYMVER@/$SYMVER_PREFIX/g" \
+      > zlib${SUFFIX}.map
   LDVERSIONSCRIPT="-Wl,--version-script,$BUILDDIR/$MAPNAME"
   if try $CC -c $SFLAGS $test.c && try $LDSHARED $LDVERSIONSCRIPT $LDSHAREDFLAGS $LDFLAGS -o $test$shared_ext $test.o $LDSHAREDLIBC; then
     echo "Checking for version script support... $LDVERSIONSCRIPT." | tee -a configure.log

--- a/configure
+++ b/configure
@@ -627,22 +627,6 @@ else
   esac
 fi
 
-# Symbol versioning
-case "$uname" in
-  CYGWIN* | Cygwin* | cygwin* | MINGW* | mingw* | MSYS* | msys* | Darwin* | darwin*)
-    echo "Checking for Symbol versioning... No."
-  ;;
-  *)
-    if test $shared -eq 1; then
-      echo "Checking for Symbol versioning... Yes."
-      CFLAGS="${CFLAGS} -DHAVE_SYMVER"
-      SFLAGS="${SFLAGS} -DHAVE_SYMVER"
-    else
-      echo "Checking for Symbol versioning... No."
-    fi
-  ;;
-esac
-
 # Simplify some later conditionals
 LINUX=0
 FREEBSD=0
@@ -777,30 +761,6 @@ if $cc $CFLAGS -Werror=unused-command-line-argument -c $test.c >> configure.log 
 else
   echo "Checking for -Werror=unused-command-line-argument... No." | tee -a configure.log
 fi
-
-# check for version script support
-cat > $test.c <<EOF
-int foo(void) { return 0; }
-EOF
-cat > $test.map <<EOF
-{
-  global:
-    foo;
-  local:
-    *;
-};
-EOF
-if test $shared -eq 1; then
-  sed < $SRCDIR/zlib${SUFFIX}.map.in "s/@ZLIB_SYMBOL_PREFIX@/$symbol_prefix/g" > zlib${SUFFIX}.map
-  LDVERSIONSCRIPT="-Wl,--version-script,$BUILDDIR/$MAPNAME"
-  if try $CC -c $SFLAGS $test.c && try $LDSHARED $LDVERSIONSCRIPT $LDSHAREDFLAGS $LDFLAGS -o $test$shared_ext $test.o $LDSHAREDLIBC; then
-    echo "Checking for version script support... $LDVERSIONSCRIPT." | tee -a configure.log
-  else
-    echo "Checking for version script support... No." | tee -a configure.log
-    LDVERSIONSCRIPT=""
-  fi
-fi
-echo >> configure.log
 
 # check for cpuid support: GNU extensions
 cat > $test.c <<EOF
@@ -1092,6 +1052,25 @@ else
     echo "Checking for attribute(aligned) ... No." | tee -a configure.log
 fi
 
+# Check for attribute(symver) support in compiler
+cat > $test.c << EOF
+void foo(void);
+__attribute__((__symver__("foo@VERS_1.0"))) void foo(void) {}
+int main(void) {
+    return 0;
+}
+EOF
+if try ${CC} ${CFLAGS} $test.c $LDSHAREDLIBC; then
+    echo "Checking for attribute(symver) ... Yes." | tee -a configure.log
+    CFLAGS="$CFLAGS -DHAVE_ATTRIBUTE_SYMVER"
+    SFLAGS="$SFLAGS -DHAVE_ATTRIBUTE_SYMVER"
+    SYMVER_PREFIX=""
+else
+    echo "Checking for attribute(symver) ... No." | tee -a configure.log
+    echo "Warning: Unable to provide support for deprecated functions without '__attribute__((__symver__(x)))'" | tee -a configure.log
+    SYMVER_PREFIX="#"
+fi
+
 # Check for __builtin_assume_aligned(x,n) support in compiler
 cat > $test.c << EOF
 char *test(char *buffer) {
@@ -1109,6 +1088,31 @@ if try ${CC} ${CFLAGS} $test.c $LDSHAREDLIBC; then
 else
     echo "Checking for __builtin_assume_aligned() ... No." | tee -a configure.log
 fi
+
+# check for version script support
+cat > $test.c <<EOF
+int foo(void) { return 0; }
+EOF
+cat > $test.map <<EOF
+{
+  global:
+    foo;
+  local:
+    *;
+};
+EOF
+if test $shared -eq 1; then
+  sed < $SRCDIR/zlib${SUFFIX}.map.in "s/@ZLIB_SYMBOL_PREFIX@/$symbol_prefix/g" > zlib${SUFFIX}.map
+  sed < $SRCDIR/zlib${SUFFIX}.map.in "s/@COMMENT_IF_NO_SYMVER@/$SYMVER_PREFIX/g" > zlib${SUFFIX}.map
+  LDVERSIONSCRIPT="-Wl,--version-script,$BUILDDIR/$MAPNAME"
+  if try $CC -c $SFLAGS $test.c && try $LDSHARED $LDVERSIONSCRIPT $LDSHAREDFLAGS $LDFLAGS -o $test$shared_ext $test.o $LDSHAREDLIBC; then
+    echo "Checking for version script support... $LDVERSIONSCRIPT." | tee -a configure.log
+  else
+    echo "Checking for version script support... No." | tee -a configure.log
+    LDVERSIONSCRIPT=""
+  fi
+fi
+echo >> configure.log
 
 check_avx2_intrinsics() {
     # Check whether compiler supports AVX2 intrinsics

--- a/configure
+++ b/configure
@@ -1052,22 +1052,50 @@ else
     echo "Checking for attribute(aligned) ... No." | tee -a configure.log
 fi
 
-# Check for attribute(symver) support in compiler
-cat > $test.c << EOF
+case "$uname" in
+    CYGWIN* | Cygwin* | cygwin* | MSYS* | msys* | MINGW* | mingw* | Darwin* | darwin* | AIX*)
+        with_symver=0 ;;
+    *)
+        with_symver=1 ;;
+esac
+if test $compat -eq 0 -a $with_symver -eq 1; then
+    # Check for attribute(symver) support in compiler
+    cat > $test.c << EOF
 void foo(void);
 __attribute__((__symver__("foo@VERS_1.0"))) void foo(void) {}
 int main(void) {
     return 0;
 }
 EOF
-if try ${CC} ${CFLAGS} $test.c $LDSHAREDLIBC; then
-    echo "Checking for attribute(symver) ... Yes." | tee -a configure.log
-    CFLAGS="$CFLAGS -DHAVE_ATTRIBUTE_SYMVER"
-    SFLAGS="$SFLAGS -DHAVE_ATTRIBUTE_SYMVER"
-    SYMVER_PREFIX=""
+    if try ${CC} ${CFLAGS} $test.c $LDSHAREDLIBC; then
+        echo "Checking for attribute(symver) ... Yes." | tee -a configure.log
+        CFLAGS="$CFLAGS -DHAVE_ATTRIBUTE_SYMVER"
+        SFLAGS="$SFLAGS -DHAVE_ATTRIBUTE_SYMVER"
+        SYMVER_PREFIX=""
+    else
+        echo "Checking for attribute(symver) ... No." | tee -a configure.log
+
+        # Check for asm .symver support in compiler
+        cat > $test.c << EOF
+void foo(void);
+__asm__(".symver foo, foo@VERS_1.0");
+void foo(void) {}
+int main(void) {
+    return 0;
+}
+EOF
+        if try ${CC} ${CFLAGS} $test.c $LDSHAREDLIBC; then
+            echo "Checking for asm .symver ... Yes." | tee -a configure.log
+            CFLAGS="$CFLAGS -DHAVE_ASM_SYMVER"
+            SFLAGS="$SFLAGS -DHAVE_ASM_SYMVER"
+        else
+            echo "Checking for asm .symver ... No." | tee -a configure.log
+
+            echo "Warning: Unable to provide support for deprecated functions without '__attribute__((__symver__(x)))' or '__asm__(".symver foo, foo@VERS_1.0")'" | tee -a configure.log
+            SYMVER_PREFIX="#"
+        fi
+    fi
 else
-    echo "Checking for attribute(symver) ... No." | tee -a configure.log
-    echo "Warning: Unable to provide support for deprecated functions without '__attribute__((__symver__(x)))'" | tee -a configure.log
     SYMVER_PREFIX="#"
 fi
 
@@ -1102,8 +1130,9 @@ cat > $test.map <<EOF
 };
 EOF
 if test $shared -eq 1; then
-  sed < $SRCDIR/zlib${SUFFIX}.map.in "s/@ZLIB_SYMBOL_PREFIX@/$symbol_prefix/g" > zlib${SUFFIX}.map
-  sed < $SRCDIR/zlib${SUFFIX}.map.in "s/@COMMENT_IF_NO_SYMVER@/$SYMVER_PREFIX/g" > zlib${SUFFIX}.map
+  sed < $SRCDIR/zlib${SUFFIX}.map.in -e "s/@ZLIB_SYMBOL_PREFIX@/$symbol_prefix/g"   \
+                                     -e "s/@COMMENT_IF_NO_SYMVER@/$SYMVER_PREFIX/g" \
+      > zlib${SUFFIX}.map
   LDVERSIONSCRIPT="-Wl,--version-script,$BUILDDIR/$MAPNAME"
   if try $CC -c $SFLAGS $test.c && try $LDSHARED $LDVERSIONSCRIPT $LDSHAREDFLAGS $LDFLAGS -o $test$shared_ext $test.o $LDSHAREDLIBC; then
     echo "Checking for version script support... $LDVERSIONSCRIPT." | tee -a configure.log

--- a/crc32.c
+++ b/crc32.c
@@ -13,7 +13,7 @@
 
 /* ========================================================================= */
 
-const uint32_t * Z_EXPORT PREFIX(get_crc_table)(void) {
+Z_EXPORT const uint32_t * PREFIX(get_crc_table)(void) {
     return (const uint32_t *)crc_table;
 }
 
@@ -26,28 +26,51 @@ Z_INTERNAL uint32_t crc32_small(uint32_t crc, const uint8_t *buf, size_t len) {
     return ~crc32_copy_small(~crc, NULL, buf, len, 32, 0);
 }
 
+
 #ifdef ZLIB_COMPAT
-unsigned long Z_EXPORT PREFIX(crc32_z)(unsigned long crc, const unsigned char *buf, size_t len) {
+Z_EXPORT unsigned long crc32_z(unsigned long crc, const unsigned char *buf, size_t len) {
     if (buf == NULL)
         return CRC32_INITIAL_VALUE;
     return (unsigned long)FUNCTABLE_CALL(crc32)((uint32_t)crc, buf, len);
 }
-#else
-uint32_t Z_EXPORT PREFIX(crc32_z)(uint32_t crc, const unsigned char *buf, size_t len) {
+Z_EXPORT unsigned long crc32(unsigned long crc, const unsigned char *buf, unsigned int len) {
+    if (buf == NULL)
+        return CRC32_INITIAL_VALUE;
+    return (unsigned long)FUNCTABLE_CALL(crc32)((uint32_t)crc, buf, len);
+}
+#endif
+
+#ifndef ZLIB_COMPAT
+#  if defined(HAVE_SYMVER)
+// Preferred function
+ZSYMVER_DEF(zng_crc32_sizet, zng_crc32, "ZLIB_NG_2.4.0")
+Z_EXPORT uint32_t zng_crc32_sizet(uint32_t crc, const unsigned char *buf, size_t len) {
     if (buf == NULL)
         return CRC32_INITIAL_VALUE;
     return FUNCTABLE_CALL(crc32)(crc, buf, len);
 }
-#endif
-
-#ifdef ZLIB_COMPAT
-unsigned long Z_EXPORT PREFIX(crc32)(unsigned long crc, const unsigned char *buf, unsigned int len) {
+// Deprecated function
+ZSYMVER(zng_crc32_uint32, zng_crc32, "ZLIB_NG_2.0.0")
+Z_EXPORT uint32_t zng_crc32_uint32(uint32_t crc, const unsigned char *buf, uint32_t len) {
     if (buf == NULL)
         return CRC32_INITIAL_VALUE;
-    return (unsigned long)FUNCTABLE_CALL(crc32)((uint32_t)crc, buf, len);
+    return FUNCTABLE_CALL(crc32)(crc, buf, len);
 }
-#else
-uint32_t Z_EXPORT PREFIX(crc32)(uint32_t crc, const unsigned char *buf, uint32_t len) {
+
+#  else
+// Fallback to preferred function
+Z_EXPORT uint32_t zng_crc32(uint32_t crc, const unsigned char *buf, size_t len) {
+    if (buf == NULL)
+        return CRC32_INITIAL_VALUE;
+    return FUNCTABLE_CALL(crc32)(crc, buf, len);
+}
+#  endif
+
+#    ifdef zng_crc32_z
+#      undef zng_crc32_z
+#    endif
+// Deprecated function
+Z_EXPORT uint32_t zng_crc32_z(uint32_t crc, const unsigned char *buf, size_t len) {
     if (buf == NULL)
         return CRC32_INITIAL_VALUE;
     return FUNCTABLE_CALL(crc32)(crc, buf, len);

--- a/zbuild.h
+++ b/zbuild.h
@@ -171,15 +171,22 @@
 #  define Z_INTERNAL
 #endif
 
+#define Z_STRING(s) #s
+
 /* Symbol versioning helpers, allowing multiple versions of a function to exist.
  * Functions using this must also be added to zlib-ng.map for each version.
  * Double @@ means this is the default for newly compiled applications to link against.
  * Single @ means this is kept for backwards compatibility.
  * This is only used for Zlib-ng native API, and only on platforms supporting this.
  */
-#if defined(HAVE_SYMVER)
-#  define ZSYMVER(func,alias,ver) __asm__(".symver " func ", " alias "@ZLIB_NG_" ver);
-#  define ZSYMVER_DEF(func,alias,ver) __asm__(".symver " func ", " alias "@@ZLIB_NG_" ver);
+#if defined(HAVE_ATTRIBUTE_SYMVER)
+#  define ZSYMVER(func,alias,ver) __attribute__((__symver__(Z_STRING(alias) "@" ver)))
+#  define ZSYMVER_DEF(func,alias,ver) __attribute__((__symver__(Z_STRING(alias) "@@" ver)))
+#  define HAVE_SYMVER
+#elif defined(HAVE_ASM_SYMVER)
+#  define ZSYMVER(func,alias,ver) __asm__(".symver " func ", " Z_STRING(alias) "@" ver);
+#  define ZSYMVER_DEF(func,alias,ver) __asm__(".symver " func ", " Z_STRING(alias) "@@" ver);
+#  define HAVE_SYMVER
 #else
 #  define ZSYMVER(func,alias,ver)
 #  define ZSYMVER_DEF(func,alias,ver)

--- a/zbuild.h
+++ b/zbuild.h
@@ -184,8 +184,8 @@
 #  define ZSYMVER_DEF(func,alias,ver) __attribute__((__symver__(Z_STRING(alias) "@@" ver)))
 #  define HAVE_SYMVER
 #elif defined(HAVE_ASM_SYMVER)
-#  define ZSYMVER(func,alias,ver) __asm__(".symver " func ", " Z_STRING(alias) "@" ver);
-#  define ZSYMVER_DEF(func,alias,ver) __asm__(".symver " func ", " Z_STRING(alias) "@@" ver);
+#  define ZSYMVER(func,alias,ver) __asm__(".symver " Z_STRING(func) ", " Z_STRING(alias) "@" ver);
+#  define ZSYMVER_DEF(func,alias,ver) __asm__(".symver " Z_STRING(func) ", " Z_STRING(alias) "@@" ver);
 #  define HAVE_SYMVER
 #else
 #  define ZSYMVER(func,alias,ver)

--- a/zlib-ng.h.in
+++ b/zlib-ng.h.in
@@ -1733,7 +1733,7 @@ void zng_gzclearerr(gzFile file);
 */
 
 Z_EXTERN Z_EXPORT
-uint32_t zng_adler32(uint32_t adler, const uint8_t *buf, uint32_t len);
+uint32_t zng_adler32(uint32_t adler, const uint8_t *buf, size_t len);
 /*
      Update a running Adler-32 checksum with the bytes buf[0..len-1] and
    return the updated checksum. An Adler-32 value is in the range of a 32-bit
@@ -1754,12 +1754,6 @@ uint32_t zng_adler32(uint32_t adler, const uint8_t *buf, uint32_t len);
 */
 
 Z_EXTERN Z_EXPORT
-uint32_t zng_adler32_z(uint32_t adler, const uint8_t *buf, size_t len);
-/*
-     Same as adler32(), but with a size_t length.
-*/
-
-Z_EXTERN Z_EXPORT
 uint32_t zng_adler32_combine(uint32_t adler1, uint32_t adler2, z_off64_t len2);
 /*
      Combine two Adler-32 checksums into one.  For two sequences of bytes, seq1
@@ -1771,7 +1765,7 @@ uint32_t zng_adler32_combine(uint32_t adler1, uint32_t adler2, z_off64_t len2);
 */
 
 Z_EXTERN Z_EXPORT
-uint32_t zng_crc32(uint32_t crc, const uint8_t *buf, uint32_t len);
+uint32_t zng_crc32(uint32_t crc, const uint8_t *buf, size_t len);
 /*
      Update a running CRC-32 with the bytes buf[0..len-1] and return the
    updated CRC-32. A CRC-32 value is in the range of a 32-bit unsigned integer.
@@ -1787,12 +1781,6 @@ uint32_t zng_crc32(uint32_t crc, const uint8_t *buf, uint32_t len);
        crc = crc32(crc, buffer, length);
      }
      if (crc != original_crc) error();
-*/
-
-Z_EXTERN Z_EXPORT
-uint32_t zng_crc32_z(uint32_t crc, const uint8_t *buf, size_t len);
-/*
-     Same as crc32(), but with a size_t length.
 */
 
 Z_EXTERN Z_EXPORT
@@ -1907,6 +1895,10 @@ Z_EXTERN Z_EXPORT int32_t          zng_deflateResetKeep (zng_stream *);
 #  endif
 Z_EXTERN Z_EXPORTVA int32_t zng_gzvprintf(gzFile file, const char *format, va_list va);
 #endif
+
+/* Aliases for backwards compatibility */
+#define zng_crc32_z @ZLIB_SYMBOL_PREFIX@zng_crc32
+#define zng_adler32_z @ZLIB_SYMBOL_PREFIX@zng_adler32
 
 #ifdef __cplusplus
 }

--- a/zlib-ng.h.in
+++ b/zlib-ng.h.in
@@ -1695,7 +1695,7 @@ void zng_gzclearerr(gzFile file);
 */
 
 Z_EXTERN Z_EXPORT
-uint32_t zng_adler32(uint32_t adler, const uint8_t *buf, uint32_t len);
+uint32_t zng_adler32(uint32_t adler, const uint8_t *buf, size_t len);
 /*
      Update a running Adler-32 checksum with the bytes buf[0..len-1] and
    return the updated checksum. An Adler-32 value is in the range of a 32-bit
@@ -1716,12 +1716,6 @@ uint32_t zng_adler32(uint32_t adler, const uint8_t *buf, uint32_t len);
 */
 
 Z_EXTERN Z_EXPORT
-uint32_t zng_adler32_z(uint32_t adler, const uint8_t *buf, size_t len);
-/*
-     Same as adler32(), but with a size_t length.
-*/
-
-Z_EXTERN Z_EXPORT
 uint32_t zng_adler32_combine(uint32_t adler1, uint32_t adler2, z_off64_t len2);
 /*
      Combine two Adler-32 checksums into one.  For two sequences of bytes, seq1
@@ -1733,7 +1727,7 @@ uint32_t zng_adler32_combine(uint32_t adler1, uint32_t adler2, z_off64_t len2);
 */
 
 Z_EXTERN Z_EXPORT
-uint32_t zng_crc32(uint32_t crc, const uint8_t *buf, uint32_t len);
+uint32_t zng_crc32(uint32_t crc, const uint8_t *buf, size_t len);
 /*
      Update a running CRC-32 with the bytes buf[0..len-1] and return the
    updated CRC-32. A CRC-32 value is in the range of a 32-bit unsigned integer.
@@ -1749,12 +1743,6 @@ uint32_t zng_crc32(uint32_t crc, const uint8_t *buf, uint32_t len);
        crc = crc32(crc, buffer, length);
      }
      if (crc != original_crc) error();
-*/
-
-Z_EXTERN Z_EXPORT
-uint32_t zng_crc32_z(uint32_t crc, const uint8_t *buf, size_t len);
-/*
-     Same as crc32(), but with a size_t length.
 */
 
 Z_EXTERN Z_EXPORT
@@ -1869,6 +1857,10 @@ Z_EXTERN Z_EXPORT int32_t          zng_deflateResetKeep (zng_stream *);
 #  endif
 Z_EXTERN Z_EXPORTVA int32_t zng_gzvprintf(gzFile file, const char *format, va_list va);
 #endif
+
+/* Aliases for backwards compatibility */
+#define zng_crc32_z @ZLIB_SYMBOL_PREFIX@zng_crc32
+#define zng_adler32_z @ZLIB_SYMBOL_PREFIX@zng_adler32
 
 #ifdef __cplusplus
 }

--- a/zlib-ng.map.in
+++ b/zlib-ng.map.in
@@ -1,6 +1,8 @@
 ZLIB_NG_2.4.0 {
   global:
+    @ZLIB_SYMBOL_PREFIX@zng_adler32;
     @ZLIB_SYMBOL_PREFIX@zng_deflateUsed;
+    @ZLIB_SYMBOL_PREFIX@zng_crc32;
 };
 
 ZLIB_NG_2.1.0 {
@@ -15,13 +17,13 @@ ZLIB_NG_2.1.0 {
 
 ZLIB_NG_2.0.0 {
   global:
-    @ZLIB_SYMBOL_PREFIX@zng_adler32;
+    @COMMENT_IF_NO_SYMVER@@ZLIB_SYMBOL_PREFIX@zng_adler32;
     @ZLIB_SYMBOL_PREFIX@zng_adler32_combine;
     @ZLIB_SYMBOL_PREFIX@zng_adler32_z;
     @ZLIB_SYMBOL_PREFIX@zng_compress;
     @ZLIB_SYMBOL_PREFIX@zng_compress2;
     @ZLIB_SYMBOL_PREFIX@zng_compressBound;
-    @ZLIB_SYMBOL_PREFIX@zng_crc32;
+    @COMMENT_IF_NO_SYMVER@@ZLIB_SYMBOL_PREFIX@zng_crc32;
     @ZLIB_SYMBOL_PREFIX@zng_crc32_combine;
     @ZLIB_SYMBOL_PREFIX@zng_crc32_combine_gen;
     @ZLIB_SYMBOL_PREFIX@zng_crc32_combine_op;

--- a/zlib-ng.map.in
+++ b/zlib-ng.map.in
@@ -1,3 +1,9 @@
+ZLIB_NG_2.4.0 {
+  global:
+    @ZLIB_SYMBOL_PREFIX@zng_adler32;
+    @ZLIB_SYMBOL_PREFIX@zng_crc32;
+};
+
 ZLIB_NG_2.1.0 {
   global:
     @ZLIB_SYMBOL_PREFIX@zng_deflateInit;
@@ -10,13 +16,13 @@ ZLIB_NG_2.1.0 {
 
 ZLIB_NG_2.0.0 {
   global:
-    @ZLIB_SYMBOL_PREFIX@zng_adler32;
+    @COMMENT_IF_NO_SYMVER@@ZLIB_SYMBOL_PREFIX@zng_adler32;
     @ZLIB_SYMBOL_PREFIX@zng_adler32_combine;
     @ZLIB_SYMBOL_PREFIX@zng_adler32_z;
     @ZLIB_SYMBOL_PREFIX@zng_compress;
     @ZLIB_SYMBOL_PREFIX@zng_compress2;
     @ZLIB_SYMBOL_PREFIX@zng_compressBound;
-    @ZLIB_SYMBOL_PREFIX@zng_crc32;
+    @COMMENT_IF_NO_SYMVER@@ZLIB_SYMBOL_PREFIX@zng_crc32;
     @ZLIB_SYMBOL_PREFIX@zng_crc32_combine;
     @ZLIB_SYMBOL_PREFIX@zng_crc32_combine_gen;
     @ZLIB_SYMBOL_PREFIX@zng_crc32_combine_op;

--- a/zlib_name_mangling-ng.h.in
+++ b/zlib_name_mangling-ng.h.in
@@ -17,7 +17,6 @@
 #define zng_adler32               @ZLIB_SYMBOL_PREFIX@zng_adler32
 #define zng_adler32_combine       @ZLIB_SYMBOL_PREFIX@zng_adler32_combine
 #define zng_adler32_combine64     @ZLIB_SYMBOL_PREFIX@zng_adler32_combine64
-#define zng_adler32_z             @ZLIB_SYMBOL_PREFIX@zng_adler32_z
 #define zng_compress              @ZLIB_SYMBOL_PREFIX@zng_compress
 #define zng_compress2             @ZLIB_SYMBOL_PREFIX@zng_compress2
 #define zng_compressBound         @ZLIB_SYMBOL_PREFIX@zng_compressBound
@@ -27,7 +26,6 @@
 #define zng_crc32_combine_gen     @ZLIB_SYMBOL_PREFIX@zng_crc32_combine_gen
 #define zng_crc32_combine_gen64   @ZLIB_SYMBOL_PREFIX@zng_crc32_combine_gen64
 #define zng_crc32_combine_op      @ZLIB_SYMBOL_PREFIX@zng_crc32_combine_op
-#define zng_crc32_z               @ZLIB_SYMBOL_PREFIX@zng_crc32_z
 #define zng_deflate               @ZLIB_SYMBOL_PREFIX@zng_deflate
 #define zng_deflateBound          @ZLIB_SYMBOL_PREFIX@zng_deflateBound
 #define zng_deflateCopy           @ZLIB_SYMBOL_PREFIX@zng_deflateCopy


### PR DESCRIPTION
Native API changes: Remove adler32_z and crc32_z.
Promote adler32 and crc32 to use size_t len.
Add Symver to provide old functions to temporarily remain ABI compatible with older zlib-ng versions.

The library will remain ABI backwards compatible only if compiled with symver, for compilers/platforms without symver there will be no backwards compatibility and they will have to use 2.3.x zlib-ng library or recompile the application with 2.4.x.