### PR TITLE
Draft: Split adler32/crc32 copy functions

### DIFF
--- a/adler32_p.h
+++ b/adler32_p.h
@@ -15,6 +15,8 @@
 /* NMAX is the largest n such that 255n(n+1)/2 + (n+1)(BASE-1) <= 2^32-1 */
 #define NMAX_ALIGNED32 (NMAX & ~31)
 /* NMAX rounded down to a multiple of 32 is 5536 */
+#define NMAX_ALIGNED64 (NMAX & ~63)
+/* NMAX rounded down to a multiple of 64 is 5504 */
 
 #define ADLER_DO1(sum1, sum2, buf, i)  {(sum1) += buf[(i)]; (sum2) += (sum1);}
 #define ADLER_DO2(sum1, sum2, buf, i)  {ADLER_DO1(sum1, sum2, buf, i); ADLER_DO1(sum1, sum2, buf, i+1);}

--- a/arch/x86/adler32_avx512.c
+++ b/arch/x86/adler32_avx512.c
@@ -91,12 +91,72 @@ rem_peel:
     return adler;
 }
 
+// Deflate copying variant
+Z_FORCEINLINE static uint32_t adler32_copy_def(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len) {
+    uint32_t adler0, adler1;
+    adler1 = (adler >> 16) & 0xffff;
+    adler0 = adler & 0xffff;
+
+    __m512i vbuf, vs1_0, vs3;
+
+    const __m512i dot2v = _mm512_set_epi8(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+                                          20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37,
+                                          38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55,
+                                          56, 57, 58, 59, 60, 61, 62, 63, 64);
+    const __m512i dot3v = _mm512_set1_epi16(1);
+    const __m512i zero = _mm512_setzero_si512();
+
+    while (len >= 64) {
+        __m512i vs1 = _mm512_zextsi128_si512(_mm_cvtsi32_si128(adler0));
+        __m512i vs2 = _mm512_zextsi128_si512(_mm_cvtsi32_si128(adler1));
+        vs1_0 = vs1;
+        vs3 = _mm512_setzero_si512();
+
+        size_t k = MIN(len, NMAX_ALIGNED64);
+        len -= k;
+
+        while (k >= 64) {
+            /*
+               vs1 = adler + sum(c[i])
+               vs2 = sum2 + 64 vs1 + sum( (64-i+1) c[i] )
+            */
+            vbuf = _mm512_load_si512(src);
+
+            _mm512_store_si512(dst, vbuf);
+            dst += 64;
+
+            src += 64;
+            k -= 64;
+
+            __m512i vs1_sad = _mm512_sad_epu8(vbuf, zero);
+            __m512i v_short_sum2 = _mm512_maddubs_epi16(vbuf, dot2v);
+            vs1 = _mm512_add_epi32(vs1_sad, vs1);
+            vs3 = _mm512_add_epi32(vs3, vs1_0);
+            __m512i vsum2 = _mm512_madd_epi16(v_short_sum2, dot3v);
+            vs2 = _mm512_add_epi32(vsum2, vs2);
+            vs1_0 = vs1;
+        }
+
+        vs3 = _mm512_slli_epi32(vs3, 6);
+        vs2 = _mm512_add_epi32(vs2, vs3);
+
+        adler0 = partial_hsum(vs1) % BASE;
+        adler1 = _mm512_reduce_add_epu32(vs2) % BASE;
+    }
+
+    return adler0 | (adler1 << 16);
+}
+
 Z_INTERNAL uint32_t adler32_avx512(uint32_t adler, const uint8_t *src, size_t len) {
     return adler32_copy_impl(adler, NULL, src, len, 0);
 }
 
