### PR TITLE
Fix warnings triggered by NVHPC/nvc.

### DIFF
--- a/arch/x86/adler32_ssse3.c
+++ b/arch/x86/adler32_ssse3.c
@@ -57,13 +57,15 @@ Z_INTERNAL uint32_t adler32_ssse3(uint32_t adler, const uint8_t *buf, size_t len
         goto unaligned_jmp;
     }
 
-    size_t align_diff = MIN(ALIGN_DIFF(buf, 16), len);
-    if (align_diff) {
-        adler32_copy_align(&adler, NULL, buf, align_diff, &sum2, 15, 0);
+    {
+        size_t align_diff = MIN(ALIGN_DIFF(buf, 16), len);
+        if (align_diff) {
+            adler32_copy_align(&adler, NULL, buf, align_diff, &sum2, 15, 0);
 
-        buf += align_diff;
-        len -= align_diff;
-        n -= align_diff;
+            buf += align_diff;
+            len -= align_diff;
+            n -= align_diff;
+        }
     }
 
     while (len >= 16) {

--- a/deflate.c
+++ b/deflate.c
@@ -994,8 +994,10 @@ int32_t Z_EXPORT PREFIX(deflate)(PREFIX3(stream) *strm, int32_t flush) {
     if (strm->avail_in != 0 || s->lookahead != 0 || (flush != Z_NO_FLUSH && s->status != FINISH_STATE)) {
         block_state bstate;
 
-        bstate = DEFLATE_HOOK(strm, flush, &bstate) ? bstate :  /* hook for IBM Z DFLTCC */
-                 s->level == 0 ? deflate_stored(s, flush) :
+#ifndef _MSC_VER
+        if (DEFLATE_HOOK(strm, flush, &bstate) == 0) /* hook for IBM Z DFLTCC */
+#endif
+            bstate = s->level == 0 ? deflate_stored(s, flush) :
                  s->strategy == Z_HUFFMAN_ONLY ? deflate_huff(s, flush) :
                  s->strategy == Z_RLE ? deflate_rle(s, flush) :
                  (*(configuration_table[s->level].func))(s, flush);

--- a/test/test_adler32.cc
+++ b/test/test_adler32.cc
@@ -31,6 +31,7 @@ INSTANTIATE_TEST_SUITE_P(adler32, adler32_variant, testing::ValuesIn(hash_tests)
     TEST_P(adler32_variant, name) { \
         if (!(support_flag)) { \
             GTEST_SKIP(); \
+            Z_UNREACHABLE(); \
             return; \
         } \
         hash(GetParam(), func); \

--- a/test/test_adler32_copy.cc
+++ b/test/test_adler32_copy.cc
@@ -34,6 +34,7 @@ INSTANTIATE_TEST_SUITE_P(adler32_copy, adler32_copy_variant, testing::ValuesIn(h
     TEST_P(adler32_copy_variant, name) { \
         if (!(support_flag)) { \
             GTEST_SKIP(); \
+            Z_UNREACHABLE(); \
             return; \
         } \
         adler32_copy_test(copyfunc, GetParam()); \

--- a/test/test_compare256.cc
+++ b/test/test_compare256.cc
@@ -54,6 +54,7 @@ static inline void compare256_match_check(compare256_func compare256) {
     TEST(compare256, name) { \
         if (!(support_flag)) { \
             GTEST_SKIP(); \
+            Z_UNREACHABLE(); \
             return; \
         } \
         compare256_match_check(func); \

--- a/test/test_compare256_rle.cc
+++ b/test/test_compare256_rle.cc
@@ -45,6 +45,7 @@ static inline void compare256_rle_match_check(compare256_rle_func compare256_rle
     TEST(compare256_rle, name) { \
         if (!(support_flag)) { \
             GTEST_SKIP(); \
+            Z_UNREACHABLE(); \
             return; \
         } \
         compare256_rle_match_check(func); \

--- a/test/test_crc32.cc
+++ b/test/test_crc32.cc
@@ -65,6 +65,7 @@ INSTANTIATE_TEST_SUITE_P(crc32, crc32_variant, testing::ValuesIn(hash_tests));
     TEST_P(crc32_variant, name) { \
         if (!(support_flag)) { \
             GTEST_SKIP(); \
+            Z_UNREACHABLE(); \
             return; \
         } \
         hash(GetParam(), func); \
@@ -72,6 +73,7 @@ INSTANTIATE_TEST_SUITE_P(crc32, crc32_variant, testing::ValuesIn(hash_tests));
     TEST_F(crc32_large_buf, name) { \
         if (!(support_flag)) { \
             GTEST_SKIP(); \
+            Z_UNREACHABLE(); \
             return; \
         } \
         hash(func); \

--- a/test/test_crc32_copy.cc
+++ b/test/test_crc32_copy.cc
@@ -34,6 +34,7 @@ INSTANTIATE_TEST_SUITE_P(crc32_copy, crc32_copy_variant, testing::ValuesIn(hash_
     TEST_P(crc32_copy_variant, name) { \
         if (!(support_flag)) { \
             GTEST_SKIP(); \
+            Z_UNREACHABLE(); \
             return; \
         } \
         crc32_copy_test(copyfunc, GetParam()); \


### PR DESCRIPTION
* Fix jump with `goto` past variable declaration
* Fix variable initialized with itself / use before initialization
* Mark unreachable code with `Z_UNREACHABLE()` inside macro definition

Depends on: #2306, #2310