### PR TITLE
Rename hash insert helpers by hash method

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -409,7 +409,7 @@ static int deflateStateCheck(PREFIX3(stream) *strm) {
 /* ========================================================================= */
 int32_t Z_EXPORT PREFIX(deflateSetDictionary)(PREFIX3(stream) *strm, const uint8_t *dictionary, uint32_t dictLength) {
     deflate_state *s;
-    insert_string_cb insert_string_func;
+    insert_batch_func insert_batch;
     unsigned int str, n;
     int wrap;
     uint32_t avail;
@@ -423,9 +423,9 @@ int32_t Z_EXPORT PREFIX(deflateSetDictionary)(PREFIX3(stream) *strm, const uint8
         return Z_STREAM_ERROR;
 
     if (s->level >= 9)
-        insert_string_func = insert_string_roll;
+        insert_batch = insert_roll_batch;
     else
-        insert_string_func = insert_string;
+        insert_batch = insert_knuth_batch;
 
     /* when using zlib wrappers, compute Adler-32 for provided dictionary */
     if (wrap == 1)
@@ -454,7 +454,7 @@ int32_t Z_EXPORT PREFIX(deflateSetDictionary)(PREFIX3(stream) *strm, const uint8
     while (s->lookahead >= STD_MIN_MATCH) {
         str = s->strstart;
         n = s->lookahead - (STD_MIN_MATCH - 1);
-        insert_string_func(s, s->window, str, n);
+        insert_batch(s, s->window, str, n);
         s->strstart = str + n;
         s->lookahead = STD_MIN_MATCH - 1;
         PREFIX(fill_window)(s);
@@ -1184,7 +1184,7 @@ static void lm_init(deflate_state *s) {
 
 void Z_INTERNAL PREFIX(fill_window)(deflate_state *s) {
     PREFIX3(stream) *strm = s->strm;
-    insert_string_cb insert_string_func;
+    insert_batch_func insert_batch;
     unsigned char *window = s->window;
     unsigned n;
     unsigned int more;    /* Amount of free space at the end of the window. */
@@ -1194,9 +1194,9 @@ void Z_INTERNAL PREFIX(fill_window)(deflate_state *s) {
     Assert(s->lookahead < MIN_LOOKAHEAD, "already enough lookahead");
 
     if (level >= 9)
-        insert_string_func = insert_string_roll;
+        insert_batch = insert_roll_batch;
     else
-        insert_string_func = insert_string;
+        insert_batch = insert_knuth_batch;
 
     do {
         more = s->window_size - s->lookahead - s->strstart;
@@ -1244,14 +1244,14 @@ void Z_INTERNAL PREFIX(fill_window)(deflate_state *s) {
             if (UNLIKELY(level >= 9)) {
                 s->ins_h = update_hash_roll(window[str], window[str+1]);
             } else if (str >= 1) {
-                quick_insert_string(s, window, str + 2 - STD_MIN_MATCH);
+                insert_knuth(s, window, str + 2 - STD_MIN_MATCH);
             }
             unsigned int count = s->insert;
             if (UNLIKELY(s->lookahead == 1)) {
                 count -= 1;
             }
             if (count > 0) {
-                insert_string_func(s, window, str, count);
+                insert_batch(s, window, str, count);
                 s->insert -= count;
             }
         }

--- a/deflate.h
+++ b/deflate.h
@@ -120,9 +120,9 @@ typedef uint16_t Pos;
 /* Type definitions for hash callbacks */
 typedef struct internal_state deflate_state;
 
-typedef void    (* insert_string_cb)    (deflate_state *const s, unsigned char *window, uint32_t str, uint32_t count);
-void            insert_string           (deflate_state *const s, unsigned char *window, uint32_t str, uint32_t count);
-void            insert_string_roll      (deflate_state *const s, unsigned char *window, uint32_t str, uint32_t count);
+typedef void (* insert_batch_func) (deflate_state *const s, unsigned char *window, uint32_t str, uint32_t count);
+void         insert_knuth_batch    (deflate_state *const s, unsigned char *window, uint32_t str, uint32_t count);
+void         insert_roll_batch     (deflate_state *const s, unsigned char *window, uint32_t str, uint32_t count);
 
 /* Struct for memory allocation handling */
 typedef struct deflate_allocs_s {

--- a/deflate_fast.c
+++ b/deflate_fast.c
@@ -45,7 +45,7 @@ Z_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
          */
         if (LIKELY(s->lookahead >= WANT_MIN_MATCH)) {
             uint32_t str_val = Z_U32_FROM_LE(zng_memread_4(window + s->strstart));
-            uint32_t hash_head = quick_insert_value(s, s->strstart, str_val);
+            uint32_t hash_head = insert_knuth_val(s, s->strstart, str_val);
             int64_t dist = (int64_t)s->strstart - hash_head;
             lc = (uint8_t)str_val;
 
@@ -80,11 +80,11 @@ Z_INTERNAL block_state deflate_fast(deflate_state *s, int flush) {
                 match_len--; /* string at strstart already in table */
                 s->strstart++;
 
-                insert_string_static(s, window, s->strstart, match_len);
+                insert_knuth_batch_static(s, window, s->strstart, match_len);
                 s->strstart += match_len;
             } else {
                 s->strstart += match_len;
-                quick_insert_string(s, window, s->strstart + 2 - STD_MIN_MATCH);
+                insert_knuth(s, window, s->strstart + 2 - STD_MIN_MATCH);
 
                 /* If lookahead < STD_MIN_MATCH, ins_h is garbage, but it does not
                  * matter since it will be recomputed at next deflate call.

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -55,9 +55,9 @@ static void insert_match(deflate_state *s, unsigned char *window, struct match m
         if (UNLIKELY(match_len > 0)) {
             if (strstart >= match.orgstart) {
                 if (strstart + match_len - 1 >= match.orgstart) {
-                    insert_string(s, window, strstart, match_len);
+                    insert_knuth_batch(s, window, strstart, match_len);
                 } else {
-                    insert_string(s, window, strstart, match.orgstart - strstart + 1);
+                    insert_knuth_batch(s, window, strstart, match.orgstart - strstart + 1);
                 }
             }
         }
@@ -73,16 +73,16 @@ static void insert_match(deflate_state *s, unsigned char *window, struct match m
 
         if (LIKELY(strstart >= match.orgstart)) {
             if (LIKELY(strstart + match_len - 1 >= match.orgstart)) {
-                insert_string(s, window, strstart, match_len);
+                insert_knuth_batch(s, window, strstart, match_len);
             } else {
-                insert_string(s, window, strstart, match.orgstart - strstart + 1);
+                insert_knuth_batch(s, window, strstart, match.orgstart - strstart + 1);
             }
         } else if (match.orgstart < strstart + match_len) {
-            insert_string(s, window, match.orgstart, strstart + match_len - match.orgstart);
+            insert_knuth_batch(s, window, match.orgstart, strstart + match_len - match.orgstart);
         }
     } else {
         strstart += match_len;
-        quick_insert_string(s, window, strstart + 2 - STD_MIN_MATCH);
+        insert_knuth(s, window, strstart + 2 - STD_MIN_MATCH);
 
         /* If lookahead < WANT_MIN_MATCH, ins_h is garbage, but it does not
          * matter since it will be recomputed at next deflate call.
@@ -214,7 +214,7 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
         } else {
             hash_head = 0;
             if (LIKELY(s->lookahead >= WANT_MIN_MATCH)) {
-                hash_head = quick_insert_string(s, window, s->strstart);
+                hash_head = insert_knuth(s, window, s->strstart);
             }
 
             current_match = find_best_match(s, hash_head);
@@ -226,7 +226,7 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
         /* now, look ahead one */
         if (LIKELY(!early_exit && s->lookahead > MIN_LOOKAHEAD && (uint32_t)(current_match.strstart + current_match.match_length) < (s->window_size - MIN_LOOKAHEAD))) {
             s->strstart = current_match.strstart + current_match.match_length;
-            hash_head = quick_insert_string(s, window, s->strstart);
+            hash_head = insert_knuth(s, window, s->strstart);
 
             next_match = find_best_match(s, hash_head);
 

--- a/deflate_quick.c
+++ b/deflate_quick.c
@@ -95,7 +95,7 @@ Z_FORCEINLINE static block_state deflate_quick_impl(deflate_state *s, int flush,
         uint32_t str_val = Z_U32_FROM_LE(zng_memread_4(window + strstart));
 
         if (LIKELY(lookahead >= WANT_MIN_MATCH)) {
-            uint32_t hash_head = quick_insert_value(s, strstart, str_val);
+            uint32_t hash_head = insert_knuth_val(s, strstart, str_val);
             int64_t dist = (int64_t)strstart - hash_head;
 
             if (dist <= MAX_DIST(s) && dist > 0) {

--- a/deflate_slow.c
+++ b/deflate_slow.c
@@ -17,17 +17,17 @@
  */
 Z_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
     match_func longest_match;
-    insert_string_cb insert_string_func;
+    insert_batch_func insert_batch;
     unsigned char *window = s->window;
     int bflush;              /* set if current block must be flushed */
     int level = s->level;
 
     if (level >= 9) {
         longest_match = FUNCTABLE_FPTR(longest_match_roll);
-        insert_string_func = insert_string_roll;
+        insert_batch = insert_roll_batch;
     } else {
         longest_match = FUNCTABLE_FPTR(longest_match);
-        insert_string_func = insert_string;
+        insert_batch = insert_knuth_batch;
     }
 
     /* Process the input block. */
@@ -52,9 +52,9 @@ Z_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
         uint32_t hash_head = 0;
         if (LIKELY(s->lookahead >= WANT_MIN_MATCH)) {
             if (level >= 9)
-                hash_head = quick_insert_string_roll(s, window, s->strstart);
+                hash_head = insert_roll(s, window, s->strstart);
             else
-                hash_head = quick_insert_string(s, window, s->strstart);
+                hash_head = insert_knuth(s, window, s->strstart);
         }
 
         /* Find the longest match, discarding those <= prev_length.
@@ -103,7 +103,7 @@ Z_INTERNAL block_state deflate_slow(deflate_state *s, int flush) {
                 unsigned int insert_cnt = mov_fwd;
                 if (UNLIKELY(insert_cnt > max_insert - s->strstart))
                     insert_cnt = max_insert - s->strstart;
-                insert_string_func(s, window, s->strstart + 1, insert_cnt);
+                insert_batch(s, window, s->strstart + 1, insert_cnt);
             }
             s->prev_length = 0;
             s->match_available = 0;

--- a/insert_string.c
+++ b/insert_string.c
@@ -9,10 +9,10 @@
 #include "deflate.h"
 #include "insert_string_p.h"
 
-Z_INTERNAL void insert_string(deflate_state *const s, unsigned char *window, uint32_t str, uint32_t count) {
-    insert_string_static(s, window, str, count);
+Z_INTERNAL void insert_knuth_batch(deflate_state *const s, unsigned char *window, uint32_t str, uint32_t count) {
+    insert_knuth_batch_static(s, window, str, count);
 }
 
-Z_INTERNAL void insert_string_roll(deflate_state *const s, unsigned char *window, uint32_t str, uint32_t count) {
-    insert_string_roll_static(s, window, str, count);
+Z_INTERNAL void insert_roll_batch(deflate_state *const s, unsigned char *window, uint32_t str, uint32_t count) {
+    insert_roll_batch_static(s, window, str, count);
 }

--- a/insert_string_p.h
+++ b/insert_string_p.h
@@ -1,4 +1,4 @@
-/* insert_string_p.h -- static insert_string and insert_string_roll functions
+/* insert_string_p.h -- static single and batch hash insert functions
  *
  * Copyright (C) 1995-2024 Jean-loup Gailly and Mark Adler
  * For conditions of distribution and use, see copyright notice in zlib.h
@@ -6,7 +6,7 @@
 #ifndef INSERT_STRING_P_H_
 #define INSERT_STRING_P_H_
 
-#define UPDATE_HASH_INT(h,val) h = (((val) * 2654435761U) >> 16) & HASH_MASK
+#define UPDATE_HASH_KNUTH(h,val) h = (((val) * 2654435761U) >> 16) & HASH_MASK
 #define UPDATE_HASH_ROLL(h,val) h = ((h << 5) ^ ((uint8_t)(val))) & (32768u - 1u)
 
 /* ===========================================================================
@@ -21,14 +21,14 @@ Z_FORCEINLINE static uint32_t update_hash_roll(uint32_t h, uint32_t val) {
 }
 
 /* ===========================================================================
- * Quick insert string str in the dictionary using a pre-read value and set match_head
+ * Insert string str in the dictionary using a pre-read value and set match_head
  * to the previous head of the hash chain (the most recent string with same hash key).
  * Return the previous length of the hash chain.
  */
-Z_FORCEINLINE static uint32_t quick_insert_value(deflate_state *const s, uint32_t str, uint32_t val) {
+Z_FORCEINLINE static uint32_t insert_knuth_val(deflate_state *const s, uint32_t str, uint32_t val) {
     uint32_t h, head;
 
-    UPDATE_HASH_INT(h, val);
+    UPDATE_HASH_KNUTH(h, val);
 
     head = s->head[h];
     if (LIKELY(head != str)) {
@@ -39,16 +39,16 @@ Z_FORCEINLINE static uint32_t quick_insert_value(deflate_state *const s, uint32_
 }
 
 /* ===========================================================================
- * Quick insert string str in the dictionary and set match_head to the previous head
+ * Insert string str in the dictionary and set match_head to the previous head
  * of the hash chain (the most recent string with same hash key). Return
  * the previous length of the hash chain.
  */
-Z_FORCEINLINE static uint32_t quick_insert_string(deflate_state *const s, unsigned char *window, uint32_t str) {
+Z_FORCEINLINE static uint32_t insert_knuth(deflate_state *const s, unsigned char *window, uint32_t str) {
     uint8_t *strstart = window + str;
     uint32_t val, h, head;
 
     val = Z_U32_FROM_LE(zng_memread_4(strstart));
-    UPDATE_HASH_INT(h, val);
+    UPDATE_HASH_KNUTH(h, val);
 
     head = s->head[h];
     if (LIKELY(head != str)) {
@@ -58,7 +58,7 @@ Z_FORCEINLINE static uint32_t quick_insert_string(deflate_state *const s, unsign
     return head;
 }
 
-Z_FORCEINLINE static uint32_t quick_insert_string_roll(deflate_state *const s, unsigned char *window, uint32_t str) {
+Z_FORCEINLINE static uint32_t insert_roll(deflate_state *const s, unsigned char *window, uint32_t str) {
     uint8_t *strstart = window + str + (STD_MIN_MATCH-1);
     uint32_t h, head;
 
@@ -78,11 +78,11 @@ Z_FORCEINLINE static uint32_t quick_insert_string_roll(deflate_state *const s, u
  * Insert string str in the dictionary and set match_head to the previous head
  * of the hash chain (the most recent string with same hash key). Return
  * the previous length of the hash chain.
- * IN  assertion: all calls to INSERT_STRING are made with consecutive
+ * IN  assertion: all calls to insert_knuth_batch are made with consecutive
  *    input characters and the first STD_MIN_MATCH bytes of str are valid
  *    (except for the last STD_MIN_MATCH-1 bytes of the input file).
  */
-Z_FORCEINLINE static void insert_string_static(deflate_state *const s, unsigned char *window, uint32_t str, uint32_t count) {
+Z_FORCEINLINE static void insert_knuth_batch_static(deflate_state *const s, unsigned char *window, uint32_t str, uint32_t count) {
     uint8_t *strstart = window + str;
     uint8_t *strend = strstart + count;
 
@@ -95,7 +95,7 @@ Z_FORCEINLINE static void insert_string_static(deflate_state *const s, unsigned 
         uint32_t val, h, head;
 
         val = Z_U32_FROM_LE(zng_memread_4(strstart));
-        UPDATE_HASH_INT(h, val);
+        UPDATE_HASH_KNUTH(h, val);
 
         head = headp[h];
         if (LIKELY(head != idx)) {
@@ -105,7 +105,7 @@ Z_FORCEINLINE static void insert_string_static(deflate_state *const s, unsigned 
     }
 }
 
-Z_FORCEINLINE static void insert_string_roll_static(deflate_state *const s, unsigned char *window, uint32_t str, uint32_t count) {
+Z_FORCEINLINE static void insert_roll_batch_static(deflate_state *const s, unsigned char *window, uint32_t str, uint32_t count) {
     uint8_t *strstart = window + str + (STD_MIN_MATCH-1);
     uint8_t *strend = strstart + count;
 

--- a/test/benchmarks/benchmark_insert_string.cc
+++ b/test/benchmarks/benchmark_insert_string.cc
@@ -19,7 +19,7 @@ extern "C" {
 #define MAX_WSIZE 32768
 #define TEST_WINDOW_SIZE (MAX_WSIZE * 2)
 
-typedef uint32_t (* quick_insert_string_cb)(deflate_state *const s, unsigned char *window, uint32_t str);
+typedef uint32_t (* insert_single_func)(deflate_state *const s, unsigned char *window, uint32_t str);
 
 // Base class with common setup/teardown for both insert_string benchmarks
 class insert_string_base: public benchmark::Fixture {
@@ -66,9 +66,9 @@ public:
     }
 };
 
-class insert_string_bench: public insert_string_base {
+class insert_batch_bench: public insert_string_base {
 public:
-    void Bench(benchmark::State& state, insert_string_cb insert_func) {
+    void Bench(benchmark::State& state, insert_batch_func insert_batch) {
         uint32_t str_pos = (uint32_t)state.range(0);  // Starting position
         uint32_t count = (uint32_t)state.range(1);    // Number of strings to insert
 
@@ -88,21 +88,21 @@ public:
 
             state.ResumeTiming();
 
-            // Benchmark the insert_string function
-            insert_func(s, window, str_pos, count);
+            // Benchmark the batch insert function
+            insert_batch(s, window, str_pos, count);
         }
     }
 };
 
-#define BENCHMARK_INSERT_STRING(name, fptr, support_flag) \
-    BENCHMARK_DEFINE_F(insert_string_bench, name)(benchmark::State& state) { \
+#define BENCHMARK_INSERT_BATCH(name, fptr, support_flag) \
+    BENCHMARK_DEFINE_F(insert_batch_bench, name)(benchmark::State& state) { \
         if (!(support_flag)) { \
             state.SkipWithError("Function " #name " not supported"); \
             return; \
         } \
         Bench(state, fptr); \
     } \
-    BENCHMARK_REGISTER_F(insert_string_bench, name) \
+    BENCHMARK_REGISTER_F(insert_batch_bench, name) \
         ->Args({100, 3})        /* Most common case */ \
         ->Args({100, 4})        \
         ->Args({100, 5})        \
@@ -113,16 +113,16 @@ public:
         ->Args({100, 255})      /* Near maximum observed values */ \
         ->Unit(benchmark::kNanosecond);
 
-// Benchmark the standard integer hash variant
-BENCHMARK_INSERT_STRING(integer_hash, ::insert_string, 1);
+// Benchmark the Knuth multiplicative hash variant
+BENCHMARK_INSERT_BATCH(knuth_hash, ::insert_knuth_batch, 1);
 
 // Benchmark the rolling hash variant
-BENCHMARK_INSERT_STRING(rolling_hash, ::insert_string_roll, 1);
+BENCHMARK_INSERT_BATCH(roll_hash, ::insert_roll_batch, 1);
 
-// Additional benchmark class for quick_insert_string functions
-class quick_insert_string_bench: public insert_string_base {
+// Additional benchmark class for single insert functions
+class insert_single_bench: public insert_string_base {
 public:
-    void Bench(benchmark::State& state, quick_insert_string_cb quick_insert_func) {
+    void Bench(benchmark::State& state, insert_single_func insert_single) {
         uint32_t start_pos = (uint32_t)state.range(0);  // Starting position
         uint32_t count = (uint32_t)state.range(1);      // Number of insertions
 
@@ -141,28 +141,28 @@ public:
 
             state.ResumeTiming();
 
-            // Benchmark quick_insert_string (single insertions)
+            // Benchmark single insertions
             for (uint32_t i = 0; i < count; i++) {
-                uint32_t result = quick_insert_func(s, window, start_pos + i);
+                uint32_t result = insert_single(s, window, start_pos + i);
                 benchmark::DoNotOptimize(result);
             }
         }
     }
 };
 
-#define BENCHMARK_QUICK_INSERT_STRING(name, fptr, support_flag) \
-    BENCHMARK_DEFINE_F(quick_insert_string_bench, name)(benchmark::State& state) { \
+#define BENCHMARK_INSERT_SINGLE(name, fptr, support_flag) \
+    BENCHMARK_DEFINE_F(insert_single_bench, name)(benchmark::State& state) { \
         if (!(support_flag)) { \
             state.SkipWithError("Function " #name " not supported"); \
             return; \
         } \
         Bench(state, fptr); \
     } \
-    BENCHMARK_REGISTER_F(quick_insert_string_bench, name) \
+    BENCHMARK_REGISTER_F(insert_single_bench, name) \
         ->Args({100, 1})        /* Single insertion (baseline) */ \
         ->Args({100, 100})      /* 100 insertions (measure amortized cost) */ \
         ->Args({16000, 100})    /* 100 insertions at mid window (different hash distribution) */ \
         ->Unit(benchmark::kNanosecond);
 
-BENCHMARK_QUICK_INSERT_STRING(quick_integer_hash, ::quick_insert_string, 1);
-BENCHMARK_QUICK_INSERT_STRING(quick_rolling_hash, ::quick_insert_string_roll, 1);
+BENCHMARK_INSERT_SINGLE(knuth_hash, ::insert_knuth, 1);
+BENCHMARK_INSERT_SINGLE(roll_hash, ::insert_roll, 1);


### PR DESCRIPTION
Replaces the `quick_` prefixed and unmarked `insert_string` helpers with names based on the hash method: `insert_knuth` (Knuth multiplicative hashing) and `insert_roll` (rolling hash). The common case — insert one window position, reading its bytes from the window — is unmarked; `_val` marks the variant taking a caller-supplied value and `_batch` marks the variants inserting a run of positions. `UPDATE_HASH_INT` becomes `UPDATE_HASH_KNUTH` to match.

This covers the callback type, the dispatch pointers, and the `insert_string` benchmark harness. Naming scheme per the review discussion below.

Pure renaming, no behavior change. Split out of #2327 so the naming cleanup can land independently of the deflate_quick hash-maintenance changes.