### PR TITLE
Add Win32 CPU scheduling flags to benchmark suite

### DIFF
--- a/test/benchmarks/README.md
+++ b/test/benchmarks/README.md
@@ -17,13 +17,17 @@ To filter out which benchmarks are performed use:
 --benchmark_filter="adler32*"
 ```
 
-*Cooldown*
+*Custom arguments*
 
-To insert a cooldown sleep between benchmark families to mitigate thermal throttling:
+In addition to the standard Google Benchmark flags, the suite adds the following arguments.
+The CPU scheduling controls are only available on Windows and are ignored elsewhere.
 
-```sh
---benchmark_cooldown=3
-```
+| Argument | Platform | Description |
+|----------|----------|-------------|
+| `--benchmark_cooldown=<seconds>` | All | Sleep between benchmark families to mitigate thermal throttling. Not applied between repetitions of the same benchmark. |
+| `--benchmark_cpu_affinity=<cpulist>` | Windows | Pin the process to the listed CPUs, `taskset`-style (`3`, `0,2,4`, or `0-3`). |
+| `--benchmark_no_power_throttling` | Windows | Opt out of EcoQoS so the process runs at full clock on performance cores. |
+| `--benchmark_priority=<normal\|high\|realtime>` | Windows | Set the process priority class for more deterministic scheduling. |
 
 There are two different benchmarks, micro and macro.
 

--- a/test/benchmarks/benchmark_main.cc
+++ b/test/benchmarks/benchmark_main.cc
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <limits.h>
 
 #ifdef _WIN32
 #  define NOMINMAX
@@ -66,8 +67,46 @@ private:
     bool first_report_;
 };
 
+#ifdef _WIN32
+/* Parses a taskset-style CPU list ("3", "0,2,4", "0-3") into an affinity mask. Returns false on
+   malformed input. CPUs beyond the mask width are ignored since a mask covers one processor group. */
+static bool parse_cpu_mask(const char *list, DWORD_PTR *mask_out) {
+    DWORD_PTR mask = 0;
+    while (*list) {
+        char *end;
+        long lo = strtol(list, &end, 10);
+        if (end == list)
+            return false;
+        long hi = lo;
+        if (*end == '-') {
+            char *range_end;
+            hi = strtol(end + 1, &range_end, 10);
+            if (range_end == end + 1 || hi < lo)
+                return false;
+            end = range_end;
+        }
+        if (*end != '\0' && *end != ',')
+            return false;
+        for (long cpu = lo; cpu <= hi && cpu < (long)(sizeof(DWORD_PTR) * CHAR_BIT); cpu++) {
+            if (cpu >= 0)
+                mask |= (DWORD_PTR)1 << cpu;
+        }
+        while (*end == ',')
+            end++;
+        list = end;
+    }
+    *mask_out = mask;
+    return true;
+}
+#endif
+
 int main(int argc, char** argv) {
     uint32_t cooldown_secs = 0;
+#ifdef _WIN32
+    const char *cpu_affinity = nullptr;
+    const char *priority = nullptr;
+    bool no_power_throttling = false;
+#endif
 
 #ifndef BUILD_ALT
 #  ifndef DISABLE_RUNTIME_CPU_DETECTION
@@ -78,14 +117,67 @@ int main(int argc, char** argv) {
     for (int i = 1; i < argc; i++) {
         if (strncmp(argv[i], "--benchmark_cooldown=", 21) == 0) {
             cooldown_secs = strtoul(argv[i] + 21, nullptr, 10);
-            break;
         }
+#ifdef _WIN32
+        else if (strncmp(argv[i], "--benchmark_cpu_affinity=", 25) == 0) {
+            cpu_affinity = argv[i] + 25;
+        } else if (strncmp(argv[i], "--benchmark_priority=", 21) == 0) {
+            priority = argv[i] + 21;
+        } else if (strcmp(argv[i], "--benchmark_no_power_throttling") == 0) {
+            no_power_throttling = true;
+        }
+#endif
     }
 
     ::benchmark::Initialize(&argc, argv, []() {
         ::benchmark::PrintDefaultHelp();
         printf("          [--benchmark_cooldown=<seconds>]\n");
+#ifdef _WIN32
+        printf("          [--benchmark_cpu_affinity=<cpulist>]\n");
+        printf("          [--benchmark_no_power_throttling]\n");
+        printf("          [--benchmark_priority=<normal|high|realtime>]\n");
+#endif
     });
+
+#ifdef _WIN32
+    if (cpu_affinity != nullptr) {
+        DWORD_PTR mask;
+        if (!parse_cpu_mask(cpu_affinity, &mask))
+            fprintf(stderr, "warning: invalid --benchmark_cpu_affinity='%s'\n", cpu_affinity);
+        else if (mask == 0)
+            fprintf(stderr, "warning: --benchmark_cpu_affinity='%s' parsed to an empty mask\n", cpu_affinity);
+        else if (!SetProcessAffinityMask(GetCurrentProcess(), mask))
+            fprintf(stderr, "warning: SetProcessAffinityMask failed (error %lu)\n", GetLastError());
+    }
+
+    if (no_power_throttling) {
+#  ifdef PROCESS_POWER_THROTTLING_CURRENT_VERSION
+        /* Clear the execution-speed bit to opt out of EcoQoS so the process runs at full
+           clock on performance cores. */
+        PROCESS_POWER_THROTTLING_STATE state;
+        memset(&state, 0, sizeof(state));
+        state.Version = PROCESS_POWER_THROTTLING_CURRENT_VERSION;
+        state.ControlMask = PROCESS_POWER_THROTTLING_EXECUTION_SPEED;
+        state.StateMask = 0;
+        if (!SetProcessInformation(GetCurrentProcess(), ProcessPowerThrottling, &state, sizeof(state)))
+            fprintf(stderr, "warning: failed to disable power throttling (error %lu)\n", GetLastError());
+#  else
+        fprintf(stderr, "warning: --benchmark_no_power_throttling requires a Windows 10 SDK\n");
+#  endif
+    }
+
+    if (priority != nullptr) {
+        DWORD priority_class = NORMAL_PRIORITY_CLASS;
+        if (strcmp(priority, "high") == 0)
+            priority_class = HIGH_PRIORITY_CLASS;
+        else if (strcmp(priority, "realtime") == 0)
+            priority_class = REALTIME_PRIORITY_CLASS;
+        else if (strcmp(priority, "normal") != 0)
+            fprintf(stderr, "warning: unknown --benchmark_priority '%s', using normal\n", priority);
+        if (!SetPriorityClass(GetCurrentProcess(), priority_class))
+            fprintf(stderr, "warning: SetPriorityClass failed (error %lu)\n", GetLastError());
+    }
+#endif
 
     if (cooldown_secs > 0) {
         benchmark::BenchmarkReporter *display = benchmark::CreateDefaultDisplayReporter();


### PR DESCRIPTION
Adds three Windows-only command-line flags to the benchmark suite to cut run-to-run variance, which is otherwise hard to control on hybrid (P/E core) Windows machines.

`--benchmark_cpu_affinity=<cpulist>` pins the process to a `taskset`-style CPU list (`3`, `0,2,4`, `0-3`) via `SetProcessAffinityMask`.

`--benchmark_no_power_throttling` opts the process out of EcoQoS via `SetProcessInformation(ProcessPowerThrottling)`, keeping it at full clock on performance cores. Guarded so it degrades to a warning on pre-Windows-10 SDKs.

`--benchmark_priority=<normal|high|realtime>` sets the process priority class via `SetPriorityClass`.

All three are wrapped in `#ifdef _WIN32` and ignored on other platforms. Bad input warns to stderr rather than aborting. The README gains a table documenting these alongside the existing `--benchmark_cooldown`.

Google Benchmark itself has no built-in affinity control (see google/benchmark#185 and google/benchmark#1518); the cross-platform attempt stalled because macOS lacks a true affinity API. This keeps the feature scoped to where it actually works.