### PR TITLE
Enable -Werror with GCC, Clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,6 +280,9 @@ elseif(CMAKE_C_COMPILER_ID MATCHES "GNU" OR CMAKE_C_COMPILER_ID MATCHES "Clang" 
     # Enable warnings in GCC and Clang
     set(WARNFLAGS -Wall)
     set(WARNFLAGS_MAINTAINER -Wextra)
+    if(CMAKE_C_COMPILER_ID MATCHES "GNU" OR CMAKE_C_COMPILER_ID MATCHES "Clang")
+        set(WARNFLAGS_MAINTAINER ${WARNFLAGS_MAINTAINER} -Werror)
+    endif()
     set(WARNFLAGS_DISABLE)
     # Check whether -fno-lto is available
     set(CMAKE_REQUIRED_FLAGS "-fno-lto")

--- a/arch/riscv/crc32_zbc.c
+++ b/arch/riscv/crc32_zbc.c
@@ -35,6 +35,7 @@ Z_FORCEINLINE static uint32_t crc32_clmul_impl(uint64_t crc, const unsigned char
     const uint64_t *buf64 = (const uint64_t *)buf;
     uint64_t low = buf64[0] ^ crc;
     uint64_t high = buf64[1];
+    uint64_t fold_t3, fold_t2, combined, reduced_low, barrett, final;
 
     if (len < 16)
         goto finish_fold;
@@ -61,19 +62,19 @@ Z_FORCEINLINE static uint32_t crc32_clmul_impl(uint64_t crc, const unsigned char
 
 finish_fold:
     // Fold the 128-bit result into 64 bits
-    uint64_t fold_t3 = clmulh(low, CONSTANT_R4);
-    uint64_t fold_t2 = clmul(low, CONSTANT_R4);
+    fold_t3 = clmulh(low, CONSTANT_R4);
+    fold_t2 = clmul(low, CONSTANT_R4);
     low = high ^ fold_t2;
     high = fold_t3;
 
     // Combine the low and high parts and perform polynomial reduction
-    uint64_t combined = (low >> 32) | ((high & MASK32) << 32);
-    uint64_t reduced_low = clmul(low & MASK32, CONSTANT_R5) ^ combined;
+    combined = (low >> 32) | ((high & MASK32) << 32);
+    reduced_low = clmul(low & MASK32, CONSTANT_R5) ^ combined;
 
     // Barrett reduction step
-    uint64_t barrett = clmul(reduced_low & MASK32, CONSTANT_RU) & MASK32;
+    barrett = clmul(reduced_low & MASK32, CONSTANT_RU) & MASK32;
     barrett = clmul(barrett, CRCPOLY_TRUE_LE_FULL);
-    uint64_t final = barrett ^ reduced_low;
+    final = barrett ^ reduced_low;
 
     // Return the high 32 bits as the final CRC
     return (uint32_t)(final >> 32);

--- a/configure
+++ b/configure
@@ -445,6 +445,9 @@ if test "$gcc" -eq 1 && ($cc $CFLAGS -c $test.c) >> configure.log 2>&1; then
   SFLAGS="${CFLAGS} -fPIC"
   if test "$warn" -eq 1; then
     CFLAGS="${CFLAGS} -Wextra"
+    if test $nvc -eq 0; then
+      CFLAGS="${CFLAGS} -Werror"
+    fi
   fi
   if test $debug -eq 1; then
     CFLAGS="${CFLAGS} -DZLIB_DEBUG"

--- a/test/benchmarks/CMakeLists.txt
+++ b/test/benchmarks/CMakeLists.txt
@@ -37,6 +37,11 @@ if(NOT benchmark_FOUND)
     if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
         target_compile_options(benchmark PRIVATE -Wno-maybe-uninitialized)
     endif()
+
+    # LCC: Suppress warnings in Google Benchmark
+    if(CMAKE_CXX_COMPILER_ID MATCHES "LCC")
+        target_compile_options(benchmark PRIVATE -Wno-invalid-offsetof -Wno-unused-function -Wno-conversion -Wno-error)
+    endif()
 endif()
 
 # Public API benchmarks

--- a/test/fuzz/fuzzer_example_large.c
+++ b/test/fuzz/fuzzer_example_large.c
@@ -14,8 +14,6 @@
     } \
 }
 
-static const uint8_t *data;
-static size_t dataLen;
 static alloc_func zalloc = NULL;
 static free_func zfree = NULL;
 static unsigned int diff;
@@ -109,6 +107,7 @@ void test_large_inflate(unsigned char *compr, size_t comprLen, unsigned char *un
 }
 
 int LLVMFuzzerTestOneInput(const uint8_t *d, size_t size) {
+    Z_UNUSED(d);
     size_t comprLen = 100 + 3 * size;
     size_t uncomprLen = comprLen;
     uint8_t *compr, *uncompr;
@@ -119,8 +118,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *d, size_t size) {
     if (size < 1 || size > kMaxSize)
         return 0;
 
-    data = d;
-    dataLen = size;
     compr = (uint8_t *)calloc(1, comprLen);
     uncompr = (uint8_t *)calloc(1, uncomprLen);
 

--- a/test/test_gzio.cc
+++ b/test/test_gzio.cc
@@ -23,14 +23,12 @@ TEST(gzip, readwrite) {
     fprintf(stderr, "NO_GZCOMPRESS -- gz* functions cannot compress\n");
     GTEST_SKIP();
 #else
-    uint8_t compr[128], uncompr[128];
-    uint32_t compr_len = sizeof(compr), uncompr_len = sizeof(uncompr);
-    size_t read;
+    uint8_t uncompr[128];
+    uint32_t compr_len, uncompr_len = sizeof(uncompr);
     int64_t pos;
     gzFile file;
     int err;
 
-    Z_UNUSED(compr);
     /* Write gz file with test data */
     file = PREFIX(gzopen)(TESTFILE, "wb");
     ASSERT_TRUE(file != NULL);
@@ -82,7 +80,7 @@ TEST(gzip, readwrite) {
     EXPECT_EQ(PREFIX(gzeof)(file), 0);
     /* Read first hello, hello! string with gzfread */
     strcpy((char*)uncompr, "garbages");
-    read = PREFIX(gzfread)(uncompr, uncompr_len, 1, file);
+    PREFIX(gzfread)(uncompr, uncompr_len, 1, file);
     EXPECT_STREQ((const char *)uncompr, hello);
 
     pos = PREFIX(gzoffset)(file);
@@ -101,6 +99,5 @@ TEST(gzip, readwrite) {
     PREFIX(gzclose)(file);
 
     EXPECT_EQ(PREFIX(gzclose)(NULL), Z_STREAM_ERROR);
-    Z_UNUSED(read);
 #endif
 }


### PR DESCRIPTION
- Enable `-Werror` with GCC, Clang ~~and NVCC~~
- Fix GCC/Clang warnings

LCC errors will be fixed in the PR: https://github.com/zlib-ng/zlib-ng/pull/2302 (merged)