### PR TITLE
build: add missing versioned symbols

### DIFF
--- a/zlib.map.in
+++ b/zlib.map.in
@@ -1,3 +1,48 @@
+ZLIB_1.1.4 {
+  global:
+    @ZLIB_SYMBOL_PREFIX@adler32;
+    @ZLIB_SYMBOL_PREFIX@compress2;
+    @ZLIB_SYMBOL_PREFIX@compress;
+    @ZLIB_SYMBOL_PREFIX@crc32;
+    @ZLIB_SYMBOL_PREFIX@deflate;
+    @ZLIB_SYMBOL_PREFIX@deflateCopy;
+    @ZLIB_SYMBOL_PREFIX@deflateEnd;
+    @ZLIB_SYMBOL_PREFIX@deflateInit2_;
+    @ZLIB_SYMBOL_PREFIX@deflateInit_;
+    @ZLIB_SYMBOL_PREFIX@deflateParams;
+    @ZLIB_SYMBOL_PREFIX@deflateReset;
+    @ZLIB_SYMBOL_PREFIX@deflateSetDictionary;
+    @ZLIB_SYMBOL_PREFIX@get_crc_table;
+    @ZLIB_SYMBOL_PREFIX@gzclose;
+    @ZLIB_SYMBOL_PREFIX@gzdopen;
+    @ZLIB_SYMBOL_PREFIX@gzeof;
+    @ZLIB_SYMBOL_PREFIX@gzerror;
+    @ZLIB_SYMBOL_PREFIX@gzflush;
+    @ZLIB_SYMBOL_PREFIX@gzgetc;
+    @ZLIB_SYMBOL_PREFIX@gzgets;
+    @ZLIB_SYMBOL_PREFIX@gzopen;
+    @ZLIB_SYMBOL_PREFIX@gzprintf;
+    @ZLIB_SYMBOL_PREFIX@gzputc;
+    @ZLIB_SYMBOL_PREFIX@gzputs;
+    @ZLIB_SYMBOL_PREFIX@gzread;
+    @ZLIB_SYMBOL_PREFIX@gzrewind;
+    @ZLIB_SYMBOL_PREFIX@gzseek;
+    @ZLIB_SYMBOL_PREFIX@gzsetparams;
+    @ZLIB_SYMBOL_PREFIX@gztell;
+    @ZLIB_SYMBOL_PREFIX@gzwrite;
+    @ZLIB_SYMBOL_PREFIX@inflate;
+    @ZLIB_SYMBOL_PREFIX@inflateEnd;
+    @ZLIB_SYMBOL_PREFIX@inflateInit2_;
+    @ZLIB_SYMBOL_PREFIX@inflateInit_;
+    @ZLIB_SYMBOL_PREFIX@inflateReset;
+    @ZLIB_SYMBOL_PREFIX@inflateSetDictionary;
+    @ZLIB_SYMBOL_PREFIX@inflateSync;
+    @ZLIB_SYMBOL_PREFIX@inflateSyncPoint;
+    @ZLIB_SYMBOL_PREFIX@uncompress;
+    @ZLIB_SYMBOL_PREFIX@zError;
+    @ZLIB_SYMBOL_PREFIX@zlibVersion;
+};
+
 ZLIB_1.2.0 {
   global:
     @ZLIB_SYMBOL_PREFIX@compressBound;
@@ -15,7 +60,7 @@ ZLIB_1.2.0 {
     @ZLIB_SYMBOL_PREFIX@gz_error;
     @ZLIB_SYMBOL_PREFIX@gz_intmax;
     _*;
-};
+} ZLIB_1.1.4;
 
 ZLIB_1.2.0.2 {
     @ZLIB_SYMBOL_PREFIX@gzclearerr;


### PR DESCRIPTION
Symbols added to the map in this commit were present in 1.1.4 and are not versioned in the current release.