### PR TITLE
Add missing return after SkipWithError in benchmarks

### DIFF
--- a/test/benchmarks/benchmark_adler32.cc
+++ b/test/benchmarks/benchmark_adler32.cc
@@ -56,6 +56,7 @@ public:
     BENCHMARK_DEFINE_F(adler32, name)(benchmark::State& state) { \
         if (!(support_flag)) { \
             state.SkipWithError("CPU does not support " #name); \
+            return; \
         } \
         Bench(state, hashfunc, 0); \
     } \
@@ -67,6 +68,7 @@ public:
     BENCHMARK_DEFINE_F(adler32, ALIGNED_NAME(name))(benchmark::State& state) { \
         if (!(support_flag)) { \
             state.SkipWithError("CPU does not support " #name); \
+            return; \
         } \
         Bench(state, hashfunc, 1); \
     } \

--- a/test/benchmarks/benchmark_adler32_copy.cc
+++ b/test/benchmarks/benchmark_adler32_copy.cc
@@ -62,6 +62,7 @@ public:
     BENCHMARK_DEFINE_F(adler32_copy, name)(benchmark::State& state) { \
         if (!(support_flag)) { \
             state.SkipWithError("CPU does not support " #name); \
+            return; \
         } \
         Bench(state, copyfunc, 0); \
     } \
@@ -73,6 +74,7 @@ public:
     BENCHMARK_DEFINE_F(adler32_copy, ALIGNED_NAME(name))(benchmark::State& state) { \
         if (!(support_flag)) { \
             state.SkipWithError("CPU does not support " #name); \
+            return; \
         } \
         Bench(state, copyfunc, 1); \
     } \
@@ -86,6 +88,7 @@ public:
     BENCHMARK_DEFINE_F(adler32_copy, MEMCPY_NAME(name))(benchmark::State& state) { \
         if (!(support_flag)) { \
             state.SkipWithError("CPU does not support " #name); \
+            return; \
         } \
         Bench(state, [](uint32_t init_sum, unsigned char *dst, \
                         const uint8_t *buf, size_t len) -> uint32_t { \
@@ -100,6 +103,7 @@ public:
     BENCHMARK_DEFINE_F(adler32_copy, MEMCPY_ALIGNED_NAME(name))(benchmark::State& state) { \
         if (!(support_flag)) { \
             state.SkipWithError("CPU does not support " #name); \
+            return; \
         } \
         Bench(state, [](uint32_t init_sum, unsigned char *dst, \
                         const uint8_t *buf, size_t len) -> uint32_t { \

--- a/test/benchmarks/benchmark_chunkmemset.cc
+++ b/test/benchmarks/benchmark_chunkmemset.cc
@@ -78,6 +78,7 @@ public:
     BENCHMARK_DEFINE_F(chunkmemset, name)(benchmark::State& state) {           \
         if (!(support_flag)) {                                                 \
             state.SkipWithError("CPU does not support " #name);                \
+            return;                                                            \
         }                                                                      \
         Bench(state, fn);                                                      \
     }                                                                          \

--- a/test/benchmarks/benchmark_compare256.cc
+++ b/test/benchmarks/benchmark_compare256.cc
@@ -64,6 +64,7 @@ public:
     BENCHMARK_DEFINE_F(compare256, name)(benchmark::State& state) { \
         if (!(support_flag)) { \
             state.SkipWithError("CPU does not support " #name); \
+            return; \
         } \
         Bench(state, comparefunc); \
     } \

--- a/test/benchmarks/benchmark_compare256_rle.cc
+++ b/test/benchmarks/benchmark_compare256_rle.cc
@@ -63,6 +63,7 @@ public:
     BENCHMARK_DEFINE_F(compare256_rle, name)(benchmark::State& state) { \
         if (!(support_flag)) { \
             state.SkipWithError("CPU does not support " #name); \
+            return; \
         } \
         Bench(state, comparefunc); \
     } \

--- a/test/benchmarks/benchmark_crc32.cc
+++ b/test/benchmarks/benchmark_crc32.cc
@@ -56,6 +56,7 @@ public:
     BENCHMARK_DEFINE_F(crc32, name)(benchmark::State& state) { \
         if (!(support_flag)) { \
             state.SkipWithError("CPU does not support " #name); \
+            return; \
         } \
         Bench(state, hashfunc, 0); \
     } \
@@ -67,6 +68,7 @@ public:
     BENCHMARK_DEFINE_F(crc32, ALIGNED_NAME(name))(benchmark::State& state) { \
         if (!(support_flag)) { \
             state.SkipWithError("CPU does not support " #name); \
+            return; \
         } \
         Bench(state, hashfunc, 1); \
     } \

--- a/test/benchmarks/benchmark_crc32_copy.cc
+++ b/test/benchmarks/benchmark_crc32_copy.cc
@@ -62,6 +62,7 @@ public:
     BENCHMARK_DEFINE_F(crc32_copy, name)(benchmark::State& state) { \
         if (!(support_flag)) { \
             state.SkipWithError("CPU does not support " #name); \
+            return; \
         } \
         Bench(state, copyfunc, 0); \
     } \
@@ -73,6 +74,7 @@ public:
     BENCHMARK_DEFINE_F(crc32_copy, ALIGNED_NAME(name))(benchmark::State& state) { \
         if (!(support_flag)) { \
             state.SkipWithError("CPU does not support " #name); \
+            return; \
         } \
         Bench(state, copyfunc, 1); \
     } \
@@ -85,6 +87,7 @@ public:
     BENCHMARK_DEFINE_F(crc32_copy, MEMCPY_NAME(name))(benchmark::State& state) { \
         if (!(support_flag)) { \
             state.SkipWithError("CPU does not support " #name); \
+            return; \
         } \
 	Bench(state, [](uint32_t init_sum, unsigned char *dst, \
                         const uint8_t *buf, size_t len) -> uint32_t { \
@@ -99,6 +102,7 @@ public:
     BENCHMARK_DEFINE_F(crc32_copy, MEMCPY_ALIGNED_NAME(name))(benchmark::State& state) { \
         if (!(support_flag)) { \
             state.SkipWithError("CPU does not support " #name); \
+            return; \
         } \
 	Bench(state, [](uint32_t init_sum, unsigned char *dst, \
                         const uint8_t *buf, size_t len) -> uint32_t { \

--- a/test/benchmarks/benchmark_insert_string.cc
+++ b/test/benchmarks/benchmark_insert_string.cc
@@ -98,6 +98,7 @@ public:
     BENCHMARK_DEFINE_F(insert_string_bench, name)(benchmark::State& state) { \
         if (!(support_flag)) { \
             state.SkipWithError("Function " #name " not supported"); \
+            return; \
         } \
         Bench(state, fptr); \
     } \
@@ -153,6 +154,7 @@ public:
     BENCHMARK_DEFINE_F(quick_insert_string_bench, name)(benchmark::State& state) { \
         if (!(support_flag)) { \
             state.SkipWithError("Function " #name " not supported"); \
+            return; \
         } \
         Bench(state, fptr); \
     } \

--- a/test/benchmarks/benchmark_png_decode.cc
+++ b/test/benchmarks/benchmark_png_decode.cc
@@ -109,6 +109,7 @@ public:
     void Bench(benchmark::State &state) {
         if (!test_files_found) {
             state.SkipWithError("Test imagery in test_pngs not found");
+            return;
         }
 
         png_decode::Bench(state);

--- a/test/benchmarks/benchmark_slidehash.cc
+++ b/test/benchmarks/benchmark_slidehash.cc
@@ -72,6 +72,7 @@ public:
     BENCHMARK_DEFINE_F(slide_hash, name)(benchmark::State& state) { \
         if (!(support_flag)) { \
             state.SkipWithError("CPU does not support " #name); \
+            return; \
         } \
         Bench(state, fptr); \
     } \


### PR DESCRIPTION
Several benchmark fixtures call `state.SkipWithError(...)` for unsupported CPU features or missing test setup, but do not `return` afterward.

`SkipWithError` only marks the run as skipped, it does not exit the scope (per its own documentation). The benchmark loop body is skipped once the error is set, so this change is behavior neutral today.

It makes the skip handling consistent with the surrounding cases in these files that already `return`, follows Google Benchmark's documented contract that exiting the scope is the caller's responsibility, and keeps the code correct if a fixture is later refactored to do work before the `for (auto _ : state)` loop.

The CPU-support checks live inside the `BENCHMARK_*` registration macros, so the fix is a one-line addition per macro.
