### PR TITLE
gzread: Fix compilation on AIX

### DIFF
--- a/zbuild.h
+++ b/zbuild.h
@@ -21,6 +21,10 @@
 #include <stdint.h>
 #include <stdio.h>
 
+#ifdef _AIX
+#  include <sys/stdint.h>
+#endif
+
 #include "zarch.h"
 
 /* Determine compiler version of C Standard */


### PR DESCRIPTION
Otherwise compilation would fail:

```
/home/aelin/zlib-ng/gzread.c: In function 'gzfread':
/home/aelin/zlib-ng/gzread.c:403:17: error: 'SIZE_MAX' undeclared (first use in this function)
  402 |     if (size && SIZE_MAX / size < nitems) {
      |                 ^~~~~~~~
/home/aelin/zlib-ng/gzread.c:10:1: note: 'SIZE_MAX' is defined in header '<stdint.h>'; did you forget to '#include <stdint.h>'?
    9 | #include "gzread_mangle.h"
  +++ |+#include <stdint.h>
   10 |
/home/aelin/zlib-ng/gzread.c:403:17: note: each undeclared identifier is reported only once for each function it appears in
  402 |     if (size && SIZE_MAX / size < nitems) {
      |                 ^~~~~~~~
```

The suggestion from GCC is wrong, on AIX `SIZE_MAX` is in `sys/stdint.h`, not in `stdint.h`:

excerpt from `/usr/include/sys/stdint.h`:

```
#if (__64BIT__)
#define SIZE_MAX        UINT64_MAX
#else
#define SIZE_MAX        (4294967295UL)
#endif
```