### PR TITLE
Unify slide_hash_sse2 to follow same style as the other variants

### DIFF
--- a/arch/x86/slide_hash_sse2.c
+++ b/arch/x86/slide_hash_sse2.c
@@ -15,43 +15,25 @@
 #include "deflate.h"
 
 #include <immintrin.h>
-#include <assert.h>
 
-static inline void slide_hash_chain(Pos *table0, Pos *table1, uint32_t entries0,
-                                    uint32_t entries1, const __m128i wsize) {
-    uint32_t entries;
-    Pos *table;
-    __m128i value0, value1, result0, result1;
-
-    int on_chain = 0;
-
-next_chain:
-    table = (on_chain) ? table1 : table0;
-    entries = (on_chain) ? entries1 : entries0;
-
+static inline void slide_hash_chain(Pos *table, uint32_t entries, const __m128i wsize) {
     table += entries;
     table -= 16;
 
-    /* ZALLOC allocates this pointer unless the user chose a custom allocator.
-     * Our alloc function is aligned to 64 byte boundaries */
+    /* alloc_deflate() ensures this pointer is aligned on an 64 byte boundary */
     do {
-        value0 = _mm_load_si128((__m128i *)table);
-        value1 = _mm_load_si128((__m128i *)(table + 8));
-        result0 = _mm_subs_epu16(value0, wsize);
+        __m128i value1, value2, result1, result2;
+
+        value1 = _mm_load_si128((__m128i *)table);
+        value2 = _mm_load_si128((__m128i *)(table + 8));
         result1 = _mm_subs_epu16(value1, wsize);
-        _mm_store_si128((__m128i *)table, result0);
-        _mm_store_si128((__m128i *)(table + 8), result1);
+        result2 = _mm_subs_epu16(value2, wsize);
+        _mm_store_si128((__m128i *)table, result1);
+        _mm_store_si128((__m128i *)(table + 8), result2);
 
         table -= 16;
         entries -= 16;
     } while (entries > 0);
-
-    ++on_chain;
-    if (on_chain > 1) {
-        return;
-    } else {
-        goto next_chain;
-    }
 }
 
 Z_INTERNAL void slide_hash_sse2(deflate_state *s) {
@@ -59,10 +41,8 @@ Z_INTERNAL void slide_hash_sse2(deflate_state *s) {
     uint16_t wsize = (uint16_t)s->w_size;
     const __m128i xmm_wsize = _mm_set1_epi16((short)wsize);
 
-    assert(((uintptr_t)s->head & 15) == 0);
-    assert(((uintptr_t)s->prev & 15) == 0);
-
-    slide_hash_chain(s->head, s->prev, HASH_SIZE, wsize, xmm_wsize);
+    slide_hash_chain(s->head, HASH_SIZE, xmm_wsize);
+    slide_hash_chain(s->prev, wsize, xmm_wsize);
 }
 
 #endif


### PR DESCRIPTION
This cleans up the code to be simpler and more readable and also prepares it for #2327.

Performance is well within noise in my tests.

Code size increases slightly by 64bytes
`180104    1328       8  181440   2c4c0 libz-ng.so.2`
to:
`180168    1328       8  181504   2c500 libz-ng.so.2`