### PR TITLE
Fix build with macOS 26.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -729,7 +729,7 @@ jobs:
             coverage: macos_clang_arm64_ubsan
 
           - name: macOS Clang (ARM64) Native Instructions
-            os: macos-latest
+            os: macos-26
             compiler: clang
             cxx-compiler: clang++
             cmake-args: -DWITH_NATIVE_INSTRUCTIONS=ON

--- a/.github/workflows/pkgcheck.yml
+++ b/.github/workflows/pkgcheck.yml
@@ -77,12 +77,12 @@ jobs:
             packages: qemu-user gcc-riscv64-linux-gnu g++-riscv64-linux-gnu libc6-dev-riscv64-cross
 
           - name: macOS Clang
-            os: macOS-latest
+            os: macOS-26
             compiler: clang
             cxx-compiler: clang++
 
           - name: macOS Clang Symbol Prefix
-            os: macOS-latest
+            os: macOS-26
             compiler: clang
             cxx-compiler: clang++
             cmake-args: -DZLIB_SYMBOL_PREFIX=zTest_
@@ -121,7 +121,7 @@ jobs:
       if: runner.os == 'macOS'
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '16.4'
+        xcode-version: '26.5'
 
     - name: Compare builds
       run: sh test/pkgcheck.sh

--- a/arch/arm/adler32_neon_dotprod.c
+++ b/arch/arm/adler32_neon_dotprod.c
@@ -13,11 +13,11 @@
 #define USE_DOTPROD
 #include "adler32_neon_tpl.h"
 
