### PR TITLE
Add initial support for musttail attribute.

### DIFF
--- a/adler32.c
+++ b/adler32.c
@@ -17,7 +17,7 @@ unsigned long Z_EXPORT PREFIX(adler32_z)(unsigned long adler, const unsigned cha
 uint32_t Z_EXPORT PREFIX(adler32_z)(uint32_t adler, const unsigned char *buf, size_t len) {
     if (buf == NULL)
         return ADLER32_INITIAL_VALUE;
-    return FUNCTABLE_CALL(adler32)(adler, buf, len);
+    Z_MUSTTAIL_FT return FUNCTABLE_CALL(adler32)(adler, buf, len);
 }
 #endif
 

--- a/arch/x86/adler32_avx512_vnni.c
+++ b/arch/x86/adler32_avx512_vnni.c
@@ -24,10 +24,10 @@ Z_INTERNAL uint32_t adler32_avx512_vnni(uint32_t adler, const uint8_t *src, size
 
 rem_peel:
     if (len < 32)
-        return adler32_ssse3(adler, src, len);
+        Z_MUSTTAIL2 return adler32_ssse3(adler, src, len);
 
     if (len < 64)
-        return adler32_avx2(adler, src, len);
+        Z_MUSTTAIL2 return adler32_avx2(adler, src, len);
 
     const __m512i dot2v = _mm512_set_epi8(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
                                           20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37,

--- a/crc32.c
+++ b/crc32.c
@@ -36,7 +36,7 @@ unsigned long Z_EXPORT PREFIX(crc32_z)(unsigned long crc, const unsigned char *b
 uint32_t Z_EXPORT PREFIX(crc32_z)(uint32_t crc, const unsigned char *buf, size_t len) {
     if (buf == NULL)
         return CRC32_INITIAL_VALUE;
-    return FUNCTABLE_CALL(crc32)(crc, buf, len);
+    Z_MUSTTAIL_FT return FUNCTABLE_CALL(crc32)(crc, buf, len);
 }
 #endif
 

--- a/functable.c
+++ b/functable.c
@@ -478,32 +478,32 @@ static int force_init_stub(void) {
 
 static uint32_t adler32_stub(uint32_t adler, const uint8_t* buf, size_t len) {
     FUNCTABLE_INIT_ABORT;
-    return functable.adler32(adler, buf, len);
+    Z_MUSTTAIL_FT return functable.adler32(adler, buf, len);
 }
 
 static uint32_t adler32_copy_stub(uint32_t adler, uint8_t* dst, const uint8_t* src, size_t len) {
     FUNCTABLE_INIT_ABORT;
-    return functable.adler32_copy(adler, dst, src, len);
+    Z_MUSTTAIL_FT return functable.adler32_copy(adler, dst, src, len);
 }
 
 static uint8_t* chunkmemset_safe_stub(uint8_t* out, uint8_t *from, size_t len, size_t left) {
     FUNCTABLE_INIT_ABORT;
-    return functable.chunkmemset_safe(out, from, len, left);
+    Z_MUSTTAIL_FT return functable.chunkmemset_safe(out, from, len, left);
 }
 
 static uint32_t compare256_stub(const uint8_t* src0, const uint8_t* src1) {
     FUNCTABLE_INIT_ABORT;
-    return functable.compare256(src0, src1);
+    Z_MUSTTAIL_FT return functable.compare256(src0, src1);
 }
 
 static uint32_t crc32_stub(uint32_t crc, const uint8_t* buf, size_t len) {
     FUNCTABLE_INIT_ABORT;
-    return functable.crc32(crc, buf, len);
+    Z_MUSTTAIL_FT return functable.crc32(crc, buf, len);
 }
 
 static uint32_t crc32_copy_stub(uint32_t crc, uint8_t *dst, const uint8_t *src, size_t len) {
     FUNCTABLE_INIT_ABORT;
-    return functable.crc32_copy(crc, dst, src, len);
+    Z_MUSTTAIL_FT return functable.crc32_copy(crc, dst, src, len);
 }
 
 static void inflate_fast_stub(PREFIX3(stream) *strm, uint32_t start, int safe_mode) {
@@ -513,12 +513,12 @@ static void inflate_fast_stub(PREFIX3(stream) *strm, uint32_t start, int safe_mo
 
 static uint32_t longest_match_stub(deflate_state* const s, uint32_t cur_match) {
     FUNCTABLE_INIT_ABORT;
-    return functable.longest_match(s, cur_match);
+    Z_MUSTTAIL_FT return functable.longest_match(s, cur_match);
 }
 
 static uint32_t longest_match_roll_stub(deflate_state* const s, uint32_t cur_match) {
     FUNCTABLE_INIT_ABORT;
-    return functable.longest_match_roll(s, cur_match);
+    Z_MUSTTAIL_FT return functable.longest_match_roll(s, cur_match);
 }
 
 static void slide_hash_stub(deflate_state* s) {

--- a/gzlib.c
+++ b/gzlib.c
@@ -330,7 +330,7 @@ z_int32_t Z_EXPORT PREFIX(gzclose)(gzFile file) {
 
     return state->mode == GZ_READ ? PREFIX(gzclose_r)(file) : PREFIX(gzclose_w)(file);
 #else
-    return PREFIX(gzclose_r)(file);
+    Z_MUSTTAIL return PREFIX(gzclose_r)(file);
 #endif
 }
 

--- a/gzread.c
+++ b/gzread.c
@@ -449,7 +449,7 @@ z_int32_t Z_EXPORT PREFIX(gzgetc)(gzFile file) {
 
 #ifdef ZLIB_COMPAT
 int Z_EXPORT PREFIX(gzgetc_)(gzFile file) {
-    return PREFIX(gzgetc)(file);
+    Z_MUSTTAIL return PREFIX(gzgetc)(file);
 }
 #endif
 

--- a/inflate.c
+++ b/inflate.c
@@ -101,7 +101,7 @@ int32_t Z_EXPORT PREFIX(inflateReset)(PREFIX3(stream) *strm) {
     state->wsize = 0;
     state->whave = 0;
     state->wnext = 0;
-    return PREFIX(inflateResetKeep)(strm);
+    Z_MUSTTAIL return PREFIX(inflateResetKeep)(strm);
 }
 
 int32_t Z_EXPORT PREFIX(inflateReset2)(PREFIX3(stream) *strm, int32_t windowBits) {

--- a/zbuild.h
+++ b/zbuild.h
@@ -72,6 +72,34 @@
 #  endif
 #endif
 
+#ifndef Z_MUSTTAIL
+#  if defined(__clang__) && __clang_major__ >= 17 && !defined(ARCH_WASM)
+#    define Z_MUSTTAIL [[clang::musttail]]
+#    define Z_MUSTTAIL2 [[clang::musttail]]
+#    if defined(ARCH_POWER) && !defined(DISABLE_RUNTIME_CPU_DETECTION)
+#      define Z_MUSTTAIL_FT
+#    else
+#      define Z_MUSTTAIL_FT [[clang::musttail]]
+#    endif
+#  elif defined(__GNUC__) && __GNUC__ >= 15
+#    define Z_MUSTTAIL [[gnu::musttail]]
+#    define Z_MUSTTAIL2 [[gnu::musttail]]
+#    if defined(ARCH_POWER) && !defined(DISABLE_RUNTIME_CPU_DETECTION)
+#      define Z_MUSTTAIL_FT
+#    else
+#      define Z_MUSTTAIL_FT [[gnu::musttail]]
+#    endif
+#  elif defined(_MSC_VER) && _MSC_VER >= 1950 && defined(NDEBUG)
+#    define Z_MUSTTAIL [[msvc::musttail]]
+#    define Z_MUSTTAIL2
+#    define Z_MUSTTAIL_FT [[msvc::musttail]]
+#  else
+#    define Z_MUSTTAIL
+#    define Z_MUSTTAIL2
+#    define Z_MUSTTAIL_FT
+#  endif
+#endif
+
 #ifndef Z_TARGET
 #  if Z_HAS_ATTRIBUTE(__target__)
 #    define Z_TARGET(x) __attribute__((__target__(x)))


### PR DESCRIPTION
* Add initial support for experimental `musttail` attribute for GCC, Clang and Visual C++
* Visual C++ only allows `musttail` on last line of the function, GCC and Clang allow on any line