### PR TITLE
Fix this compilation issue for non-windows machines

### DIFF
--- a/test/benchmarks/benchmark_png_shared.h
+++ b/test/benchmarks/benchmark_png_shared.h
@@ -11,6 +11,9 @@ extern "C" {
 #  include <png.h>
 }
 
+#define MAX(a, b) std::max(a, b)
+#define MIN(a, b) std::min(a, b)
+
 typedef struct _png_dat {
     uint8_t *buf;
     int64_t len;


### PR DESCRIPTION
I've been manually fixing this up for a bit. We're on C++ so let's just use STL's functions here, which should compile down to min and max instructions.