### PR TITLE
Always check that distance is too far back in inflateBack.

### DIFF
--- a/infback.c
+++ b/infback.c
@@ -460,12 +460,10 @@ int32_t Z_EXPORT PREFIX(inflateBack)(PREFIX3(stream) *strm, in_func in, void *in
                 state->offset += BITS(state->extra);
                 DROPBITS(state->extra);
             }
-#ifdef INFLATE_STRICT
             if (state->offset > state->wsize - (state->whave < state->wsize ? left : 0)) {
                 SET_BAD("invalid distance too far back");
                 break;
             }
-#endif
             TRACE_DISTANCE(state->offset);
 
             /* copy match from window to output */


### PR DESCRIPTION
* Making the distance check conditional did trap AddressSanitizer with 512 byte (9 bits) window. Although 32 kilobyte window is the default, `inflateBackInit_` allows setting smaller window size. With larger window sizes, it is not possible to generate large enough distance code, even manually, to trigger the OOB read.

Fixes #2244