### PR TITLE
[CI] Add NVHPC to CMake workflow.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -500,6 +500,14 @@ jobs:
             msan-options: use_sigaltstack=0
             # Coverage disabled for clang-20, errors
 
+          - name: Ubuntu NVC Native
+            os: ubuntu-latest
+            compiler: nvc
+            cxx-compiler: nvc++
+            cmake-args: -G Ninja -DWITH_NATIVE_INSTRUCTIONS=ON
+            packages: ninja-build nvhpc-26-3
+            # Coverage disabled for NVHPC
+
           - name: Ubuntu Emscripten WASM32
             os: ubuntu-latest
             chost: wasm32
@@ -809,8 +817,15 @@ jobs:
         curl http://mirrors.ubuntu.com/mirrors.txt | sudo tee --append /etc/apt/mirrors.txt
         sudo sed -i 's#http://azure.archive.ubuntu.com/ubuntu/#mirror+file:/etc/apt/mirrors.txt#' /etc/apt/sources.list
 
+    - name: Download NVHPC package keys (Ubuntu)
+      if: runner.os == 'Linux' && contains(matrix.name, 'NVC')
+      run: |
+        curl -fsSL https://developer.download.nvidia.com/hpc-sdk/ubuntu/DEB-GPG-KEY-NVIDIA-HPC-SDK | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg
+        echo 'deb [signed-by=/usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg] https://developer.download.nvidia.com/hpc-sdk/ubuntu/amd64 /' | sudo tee /etc/apt/sources.list.d/nvhpc.list
+        echo '/opt/nvidia/hpc_sdk/Linux_x86_64/2026/compilers/bin' >> $GITHUB_PATH
+
     - name: Restore cached packages (Ubuntu)
-      if: runner.os == 'Linux' && matrix.packages && !contains(matrix.os, 'z15')
+      if: runner.os == 'Linux' && matrix.packages && !contains(matrix.os, 'z15') && !contains(matrix.name, 'NVC')
       id: restore-apt-cache
       uses: ./.github/actions/restore-apt-cache
       with:
@@ -825,7 +840,7 @@ jobs:
             ${{ matrix.packages || 'libgtest-dev libbenchmark-dev' }}
 
     - name: Update package cache (Ubuntu)
-      if: runner.os == 'Linux' && matrix.packages && !contains(matrix.os, 'z15') && steps.restore-apt-cache.outputs.cache-hit != 'true'
+      if: runner.os == 'Linux' && matrix.packages && !contains(matrix.os, 'z15') && steps.restore-apt-cache.outputs.cache-hit != 'true' && !contains(matrix.name, 'NVC')
       uses: ./.github/actions/update-apt-cache
 
     - name: Install packages (Windows)

--- a/zbuild.h
+++ b/zbuild.h
@@ -149,7 +149,7 @@
 /* Force the compiler to treat variable as modified. Empty asm statement with a "+r" constraint prevents
    the compiler from reordering or eliminating loads into the variable. This can help keep critical latency
    chains in the hot path from being shortened or optimized away. */
-#if (defined(__GNUC__) || defined(__clang__)) && \
+#if (defined(__GNUC__) || defined(__clang__)) && !defined(__NVCOMPILER) && \
         (defined(ARCH_X86) || (defined(ARCH_ARM) && defined(ARCH_64BIT)))
 #  define Z_TOUCH(var) __asm__ ("" : "+r"(var))
 #else


### PR DESCRIPTION
* Fix error with invalid inline assembly
* Don't cache NVHPC package as it is over 4 GB in size