### PR TITLE
[CI] Add configure workflow for Windows ARM64 with Clang.

### DIFF
--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -250,6 +250,11 @@ jobs:
             cflags: -static
             ldflags: -static
 
+          - name: Windows Clang ARM64
+            os: windows-11-arm
+            shell: msys2 {0}
+            compiler: aarch64-w64-mingw32-clang
+
           - name: Windows GCC MinGW32
             os: windows-latest
             shell: msys2 {0}
@@ -301,6 +306,18 @@ jobs:
           make
           git
           mingw-w64-x86_64-toolchain
+
+    - name: Setup MinGW64 (ARM64)
+      if: runner.os == 'Windows' && contains(matrix.name, 'ARM64')
+      uses: msys2/setup-msys2@v2
+      with:
+        update: true
+        msystem: CLANGARM64
+        install: >-
+          pkg-config
+          make
+          git
+          mingw-w64-clang-aarch64-clang
 
     - name: Add ubuntu mirrors
       if: runner.os == 'Linux' && matrix.packages

--- a/configure
+++ b/configure
@@ -145,6 +145,7 @@ without_optimizations=0
 without_new_strategies=0
 reducedmem=0
 gcc=0
+clang=0
 nvc=0
 warn=0
 debug=0
@@ -310,14 +311,16 @@ fi
 printf "Checking for compiler... " | tee -a configure.log
 case "$cc" in
   *gcc*) gcc=1 ;;
-  *clang*) gcc=1 ;;
+  *clang*) gcc=1
+           clang=1 ;;
   *nvc) gcc=1
         nvc=1 ;;
 esac
 # nvc requires input file for -v and prints warning, use --version instead as it's supported by all
 case $($cc --version 2>&1) in
   *gcc*) gcc=1 ;;
-  *clang*) gcc=1 ;;
+  *clang*) gcc=1
+           clang=1 ;;
   *nvc\ *) gcc=1
            nvc=1 ;;
 esac
@@ -522,7 +525,10 @@ if test "$gcc" -eq 1 && ($cc $CFLAGS -c $test.c) >> configure.log 2>&1; then
   MINGW* | mingw*)
         visibility=0
         ARFLAGS="rcs"
-        CFLAGS="${CFLAGS} -D_POSIX_C_SOURCE=200809L -D_GNU_SOURCE=1 -Wno-pedantic-ms-format"
+        CFLAGS="${CFLAGS} -D_POSIX_C_SOURCE=200809L -D_GNU_SOURCE=1"
+        if test $clang -eq 0; then
+          CFLAGS="${CFLAGS} -Wno-pedantic-ms-format"
+        fi
         SFLAGS="${CFLAGS}"
         shared_ext='.dll'
         sharedlibdir='${bindir}'


### PR DESCRIPTION
* Installs full MinGW64 environment for AArch64/ARM64, so we can have clang instead of just gcc
* Fix `configure` to not add unsupported warning option when using clang for MinGW.