### PR TITLE
Extend the MSVC 2015 AVX2/AVX512 workaround to MSVC 2017.

### DIFF
--- a/arch/x86/chunkset_avx2.c
+++ b/arch/x86/chunkset_avx2.c
@@ -41,7 +41,7 @@ static inline void chunkmemset_8(uint8_t *from, chunk_t *chunk) {
 
 static inline void chunkmemset_16(uint8_t *from, chunk_t *chunk) {
     /* See explanation in chunkset_avx512.c */
-#if defined(_MSC_VER) && _MSC_VER <= 1900
+#if defined(_MSC_VER) && _MSC_VER < 1920
     halfchunk_t half = _mm_loadu_si128((__m128i*)from);
     *chunk = _mm256_inserti128_si256(_mm256_castsi128_si256(half), half, 1);
 #else

--- a/arch/x86/chunkset_avx512.c
+++ b/arch/x86/chunkset_avx512.c
@@ -52,12 +52,13 @@ static inline void chunkmemset_8(uint8_t *from, chunk_t *chunk) {
 }
 
 static inline void chunkmemset_16(uint8_t *from, chunk_t *chunk) {
-    /* Unfortunately there seems to be a compiler bug in Visual Studio 2015 where
+    /* Unfortunately there seems to be a compiler bug in Visual Studio 2015/2017 where
      * the load is dumped to the stack with an aligned move for this memory-register
-     * broadcast. The vbroadcasti128 instruction is 2 fewer cycles and this dump to
-     * stack doesn't exist if compiled with optimizations. For the sake of working
+     * broadcast, and the stack isn't 16-byte aligned on i386 in debug builds.
+     * The vbroadcasti128 instruction is 2 fewer cycles and this dump to stack
+     * doesn't exist if compiled with optimizations. For the sake of working
      * properly in a debugger, let's take the 2 cycle penalty */
-#if defined(_MSC_VER) && _MSC_VER <= 1900
+#if defined(_MSC_VER) && _MSC_VER < 1920
     halfchunk_t half = _mm_loadu_si128((__m128i*)from);
     *chunk = _mm256_inserti128_si256(_mm256_castsi128_si256(half), half, 1);
 #else


### PR DESCRIPTION
The 32-bit MSVC 2015 debug build randomly crashes without this because the stack ends up not being 16-byte aligned, and MSVC adds a vmovdqa instruction.

MSVC 2022 and 2026 align the stack properly before using vmovdqa.