### PR TITLE
Show --benchmark_cooldown in benchmark_zlib --help output

### DIFF
--- a/test/benchmarks/benchmark_main.cc
+++ b/test/benchmarks/benchmark_main.cc
@@ -82,7 +82,10 @@ int main(int argc, char** argv) {
         }
     }
 
-    ::benchmark::Initialize(&argc, argv);
+    ::benchmark::Initialize(&argc, argv, []() {
+        ::benchmark::PrintDefaultHelp();
+        printf("          [--benchmark_cooldown=<seconds>]\n");
+    });
 
     if (cooldown_secs > 0) {
         benchmark::BenchmarkReporter *display = benchmark::CreateDefaultDisplayReporter();


### PR DESCRIPTION
## Summary
- Use the custom help printer callback in `benchmark::Initialize` to append the `--benchmark_cooldown` flag to the standard help text.