### PR TITLE
Add branch prediction hints to deflate strategy hot loops

### DIFF
--- a/deflate_fast.c
+++ b/deflate_fast.c
@@ -31,7 +31,7 @@ Z_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
          * for the next match, plus WANT_MIN_MATCH bytes to insert the
          * string following the next match.
          */
-        if (s->lookahead < MIN_LOOKAHEAD) {
+        if (UNLIKELY(s->lookahead < MIN_LOOKAHEAD)) {
             PREFIX(fill_window)(s);
             if (UNLIKELY(s->lookahead < MIN_LOOKAHEAD && flush == Z_NO_FLUSH)) {
                 return need_more;
@@ -43,7 +43,7 @@ Z_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
         /* Insert the string window[strstart .. strstart+2] in the
          * dictionary, and set hash_head to the head of the hash chain:
          */
-        if (s->lookahead >= WANT_MIN_MATCH) {
+        if (LIKELY(s->lookahead >= WANT_MIN_MATCH)) {
             uint32_t str_val = Z_U32_FROM_LE(zng_memread_4(window + s->strstart));
             uint32_t hash_head = quick_insert_value(s, s->strstart, str_val);
             int64_t dist = (int64_t)s->strstart - hash_head;

--- a/deflate_huff.c
+++ b/deflate_huff.c
@@ -19,9 +19,9 @@ Z_INTERNAL block_state deflate_huff(deflate_state *s, int flush) {
 
     for (;;) {
         /* Make sure that we have a literal to write. */
-        if (s->lookahead == 0) {
+        if (UNLIKELY(s->lookahead == 0)) {
             PREFIX(fill_window)(s);
-            if (s->lookahead == 0) {
+            if (UNLIKELY(s->lookahead == 0)) {
                 if (flush == Z_NO_FLUSH)
                     return need_more;
                 break;      /* flush the current block */

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -193,9 +193,9 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
          * for the next match, plus WANT_MIN_MATCH bytes to insert the
          * string following the next current_match.
          */
-        if (s->lookahead < MIN_LOOKAHEAD) {
+        if (UNLIKELY(s->lookahead < MIN_LOOKAHEAD)) {
             PREFIX(fill_window)(s);
-            if (s->lookahead < MIN_LOOKAHEAD && flush == Z_NO_FLUSH) {
+            if (UNLIKELY(s->lookahead < MIN_LOOKAHEAD && flush == Z_NO_FLUSH)) {
                 return need_more;
             }
             if (UNLIKELY(s->lookahead == 0))
@@ -213,7 +213,7 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
             next_match.match_length = 0;
         } else {
             hash_head = 0;
-            if (s->lookahead >= WANT_MIN_MATCH) {
+            if (LIKELY(s->lookahead >= WANT_MIN_MATCH)) {
                 hash_head = quick_insert_string(s, window, s->strstart);
             }
 

--- a/deflate_rle.c
+++ b/deflate_rle.c
@@ -32,16 +32,16 @@ Z_INTERNAL block_state deflate_rle(deflate_state *s, int flush) {
          * at the end of the input file. We need STD_MAX_MATCH bytes
          * for the longest run, plus one for the unrolled loop.
          */
-        if (s->lookahead <= STD_MAX_MATCH) {
+        if (UNLIKELY(s->lookahead <= STD_MAX_MATCH)) {
             PREFIX(fill_window)(s);
-            if (s->lookahead <= STD_MAX_MATCH && flush == Z_NO_FLUSH)
+            if (UNLIKELY(s->lookahead <= STD_MAX_MATCH && flush == Z_NO_FLUSH))
                 return need_more;
-            if (s->lookahead == 0)
+            if (UNLIKELY(s->lookahead == 0))
                 break; /* flush the current block */
         }
 
         /* See how many times the previous byte repeats */
-        if (s->lookahead >= STD_MIN_MATCH && s->strstart > 0) {
+        if (LIKELY(s->lookahead >= STD_MIN_MATCH && s->strstart > 0)) {
             scan = window + s->strstart - 1;
             if (scan[0] == scan[1] && scan[1] == scan[2]) {
                 match_len = compare256_rle(scan, scan+3)+2;

--- a/deflate_slow.c
+++ b/deflate_slow.c
@@ -37,7 +37,7 @@ Z_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
          * for the next match, plus WANT_MIN_MATCH bytes to insert the
          * string following the next match.
          */
-        if (s->lookahead < MIN_LOOKAHEAD) {
+        if (UNLIKELY(s->lookahead < MIN_LOOKAHEAD)) {
             PREFIX(fill_window)(s);
             if (UNLIKELY(s->lookahead < MIN_LOOKAHEAD && flush == Z_NO_FLUSH)) {
                 return need_more;


### PR DESCRIPTION
The deflate strategies are inconsistent about branch-prediction hints on their per-iteration lookahead checks. `deflate_quick` marks both the window-refill path `UNLIKELY` and the steady-state path `LIKELY`; `deflate_slow` marks only the steady-state path; `deflate_fast` and `deflate_medium` mark neither, leaving the compiler to guess each inner loop's hot/cold block placement.

This propagates `deflate_quick`'s convention to the other strategies: the window-refill and end-of-input paths are marked `UNLIKELY` and the steady-state path `LIKELY` in `deflate_fast`, `deflate_slow`, `deflate_medium`, `deflate_rle`, and `deflate_huff`, so the rarely-taken refill block stays off the hot fall-through path. No logic changes; compression output is bit-identical.

## Why

- Consistency: all strategies now follow the same hinting convention as `deflate_quick` ([refill `UNLIKELY`](https://github.com/zlib-ng/zlib-ng/blob/ad1c6d542403a78faf10110ac497e02846c75098/deflate_quick.c#L76), [steady-state `LIKELY`](https://github.com/zlib-ng/zlib-ng/blob/ad1c6d542403a78faf10110ac497e02846c75098/deflate_quick.c#L91), pinned to `develop` @ `ad1c6d5`).
- Determinism: the hot loop's block placement no longer depends on the compiler guessing branch direction, which this work found to be a real source of run-to-run codegen/layout variance.

## Benchmarks (Apple Silicon, levels at 1 MiB unless noted)

Measured with a stabilized harness (sanity-gated, low-CV) and confirmed across two independent runs:

| strategy | Δ time | confidence |
|---|---|---|
| deflate_rle | ~ -11% | reproduced both runs |
| deflate_fast (level 3) | ~ -8% (-3 to -6% at 128 KiB) | reproduced both runs |
| deflate_quick / medium / filtered | flat (within ~±1.5% noise) | unchanged-code `quick` is the control |
| deflate_huff / deflate_slow | inconclusive | later/longer benchmarks were thermally contaminated on the test host; no regression observed, no gain claimed |

Compression ratios are unchanged across all levels and strategies, and the deflate/compress/dictionary/rle/huffman test suites pass with `-D WITH_MAINTAINER_WARNINGS=ON`. Independent benchmarks on other platforms (and clean numbers for huffman/slow) are very welcome.