-Z_INTERNAL uint32_t adler32_copy_avx512(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len) {
+Z_INTERNAL uint32_t adler32_copy_avx512_inf(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len) {
     return adler32_copy_impl(adler, dst, src, len, 1);
+}
+
+Z_INTERNAL uint32_t adler32_copy_avx512_def(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len) {
+    return adler32_copy_def(adler, dst, src, len);
 }
 
 #endif

--- a/arch/x86/x86_functions.h
+++ b/arch/x86/x86_functions.h
@@ -70,7 +70,8 @@ void slide_hash_avx2(deflate_state *s);
 #endif
 #ifdef X86_AVX512
 uint32_t adler32_avx512(uint32_t adler, const uint8_t *buf, size_t len);
-uint32_t adler32_copy_avx512(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len);
+uint32_t adler32_copy_avx512_inf(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len);
+uint32_t adler32_copy_avx512_def(uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len);
 uint8_t* chunkmemset_safe_avx512(uint8_t *out, uint8_t *from, size_t len, size_t left);
 uint32_t compare256_avx512(const uint8_t *src0, const uint8_t *src1);
 void inflate_fast_avx512(PREFIX3(stream)* strm, uint32_t start, int safe_mode);

--- a/deflate_p.h
+++ b/deflate_p.h
@@ -167,10 +167,10 @@ Z_FORCEINLINE static unsigned read_buf(PREFIX3(stream) *strm, unsigned char *buf
         memcpy(buf, strm->next_in, len);
 #ifdef GZIP
     } else if (s->wrap == 2) {
-        strm->adler = FUNCTABLE_CALL(crc32_copy)(strm->adler, buf, strm->next_in, len);
+        strm->adler = FUNCTABLE_CALL(crc32_copy_def)(strm->adler, buf, strm->next_in, len);
 #endif
     } else if (s->wrap == 1) {
-        strm->adler = FUNCTABLE_CALL(adler32_copy)(strm->adler, buf, strm->next_in, len);
+        strm->adler = FUNCTABLE_CALL(adler32_copy_def)(strm->adler, buf, strm->next_in, len);
     } else {
         memcpy(buf, strm->next_in, len);
     }

--- a/functable.c
+++ b/functable.c
@@ -78,7 +78,8 @@ static int init_functable(void) {
     // Only use necessary generic functions when no suitable simd versions are available.
 #ifdef ADLER32_FALLBACK
     ft.adler32 = &adler32_c;
-    ft.adler32_copy = &adler32_copy_c;
+    ft.adler32_copy_inf = &adler32_copy_c;
+    ft.adler32_copy_def = &adler32_copy_c;
 #endif
 #ifdef CHUNKSET_FALLBACK
     ft.chunkmemset_safe = &chunkmemset_safe_c;
@@ -91,7 +92,8 @@ static int init_functable(void) {
 #endif
 #ifdef CRC32_BRAID_FALLBACK
     ft.crc32 = &crc32_braid;
-    ft.crc32_copy = &crc32_copy_braid;
+    ft.crc32_copy_inf = &crc32_copy_braid;
+    ft.crc32_copy_def = &crc32_copy_braid;
 #endif
 #ifdef SLIDE_HASH_FALLBACK
     ft.slide_hash = &slide_hash_c;
@@ -103,7 +105,8 @@ static int init_functable(void) {
     // Chorba generic C fallback
 #ifdef CRC32_CHORBA_FALLBACK
     ft.crc32 = &crc32_chorba;
-    ft.crc32_copy = &crc32_copy_chorba;
+    ft.crc32_copy_inf = &crc32_copy_chorba;
+    ft.crc32_copy_def = &crc32_copy_chorba;
 #endif
 
     // X86 - SSE2
@@ -122,7 +125,8 @@ static int init_functable(void) {
 #  endif
 #  if defined(CRC32_CHORBA_SSE_FALLBACK) && !defined(X86_SSE41_NATIVE) && !defined(X86_PCLMULQDQ_NATIVE)
         ft.crc32 = &crc32_chorba_sse2;
-        ft.crc32_copy = &crc32_copy_chorba_sse2;
+        ft.crc32_copy_inf = &crc32_copy_chorba_sse2;
+        ft.crc32_copy_def = &crc32_copy_chorba_sse2;
 #  endif
     }
 #endif
@@ -133,7 +137,8 @@ static int init_functable(void) {
 #  endif
     {
         ft.adler32 = &adler32_ssse3;
-        ft.adler32_copy = &adler32_copy_ssse3;
+        ft.adler32_copy_inf = &adler32_copy_ssse3;
+        ft.adler32_copy_def = &adler32_copy_ssse3;
 #  ifndef X86_AVX2_NATIVE
         ft.chunkmemset_safe = &chunkmemset_safe_ssse3;
         ft.inflate_fast = &inflate_fast_ssse3;
@@ -149,7 +154,8 @@ static int init_functable(void) {
     {
 #  ifdef CRC32_CHORBA_SSE_FALLBACK
         ft.crc32 = &crc32_chorba_sse41;
-        ft.crc32_copy = &crc32_copy_chorba_sse41;
+        ft.crc32_copy_inf = &crc32_copy_chorba_sse41;
+        ft.crc32_copy_def = &crc32_copy_chorba_sse41;
 #  endif
     }
 #endif
@@ -160,7 +166,8 @@ static int init_functable(void) {
     if (cf.x86.has_sse42)
 #  endif
     {
-        ft.adler32_copy = &adler32_copy_sse42;
+        ft.adler32_copy_inf = &adler32_copy_sse42;
+        ft.adler32_copy_def = &adler32_copy_sse42;
     }
 #endif
     // X86 - PCLMUL
@@ -170,7 +177,8 @@ static int init_functable(void) {
 #  endif
     {
         ft.crc32 = &crc32_pclmulqdq;
-        ft.crc32_copy = &crc32_copy_pclmulqdq;
+        ft.crc32_copy_inf = &crc32_copy_pclmulqdq;
+        ft.crc32_copy_def = &crc32_copy_pclmulqdq;
     }
 #endif
     // X86 - AVX2
@@ -185,7 +193,8 @@ static int init_functable(void) {
     {
 #  ifndef X86_AVX512_NATIVE
         ft.adler32 = &adler32_avx2;
-        ft.adler32_copy = &adler32_copy_avx2;
+        ft.adler32_copy_inf = &adler32_copy_avx2;
+        ft.adler32_copy_def = &adler32_copy_avx2;
         ft.chunkmemset_safe = &chunkmemset_safe_avx2;
         ft.compare256 = &compare256_avx2;
         ft.inflate_fast = &inflate_fast_avx2;
@@ -203,7 +212,8 @@ static int init_functable(void) {
     {
 #  ifndef X86_AVX512VNNI_NATIVE
         ft.adler32 = &adler32_avx512;
-        ft.adler32_copy = &adler32_copy_avx512;
+        ft.adler32_copy_inf = &adler32_copy_avx512;
+        ft.adler32_copy_def = &adler32_copy_avx512;
 #  endif
         ft.chunkmemset_safe = &chunkmemset_safe_avx512;
         ft.compare256 = &compare256_avx512;
@@ -218,7 +228,8 @@ static int init_functable(void) {
 #  endif
     {
         ft.adler32 = &adler32_avx512_vnni;
-        ft.adler32_copy = &adler32_copy_avx512_vnni;
+        ft.adler32_copy_inf = &adler32_copy_avx512_vnni;
+        ft.adler32_copy_def = &adler32_copy_avx512_vnni;
     }
 #endif
     // X86 - VPCLMULQDQ (AVX2)
@@ -228,7 +239,8 @@ static int init_functable(void) {
 #  endif
     {
         ft.crc32 = &crc32_vpclmulqdq_avx2;
-        ft.crc32_copy = &crc32_copy_vpclmulqdq_avx2;
+        ft.crc32_copy_inf = &crc32_copy_vpclmulqdq_avx2;
+        ft.crc32_copy_def = &crc32_copy_vpclmulqdq_avx2;
     }
 #endif
     // X86 - VPCLMULQDQ (AVX-512)
@@ -238,7 +250,8 @@ static int init_functable(void) {
 #  endif
     {
         ft.crc32 = &crc32_vpclmulqdq_avx512;
-        ft.crc32_copy = &crc32_copy_vpclmulqdq_avx512;
+        ft.crc32_copy_inf = &crc32_copy_vpclmulqdq_avx512;
+        ft.crc32_copy_def = &crc32_copy_vpclmulqdq_avx512;
     }
 #endif
 
@@ -259,7 +272,8 @@ static int init_functable(void) {
 #  endif
     {
         ft.adler32 = &adler32_neon;
-        ft.adler32_copy = &adler32_copy_neon;
+        ft.adler32_copy_inf = &adler32_copy_neon;
+        ft.adler32_copy_def = &adler32_copy_neon;
         ft.chunkmemset_safe = &chunkmemset_safe_neon;
         ft.compare256 = &compare256_neon;
         ft.inflate_fast = &inflate_fast_neon;
@@ -275,7 +289,8 @@ static int init_functable(void) {
 #  endif
     {
         ft.adler32 = &adler32_neon_dotprod;
-        ft.adler32_copy = &adler32_copy_neon_dotprod;
+        ft.adler32_copy_inf = &adler32_copy_neon_dotprod;
+        ft.adler32_copy_def = &adler32_copy_neon_dotprod;
     }
 #endif
     // ARM - CRC32
@@ -285,7 +300,8 @@ static int init_functable(void) {
 #  endif
     {
         ft.crc32 = &crc32_armv8;
-        ft.crc32_copy = &crc32_copy_armv8;
+        ft.crc32_copy_inf = &crc32_copy_armv8;
+        ft.crc32_copy_def = &crc32_copy_armv8;
     }
 #endif
     // ARM - PMULL EOR3
@@ -295,7 +311,8 @@ static int init_functable(void) {
 #  endif
     {
         ft.crc32 = &crc32_armv8_pmull_eor3;
-        ft.crc32_copy = &crc32_copy_armv8_pmull_eor3;
+        ft.crc32_copy_inf = &crc32_copy_armv8_pmull_eor3;
+        ft.crc32_copy_def = &crc32_copy_armv8_pmull_eor3;
     }
 #endif
 
@@ -306,7 +323,8 @@ static int init_functable(void) {
 #  endif
     {
         ft.adler32 = &adler32_vmx;
-        ft.adler32_copy = &adler32_copy_vmx;
+        ft.adler32_copy_inf = &adler32_copy_vmx;
+        ft.adler32_copy_def = &adler32_copy_vmx;
         ft.slide_hash = &slide_hash_vmx;
     }
 #endif
@@ -317,7 +335,8 @@ static int init_functable(void) {
 #  endif
     {
         ft.adler32 = &adler32_power8;
-        ft.adler32_copy = &adler32_copy_power8;
+        ft.adler32_copy_inf = &adler32_copy_power8;
+        ft.adler32_copy_def = &adler32_copy_power8;
         ft.chunkmemset_safe = &chunkmemset_safe_power8;
         ft.inflate_fast = &inflate_fast_power8;
         ft.slide_hash = &slide_hash_power8;
@@ -329,7 +348,8 @@ static int init_functable(void) {
 #  endif
     {
         ft.crc32 = &crc32_power8;
-        ft.crc32_copy = &crc32_copy_power8;
+        ft.crc32_copy_inf = &crc32_copy_power8;
+        ft.crc32_copy_def = &crc32_copy_power8;
     }
 #endif
     // Power9
@@ -352,7 +372,8 @@ static int init_functable(void) {
 #  endif
     {
         ft.adler32 = &adler32_rvv;
-        ft.adler32_copy = &adler32_copy_rvv;
+        ft.adler32_copy_inf = &adler32_copy_rvv;
+        ft.adler32_copy_def = &adler32_copy_rvv;
         ft.chunkmemset_safe = &chunkmemset_safe_rvv;
         ft.compare256 = &compare256_rvv;
         ft.inflate_fast = &inflate_fast_rvv;
@@ -369,7 +390,8 @@ static int init_functable(void) {
 #  endif
     {
         ft.crc32 = &crc32_riscv64_zbc;
-        ft.crc32_copy = &crc32_copy_riscv64_zbc;
+        ft.crc32_copy_inf = &crc32_copy_riscv64_zbc;
+        ft.crc32_copy_def = &crc32_copy_riscv64_zbc;
     }
 #endif
 
@@ -380,7 +402,8 @@ static int init_functable(void) {
 #  endif
     {
         ft.crc32 = &crc32_s390_vx;
-        ft.crc32_copy = &crc32_copy_s390_vx;
+        ft.crc32_copy_inf = &crc32_copy_s390_vx;
+        ft.crc32_copy_def = &crc32_copy_s390_vx;
         ft.slide_hash = &slide_hash_vx;
     }
 #endif
@@ -392,7 +415,8 @@ static int init_functable(void) {
 #  endif
     {
         ft.crc32 = &crc32_loongarch64;
-        ft.crc32_copy = &crc32_copy_loongarch64;
+        ft.crc32_copy_inf = &crc32_copy_loongarch64;
+        ft.crc32_copy_def = &crc32_copy_loongarch64;
     }
 #endif
 #if defined(LOONGARCH_LSX) && !defined(LOONGARCH_LASX_NATIVE)
@@ -401,7 +425,8 @@ static int init_functable(void) {
 #  endif
     {
         ft.adler32 = &adler32_lsx;
-        ft.adler32_copy = &adler32_copy_lsx;
+        ft.adler32_copy_inf = &adler32_copy_lsx;
+        ft.adler32_copy_def = &adler32_copy_lsx;
         ft.chunkmemset_safe = &chunkmemset_safe_lsx;
         ft.compare256 = &compare256_lsx;
         ft.inflate_fast = &inflate_fast_lsx;
@@ -416,7 +441,8 @@ static int init_functable(void) {
 #  endif
     {
         ft.adler32 = &adler32_lasx;
-        ft.adler32_copy = &adler32_copy_lasx;
+        ft.adler32_copy_inf = &adler32_copy_lasx;
+        ft.adler32_copy_def = &adler32_copy_lasx;
         ft.chunkmemset_safe = &chunkmemset_safe_lasx;
         ft.compare256 = &compare256_lasx;
         ft.inflate_fast = &inflate_fast_lasx;
@@ -431,11 +457,13 @@ static int init_functable(void) {
     // Assign function pointers individually for atomic operation
     FUNCTABLE_ASSIGN(ft, force_init);
     FUNCTABLE_VERIFY_ASSIGN(ft, adler32);
-    FUNCTABLE_VERIFY_ASSIGN(ft, adler32_copy);
+    FUNCTABLE_VERIFY_ASSIGN(ft, adler32_copy_inf);
+    FUNCTABLE_VERIFY_ASSIGN(ft, adler32_copy_def);
     FUNCTABLE_VERIFY_ASSIGN(ft, chunkmemset_safe);
     FUNCTABLE_VERIFY_ASSIGN(ft, compare256);
     FUNCTABLE_VERIFY_ASSIGN(ft, crc32);
-    FUNCTABLE_VERIFY_ASSIGN(ft, crc32_copy);
+    FUNCTABLE_VERIFY_ASSIGN(ft, crc32_copy_inf);
+    FUNCTABLE_VERIFY_ASSIGN(ft, crc32_copy_def);
     FUNCTABLE_VERIFY_ASSIGN(ft, inflate_fast);
     FUNCTABLE_VERIFY_ASSIGN(ft, longest_match);
     FUNCTABLE_VERIFY_ASSIGN(ft, longest_match_roll);
@@ -465,7 +493,8 @@ static uint32_t adler32_stub(uint32_t adler, const uint8_t* buf, size_t len) {
 
 static uint32_t adler32_copy_stub(uint32_t adler, uint8_t* dst, const uint8_t* src, size_t len) {
     FUNCTABLE_INIT_ABORT;
-    return functable.adler32_copy(adler, dst, src, len);
+    // Use safe inflate-variant for stub fallback
+    return functable.adler32_copy_inf(adler, dst, src, len);
 }
 
 static uint8_t* chunkmemset_safe_stub(uint8_t* out, uint8_t *from, size_t len, size_t left) {
@@ -485,7 +514,8 @@ static uint32_t crc32_stub(uint32_t crc, const uint8_t* buf, size_t len) {
 
 static uint32_t crc32_copy_stub(uint32_t crc, uint8_t *dst, const uint8_t *src, size_t len) {
     FUNCTABLE_INIT_ABORT;
-    return functable.crc32_copy(crc, dst, src, len);
+    // Use safe inflate-variant for stub fallback
+    return functable.crc32_copy_inf(crc, dst, src, len);
 }
 
 static void inflate_fast_stub(PREFIX3(stream) *strm, uint32_t start, int safe_mode) {
@@ -513,9 +543,11 @@ Z_INTERNAL struct functable_s functable = {
     force_init_stub,
     adler32_stub,
     adler32_copy_stub,
+    adler32_copy_stub,
     chunkmemset_safe_stub,
     compare256_stub,
     crc32_stub,
+    crc32_copy_stub,
     crc32_copy_stub,
     inflate_fast_stub,
     longest_match_stub,

--- a/functable.c
+++ b/functable.c
@@ -212,8 +212,8 @@ static int init_functable(void) {
     {
 #  ifndef X86_AVX512VNNI_NATIVE
         ft.adler32 = &adler32_avx512;
-        ft.adler32_copy_inf = &adler32_copy_avx512;
-        ft.adler32_copy_def = &adler32_copy_avx512;
+        ft.adler32_copy_inf = &adler32_copy_avx512_inf;
+        ft.adler32_copy_def = &adler32_copy_avx512_def;
 #  endif
         ft.chunkmemset_safe = &chunkmemset_safe_avx512;
         ft.compare256 = &compare256_avx512;

--- a/functable.h
+++ b/functable.h
@@ -25,11 +25,13 @@
 struct functable_s {
     int      (* force_init)         (void);
     uint32_t (* adler32)            (uint32_t adler, const uint8_t *buf, size_t len);
-    uint32_t (* adler32_copy)       (uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len);
+    uint32_t (* adler32_copy_inf)   (uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len);
+    uint32_t (* adler32_copy_def)   (uint32_t adler, uint8_t *dst, const uint8_t *src, size_t len);
     uint8_t* (* chunkmemset_safe)   (uint8_t *out, uint8_t *from, size_t len, size_t left);
     uint32_t (* compare256)         (const uint8_t *src0, const uint8_t *src1);
     uint32_t (* crc32)              (uint32_t crc, const uint8_t *buf, size_t len);
-    uint32_t (* crc32_copy)         (uint32_t crc, uint8_t *dst, const uint8_t *src, size_t len);
+    uint32_t (* crc32_copy_inf)     (uint32_t crc, uint8_t *dst, const uint8_t *src, size_t len);
+    uint32_t (* crc32_copy_def)     (uint32_t crc, uint8_t *dst, const uint8_t *src, size_t len);
     void     (* inflate_fast)       (PREFIX3(stream) *strm, uint32_t start, int safe_mode);
     uint32_t (* longest_match)      (deflate_state *const s, uint32_t cur_match);
     uint32_t (* longest_match_roll) (deflate_state *const s, uint32_t cur_match);

--- a/inflate.c
+++ b/inflate.c
@@ -30,11 +30,11 @@ static inline void inf_chksum_cpy(PREFIX3(stream) *strm, uint8_t *dst,
     struct inflate_state *state = (struct inflate_state*)strm->state;
 #ifdef GUNZIP
     if (state->flags) {
-        strm->adler = state->check = FUNCTABLE_CALL(crc32_copy)(state->check, dst, src, copy);
+        strm->adler = state->check = FUNCTABLE_CALL(crc32_copy_inf)(state->check, dst, src, copy);
     } else
 #endif
     {
-        strm->adler = state->check = FUNCTABLE_CALL(adler32_copy)(state->check, dst, src, copy);
+        strm->adler = state->check = FUNCTABLE_CALL(adler32_copy_inf)(state->check, dst, src, copy);
     }
 }
 

--- a/test/benchmarks/benchmark_adler32_copy.cc
+++ b/test/benchmarks/benchmark_adler32_copy.cc
@@ -13,7 +13,7 @@ extern "C" {
 
 // Hash copy functions are used on strm->next_in buffers, we process
 // 512-32k sizes (x2 for initial fill) at a time if enough data is available.
-#define BUFSIZE (65536 + 64)
+#define BUFSIZE (65536)
 
 class adler32_copy: public benchmark::Fixture {
 private:
@@ -34,17 +34,12 @@ public:
         }
     }
 
-    // Benchmark Adler32_copy, with rolling buffer misalignment for consistent results
-    void Bench(benchmark::State& state, adler32_copy_func adler32_copy, const int DO_ALIGNED) {
-        int misalign = 0;
+    // Benchmark Adler32_copy
+    void Bench(benchmark::State& state, adler32_copy_func adler32_copy) {
         uint32_t hash = 0;
 
         for (auto _ : state) {
-            hash = adler32_copy(hash, dstbuf + misalign, (const unsigned char*)testdata + misalign, (size_t)state.range(0));
-            if (misalign >= 63)
-                misalign = 0;
-            else
-                misalign += (DO_ALIGNED) ? 16 : 1;
+            hash = adler32_copy(hash, dstbuf, (const unsigned char*)testdata, (size_t)state.range(0));
 
             // Prevent the result from being optimized away
             benchmark::DoNotOptimize(hash);
@@ -57,50 +52,22 @@ public:
     }
 };
 
-// Misaligned
-#define BENCHMARK_ADLER32_COPY_MISALIGNED(name, copyfunc, support_flag) \
+#define BENCHMARK_ADLER32_COPY_ONLY(name, copyfunc, support_flag) \
     BENCHMARK_DEFINE_F(adler32_copy, name)(benchmark::State& state) { \
         if (!(support_flag)) { \
             state.SkipWithError("CPU does not support " #name); \
             return; \
         } \
-        Bench(state, copyfunc, 0); \
+        Bench(state, copyfunc); \
     } \
-    BENCHMARK_REGISTER_F(adler32_copy, name)->Arg(32)->Arg(512)->Arg(8<<10)->Arg(32<<10)->Arg(64<<10);
-
-// Aligned
-#define ALIGNED_NAME(name) name##_aligned
-#define BENCHMARK_ADLER32_COPY_ALIGNED(name, copyfunc, support_flag) \
-    BENCHMARK_DEFINE_F(adler32_copy, ALIGNED_NAME(name))(benchmark::State& state) { \
-        if (!(support_flag)) { \
-            state.SkipWithError("CPU does not support " #name); \
-            return; \
-        } \
-        Bench(state, copyfunc, 1); \
-    } \
-    BENCHMARK_REGISTER_F(adler32_copy, ALIGNED_NAME(name))->Arg(32)->Arg(512)->Arg(8<<10)->Arg(32<<10)->Arg(64<<10);
+    BENCHMARK_REGISTER_F(adler32_copy, name)->Arg(512)->Arg(8<<10)->Arg(32<<10)->Arg(64<<10);
 
 
 // Adler32 + memcpy benchmarks for reference
 #ifdef HASH_BASELINE
 #define MEMCPY_NAME(name) name##_memcpy
-#define BENCHMARK_ADLER32_MEMCPY_MISALIGNED(name, hashfunc, support_flag) \
+#define BENCHMARK_ADLER32_MEMCPY(name, hashfunc, support_flag) \
     BENCHMARK_DEFINE_F(adler32_copy, MEMCPY_NAME(name))(benchmark::State& state) { \
-        if (!(support_flag)) { \
-            state.SkipWithError("CPU does not support " #name); \
-            return; \
-        } \
-        Bench(state, [](uint32_t init_sum, unsigned char *dst, \
-                        const uint8_t *buf, size_t len) -> uint32_t { \
-            memcpy(dst, buf, (size_t)len); \
-            return hashfunc(init_sum, buf, len); \
-        }, 0); \
-    } \
-    BENCHMARK_REGISTER_F(adler32_copy, MEMCPY_NAME(name))->Arg(32)->Arg(512)->Arg(8<<10)->Arg(32<<10)->Arg(64<<10);
-
-#define MEMCPY_ALIGNED_NAME(name) name##_memcpy_aligned
-#define BENCHMARK_ADLER32_MEMCPY_ALIGNED(name, hashfunc, support_flag) \
-    BENCHMARK_DEFINE_F(adler32_copy, MEMCPY_ALIGNED_NAME(name))(benchmark::State& state) { \
         if (!(support_flag)) { \
             state.SkipWithError("CPU does not support " #name); \
             return; \
@@ -111,22 +78,15 @@ public:
             return hashfunc(init_sum, buf, len); \
         }, 1); \
     } \
-    BENCHMARK_REGISTER_F(adler32_copy, MEMCPY_ALIGNED_NAME(name))->Arg(32)->Arg(512)->Arg(8<<10)->Arg(32<<10)->Arg(64<<10);
+    BENCHMARK_REGISTER_F(adler32_copy, MEMCPY_NAME(name))->Arg(512)->Arg(8<<10)->Arg(32<<10)->Arg(64<<10);
 #endif
 
-
-// Queue both misaligned and aligned for each benchmark
-#define BENCHMARK_ADLER32_COPY_ONLY(name, copyfunc, support_flag) \
-    BENCHMARK_ADLER32_COPY_MISALIGNED(name, copyfunc, support_flag); \
-    BENCHMARK_ADLER32_COPY_ALIGNED(name, copyfunc, support_flag);
 
 // Optionally also benchmark using memcpy with normal hash function for baseline
 #ifdef HASH_BASELINE
 #define BENCHMARK_ADLER32_COPY(name, hashfunc, copyfunc, support_flag) \
-    BENCHMARK_ADLER32_COPY_MISALIGNED(name, copyfunc, support_flag); \
-    BENCHMARK_ADLER32_COPY_ALIGNED(name, copyfunc, support_flag); \
-    BENCHMARK_ADLER32_MEMCPY_MISALIGNED(name, copyfunc, support_flag); \
-    BENCHMARK_ADLER32_MEMCPY_ALIGNED(name, copyfunc, support_flag);
+    BENCHMARK_ADLER32_COPY_ONLY(name, copyfunc, support_flag); \
+    BENCHMARK_ADLER32_MEMCPY(name, copyfunc, support_flag);
 #else
 #define BENCHMARK_ADLER32_COPY(name, hashfunc, copyfunc, support_flag) \
     BENCHMARK_ADLER32_COPY_ONLY(name, copyfunc, support_flag)

--- a/test/benchmarks/benchmark_adler32_copy.cc
+++ b/test/benchmarks/benchmark_adler32_copy.cc
@@ -129,7 +129,8 @@ BENCHMARK_ADLER32_COPY_ONLY(sse42, adler32_copy_sse42, test_cpu_features.x86.has
 BENCHMARK_ADLER32_COPY(avx2, adler32_avx, adler32_copy_avx2, test_cpu_features.x86.has_avx2);
 #endif
 #ifdef X86_AVX512
-BENCHMARK_ADLER32_COPY(avx512, adler32_avx512, adler32_copy_avx512, test_cpu_features.x86.has_avx512_common);
+BENCHMARK_ADLER32_COPY(avx512_inf, adler32_avx512, adler32_copy_avx512_inf, test_cpu_features.x86.has_avx512_common);
+BENCHMARK_ADLER32_COPY(avx512_def, adler32_avx512, adler32_copy_avx512_def, test_cpu_features.x86.has_avx512_common);
 #endif
 #ifdef X86_AVX512VNNI
 BENCHMARK_ADLER32_COPY(avx512_vnni, adler32_avx512_vnni, adler32_copy_avx512_vnni, test_cpu_features.x86.has_avx512vnni);

--- a/test/hash_test_strings_p.h
+++ b/test/hash_test_strings_p.h
@@ -372,4 +372,10 @@ static const hash_test hash_tests[] = {
   {615336, big_test, 0x0, 0xe3274b6f, 0x0, 0x27b91614},
 };
 
+// Tests specifically for adler32_copy/crc32_copy using window-sized tests
+static const hash_test copy_tests[] = {
+  {32768, big_test, 0x0, 0xbfcdc3b1, 0x0, 0x217726b2},
+  {16384, big_test, 0x0, 0x186ae1d1, 0x0, 0xe81722f0},
+};
+
 #endif  /* HASH_TEST_STRINGS_P_H */

--- a/test/test_adler32_copy.cc
+++ b/test/test_adler32_copy.cc
@@ -12,23 +12,42 @@ extern "C" {
 #  include "hash_test_strings_p.h"
 }
 
+#define BUFSIZE 64 * 1024
+
 class adler32_copy_variant : public ::testing::TestWithParam<hash_test> {
 protected:
-    uint8_t dstbuf[HASH_TEST_MAX_LENGTH];
+    static uint8_t *testdata;
+    static uint8_t *dstbuf;
+
+    static void SetUpTestSuite() {
+        testdata = (uint8_t *)zng_alloc_aligned(BUFSIZE, 64);
+        dstbuf = (uint8_t *)zng_alloc_aligned(BUFSIZE, 64);
+    }
+
+    static void TearDownTestSuite() {
+        zng_free_aligned(testdata);
+        zng_free_aligned(dstbuf);
+    }
 
 public:
     /* Ensure that adler32 copy functions returns the correct adler and copies the data */
     void adler32_copy_test(adler32_copy_func copyfunc, hash_test params) {
-        ASSERT_LE(params.len, HASH_TEST_MAX_LENGTH);
+        ASSERT_LE(params.len, BUFSIZE);
 
-        uint32_t adler = copyfunc(params.initial_adler, dstbuf, params.buf, params.len);
+        // Copy testdata to aligned buffer
+        memcpy(testdata, params.buf, params.len);
+
+        uint32_t adler = copyfunc(params.initial_adler, dstbuf, testdata, params.len);
 
         EXPECT_EQ(adler, params.expect_adler);
-        EXPECT_EQ(0, memcmp(params.buf, dstbuf, params.len));
+        EXPECT_EQ(0, memcmp(testdata, dstbuf, params.len));
     }
 };
 
-INSTANTIATE_TEST_SUITE_P(adler32_copy, adler32_copy_variant, testing::ValuesIn(hash_tests));
+uint8_t* adler32_copy_variant::testdata = nullptr;
+uint8_t* adler32_copy_variant::dstbuf = nullptr;
+
+INSTANTIATE_TEST_SUITE_P(adler32_copy, adler32_copy_variant, testing::ValuesIn(copy_tests));
 
 #define TEST_ADLER32_COPY(name, copyfunc, support_flag) \
     TEST_P(adler32_copy_variant, name) { \

--- a/test/test_adler32_copy.cc
+++ b/test/test_adler32_copy.cc
@@ -93,7 +93,8 @@ TEST_ADLER32_COPY(sse42, adler32_copy_sse42, test_cpu_features.x86.has_sse42)
 TEST_ADLER32_COPY(avx2, adler32_copy_avx2, test_cpu_features.x86.has_avx2)
 #endif
 #ifdef X86_AVX512
-TEST_ADLER32_COPY(avx512, adler32_copy_avx512, test_cpu_features.x86.has_avx512_common)
+TEST_ADLER32_COPY(avx512_inf, adler32_copy_avx512_inf, test_cpu_features.x86.has_avx512_common)
+TEST_ADLER32_COPY(avx512_def, adler32_copy_avx512_def, test_cpu_features.x86.has_avx512_common)
 #endif
 #ifdef X86_AVX512VNNI
 TEST_ADLER32_COPY(avx512_vnni, adler32_copy_avx512_vnni, test_cpu_features.x86.has_avx512vnni)


### PR DESCRIPTION
Splitting the hash_copy functions into:
- one for inflate to handle unaligned buffers of unknown size
- one for deflate to handl 64-byte aligned buffers of known window-sized size

This is a starting point to explore whether we can optimize the deflate hash function to better handle window hashing.

Edit: This turned out to be a failed experiment based on false assumptions.