### PR TITLE
[CI] Add ARM64 version of MinGW64 with gcc.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -610,6 +610,13 @@ jobs:
             cmake-args: -T ClangCl -A x64 -DWITH_NATIVE_INSTRUCTIONS=ON -DNATIVE_ARCH_OVERRIDE="-mavx -mpclmul"
             # Coverage disabled for clangcl
 
+          - name: Windows GCC ARM64
+            os: windows-11-arm
+            compiler: gcc
+            cxx-compiler: g++
+            cmake-args: -G Ninja
+            coverage: win64_arm64_gcc
+
           - name: Windows GCC
             os: windows-latest
             compiler: gcc


### PR DESCRIPTION
* MinGW64 for ARM64/AArch64 is experimental but it looks like it can compile zlib-ng, so good reason to add it to CI
* We already test Visual C++ and Clang/ClangCL on Windows for ARM64, so adding gcc workflow makes sense, as it allows collecting coverage data for Windows specific code paths
* Currently tests only default build using CMake, later more configurations can be added