### PR TITLE
[CI] Add coveralls as trusted formula for Homebrew under MacOS

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -910,6 +910,7 @@ jobs:
       run: |
         brew update
         brew install ninja ${{ matrix.packages }}
+        brew trust --formula coverallsapp/coveralls/coveralls
       env:
         HOMEBREW_NO_INSTALL_CLEANUP: 1
 


### PR DESCRIPTION
* Homebrew 6.0.0 requires explicit trust when installing formulae from third-party taps (repositories)