### PR TITLE
[CI] Add configure workflow for Windows AMD64 with Clang.

### DIFF
--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -255,6 +255,12 @@ jobs:
             shell: msys2 {0}
             compiler: aarch64-w64-mingw32-clang
 
+          - name: Windows Clang MinGW64
+            os: windows-latest
+            shell: msys2 {0}
+            compiler: clang
+            packages: mingw-w64-x86_64-clang
+
           - name: Windows GCC MinGW32
             os: windows-latest
             shell: msys2 {0}
@@ -305,7 +311,7 @@ jobs:
           pkg-config
           make
           git
-          mingw-w64-x86_64-toolchain
+          ${{ matrix.packages || 'mingw-w64-x86_64-toolchain' }}
 
     - name: Setup MinGW64 (ARM64)
       if: runner.os == 'Windows' && contains(matrix.name, 'ARM64')


### PR DESCRIPTION
* This complements PR #2314 by testing also AMD64/x86_64 version of Clang with MinGW64
* Adds support for specifying additional packages while installing AMD64/x86_64 version of MSYS2, defaults to installing default MinGW toolchain (GCC) like before

Depends on changes to `configure` in #2314