### PR TITLE
Skip redundant hash maintenance for deflate_quick and huffman/rle

### DIFF
--- a/arch/arm/arm_functions.h
+++ b/arch/arm/arm_functions.h
@@ -16,6 +16,7 @@ void inflate_fast_neon(PREFIX3(stream) *strm, uint32_t start, int safe_mode);
 uint32_t longest_match_neon(deflate_state *const s, uint32_t cur_match);
 uint32_t longest_match_roll_neon(deflate_state *const s, uint32_t cur_match);
 void slide_hash_neon(deflate_state *s);
+void slide_hash_head_neon(deflate_state *s);
 #endif
 
 #ifdef ARM_NEON_DOTPROD
@@ -48,6 +49,7 @@ uint32_t crc32_copy_armv8_pmull_eor3(uint32_t crc, uint8_t *dst, const uint8_t *
 
 #ifdef ARM_SIMD
 void slide_hash_armv6(deflate_state *s);
+void slide_hash_head_armv6(deflate_state *s);
 #endif
 
 #ifdef DISABLE_RUNTIME_CPU_DETECTION
@@ -55,6 +57,8 @@ void slide_hash_armv6(deflate_state *s);
 #  ifdef ARM_SIMD_NATIVE
 #    undef native_slide_hash
 #    define native_slide_hash slide_hash_armv6
+#    undef native_slide_hash_head
+#    define native_slide_hash_head slide_hash_head_armv6
 #  endif
 // ARM - NEON
 #  ifdef ARM_NEON_NATIVE
@@ -74,6 +78,8 @@ void slide_hash_armv6(deflate_state *s);
 #    define native_longest_match_roll longest_match_roll_neon
 #    undef native_slide_hash
 #    define native_slide_hash slide_hash_neon
+#    undef native_slide_hash_head
+#    define native_slide_hash_head slide_hash_head_neon
 #  endif
 // ARM - NEON DotProd
 #  ifdef ARM_NEON_DOTPROD_NATIVE

--- a/arch/arm/slide_hash_armv6.c
+++ b/arch/arm/slide_hash_armv6.c
@@ -46,4 +46,11 @@ Z_INTERNAL void slide_hash_armv6(deflate_state *s) {
     slide_hash_chain(s->head, HASH_SIZE, wsize);
     slide_hash_chain(s->prev, wsize, wsize);
 }
+
+Z_INTERNAL void slide_hash_head_armv6(deflate_state *s) {
+    Assert(s->w_size <= UINT16_MAX, "w_size should fit in uint16_t");
+    uint16_t wsize = (uint16_t)s->w_size;
+
+    slide_hash_chain(s->head, HASH_SIZE, wsize);
+}
 #endif

--- a/arch/arm/slide_hash_neon.c
+++ b/arch/arm/slide_hash_neon.c
@@ -45,4 +45,11 @@ Z_INTERNAL void slide_hash_neon(deflate_state *s) {
     slide_hash_chain(s->head, HASH_SIZE, wsize);
     slide_hash_chain(s->prev, wsize, wsize);
 }
+
+Z_INTERNAL void slide_hash_head_neon(deflate_state *s) {
+    Assert(s->w_size <= UINT16_MAX, "w_size should fit in uint16_t");
+    uint16_t wsize = (uint16_t)s->w_size;
+
+    slide_hash_chain(s->head, HASH_SIZE, wsize);
+}
 #endif

--- a/arch/generic/generic_functions.h
+++ b/arch/generic/generic_functions.h
@@ -50,6 +50,7 @@ uint32_t longest_match_roll_c(deflate_state *const s, uint32_t cur_match);
 #endif
 #ifdef SLIDE_HASH_FALLBACK
 void     slide_hash_c(deflate_state *s);
+void     slide_hash_head_c(deflate_state *s);
 #endif
 
 #ifdef DISABLE_RUNTIME_CPU_DETECTION
@@ -99,6 +100,9 @@ void     slide_hash_c(deflate_state *s);
 #  ifdef SLIDE_HASH_FALLBACK
 #    ifndef native_slide_hash
 #      define native_slide_hash slide_hash_c
+#    endif
+#    ifndef native_slide_hash_head
+#      define native_slide_hash_head slide_hash_head_c
 #    endif
 #  endif
 #endif

--- a/arch/generic/slide_hash_c.c
+++ b/arch/generic/slide_hash_c.c
@@ -55,4 +55,10 @@ Z_INTERNAL void slide_hash_c(deflate_state *s) {
     slide_hash_c_chain(s->prev, wsize, wsize);
 }
 
+Z_INTERNAL void slide_hash_head_c(deflate_state *s) {
+    uint16_t wsize = (uint16_t)s->w_size;
+
+    slide_hash_c_chain(s->head, HASH_SIZE, wsize);
+}
+
 #endif /* SLIDE_HASH_FALLBACK */

--- a/arch/loongarch/loongarch_functions.h
+++ b/arch/loongarch/loongarch_functions.h
@@ -28,6 +28,7 @@ void inflate_fast_lsx(PREFIX3(stream) *strm, uint32_t start, int safe_mode);
 uint32_t longest_match_lsx(deflate_state *const s, uint32_t cur_match);
 uint32_t longest_match_roll_lsx(deflate_state *const s, uint32_t cur_match);
 void slide_hash_lsx(deflate_state *s);
+void slide_hash_head_lsx(deflate_state *s);
 #endif
 
 #ifndef LOONGARCH_LSX_NATIVE
@@ -46,6 +47,7 @@ void inflate_fast_lasx(PREFIX3(stream) *strm, uint32_t start, int safe_mode);
 uint32_t longest_match_lasx(deflate_state *const s, uint32_t cur_match);
 uint32_t longest_match_roll_lasx(deflate_state *const s, uint32_t cur_match);
 void slide_hash_lasx(deflate_state *s);
+void slide_hash_head_lasx(deflate_state *s);
 #endif
 
 #ifdef DISABLE_RUNTIME_CPU_DETECTION
@@ -73,6 +75,8 @@ void slide_hash_lasx(deflate_state *s);
 #    define native_longest_match_roll longest_match_roll_lsx
 #    undef native_slide_hash
 #    define native_slide_hash slide_hash_lsx
+#    undef native_slide_hash_head
+#    define native_slide_hash_head slide_hash_head_lsx
 #  endif
 #  ifdef LOONGARCH_LASX_NATIVE
 #    undef native_adler32
@@ -91,6 +95,8 @@ void slide_hash_lasx(deflate_state *s);
 #    define native_longest_match_roll longest_match_roll_lasx
 #    undef native_slide_hash
 #    define native_slide_hash slide_hash_lasx
+#    undef native_slide_hash_head
+#    define native_slide_hash_head slide_hash_head_lasx
 #  endif
 #endif
 

--- a/arch/loongarch/slide_hash_lasx.c
+++ b/arch/loongarch/slide_hash_lasx.c
@@ -46,4 +46,12 @@ Z_INTERNAL void slide_hash_lasx(deflate_state *s) {
     slide_hash_chain(s->prev, wsize, ymm_wsize);
 }
 
+Z_INTERNAL void slide_hash_head_lasx(deflate_state *s) {
+    Assert(s->w_size <= UINT16_MAX, "w_size should fit in uint16_t");
+    uint16_t wsize = (uint16_t)s->w_size;
+    const __m256i ymm_wsize = __lasx_xvreplgr2vr_h((short)wsize);
+
+    slide_hash_chain(s->head, HASH_SIZE, ymm_wsize);
+}
+
 #endif

--- a/arch/loongarch/slide_hash_lsx.c
+++ b/arch/loongarch/slide_hash_lsx.c
@@ -51,4 +51,13 @@ Z_INTERNAL void slide_hash_lsx(deflate_state *s) {
     slide_hash_chain(s->prev, wsize, xmm_wsize);
 }
 
+Z_INTERNAL void slide_hash_head_lsx(deflate_state *s) {
+    Assert(s->w_size <= UINT16_MAX, "w_size should fit in uint16_t");
+    uint16_t wsize = (uint16_t)s->w_size;
+    const __m128i xmm_wsize = __lsx_vreplgr2vr_h((short)wsize);
+
+    assert(((uintptr_t)s->head & 15) == 0);
+    slide_hash_chain(s->head, HASH_SIZE, xmm_wsize);
+}
+
 #endif

--- a/arch/power/power_functions.h
+++ b/arch/power/power_functions.h
@@ -13,6 +13,7 @@
 uint32_t adler32_vmx(uint32_t adler, const uint8_t *buf, size_t len);
 uint32_t adler32_copy_vmx(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len);
 void slide_hash_vmx(deflate_state *s);
+void slide_hash_head_vmx(deflate_state *s);
 #endif
 
 #ifdef POWER8_VSX
@@ -22,6 +23,7 @@ uint8_t* chunkmemset_safe_power8(uint8_t *out, uint8_t *from, size_t len, size_t
 uint32_t crc32_power8(uint32_t crc, const uint8_t *buf, size_t len);
 uint32_t crc32_copy_power8(uint32_t crc, uint8_t *dst, const uint8_t *src, size_t len);
 void slide_hash_power8(deflate_state *s);
+void slide_hash_head_power8(deflate_state *s);
 void inflate_fast_power8(PREFIX3(stream) *strm, uint32_t start, int safe_mode);
 #endif
 
@@ -56,6 +58,8 @@ uint32_t longest_match_roll_power9(deflate_state *const s, uint32_t cur_match);
 #    define native_adler32_copy adler32_copy_vmx
 #    undef native_slide_hash
 #    define native_slide_hash slide_hash_vmx
+#    undef native_slide_hash_head
+#    define native_slide_hash_head slide_hash_head_vmx
 #  endif
 // Power8 - VSX
 #  ifdef POWER8_VSX_NATIVE
@@ -69,6 +73,8 @@ uint32_t longest_match_roll_power9(deflate_state *const s, uint32_t cur_match);
 #    define native_inflate_fast inflate_fast_power8
 #    undef native_slide_hash
 #    define native_slide_hash slide_hash_power8
+#    undef native_slide_hash_head
+#    define native_slide_hash_head slide_hash_head_power8
 #  endif
 #  ifdef POWER8_VSX_CRC32_NATIVE
 #    undef native_crc32

--- a/arch/power/slide_hash_power8.c
+++ b/arch/power/slide_hash_power8.c
@@ -7,6 +7,7 @@
 #ifdef POWER8_VSX
 
 #define SLIDE_PPC slide_hash_power8
+#define SLIDE_PPC_HEAD slide_hash_head_power8
 #include "slide_ppc_tpl.h"
 
 #endif /* POWER8_VSX */

--- a/arch/power/slide_hash_vmx.c
+++ b/arch/power/slide_hash_vmx.c
@@ -5,6 +5,7 @@
 #ifdef PPC_VMX
 
 #define SLIDE_PPC slide_hash_vmx
+#define SLIDE_PPC_HEAD slide_hash_head_vmx
 #include "slide_ppc_tpl.h"
 
 #endif /* PPC_VMX */

--- a/arch/power/slide_ppc_tpl.h
+++ b/arch/power/slide_ppc_tpl.h
@@ -42,3 +42,9 @@ void Z_INTERNAL SLIDE_PPC(deflate_state *s) {
     slide_hash_chain(s->head, HASH_SIZE, wsize);
     slide_hash_chain(s->prev, wsize, wsize);
 }
+
+void Z_INTERNAL SLIDE_PPC_HEAD(deflate_state *s) {
+    Assert(s->w_size <= UINT16_MAX, "w_size should fit in uint16_t");
+    uint16_t wsize = (uint16_t)s->w_size;
+    slide_hash_chain(s->head, HASH_SIZE, wsize);
+}

--- a/arch/riscv/riscv_functions.h
+++ b/arch/riscv/riscv_functions.h
@@ -22,6 +22,7 @@ uint32_t compare256_rvv(const uint8_t *src0, const uint8_t *src1);
 uint32_t longest_match_rvv(deflate_state *const s, uint32_t cur_match);
 uint32_t longest_match_roll_rvv(deflate_state *const s, uint32_t cur_match);
 void slide_hash_rvv(deflate_state *s);
+void slide_hash_head_rvv(deflate_state *s);
 void inflate_fast_rvv(PREFIX3(stream) *strm, uint32_t start, int safe_mode);
 #endif
 
@@ -56,6 +57,8 @@ uint32_t crc32_copy_riscv64_zbc(uint32_t crc, uint8_t *dst, const uint8_t *src, 
 #    define native_longest_match_roll longest_match_roll_rvv
 #    undef native_slide_hash
 #    define native_slide_hash slide_hash_rvv
+#    undef native_slide_hash_head
+#    define native_slide_hash_head slide_hash_head_rvv
 #  endif
 // RISCV - CRC32
 #  ifdef RISCV_ZBC_NATIVE

--- a/arch/riscv/slide_hash_rvv.c
+++ b/arch/riscv/slide_hash_rvv.c
@@ -30,4 +30,11 @@ Z_INTERNAL void slide_hash_rvv(deflate_state *s) {
     slide_hash_chain(s->prev, wsize, wsize);
 }
 
+Z_INTERNAL void slide_hash_head_rvv(deflate_state *s) {
+    Assert(s->w_size <= UINT16_MAX, "w_size should fit in uint16_t");
+    uint16_t wsize = (uint16_t)s->w_size;
+
+    slide_hash_chain(s->head, HASH_SIZE, wsize);
+}
+
 #endif // RISCV_RVV

--- a/arch/s390/s390_functions.h
+++ b/arch/s390/s390_functions.h
@@ -20,6 +20,7 @@
 uint32_t crc32_s390_vx(uint32_t crc, const uint8_t *buf, size_t len);
 uint32_t crc32_copy_s390_vx(uint32_t crc, uint8_t *dst, const uint8_t *src, size_t len);
 void slide_hash_vx(deflate_state *s);
+void slide_hash_head_vx(deflate_state *s);
 
 #ifdef __clang__
 #  if ((__clang_major__ == 18) || (__clang_major__ == 19 && (__clang_minor__ < 1 || (__clang_minor__ == 1 && __clang_patchlevel__ < 2))))
@@ -38,6 +39,8 @@ void slide_hash_vx(deflate_state *s);
 #    define native_crc32_copy crc32_copy_s390_vx
 #    undef native_slide_hash
 #    define native_slide_hash slide_hash_vx
+#    undef native_slide_hash_head
+#    define native_slide_hash_head slide_hash_head_vx
 #  endif
 #endif
 

--- a/arch/s390/slide_hash_vx.c
+++ b/arch/s390/slide_hash_vx.c
@@ -32,4 +32,11 @@ Z_INTERNAL void slide_hash_vx(deflate_state *s) {
     slide_hash_chain(s->head, HASH_SIZE, wsize);
     slide_hash_chain(s->prev, wsize, wsize);
 }
+
+Z_INTERNAL void slide_hash_head_vx(deflate_state *s) {
+    Assert(s->w_size <= UINT16_MAX, "w_size should fit in uint16_t");
+    uint16_t wsize = (uint16_t)s->w_size;
+
+    slide_hash_chain(s->head, HASH_SIZE, wsize);
+}
 #endif

--- a/arch/x86/slide_hash_avx2.c
+++ b/arch/x86/slide_hash_avx2.c
@@ -45,4 +45,12 @@ Z_INTERNAL void slide_hash_avx2(deflate_state *s) {
     slide_hash_chain(s->prev, wsize, ymm_wsize);
 }
 
+Z_INTERNAL void slide_hash_head_avx2(deflate_state *s) {
+    Assert(s->w_size <= UINT16_MAX, "w_size should fit in uint16_t");
+    uint16_t wsize = (uint16_t)s->w_size;
+    const __m256i ymm_wsize = _mm256_set1_epi16((short)wsize);
+
+    slide_hash_chain(s->head, HASH_SIZE, ymm_wsize);
+}
+
 #endif

--- a/arch/x86/slide_hash_sse2.c
+++ b/arch/x86/slide_hash_sse2.c
@@ -45,4 +45,12 @@ Z_INTERNAL void slide_hash_sse2(deflate_state *s) {
     slide_hash_chain(s->prev, wsize, xmm_wsize);
 }
 
+Z_INTERNAL void slide_hash_head_sse2(deflate_state *s) {
+    Assert(s->w_size <= UINT16_MAX, "w_size should fit in uint16_t");
+    uint16_t wsize = (uint16_t)s->w_size;
+    const __m128i xmm_wsize = _mm_set1_epi16((short)wsize);
+
+    slide_hash_chain(s->head, HASH_SIZE, xmm_wsize);
+}
+
 #endif

--- a/arch/x86/x86_functions.h
+++ b/arch/x86/x86_functions.h
@@ -22,6 +22,7 @@ void inflate_fast_sse2(PREFIX3(stream)* strm, uint32_t start, int safe_mode);
 uint32_t longest_match_sse2(deflate_state *const s, uint32_t cur_match);
 uint32_t longest_match_roll_sse2(deflate_state *const s, uint32_t cur_match);
 void slide_hash_sse2(deflate_state *s);
+void slide_hash_head_sse2(deflate_state *s);
 
 #  ifdef CRC32_CHORBA_SSE_FALLBACK
     uint32_t crc32_chorba_sse2(uint32_t crc, const uint8_t *buf, size_t len);
@@ -67,6 +68,7 @@ void inflate_fast_avx2(PREFIX3(stream)* strm, uint32_t start, int safe_mode);
 uint32_t longest_match_avx2(deflate_state *const s, uint32_t cur_match);
 uint32_t longest_match_roll_avx2(deflate_state *const s, uint32_t cur_match);
 void slide_hash_avx2(deflate_state *s);
+void slide_hash_head_avx2(deflate_state *s);
 #endif
 #ifdef X86_AVX512
 uint32_t adler32_avx512(uint32_t adler, const uint8_t *buf, size_t len);
@@ -121,6 +123,8 @@ uint32_t crc32_copy_vpclmulqdq_avx512(uint32_t crc, uint8_t *dst, const uint8_t 
 #    endif
 #    undef native_slide_hash
 #    define native_slide_hash slide_hash_sse2
+#    undef native_slide_hash_head
+#    define native_slide_hash_head slide_hash_head_sse2
 #  endif
 // X86 - SSSE3
 #  ifdef X86_SSSE3_NATIVE
@@ -172,6 +176,8 @@ uint32_t crc32_copy_vpclmulqdq_avx512(uint32_t crc, uint8_t *dst, const uint8_t 
 #    define native_longest_match_roll longest_match_roll_avx2
 #    undef native_slide_hash
 #    define native_slide_hash slide_hash_avx2
+#    undef native_slide_hash_head
+#    define native_slide_hash_head slide_hash_head_avx2
 #  endif
 // X86 - AVX2 (VNNI)
 #    if defined(X86_AVX2VNNI) && defined(__AVXVNNI__)

--- a/deflate.c
+++ b/deflate.c
@@ -135,6 +135,15 @@ static const config configuration_table[10] = {
  * meaning.
  */
 
+/* Level 1 uses deflate_quick, which only reads the hash chain head, so it can
+ * skip prev maintenance. When quick is compiled out level 1 falls back to
+ * deflate_fast, which walks the chains like every other level. */
+#ifdef NO_QUICK_STRATEGY
+#  define HAVE_QUICK_STRATEGY 0
+#else
+#  define HAVE_QUICK_STRATEGY 1
+#endif
+
 /* rank Z_BLOCK between Z_NO_FLUSH and Z_PARTIAL_FLUSH */
 #define RANK(f) (((f) * 2) - ((f) > 4 ? 9 : 0))
 
@@ -623,9 +632,10 @@ int32_t Z_EXPORT PREFIX(deflateParams)(PREFIX3(stream) *strm, int32_t level, int
     int hashless = level == 0 || strategy == Z_HUFFMAN_ONLY || strategy == Z_RLE;
     int was_hashless = s->level == 0 || s->strategy == Z_HUFFMAN_ONLY || s->strategy == Z_RLE;
 
-    /* Stale if the hash usage flipped (to/from huffman/rle/stored) or the hash
-     * function changed at level 9. */
-    int stale_chain = (hashless != was_hashless) || (level >= 9) != (s->level >= 9);
+    /* Stale if the hash usage flipped (to/from huffman/rle/stored), the hash
+     * function changed at level 9, or quick at level 1 left prev unmaintained. */
+    int stale_chain = (hashless != was_hashless) || (level >= 9) != (s->level >= 9) ||
+                      (HAVE_QUICK_STRATEGY && s->level == 1 && level != 1);
 
     /* Rebuild the hash chains when fill_window is called. */
     if (stale_chain && !hashless) {
@@ -1200,6 +1210,8 @@ void Z_INTERNAL PREFIX(fill_window)(deflate_state *s) {
 
     if (level >= 9)
         insert_batch = insert_roll_batch;
+    else if (HAVE_QUICK_STRATEGY && level == 1)
+        insert_batch = insert_knuth_batch_head;
     else
         insert_batch = insert_knuth_batch;
 
@@ -1249,7 +1261,10 @@ void Z_INTERNAL PREFIX(fill_window)(deflate_state *s) {
             if (UNLIKELY(level >= 9)) {
                 s->ins_h = update_hash_roll(window[str], window[str+1]);
             } else if (str >= 1) {
-                insert_knuth(s, window, str + 2 - STD_MIN_MATCH);
+                if (HAVE_QUICK_STRATEGY && level == 1)
+                    insert_knuth_head(s, window, str + 2 - STD_MIN_MATCH);
+                else
+                    insert_knuth(s, window, str + 2 - STD_MIN_MATCH);
             }
             unsigned int count = s->insert;
             if (UNLIKELY(s->lookahead == 1)) {

--- a/deflate.c
+++ b/deflate.c
@@ -1233,7 +1233,14 @@ void Z_INTERNAL PREFIX(fill_window)(deflate_state *s) {
             s->block_start -= (int)wsize;
             if (s->insert > s->strstart)
                 s->insert = s->strstart;
-            FUNCTABLE_CALL(slide_hash)(s);
+            if (s->strategy != Z_HUFFMAN_ONLY && s->strategy != Z_RLE) {
+                /* Z_HUFFMAN_ONLY and Z_RLE never read the hash chain. deflate_quick
+                 * reads the chain head but never walks prev, so it slides head only. */
+                if (HAVE_QUICK_STRATEGY && level == 1)
+                    FUNCTABLE_CALL(slide_hash_head)(s);
+                else
+                    FUNCTABLE_CALL(slide_hash)(s);
+            }
             more += wsize;
         }
         if (strm->avail_in == 0)

--- a/deflate.h
+++ b/deflate.h
@@ -143,9 +143,10 @@ typedef uint16_t Pos;
 /* Type definitions for hash callbacks */
 typedef struct internal_state deflate_state;
 
-typedef void (* insert_batch_func) (deflate_state *const s, unsigned char *window, uint32_t str, uint32_t count);
-void         insert_knuth_batch    (deflate_state *const s, unsigned char *window, uint32_t str, uint32_t count);
-void         insert_roll_batch     (deflate_state *const s, unsigned char *window, uint32_t str, uint32_t count);
+typedef void (* insert_batch_func)   (deflate_state *const s, unsigned char *window, uint32_t str, uint32_t count);
+void         insert_knuth_batch      (deflate_state *const s, unsigned char *window, uint32_t str, uint32_t count);
+void         insert_roll_batch       (deflate_state *const s, unsigned char *window, uint32_t str, uint32_t count);
+void         insert_knuth_batch_head (deflate_state *const s, unsigned char *window, uint32_t str, uint32_t count);
 
 /* Struct for memory allocation handling */
 typedef struct deflate_allocs_s {

--- a/deflate.h
+++ b/deflate.h
@@ -424,6 +424,7 @@ static inline void put_uint64(deflate_state *s, uint64_t lld) {
 
 void Z_INTERNAL PREFIX(fill_window)(deflate_state *s);
 void Z_INTERNAL slide_hash_c(deflate_state *s);
+void Z_INTERNAL slide_hash_head_c(deflate_state *s);
 
         /* in trees.c */
 void Z_INTERNAL zng_tr_init(deflate_state *s);

--- a/deflate_quick.c
+++ b/deflate_quick.c
@@ -95,7 +95,7 @@ Z_FORCEINLINE static block_state deflate_quick_impl(deflate_state *s, int flush,
         uint32_t str_val = Z_U32_FROM_LE(zng_memread_4(window + strstart));
 
         if (LIKELY(lookahead >= WANT_MIN_MATCH)) {
-            uint32_t hash_head = insert_knuth_val(s, strstart, str_val);
+            uint32_t hash_head = insert_knuth_val_head(s, strstart, str_val);
             int64_t dist = (int64_t)strstart - hash_head;
 
             if (dist <= MAX_DIST(s) && dist > 0) {

--- a/functable.c
+++ b/functable.c
@@ -95,6 +95,7 @@ static int init_functable(void) {
 #endif
 #ifdef SLIDE_HASH_FALLBACK
     ft.slide_hash = &slide_hash_c;
+    ft.slide_hash_head = &slide_hash_head_c;
 #endif
 
     // Select arch-optimized functions
@@ -119,6 +120,7 @@ static int init_functable(void) {
         ft.longest_match = &longest_match_sse2;
         ft.longest_match_roll = &longest_match_roll_sse2;
         ft.slide_hash = &slide_hash_sse2;
+        ft.slide_hash_head = &slide_hash_head_sse2;
 #  endif
 #  if defined(CRC32_CHORBA_SSE_FALLBACK) && !defined(X86_SSE41_NATIVE) && !defined(X86_PCLMULQDQ_NATIVE)
         ft.crc32 = &crc32_chorba_sse2;
@@ -193,6 +195,7 @@ static int init_functable(void) {
         ft.longest_match_roll = &longest_match_roll_avx2;
 #  endif
         ft.slide_hash = &slide_hash_avx2;
+        ft.slide_hash_head = &slide_hash_head_avx2;
     }
 #endif
 #ifdef X86_AVX2VNNI
@@ -256,6 +259,7 @@ static int init_functable(void) {
 #  endif
     {
         ft.slide_hash = &slide_hash_armv6;
+        ft.slide_hash_head = &slide_hash_head_armv6;
     }
 #endif
     // ARM - NEON
@@ -272,6 +276,7 @@ static int init_functable(void) {
         ft.longest_match = &longest_match_neon;
         ft.longest_match_roll = &longest_match_roll_neon;
         ft.slide_hash = &slide_hash_neon;
+        ft.slide_hash_head = &slide_hash_head_neon;
     }
 #endif
     // ARM - NEON DotProd
@@ -314,6 +319,7 @@ static int init_functable(void) {
         ft.adler32 = &adler32_vmx;
         ft.adler32_copy = &adler32_copy_vmx;
         ft.slide_hash = &slide_hash_vmx;
+        ft.slide_hash_head = &slide_hash_head_vmx;
     }
 #endif
     // Power8 - VSX
@@ -327,6 +333,7 @@ static int init_functable(void) {
         ft.chunkmemset_safe = &chunkmemset_safe_power8;
         ft.inflate_fast = &inflate_fast_power8;
         ft.slide_hash = &slide_hash_power8;
+        ft.slide_hash_head = &slide_hash_head_power8;
     }
 #endif
 #ifdef POWER8_VSX_CRC32
@@ -365,6 +372,7 @@ static int init_functable(void) {
         ft.longest_match = &longest_match_rvv;
         ft.longest_match_roll = &longest_match_roll_rvv;
         ft.slide_hash = &slide_hash_rvv;
+        ft.slide_hash_head = &slide_hash_head_rvv;
     }
 #endif
 
@@ -388,6 +396,7 @@ static int init_functable(void) {
         ft.crc32 = &crc32_s390_vx;
         ft.crc32_copy = &crc32_copy_s390_vx;
         ft.slide_hash = &slide_hash_vx;
+        ft.slide_hash_head = &slide_hash_head_vx;
     }
 #endif
 
@@ -414,6 +423,7 @@ static int init_functable(void) {
         ft.longest_match = &longest_match_lsx;
         ft.longest_match_roll = &longest_match_roll_lsx;
         ft.slide_hash = &slide_hash_lsx;
+        ft.slide_hash_head = &slide_hash_head_lsx;
     }
 #endif
 #ifdef LOONGARCH_LASX
@@ -429,6 +439,7 @@ static int init_functable(void) {
         ft.longest_match = &longest_match_lasx;
         ft.longest_match_roll = &longest_match_roll_lasx;
         ft.slide_hash = &slide_hash_lasx;
+        ft.slide_hash_head = &slide_hash_head_lasx;
     }
 #endif
 
@@ -446,6 +457,7 @@ static int init_functable(void) {
     FUNCTABLE_VERIFY_ASSIGN(ft, longest_match);
     FUNCTABLE_VERIFY_ASSIGN(ft, longest_match_roll);
     FUNCTABLE_VERIFY_ASSIGN(ft, slide_hash);
+    FUNCTABLE_VERIFY_ASSIGN(ft, slide_hash_head);
 
     // Memory barrier for weak memory order CPUs
     FUNCTABLE_BARRIER();
@@ -514,6 +526,11 @@ static void slide_hash_stub(deflate_state* s) {
     functable.slide_hash(s);
 }
 
+static void slide_hash_head_stub(deflate_state *s) {
+    FUNCTABLE_INIT_ABORT;
+    functable.slide_hash_head(s);
+}
+
 /* functable init */
 Z_INTERNAL struct functable_s functable = {
     force_init_stub,
@@ -527,6 +544,7 @@ Z_INTERNAL struct functable_s functable = {
     longest_match_stub,
     longest_match_roll_stub,
     slide_hash_stub,
+    slide_hash_head_stub,
 };
 
 #endif

--- a/functable.h
+++ b/functable.h
@@ -34,6 +34,7 @@ struct functable_s {
     uint32_t (* longest_match)      (deflate_state *const s, uint32_t cur_match);
     uint32_t (* longest_match_roll) (deflate_state *const s, uint32_t cur_match);
     void     (* slide_hash)         (deflate_state *s);
+    void     (* slide_hash_head)    (deflate_state *s);
 };
 
 Z_INTERNAL extern struct functable_s functable;

--- a/insert_string.c
+++ b/insert_string.c
@@ -16,3 +16,7 @@ Z_INTERNAL void insert_knuth_batch(deflate_state *const s, unsigned char *window
 Z_INTERNAL void insert_roll_batch(deflate_state *const s, unsigned char *window, uint32_t str, uint32_t count) {
     insert_roll_batch_static(s, window, str, count);
 }
+
+Z_INTERNAL void insert_knuth_batch_head(deflate_state *const s, unsigned char *window, uint32_t str, uint32_t count) {
+    insert_knuth_batch_head_static(s, window, str, count);
+}

--- a/insert_string_p.h
+++ b/insert_string_p.h
@@ -47,6 +47,21 @@ Z_FORCEINLINE static uint32_t insert_knuth_val(deflate_state *const s, uint32_t 
 }
 
 /* ===========================================================================
+ * Insert string str using a pre-read value, returning the previous head of the
+ * hash chain. The prev link is left untouched since deflate_quick only inspects
+ * the chain head and never walks the chain.
+ */
+Z_FORCEINLINE static uint32_t insert_knuth_val_head(deflate_state *const s, uint32_t str, uint32_t val) {
+    uint32_t h, head;
+
+    UPDATE_HASH_KNUTH(h, val);
+
+    head = s->head[h];
+    s->head[h] = (Pos)str;
+    return head;
+}
+
+/* ===========================================================================
  * Insert string str in the dictionary and set match_head to the previous head
  * of the hash chain (the most recent string with same hash key). Return
  * the previous length of the hash chain.
@@ -63,6 +78,23 @@ Z_FORCEINLINE static uint32_t insert_knuth(deflate_state *const s, unsigned char
         s->prev[str & W_MASK(s)] = (Pos)head;
         s->head[h] = (Pos)str;
     }
+    return head;
+}
+
+/* ===========================================================================
+ * Insert string str read from the window, returning the previous head of the
+ * hash chain. Like insert_knuth but leaves the prev link untouched for
+ * deflate_quick, which only inspects the chain head.
+ */
+Z_FORCEINLINE static uint32_t insert_knuth_head(deflate_state *const s, unsigned char *window, uint32_t str) {
+    uint8_t *strstart = window + str;
+    uint32_t val, h, head;
+
+    val = Z_U32_FROM_LE(zng_memread_4(strstart));
+    UPDATE_HASH_KNUTH(h, val);
+
+    head = s->head[h];
+    s->head[h] = (Pos)str;
     return head;
 }
 
@@ -110,6 +142,25 @@ Z_FORCEINLINE static void insert_knuth_batch_static(deflate_state *const s, unsi
             prevp[idx & w_mask] = (Pos)head;
             headp[h] = (Pos)idx;
         }
+    }
+}
+
+/* ===========================================================================
+ * Insert count strings read from the window, leaving the prev links untouched.
+ * Used by fill_window during deflate_quick, which only inspects the chain head.
+ */
+Z_FORCEINLINE static void insert_knuth_batch_head_static(deflate_state *const s, unsigned char *window, uint32_t str, uint32_t count) {
+    uint8_t *strstart = window + str;
+    uint8_t *strend = strstart + count;
+    Pos *headp = s->head;
+
+    for (uint32_t idx = str; strstart < strend; idx++, strstart++) {
+        uint32_t val, h;
+
+        val = Z_U32_FROM_LE(zng_memread_4(strstart));
+        UPDATE_HASH_KNUTH(h, val);
+
+        headp[h] = (Pos)idx;
     }
 }
 


### PR DESCRIPTION
`deflate_quick` only inspects the head of each hash chain — it never walks the `prev` links — and `Z_HUFFMAN_ONLY` / `Z_RLE` read neither `head` nor `prev`. This branch removes hash maintenance those strategies never use.

The main lever is the per-window-slide work. A new `slide_hash_chain` functable entry slides a single table, so `deflate_quick` slides only `head` (skipping the ~64 KB `prev` slide) while huffman/rle skip the slide entirely. Chain-walking strategies keep calling the existing `slide_hash` (both tables, inlined) and are unchanged. `slide_hash_chain` is implemented across all SIMD backends.

`deflate_quick`'s per-position inserts also drop the now-unused `prev` write.

Output is byte-identical at every level and strategy. On an Apple M5 the level-1 deflate path is about 8% faster on the no-CRC benchmark from the slide change, plus roughly 2% from the insert change.

The first commit is a no-op rename that distinguishes the single- and multi-insert helpers and frees the `quick` name for these variants.