-Z_INTERNAL uint32_t adler32_neon_dotprod(uint32_t adler, const uint8_t *src, size_t len) {
+Z_INTERNAL uint32_t Z_TARGET_DOTPROD adler32_neon_dotprod(uint32_t adler, const uint8_t *src, size_t len) {
     return adler32_copy_impl(adler, NULL, src, len, 0);
 }
 
-Z_INTERNAL uint32_t adler32_copy_neon_dotprod(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len) {
+Z_INTERNAL uint32_t Z_TARGET_DOTPROD adler32_copy_neon_dotprod(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len) {
 #if OPTIMAL_CMP >= 32
     return adler32_copy_impl(adler, dst, src, len, 1);
 #else

--- a/arch/arm/adler32_neon_tpl.h
+++ b/arch/arm/adler32_neon_tpl.h
@@ -27,7 +27,11 @@ static const uint16_t ALIGNED_(64) taps[64] = {
     16, 15, 14, 13, 12, 11, 10, 9,
     8, 7, 6, 5, 4, 3, 2, 1 };
 
+#ifdef USE_DOTPROD
+Z_FORCEINLINE static Z_TARGET_DOTPROD uint32_t adler32_copy_impl(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len, const int COPY) {
+#else
 Z_FORCEINLINE static uint32_t adler32_copy_impl(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len, const int COPY) {
+#endif
     /* split Adler-32 into component sums */
     uint32_t sum2 = (adler >> 16) & 0xffff;
     adler &= 0xffff;

--- a/arch/arm/crc32_armv8_pmull_eor3.c
+++ b/arch/arm/crc32_armv8_pmull_eor3.c
@@ -16,7 +16,7 @@
 #include "crc32_armv8_p.h"
 
 /* Carryless multiply low 64 bits: a[0] * b[0] */
-static inline uint64x2_t clmul_lo(uint64x2_t a, uint64x2_t b) {
+static Z_TARGET_PMULL_EOR3 inline uint64x2_t clmul_lo(uint64x2_t a, uint64x2_t b) {
 #if defined(_MSC_VER) && !defined(__clang__)
     return vreinterpretq_u64_p128(vmull_p64(
         vget_low_p64(vreinterpret_p64_u64(a)),
@@ -29,12 +29,12 @@ static inline uint64x2_t clmul_lo(uint64x2_t a, uint64x2_t b) {
 }
 
 /* Carryless multiply high 64 bits: a[1] * b[1] */
-static inline uint64x2_t clmul_hi(uint64x2_t a, uint64x2_t b) {
+static Z_TARGET_PMULL_EOR3 inline uint64x2_t clmul_hi(uint64x2_t a, uint64x2_t b) {
     return vreinterpretq_u64_p128(vmull_high_p64(vreinterpretq_p64_u64(a), vreinterpretq_p64_u64(b)));
 }
 
 /* Carryless multiply of two 32-bit scalars: a * b (returns 64-bit result in 128-bit vector) */
-static inline uint64x2_t clmul_scalar(uint32_t a, uint32_t b) {
+static Z_TARGET_PMULL_EOR3 inline uint64x2_t clmul_scalar(uint32_t a, uint32_t b) {
 #if defined(_MSC_VER) && !defined(__clang__)
     return vreinterpretq_u64_p128(vmull_p64(vdup_n_p64((poly64_t)a), vdup_n_p64((poly64_t)b)));
 #else
@@ -43,7 +43,7 @@ static inline uint64x2_t clmul_scalar(uint32_t a, uint32_t b) {
 }
 
 /* Compute x^n mod P (CRC-32 polynomial) in log(n) time, where P = 0x104c11db7 */
-static uint32_t xnmodp(uint64_t n) {
+static Z_TARGET_CRC uint32_t xnmodp(uint64_t n) {
   uint64_t stack = ~(uint64_t)1;
   uint32_t acc, low;
   for (; n > 191; n = (n >> 1) - 16) {
@@ -63,7 +63,7 @@ static uint32_t xnmodp(uint64_t n) {
 }
 
 /* Shift CRC forward by nbytes: equivalent to appending nbytes of zeros to the data stream */
-static inline uint64x2_t crc_shift(uint32_t crc, size_t nbytes) {
+static Z_TARGET_PMULL_EOR3 inline uint64x2_t crc_shift(uint32_t crc, size_t nbytes) {
   Assert(nbytes >= 5, "crc_shift requires nbytes >= 5");
   return clmul_scalar(crc, xnmodp(nbytes * 8 - 33));
 }

--- a/arch/arm/neon_intrins.h
+++ b/arch/arm/neon_intrins.h
@@ -8,6 +8,12 @@
 #  include <arm_neon.h>
 #endif
 
+#ifdef ARM_NEON_DOTPROD
+#  define Z_TARGET_DOTPROD Z_TARGET("+dotprod")
+#else
+#  define Z_TARGET_DOTPROD
+#endif
+
 #if defined(ARM_NEON) && defined(ARCH_ARM) && defined(ARCH_32BIT)
 /* Compatibility shim for the _high family of functions */
 #define vmull_high_u8(a, b) vmull_u8(vget_high_u8(a), vget_high_u8(b))

--- a/cmake/detect-intrinsics.cmake
+++ b/cmake/detect-intrinsics.cmake
@@ -28,7 +28,10 @@ macro(check_armv8_compiler_flag)
     # Check whether compiler supports ARMv8 inline asm
     set(CMAKE_REQUIRED_FLAGS "${ARMV8FLAG} ${NATIVEFLAG} ${ZNOLTOFLAG}")
     check_c_source_compiles(
-        "unsigned int f(unsigned int a, unsigned int b) {
+        "#ifdef __clang__
+        __attribute__((target(\"crc\")))
+        #endif
+        unsigned int f(unsigned int a, unsigned int b) {
             unsigned int c;
         #ifdef __aarch64__
             __asm__( \"crc32w %w0, %w1, %w2\" : \"=r\" (c) : \"r\" (a), \"r\" (b));
@@ -46,6 +49,9 @@ macro(check_armv8_compiler_flag)
         #include <intrin.h>
         #else
         #include <arm_acle.h>
+        #endif
+        #ifdef __clang__
+        __attribute__((target(\"crc\")))
         #endif
         unsigned int f(unsigned int a, unsigned int b) {
             return __crc32w(a, b);
@@ -81,10 +87,16 @@ macro(check_armv8_pmull_eor3_compiler_flag)
         #if defined(_MSC_VER) && !defined(__clang__)
         __n128 f(__n64 a, __n64 b) {
         #else
+        #ifdef __clang__
+        __attribute__((target(\"aes\")))
+        #endif
         poly128_t f(poly64_t a, poly64_t b) {
         #endif
             return vmull_p64(a, b);
         }
+        #ifdef __clang__
+        __attribute__((target(\"sha3\")))
+        #endif
         uint64x2_t g(uint64x2_t a, uint64x2_t b, uint64x2_t c) {
             return veor3q_u64(a, b, c);
         }
@@ -346,6 +358,9 @@ macro(check_neon_dotprod_compiler_flag)
         #  include <arm64_neon.h>
         #else
         #  include <arm_neon.h>
+        #endif
+        #ifdef __clang__
+        __attribute__((target(\"dotprod\")))
         #endif
         int main(void) {
             uint8x16_t a = vdupq_n_u8(1);


### PR DESCRIPTION
* After Clang 17 was released originally, target attribute checking was made stricter in the front-end causing all feature checks to fail
* Update feature checks to explicitly state most inclusive target attribute, avoiding including headers from zlib-ng's build tree
* Update `pkgcheck` to use macOS 26 and Xcode 26.5  

Supercedes #2340. 