### PR TITLE
Force inline compare256 helpers

### DIFF
--- a/arch/arm/compare256_neon.c
+++ b/arch/arm/compare256_neon.c
@@ -11,7 +11,7 @@
 #if defined(ARM_NEON)
 #include "neon_intrins.h"
 
-static inline uint32_t compare256_neon_static(const uint8_t *src0, const uint8_t *src1) {
+Z_FORCEINLINE static uint32_t compare256_neon_static(const uint8_t *src0, const uint8_t *src1) {
     uint32_t len = 0;
 
     do {

--- a/arch/generic/compare256_c.c
+++ b/arch/generic/compare256_c.c
@@ -13,7 +13,7 @@
 #include "fallback_builtins.h"
 
 /* 8-bit integer comparison for hardware without unaligned loads */
-static inline uint32_t compare256_8_static(const uint8_t *src0, const uint8_t *src1) {
+Z_FORCEINLINE static uint32_t compare256_8_static(const uint8_t *src0, const uint8_t *src1) {
     uint32_t len = 0;
 
     do {
@@ -40,7 +40,7 @@ static inline uint32_t compare256_8_static(const uint8_t *src0, const uint8_t *s
 }
 
 /* 64-bit integer comparison for hardware with unaligned loads */
-static inline uint32_t compare256_64_static(const uint8_t *src0, const uint8_t *src1) {
+Z_FORCEINLINE static uint32_t compare256_64_static(const uint8_t *src0, const uint8_t *src1) {
     uint32_t len = 0;
 
     do {

--- a/arch/loongarch/compare256_lasx.c
+++ b/arch/loongarch/compare256_lasx.c
@@ -15,7 +15,7 @@
 #include <lasxintrin.h>
 #include "lasxintrin_ext.h"
 
-static inline uint32_t compare256_lasx_static(const uint8_t *src0, const uint8_t *src1) {
+Z_FORCEINLINE static uint32_t compare256_lasx_static(const uint8_t *src0, const uint8_t *src1) {
     uint32_t len = 0;
 
     do {

--- a/arch/loongarch/compare256_lsx.c
+++ b/arch/loongarch/compare256_lsx.c
@@ -15,7 +15,7 @@
 #include <lsxintrin.h>
 #include "lsxintrin_ext.h"
 
-static inline uint32_t compare256_lsx_static(const uint8_t *src0, const uint8_t *src1) {
+Z_FORCEINLINE static uint32_t compare256_lsx_static(const uint8_t *src0, const uint8_t *src1) {
     __m128i xmm_src0, xmm_src1, xmm_cmp;
 
     /* Do the first load unaligned, than all subsequent ones we have at least

--- a/arch/power/compare256_power9.c
+++ b/arch/power/compare256_power9.c
@@ -24,7 +24,7 @@
 #  define zng_vec_vctzlsbb(vc, len) len = vec_cntlz_lsbb(vc)
 #endif
 
-static inline uint32_t compare256_power9_static(const uint8_t *src0, const uint8_t *src1) {
+Z_FORCEINLINE static uint32_t compare256_power9_static(const uint8_t *src0, const uint8_t *src1) {
     uint32_t len = 0, cmplen;
 
     do {

--- a/arch/riscv/compare256_rvv.c
+++ b/arch/riscv/compare256_rvv.c
@@ -12,7 +12,7 @@
 
 #include <riscv_vector.h>
 
-static inline uint32_t compare256_rvv_static(const uint8_t *src0, const uint8_t *src1) {
+Z_FORCEINLINE static uint32_t compare256_rvv_static(const uint8_t *src0, const uint8_t *src1) {
     uint32_t len = 0;
     size_t vl;
     long found_diff;

--- a/arch/x86/compare256_avx2.c
+++ b/arch/x86/compare256_avx2.c
@@ -16,7 +16,7 @@
 #  include <nmmintrin.h>
 #endif
 
-static inline uint32_t compare256_avx2_static(const uint8_t *src0, const uint8_t *src1) {
+Z_FORCEINLINE static uint32_t compare256_avx2_static(const uint8_t *src0, const uint8_t *src1) {
     uint32_t len = 0;
 
     do {

--- a/arch/x86/compare256_avx512.c
+++ b/arch/x86/compare256_avx512.c
@@ -17,7 +17,7 @@
 #  include <nmmintrin.h>
 #endif
 
-static inline uint32_t compare256_avx512_static(const uint8_t *src0, const uint8_t *src1) {
+Z_FORCEINLINE static uint32_t compare256_avx512_static(const uint8_t *src0, const uint8_t *src1) {
     __m512i zmm_src0_4, zmm_src1_4;
     __m512i zmm_src0_3, zmm_src1_3;
     __m512i zmm_src0_2, zmm_src1_2;

--- a/arch/x86/compare256_sse2.c
+++ b/arch/x86/compare256_sse2.c
@@ -13,7 +13,7 @@
 
 #include <emmintrin.h>
 
-static inline uint32_t compare256_sse2_static(const uint8_t *src0, const uint8_t *src1) {
+Z_FORCEINLINE static uint32_t compare256_sse2_static(const uint8_t *src0, const uint8_t *src1) {
     __m128i xmm_src0, xmm_src1, xmm_cmp;
 
     /* Do the first load unaligned, than all subsequent ones we have at least

--- a/compare256_rle.h
+++ b/compare256_rle.h
@@ -11,7 +11,7 @@
 typedef uint32_t (*compare256_rle_func)(const uint8_t* src0, const uint8_t* src1);
 
 /* 8-bit RLE comparison for hardware without unaligned loads */
-static inline uint32_t compare256_rle_8(const uint8_t *src0, const uint8_t *src1) {
+Z_FORCEINLINE static uint32_t compare256_rle_8(const uint8_t *src0, const uint8_t *src1) {
     uint32_t len = 0;
     uint8_t val = *src0;
 
@@ -39,7 +39,7 @@ static inline uint32_t compare256_rle_8(const uint8_t *src0, const uint8_t *src1
 }
 
 /* 64-bit RLE comparison for hardware with unaligned loads */
-static inline uint32_t compare256_rle_64(const uint8_t *src0, const uint8_t *src1) {
+Z_FORCEINLINE static uint32_t compare256_rle_64(const uint8_t *src0, const uint8_t *src1) {
     uint32_t src0_cmp32, len = 0;
     uint16_t src0_cmp;
     uint64_t sv, mv, diff;


### PR DESCRIPTION
The compare256_*_static helpers are textually included into match_tpl.h to specialize each longest_match variant, and compare256_rle_* serve the RLE path the same way.

At -O3, clang declines to inline the larger fully-unrolled bodies (the scalar fallback and NEON), emitting an out-of-line call with register spills around it on the hot path instead of inlining the comparison as the per-variant generation intends. GCC already inlines them.

Marking the helpers Z_FORCEINLINE makes clang inline every variant into its consumer, removing the call and surrounding spills. The x86 SIMD variants (SSE2/AVX2/AVX512) were already inlined, so this is a no-op for them.