### PR TITLE
Fix type mismatch in benchmark_compress.cc.

### DIFF
--- a/test/benchmarks/benchmark_compress.cc
+++ b/test/benchmarks/benchmark_compress.cc
@@ -49,7 +49,7 @@ public:
 
         for (auto _ : state) {
             z_uintmax_t compressed_size = MAX_SIZE + 16;
-            err = PREFIX(compress)(outbuff, &compressed_size, inbuff, (size_t)state.range(0));
+            err = PREFIX(compress)(outbuff, &compressed_size, inbuff, (z_uintmax_t)state.range(0));
             if (err != Z_OK) {
                 fprintf(stderr, "compress() failed with error %d\n", err);
                 abort();


### PR DESCRIPTION
* When `ZLIB_COMPAT` is set, last parameter of `compress` is `unsigned long`, not `size_t`, so we need to use `z_uintmax_t` like we already use for the second parameter.