### PR TITLE
Move LFS64 detection to preprocessor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -491,23 +491,6 @@ if(HAVE_ASM_HWPROBE_H)
 endif()
 
 #
-# Check to see if we have large file support
-#
-set(CMAKE_REQUIRED_DEFINITIONS -D_LARGEFILE64_SOURCE=1 -D__USE_LARGEFILE64)
-check_type_size(off64_t OFF64_T)
-if(HAVE_OFF64_T)
-    add_definitions(-D_LARGEFILE64_SOURCE=1 -D__USE_LARGEFILE64)
-else()
-    check_type_size(_off64_t _OFF64_T)
-    if(HAVE__OFF64_T)
-        add_definitions(-D_LARGEFILE64_SOURCE=1 -D__USE_LARGEFILE64)
-    else()
-        check_type_size(__off64_t __OFF64_T)
-    endif()
-endif()
-set(CMAKE_REQUIRED_DEFINITIONS) # clear variable
-
-#
 # Check for fseeko and other optional functions
 #
 set(CMAKE_REQUIRED_FLAGS "${ADDITIONAL_CHECK_FLAGS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -491,15 +491,8 @@ if(HAVE_ASM_HWPROBE_H)
 endif()
 
 #
-# Check for fseeko and other optional functions
+# Check for strerror
 #
-set(CMAKE_REQUIRED_FLAGS "${ADDITIONAL_CHECK_FLAGS}")
-check_function_exists(fseeko HAVE_FSEEKO)
-if(NOT HAVE_FSEEKO)
-    add_definitions(-DNO_FSEEKO)
-endif()
-set(CMAKE_REQUIRED_FLAGS)
-
 set(CMAKE_REQUIRED_FLAGS "${ADDITIONAL_CHECK_FLAGS}")
 check_function_exists(strerror HAVE_STRERROR)
 if(NOT HAVE_STRERROR)

--- a/configure
+++ b/configure
@@ -792,46 +792,20 @@ if test $shared -eq 1; then
 fi
 echo >> configure.log
 
-# check for large file support, and if none, check for fseeko()
+# check for fseeko()
 cat > $test.c <<EOF
-#include <sys/types.h>
-off64_t dummy = 0;
-EOF
-if try $CC -c $CFLAGS -D_LARGEFILE64_SOURCE=1 $test.c; then
-  CFLAGS="${CFLAGS} -D_LARGEFILE64_SOURCE=1"
-  SFLAGS="${SFLAGS} -D_LARGEFILE64_SOURCE=1"
-  echo "Checking for off64_t... Yes." | tee -a configure.log
-  echo "Checking for fseeko... Yes." | tee -a configure.log
-else
-  echo "Checking for off64_t... No." | tee -a configure.log
-  echo >> configure.log
-  cat > $test.c <<EOF
-#include <sys/types.h>
-int main() {
-  _off64_t dummy = 0;
-  return 0;
-}
-EOF
-  if try $CC $CFLAGS -o $test $test.c $LDSHAREDLIBC; then
-    echo "Checking for _off64_t... Yes." | tee -a configure.log
-  else
-    echo "Checking for _off64_t... No." | tee -a configure.log
-  fi
-  echo >> configure.log
-  cat > $test.c <<EOF
 #include <stdio.h>
 int main(void) {
   fseeko(NULL, 0, 0);
   return 0;
 }
 EOF
-  if try $CC $CFLAGS $ADDITIONAL_CHECK_FLAGS -o $test $test.c $LDSHAREDLIBC; then
-    echo "Checking for fseeko... Yes." | tee -a configure.log
-  else
-    CFLAGS="${CFLAGS} -DNO_FSEEKO"
-    SFLAGS="${SFLAGS} -DNO_FSEEKO"
-    echo "Checking for fseeko... No." | tee -a configure.log
-  fi
+if try $CC $CFLAGS $ADDITIONAL_CHECK_FLAGS -o $test $test.c $LDSHAREDLIBC; then
+  echo "Checking for fseeko... Yes." | tee -a configure.log
+else
+  CFLAGS="${CFLAGS} -DNO_FSEEKO"
+  SFLAGS="${SFLAGS} -DNO_FSEEKO"
+  echo "Checking for fseeko... No." | tee -a configure.log
 fi
 echo >> configure.log
 

--- a/configure
+++ b/configure
@@ -792,23 +792,6 @@ if test $shared -eq 1; then
 fi
 echo >> configure.log
 
-# check for fseeko()
-cat > $test.c <<EOF
-#include <stdio.h>
-int main(void) {
-  fseeko(NULL, 0, 0);
-  return 0;
-}
-EOF
-if try $CC $CFLAGS $ADDITIONAL_CHECK_FLAGS -o $test $test.c $LDSHAREDLIBC; then
-  echo "Checking for fseeko... Yes." | tee -a configure.log
-else
-  CFLAGS="${CFLAGS} -DNO_FSEEKO"
-  SFLAGS="${SFLAGS} -DNO_FSEEKO"
-  echo "Checking for fseeko... No." | tee -a configure.log
-fi
-echo >> configure.log
-
 # check for cpuid support: GNU extensions
 cat > $test.c <<EOF
 #include <cpuid.h>

--- a/gzguts.h
+++ b/gzguts.h
@@ -5,14 +5,6 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-#ifdef _LARGEFILE64_SOURCE
-#  ifndef _LARGEFILE_SOURCE
-#    define _LARGEFILE_SOURCE 1
-#  endif
-#  undef _FILE_OFFSET_BITS
-#  undef _TIME_BITS
-#endif
-
 #if defined(HAVE_VISIBILITY_INTERNAL)
 #  define Z_INTERNAL __attribute__((visibility ("internal")))
 #elif defined(HAVE_VISIBILITY_HIDDEN)

--- a/test/fuzz/fuzzer_checksum.c
+++ b/test/fuzz/fuzzer_checksum.c
@@ -1,7 +1,5 @@
-#include <stdio.h>
-#include <assert.h>
-
 #include "zbuild.h"
+#include <assert.h>
 #ifdef ZLIB_COMPAT
 #  include "zlib.h"
 #else

--- a/test/fuzz/fuzzer_compress.c
+++ b/test/fuzz/fuzzer_compress.c
@@ -1,7 +1,5 @@
-#include <stdio.h>
-#include <assert.h>
-
 #include "zbuild.h"
+#include <assert.h>
 #ifdef ZLIB_COMPAT
 #  include "zlib.h"
 #else

--- a/test/fuzz/fuzzer_example_dict.c
+++ b/test/fuzz/fuzzer_example_dict.c
@@ -1,7 +1,5 @@
-#include <stdio.h>
-#include <assert.h>
-
 #include "zbuild.h"
+#include <assert.h>
 #ifdef ZLIB_COMPAT
 #  include "zlib.h"
 #else

--- a/test/fuzz/fuzzer_example_flush.c
+++ b/test/fuzz/fuzzer_example_flush.c
@@ -1,7 +1,5 @@
-#include <stdio.h>
-#include <assert.h>
-
 #include "zbuild.h"
+#include <assert.h>
 #ifdef ZLIB_COMPAT
 #  include "zlib.h"
 #else

--- a/test/fuzz/fuzzer_example_large.c
+++ b/test/fuzz/fuzzer_example_large.c
@@ -1,8 +1,6 @@
-#include <stdio.h>
+#include "zbuild.h"
 #include <assert.h>
 #include <inttypes.h>
-
-#include "zbuild.h"
 #ifdef ZLIB_COMPAT
 #  include "zlib.h"
 #else

--- a/test/fuzz/fuzzer_example_small.c
+++ b/test/fuzz/fuzzer_example_small.c
@@ -1,7 +1,5 @@
-#include <stdio.h>
-#include <assert.h>
-
 #include "zbuild.h"
+#include <assert.h>
 #ifdef ZLIB_COMPAT
 #  include "zlib.h"
 #else

--- a/test/fuzz/fuzzer_minigzip.c
+++ b/test/fuzz/fuzzer_minigzip.c
@@ -39,12 +39,6 @@
 #  define snprintf _snprintf
 #endif
 
-#if !defined(Z_HAVE_UNISTD_H) && !defined(_LARGEFILE64_SOURCE)
-#ifndef _WIN32 /* unlink already in stdio.h for Win32 */
-extern int unlink (const char *);
-#endif
-#endif
-
 #ifndef GZ_SUFFIX
 #  define GZ_SUFFIX ".gz"
 #endif

--- a/test/fuzz/standalone_fuzz_target_runner.c
+++ b/test/fuzz/standalone_fuzz_target_runner.c
@@ -1,7 +1,5 @@
-#include <assert.h>
-#include <stdio.h>
-
 #include "zbuild.h"
+#include <assert.h>
 
 extern int LLVMFuzzerTestOneInput(const unsigned char *data, size_t size);
 

--- a/test/gh1235.c
+++ b/test/gh1235.c
@@ -1,6 +1,5 @@
+#include "zbuild.h"
 #include <assert.h>
-#include <stdio.h>
-#include <string.h>
 #include "zutil.h"
 
 int main(void) {

--- a/test/infcover.c
+++ b/test/infcover.c
@@ -5,17 +5,13 @@
 
 /* to use, do: ./configure --cover && make cover */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#undef NDEBUG
-#include <assert.h>
-#include <inttypes.h>
-
 /* get definition of internal structure so we can mess with it (see pull()),
    and so we can call inflate_trees() (see cover5()) */
 #include "zbuild.h"
 #include "zutil.h"
+#undef NDEBUG
+#include <assert.h>
+#include <inttypes.h>
 #include "inftrees.h"
 #include "inflate.h"
 

--- a/test/minigzip.c
+++ b/test/minigzip.c
@@ -41,12 +41,6 @@
 #  define snprintf _snprintf
 #endif
 
-#if !defined(Z_HAVE_UNISTD_H) && !defined(_LARGEFILE64_SOURCE)
-#ifndef _WIN32 /* unlink already in stdio.h for Win32 */
-extern int unlink (const char *);
-#endif
-#endif
-
 #ifndef GZ_SUFFIX
 #  define GZ_SUFFIX ".gz"
 #endif

--- a/test/test_cve-2003-0107.cc
+++ b/test/test_cve-2003-0107.cc
@@ -1,9 +1,6 @@
 // https://www.securityfocus.com/archive/1/312869 --- originally by Richard Kettlewell
-#include <stdlib.h>
-#include <errno.h>
-#include <stdio.h>
-
 #include "zbuild.h"
+#include <errno.h>
 #ifdef ZLIB_COMPAT
 #  include "zlib.h"
 #else

--- a/tools/makecrct.c
+++ b/tools/makecrct.c
@@ -3,9 +3,8 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
 */
 
-#include <stdio.h>
-#include <inttypes.h>
 #include "zbuild.h"
+#include <inttypes.h>
 #include "zutil.h"
 
 /*

--- a/tools/makefixed.c
+++ b/tools/makefixed.c
@@ -1,4 +1,3 @@
-#include <stdio.h>
 #include "zbuild.h"
 #include "zutil.h"
 #include "inftrees.h"

--- a/tools/maketrees.c
+++ b/tools/maketrees.c
@@ -3,7 +3,6 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-#include <stdio.h>
 #include "zbuild.h"
 #include "deflate.h"
 #include "deflate_p.h"

--- a/zbuild.h
+++ b/zbuild.h
@@ -11,6 +11,9 @@
 #ifdef __OpenBSD__
 #  define _BSD_SOURCE 1
 #endif
+#ifndef _LARGEFILE64_SOURCE
+#  define _LARGEFILE64_SOURCE 1 /* request off64_t, lseek64 on glibc; check _LFS64_LARGEFILE */
+#endif
 
 #include <stddef.h>
 #include <string.h>


### PR DESCRIPTION
Replace the CMake `check_type_size(off64_t OFF64_T)` probe (plus `_off64_t` / `__off64_t` follow-ups) with an unconditional `#define _LARGEFILE64_SOURCE 1` in `zbuild.h`. The real gating already lives in `zconf.h.in` via `_LFS64_LARGEFILE`, which glibc/musl set in `<unistd.h>` when LFS64 is supported, and the `HAVE_OFF64_T*` results were never consumed.

Avoiding `try_compile` here sidesteps a class of CMake bundle-generator bugs that misreport the test binary path on iOS, Android NDK, and other multi-arch SDK builds. Fixes #2002.

Bundled dead-code removals exposed by the move: `NO_FSEEKO` detection (zlib-ng calls `lseek*` directly), `gzguts.h` feature-macro juggling (only meaningful when `_LARGEFILE64_SOURCE` was conditional), and a redundant `unlink` forward declaration in the minigzip tests.