### PR TITLE
Move resetting state->gzhead from deflateInit2 to deflateResetKeep.

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -303,7 +303,6 @@ int32_t ZNG_CONDEXPORT PREFIX(deflateInit2)(PREFIX3(stream) *strm, int32_t level
     s->status = INIT_STATE;     /* to pass state test in deflateReset() */
 
     s->wrap = wrap;
-    s->gzhead = NULL;
     s->w_size = 1 << windowBits;
 
     s->high_water = 0;      /* nothing written to s->window yet */
@@ -521,6 +520,8 @@ int32_t Z_EXPORT PREFIX(deflateResetKeep)(PREFIX3(stream) *strm) {
 #endif
         strm->adler = ADLER32_INITIAL_VALUE;
     s->last_flush = -2;
+
+    s->gzhead = NULL; /* reset the gzip header */
 
     zng_tr_init(s);
 


### PR DESCRIPTION
* `deflateInit2` calls `deflateReset` that calls `deflateResetKeep` to do the real job
* Moving the setting `gzhead` in `deflate_state` to `NULL` later avoids duplicating the code

Fixes #2272.