### PR TITLE
Fix type mismatch errors in fuzzers.

### DIFF
--- a/test/fuzz/fuzzer_compress.c
+++ b/test/fuzz/fuzzer_compress.c
@@ -7,7 +7,7 @@
 #endif
 
 static const uint8_t *data;
-static size_t dataLen;
+static z_uintmax_t dataLen;
 
 static void check_compress_level(uint8_t *compr, z_uintmax_t comprLen,
                                  uint8_t *uncompr, z_uintmax_t uncomprLen,
@@ -50,8 +50,8 @@ static void check_decompress(uint8_t *compr, z_uintmax_t comprLen) {
 
 int LLVMFuzzerTestOneInput(const uint8_t *d, size_t size) {
     /* compressBound does not provide enough space for low compression levels. */
-    z_size_t comprLen = 100 + 2 * PREFIX(compressBound)(size);
-    z_size_t uncomprLen = (z_size_t)size;
+    z_uintmax_t comprLen = 100 + 2 * PREFIX(compressBound)((z_uintmax_t)size);
+    z_uintmax_t uncomprLen = (z_uintmax_t)size;
     uint8_t *compr, *uncompr;
 
     /* Discard inputs larger than 1Mb. */
@@ -61,7 +61,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *d, size_t size) {
         return 0;
 
     data = d;
-    dataLen = size;
+    dataLen = (z_uintmax_t)size;
     compr = (uint8_t *)calloc(1, comprLen);
     uncompr = (uint8_t *)calloc(1, uncomprLen);
 

--- a/test/fuzz/fuzzer_example_flush.c
+++ b/test/fuzz/fuzzer_example_flush.c
@@ -90,7 +90,7 @@ void test_sync(unsigned char *compr, size_t comprLen, unsigned char *uncompr, si
 }
 
 int LLVMFuzzerTestOneInput(const uint8_t *d, size_t size) {
-    z_size_t comprLen = 100 + 2 * PREFIX(compressBound)(size);
+    z_size_t comprLen = 100 + 2 * PREFIX(compressBound)((z_uintmax_t)size);
     z_size_t uncomprLen = (z_size_t)size;
     uint8_t *compr, *uncompr;
 

--- a/test/fuzz/fuzzer_example_small.c
+++ b/test/fuzz/fuzzer_example_small.c
@@ -90,7 +90,7 @@ void test_inflate(unsigned char *compr, size_t comprLen, unsigned char *uncompr,
 }
 
 int LLVMFuzzerTestOneInput(const uint8_t *d, size_t size) {
-    size_t comprLen = PREFIX(compressBound)(size);
+    size_t comprLen = PREFIX(compressBound)((z_uintmax_t)size);
     size_t uncomprLen = size;
     uint8_t *compr, *uncompr;
 


### PR DESCRIPTION
* When `ZLIB_COMPAT` is defined, some function parameters use `unsigned long` instead of `size_t`