### PR TITLE
Add Z_RESTRICT to zng_memcmp functions

### DIFF
--- a/zmemory.h
+++ b/zmemory.h
@@ -72,24 +72,24 @@ static inline void zng_memwrite_8(void *ptr, uint64_t val) {
 /* Use zng_memread_* instead of memcmp to avoid older compilers not converting memcmp
    calls to unaligned comparisons when unaligned access is supported. Use memcmp only when
    unaligned support is not available to avoid an extra call to memcpy. */
-static inline int32_t zng_memcmp_2(const void *src0, const void *src1) {
-#if defined(HAVE_MAY_ALIAS)
+static inline int32_t zng_memcmp_2(const void * Z_RESTRICT src0, const void * Z_RESTRICT src1) {
+#if defined(HAVE_MAY_ALIAS) || defined(_MSC_VER)
     return zng_memread_2(src0) != zng_memread_2(src1);
 #else
     return memcmp(src0, src1, 2);
 #endif
 }
 
-static inline int32_t zng_memcmp_4(const void *src0, const void *src1) {
-#if defined(HAVE_MAY_ALIAS)
+static inline int32_t zng_memcmp_4(const void * Z_RESTRICT src0, const void * Z_RESTRICT src1) {
+#if defined(HAVE_MAY_ALIAS) || defined(_MSC_VER)
     return zng_memread_4(src0) != zng_memread_4(src1);
 #else
     return memcmp(src0, src1, 4);
 #endif
 }
 
-static inline int32_t zng_memcmp_8(const void *src0, const void *src1) {
-#if defined(HAVE_MAY_ALIAS)
+static inline int32_t zng_memcmp_8(const void * Z_RESTRICT src0, const void * Z_RESTRICT src1) {
+#if defined(HAVE_MAY_ALIAS) || defined(_MSC_VER)
     return zng_memread_8(src0) != zng_memread_8(src1);
 #else
     return memcmp(src0, src1, 8);


### PR DESCRIPTION
* Use `zng_memread` and `zng_memwrite` functions with Visual C++ too to allow unaligned memory access

Based on comments in #2225

```
zng_memcmp_2:
  0000000000000000: 0F B7 12           movzx       edx,word ptr [rdx]
  0000000000000003: 33 C0              xor         eax,eax
  0000000000000005: 66 39 11           cmp         word ptr [rcx],dx
  0000000000000008: 0F 95 C0           setne       al
  000000000000000B: C3                 ret

zng_memcmp_4:
  0000000000000000: 8B 12              mov         edx,dword ptr [rdx]
  0000000000000002: 33 C0              xor         eax,eax
  0000000000000004: 39 11              cmp         dword ptr [rcx],edx
  0000000000000006: 0F 95 C0           setne       al
  0000000000000009: C3                 ret

zng_memcmp_8:
  0000000000000000: 48 8B 12           mov         rdx,qword ptr [rdx]
  0000000000000003: 33 C0              xor         eax,eax
  0000000000000005: 48 39 11           cmp         qword ptr [rcx],rdx
  0000000000000008: 0F 95 C0           setne       al
  000000000000000B: C3                 ret

zng_memread_2:
  0000000000000000: 0F B7 01           movzx       eax,word ptr [rcx]
  0000000000000003: C3                 ret

zng_memread_4:
  0000000000000000: 8B 01              mov         eax,dword ptr [rcx]
  0000000000000002: C3                 ret

zng_memread_8:
  0000000000000000: 48 8B 01           mov         rax,qword ptr [rcx]
  0000000000000003: C3                 ret
```