### PR TITLE
Reject asymmetric C vs C++ machine flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,9 @@ cmake_dependent_option(WITH_BENCHMARKS "Build test/benchmarks" OFF "BUILD_TESTIN
 cmake_dependent_option(WITH_BENCHMARK_APPS "Build application benchmarks" OFF "BUILD_TESTING" OFF)
 
 if(WITH_GTEST OR WITH_FUZZERS OR WITH_BENCHMARKS)
-  enable_language(CXX)
+    enable_language(CXX)
+    include(cmake/check-compiler-flags.cmake)
+    check_machine_flag_symmetry()
 endif()
 
 include(cmake/detect-arch.cmake)

--- a/cmake/check-compiler-flags.cmake
+++ b/cmake/check-compiler-flags.cmake
@@ -1,0 +1,28 @@
+# check-compiler-flags.cmake -- Check/validate compiler flags
+# Licensed under the Zlib license, see LICENSE.md for details
+
+# Extract machine flags from multi-flag command line argument.
+function(extract_machine_flags out_var flags_str)
+    string(REGEX MATCHALL
+        "-(m(arch|cpu|tune|fpu|float-abi|fp16-format|abi)|q(arch|tune)|tp|target)=[^ \t]+|/arch:[^ \t]+"
+        matches "${flags_str}")
+    string(REPLACE "\"" "" matches "${matches}")
+    string(REPLACE "'"  "" matches "${matches}")
+
+    list(SORT matches)
+    set(${out_var} "${matches}" PARENT_SCOPE)
+endfunction()
+
+# Error on asymmetric C vs C++ machine flags.
+function(check_machine_flag_symmetry)
+    extract_machine_flags(m_flag_c   "${CMAKE_C_FLAGS}")
+    extract_machine_flags(m_flag_cxx "${CMAKE_CXX_FLAGS}")
+
+    if(NOT "${m_flag_c}" STREQUAL "${m_flag_cxx}")
+        message(FATAL_ERROR
+            "C and C++ machine flags differ:\n"
+            "    CMAKE_C_FLAGS:   ${m_flag_c}\n"
+            "    CMAKE_CXX_FLAGS: ${m_flag_cxx}\n"
+            "Pass the same machine flags to both, or to neither.")
+    endif()
+endfunction()


### PR DESCRIPTION
Different machine flags in C vs C++ flags produce undefined-reference link failures.