### PR TITLE
Use alignment-safe reads in RVV chunkmemset

### DIFF
--- a/arch/riscv/chunkset_rvv.c
+++ b/arch/riscv/chunkset_rvv.c
@@ -7,6 +7,7 @@
 #ifdef RISCV_RVV
 
 #include "zbuild.h"
+#include "zmemory.h"
 
 #include <riscv_vector.h>
 
@@ -18,10 +19,10 @@
 #define HAVE_CHUNKMEMSET_4
 #define HAVE_CHUNKMEMSET_8
 
-#define CHUNK_MEMSET_RVV_IMPL(from, chunk, elen)                        \
+#define CHUNK_MEMSET_RVV_IMPL(v, chunk, elen)                           \
 do {                                                                    \
     size_t vl, len = sizeof(*chunk) / sizeof(uint##elen##_t);           \
-    uint##elen##_t val = *(uint##elen##_t*)from;                        \
+    uint##elen##_t val = (v);                                           \
     uint##elen##_t* chunk_p = (uint##elen##_t*)chunk;                   \
     do {                                                                \
         vl = __riscv_vsetvl_e##elen##m4(len);                           \
@@ -37,15 +38,15 @@ typedef struct chunk_s {
 } chunk_t;
 
 static inline void chunkmemset_2(uint8_t *from, chunk_t *chunk) {
-    CHUNK_MEMSET_RVV_IMPL(from, chunk, 16);
+    CHUNK_MEMSET_RVV_IMPL(zng_memread_2(from), chunk, 16);
 }
 
 static inline void chunkmemset_4(uint8_t *from, chunk_t *chunk) {
-    CHUNK_MEMSET_RVV_IMPL(from, chunk, 32);
+    CHUNK_MEMSET_RVV_IMPL(zng_memread_4(from), chunk, 32);
 }
 
 static inline void chunkmemset_8(uint8_t *from, chunk_t *chunk) {
-    CHUNK_MEMSET_RVV_IMPL(from, chunk, 64);
+    CHUNK_MEMSET_RVV_IMPL(zng_memread_8(from), chunk, 64);
 }
 
 static inline void loadchunk(uint8_t const *s, chunk_t *chunk) {


### PR DESCRIPTION
Fixes #1670.

`CHUNK_MEMSET_RVV_IMPL` read the broadcast value through a plain pointer cast, but `from` comes from `out - dist` in `chunkset_tpl.h` and can sit at any byte offset in the output window, so the read may be misaligned. RVV was the only chunkset implementation still doing this; every other arch (generic, NEON, SSE2/SSSE3/AVX2/AVX512, POWER8, LSX/LASX) already reads the value with `zng_memread_*` before splatting.

The read now happens at the call sites via `zng_memread_2/4/8`, passed into the macro as a value, since the macro is parameterized by element bits while `zng_memread_*` is named by bytes. The macro evaluates it once into a local.

Verified assembly with clang 22 and GCC 16 targeting rv64gcv. On targets that declare fast unaligned loads (clang `-mno-strict-align`, GCC with a fast-unaligned `-mtune`) the output is bit-identical. On strict-align targets the only change is byte-wise loads at the three one-time seed reads, outside all loops; the vector broadcast loops and `inflate_fast_rvv` are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)