### PR TITLE
fix integer overflow in gz_buffer_alloc buffer sizing

### DIFF
--- a/gzguts.h
+++ b/gzguts.h
@@ -78,6 +78,13 @@
 #  define GZBUFSIZE 131072
 #endif
 
+/* upper limit on the requested buffer size; the allocation is three times this,
+   so the cap keeps that total well inside an unsigned and far above any size
+   that is useful in practice */
+#ifndef GZBUFSIZE_MAX
+#  define GZBUFSIZE_MAX (1u << 30) /* 1 GiB */
+#endif
+
 /* gzip modes, also provide a little integrity check on the passed structure */
 #define GZ_NONE 0
 #define GZ_READ 7247

--- a/gzlib.c
+++ b/gzlib.c
@@ -69,8 +69,8 @@ static void gz_reset(gz_state *state) {
 
 /* Allocate in/out buffers for gzFile */
 int Z_INTERNAL gz_buffer_alloc(gz_state *state) {
-    size_t want = state->want;
-    size_t in_size = want, out_size = want;
+    unsigned want = state->want;
+    unsigned in_size = want, out_size = want;
 
     if (state->mode == GZ_WRITE) {
         in_size = want * 2; // double input buffer for compression (ref: gzprintf)
@@ -80,9 +80,7 @@ int Z_INTERNAL gz_buffer_alloc(gz_state *state) {
         out_size = want * 2;  // double output buffer for decompression
     }
 
-    /* gzbuffer caps want at GZBUFSIZE_MAX, so the total here stays inside the
-       unsigned that zng_alloc_aligned takes */
-    state->buffers = (unsigned char *)zng_alloc_aligned((unsigned)(in_size + out_size), 64);
+    state->buffers = (unsigned char *)zng_alloc_aligned((in_size + out_size), 64);
     state->in = state->buffers;
     if (out_size) {
         state->out = state->buffers + (in_size); // Outbuffer goes after inbuffer
@@ -95,7 +93,7 @@ int Z_INTERNAL gz_buffer_alloc(gz_state *state) {
         return -1;
     }
 
-    state->size = (unsigned)want; // mark state as initialized
+    state->size = want; // mark state as initialized
     return 0;
 }
 
@@ -338,6 +336,7 @@ z_int32_t Z_EXPORT PREFIX(gzbuffer)(gzFile file, z_uint32_t size) {
 #ifdef ZLIB_COMPAT
         size = GZBUFSIZE_MAX;   /* silently clamp to stay compatible with zlib */
 #else
+        PREFIX(gz_error)(state, Z_MEM_ERROR, "out of memory");
         return -1;              /* too large */
 #endif
     }

--- a/gzlib.c
+++ b/gzlib.c
@@ -106,7 +106,7 @@ int Z_INTERNAL gz_buffer_alloc(gz_state *state) {
         return -1;
     }
 
-    state->size = want; // mark state as initialized
+    state->size = (unsigned)want; // mark state as initialized
     return 0;
 }
 

--- a/gzlib.c
+++ b/gzlib.c
@@ -80,15 +80,8 @@ int Z_INTERNAL gz_buffer_alloc(gz_state *state) {
         out_size = want * 2;  // double output buffer for decompression
     }
 
-    /* the total reaches 3 * want but gzbuffer only guards 2 * want; cap against
-       INT_MAX (minus zng_alloc_aligned's overhead) and reject rather than wrap */
-    const size_t aligned_overhead = sizeof(void *) + 64;
-    const size_t max_size = (size_t)INT_MAX - aligned_overhead;
-    if (out_size > max_size || in_size > max_size - out_size) {
-        PREFIX(gz_error)(state, Z_MEM_ERROR, "out of memory");
-        return -1;
-    }
-
+    /* gzbuffer caps want at GZBUFSIZE_MAX, so the total here stays inside the
+       unsigned that zng_alloc_aligned takes */
     state->buffers = (unsigned char *)zng_alloc_aligned((unsigned)(in_size + out_size), 64);
     state->in = state->buffers;
     if (out_size) {
@@ -341,8 +334,13 @@ z_int32_t Z_EXPORT PREFIX(gzbuffer)(gzFile file, z_uint32_t size) {
         return -1;
 
     /* check and set requested size */
-    if ((size << 1) < size)
-        return -1;              /* need to be able to double it */
+    if (size > GZBUFSIZE_MAX) {
+#ifdef ZLIB_COMPAT
+        size = GZBUFSIZE_MAX;   /* silently clamp to stay compatible with zlib */
+#else
+        return -1;              /* too large */
+#endif
+    }
     if (size < 8)
         size = 8;               /* needed to behave well with flushing */
     state->want = size;

--- a/gzlib.c
+++ b/gzlib.c
@@ -80,12 +80,8 @@ int Z_INTERNAL gz_buffer_alloc(gz_state *state) {
         out_size = want * 2;  // double output buffer for decompression
     }
 
-    /* the total here reaches 3 * want, but gzbuffer only guarantees 2 * want
-       fits in an unsigned. zng_alloc_aligned then adds sizeof(void *) + align
-       on top before allocating, and on some platforms (e.g. FreeBSD) malloc is
-       bounded by INT_MAX because the allocator uses a signed type internally.
-       Cap the total against INT_MAX minus that overhead so we reject the
-       request rather than truncate it into an undersized allocation */
+    /* the total reaches 3 * want but gzbuffer only guards 2 * want; cap against
+       INT_MAX (minus zng_alloc_aligned's overhead) and reject rather than wrap */
     const size_t aligned_overhead = sizeof(void *) + 64;
     const size_t max_size = (size_t)INT_MAX - aligned_overhead;
     if (out_size > max_size || in_size > max_size - out_size) {

--- a/gzlib.c
+++ b/gzlib.c
@@ -69,8 +69,8 @@ static void gz_reset(gz_state *state) {
 
 /* Allocate in/out buffers for gzFile */
 int Z_INTERNAL gz_buffer_alloc(gz_state *state) {
-    int want = state->want;
-    int in_size = want, out_size = want;
+    size_t want = state->want;
+    size_t in_size = want, out_size = want;
 
     if (state->mode == GZ_WRITE) {
         in_size = want * 2; // double input buffer for compression (ref: gzprintf)
@@ -80,7 +80,15 @@ int Z_INTERNAL gz_buffer_alloc(gz_state *state) {
         out_size = want * 2;  // double output buffer for decompression
     }
 
-    state->buffers = (unsigned char *)zng_alloc_aligned((in_size + out_size), 64);
+    /* the total here reaches 3 * want, but gzbuffer only guarantees 2 * want
+       fits in an unsigned, and zng_alloc_aligned takes an unsigned size; bail
+       out rather than truncate the request into an undersized allocation */
+    if (in_size > UINT_MAX - out_size) {
+        PREFIX(gz_error)(state, Z_MEM_ERROR, "out of memory");
+        return -1;
+    }
+
+    state->buffers = (unsigned char *)zng_alloc_aligned((unsigned)(in_size + out_size), 64);
     state->in = state->buffers;
     if (out_size) {
         state->out = state->buffers + (in_size); // Outbuffer goes after inbuffer

--- a/gzlib.c
+++ b/gzlib.c
@@ -81,9 +81,14 @@ int Z_INTERNAL gz_buffer_alloc(gz_state *state) {
     }
 
     /* the total here reaches 3 * want, but gzbuffer only guarantees 2 * want
-       fits in an unsigned, and zng_alloc_aligned takes an unsigned size; bail
-       out rather than truncate the request into an undersized allocation */
-    if (in_size > UINT_MAX - out_size) {
+       fits in an unsigned. zng_alloc_aligned then adds sizeof(void *) + align
+       on top before allocating, and on some platforms (e.g. FreeBSD) malloc is
+       bounded by INT_MAX because the allocator uses a signed type internally.
+       Cap the total against INT_MAX minus that overhead so we reject the
+       request rather than truncate it into an undersized allocation */
+    const size_t aligned_overhead = sizeof(void *) + 64;
+    const size_t max_size = (size_t)INT_MAX - aligned_overhead;
+    if (out_size > max_size || in_size > max_size - out_size) {
         PREFIX(gz_error)(state, Z_MEM_ERROR, "out of memory");
         return -1;
     }

--- a/zlib-ng.h.in
+++ b/zlib-ng.h.in
@@ -1361,6 +1361,10 @@ int32_t zng_gzbuffer(gzFile file, uint32_t size);
    buffer size of, for example, 64K or 128K bytes will noticeably increase the
    speed of decompression (reading).
 
+     The requested size is limited to 1 GiB, which is far larger than is useful
+   in practice.  zng_gzbuffer() returns -1 when a larger size is requested,
+   while the zlib-compatible gzbuffer() silently clamps it to 1 GiB.
+
      The new buffer size also affects the maximum length for gzprintf().
 
      gzbuffer() returns 0 on success, or -1 on failure, such as being called


### PR DESCRIPTION
Noticed gz_buffer_alloc reads state->want into an int and then computes want*2, so a large gzbuffer request overflows the int before it ever reaches zng_alloc_aligned. The total allocation is really 3*want for both read and write, but gzbuffer only guards that 2*want fits in an unsigned, so the size can wrap to something far smaller than state->size and the later gz_write/gz_read copies overrun it. I hit it with gzbuffer(file, 0x55555558) under asan. Compute the sizes as size_t and bail out when the total would not fit the unsigned the allocator takes.