### PR TITLE
Fix undefined warnings to allow -Wundef to be used

### DIFF
--- a/arch/generic/crc32_braid_c.c
+++ b/arch/generic/crc32_braid_c.c
@@ -13,7 +13,6 @@
 /* Used by chorba fallback and by arch-specific implementations (s390 vx, risc-v zbc). */
 #ifdef CRC32_BRAID_FALLBACK
 
-#include "crc32_braid_p.h"
 #include "crc32_braid_tbl.h"
 #include "crc32_p.h"
 

--- a/arch/generic/crc32_chorba_c.c
+++ b/arch/generic/crc32_chorba_c.c
@@ -8,7 +8,6 @@
 #endif
 #include "zmemory.h"
 #include "crc32_chorba_p.h"
-#include "crc32_braid_p.h"
 #include "crc32_braid_tbl.h"
 
 /* Implement Chorba algorithm from https://arxiv.org/abs/2412.16398 */

--- a/arch/x86/crc32_chorba_sse2.c
+++ b/arch/x86/crc32_chorba_sse2.c
@@ -4,7 +4,6 @@
 #if defined(X86_SSE2) && defined(CRC32_CHORBA_SSE_FALLBACK)
 
 #include "crc32_chorba_p.h"
-#include "crc32_braid_p.h"
 #include "crc32_braid_tbl.h"
 #include <emmintrin.h>
 #include "arch/x86/x86_intrins.h"

--- a/arch/x86/crc32_chorba_sse41.c
+++ b/arch/x86/crc32_chorba_sse41.c
@@ -4,7 +4,6 @@
 #if defined(X86_SSE41) && defined(CRC32_CHORBA_SSE_FALLBACK)
 
 #include "crc32_chorba_p.h"
-#include "crc32_braid_p.h"
 #include "crc32_braid_tbl.h"
 #include <emmintrin.h>
 #include <smmintrin.h>

--- a/arch/x86/crc32_pclmulqdq_tpl.h
+++ b/arch/x86/crc32_pclmulqdq_tpl.h
@@ -23,7 +23,6 @@
 #include <wmmintrin.h>
 #include <smmintrin.h> // _mm_extract_epi32
 
-#include "crc32_braid_p.h"
 #include "crc32_braid_tbl.h"
 #include "crc32_p.h"
 #include "x86_intrins.h"

--- a/crc32_braid_comb.c
+++ b/crc32_braid_comb.c
@@ -8,7 +8,6 @@
  */
 
 #include "zutil.h"
-#include "crc32_braid_p.h"
 #include "crc32_braid_tbl.h"
 #include "crc32_braid_comb_p.h"
 

--- a/crc32_braid_tbl.h
+++ b/crc32_braid_tbl.h
@@ -1,6 +1,8 @@
 #ifndef CRC32_BRAID_TBL_H_
 #define CRC32_BRAID_TBL_H_
 
+#include "crc32_braid_p.h"
+
 /* crc32_braid_tbl.h -- tables for braided CRC calculation
  * Generated automatically by makecrct.c
  */

--- a/gzlib.c
+++ b/gzlib.c
@@ -245,7 +245,7 @@ static gzFile gz_open(const void *path, int fd, const char *mode) {
     state->fd = fd > -1 ? fd : (
 #if defined(_WIN32)
         fd == -2 ? _wopen((const wchar_t *)path, oflag, 0666) :
-#elif __CYGWIN__
+#elif defined(__CYGWIN__)
         fd == -2 ? open(state->path, oflag, 0666) :
 #endif
         open((const char *)path, oflag, 0666));

--- a/tools/makecrct.c
+++ b/tools/makecrct.c
@@ -145,6 +145,7 @@ static void print_crc_table(void) {
 
     printf("#ifndef CRC32_BRAID_TBL_H_\n");
     printf("#define CRC32_BRAID_TBL_H_\n\n");
+    printf("#include \"crc32_braid_p.h\"\n\n");
     printf("/* crc32_braid_tbl.h -- tables for braided CRC calculation\n");
     printf(" * Generated automatically by makecrct.c\n */\n\n");
 

--- a/zendian.h
+++ b/zendian.h
@@ -57,6 +57,28 @@
 #  include <endian.h>
 #endif
 
+#if !defined(BYTE_ORDER) || (!defined(LITTLE_ENDIAN) && !defined(BIG_ENDIAN))
+#  error "Unknown byte order"
+#endif
+
+#if !defined(LITTLE_ENDIAN)
+#  if BIG_ENDIAN == 1234
+#    define LITTLE_ENDIAN 4321
+#  elif BIG_ENDIAN == 4321
+#    define LITTLE_ENDIAN 1234
+#  else
+#    define LITTLE_ENDIAN -1
+#  endif
+#elif !defined(BIG_ENDIAN)
+#  if LITTLE_ENDIAN == 1234
+#    define BIG_ENDIAN 4321
+#  elif LITTLE_ENDIAN == 4321
+#    define BIG_ENDIAN 1234
+#  else
+#    define BIG_ENDIAN -1
+#  endif
+#endif
+
 #if BYTE_ORDER == LITTLE_ENDIAN
 #  define Z_U16_TO_LE(x)    (x)
 #  define Z_U32_TO_LE(x)    (x)
@@ -83,8 +105,6 @@
 #  define Z_U16_FROM_BE(x)  (x)
 #  define Z_U32_FROM_BE(x)  (x)
 #  define Z_U64_FROM_BE(x)  (x)
-#else
-#  error "Unknown byte order"
 #endif
 
 #endif


### PR DESCRIPTION
This allows me to enable `-Wundef` during reviews and testing. This is for sure a candidate for -Werror during CI to catch hard-to-spot mistakes early.

The changes to `zendian.h` defines has no effect, they already default to 0 when missing.
The changed cygwin define should have no effect, but I don't know for sure whether it should actually be checking the value or whether presence check is enough.

But the changes to BRAID_W / BRAID_N means these are now actually taken into effect instead of always using the fallback values when choosing what crc tables to use in `crc32_braid_tbl.h`.
I am a bit surprised this hasn't bitten anyone.

The offenders that included `crc32_braid_tbl.h` without also including `crc32_braid_p.h` were:
- crc32_p.h
- inflate_p.h
- arch/power/crc32_power8.c

The two includefiles caused warnings to crop up when compiling all kinds of .c files.