### PR TITLE
Use macos-15 with Xcode 16.4 for package check workflow

### DIFF
--- a/.github/workflows/pkgcheck.yml
+++ b/.github/workflows/pkgcheck.yml
@@ -77,12 +77,12 @@ jobs:
             packages: qemu-user gcc-riscv64-linux-gnu g++-riscv64-linux-gnu libc6-dev-riscv64-cross
 
           - name: macOS Clang
-            os: macOS-latest
+            os: macos-15
             compiler: clang
             cxx-compiler: clang++
 
           - name: macOS Clang Symbol Prefix
-            os: macOS-latest
+            os: macos-15
             compiler: clang
             cxx-compiler: clang++
             cmake-args: -DZLIB_SYMBOL_PREFIX=zTest_


### PR DESCRIPTION
Package Check workflow require Xcode 16.4, but it present only in macos-15.

`macos-latest` is now `macos-26` (https://github.com/actions/runner-images/issues/14167).

Error: https://github.com/phprus/zlib-ng/actions/runs/28023368389/job/82945148748#step:6:1