### PR TITLE
Optimize zng_emit_dist alternative A

### DIFF
--- a/deflate_p.h
+++ b/deflate_p.h
@@ -58,8 +58,8 @@ Z_INTERNAL void PREFIX(flush_pending)(PREFIX3(stream) *strm);
  * the current block must be flushed.
  */
 
-extern const unsigned char Z_INTERNAL zng_length_code[];
-extern const unsigned char Z_INTERNAL zng_dist_code[];
+extern Z_INTERNAL const unsigned char zng_length_code[];
+extern Z_INTERNAL const unsigned char zng_dist_code[];
 
 static inline int zng_tr_tally_lit(deflate_state *s, unsigned char c) {
     /* c is the unmatched char */

--- a/trees_emit.h
+++ b/trees_emit.h
@@ -14,8 +14,8 @@
 extern Z_INTERNAL const ct_data static_ltree[L_CODES+2];
 extern Z_INTERNAL const ct_data static_dtree[D_CODES];
 
-extern const unsigned char Z_INTERNAL zng_dist_code[DIST_CODE_LEN];
-extern const unsigned char Z_INTERNAL zng_length_code[STD_MAX_MATCH-STD_MIN_MATCH+1];
+extern Z_INTERNAL const unsigned char zng_dist_code[DIST_CODE_LEN];
+extern Z_INTERNAL const unsigned char zng_length_code[STD_MAX_MATCH-STD_MIN_MATCH+1];
 
 /* Combined mask + extra_bits tables for single-lookup optimization */
 extern Z_INTERNAL const uint16_t lmask_extra[LENGTH_CODES];

--- a/trees_emit.h
+++ b/trees_emit.h
@@ -117,7 +117,9 @@ static inline uint32_t zng_emit_dist(deflate_state *s, const ct_data *ltree, con
                                      uint32_t lc, uint32_t dist, uint64_t *bi_buf, uint32_t *bi_valid) {
     uint64_t match_bits;
     uint32_t match_bits_len;
-    uint32_t c, extra, lext, mask;
+    uint32_t mask_ext;  // Contains both mask and extra, can safely be used directly as mask
+                        // due to extra bits being outside the range of lc and dist data.
+    uint32_t c, extra;
     uint8_t code;
 
     /* 1. Process Length Code */
@@ -131,12 +133,11 @@ static inline uint32_t zng_emit_dist(deflate_state *s, const ct_data *ltree, con
     match_bits_len = ltree[c].Len;
 
     /* 2. Get extra bits count and mask */
-    lext = lmask_extra[code];
-    extra = lext >> 8;
-    mask = lext & 0xff;
+    mask_ext = lmask_extra[code];
+    extra = mask_ext >> 8;
 
     /*    Send length extra bits */
-    match_bits |= (uint64_t)(lc & mask) << match_bits_len;
+    match_bits |= (uint64_t)(lc & mask_ext) << match_bits_len;
     match_bits_len += extra;
 
     /* 3. Process Distance Code */
@@ -150,12 +151,11 @@ static inline uint32_t zng_emit_dist(deflate_state *s, const ct_data *ltree, con
     match_bits_len += dtree[code].Len;
 
     /* 4. Get extra bits count and mask */
-    lext = dmask_extra[code];
-    extra = lext >> 16;
-    mask = lext & 0xffff;
+    mask_ext = dmask_extra[code];
+    extra = mask_ext >> 16;
 
     /*    Send dist extra bits */
-    match_bits |= ((uint64_t)(dist & mask) << match_bits_len);
+    match_bits |= ((uint64_t)(dist & mask_ext) << match_bits_len);
     match_bits_len += extra;
 
     send_bits(s, match_bits, match_bits_len, *bi_buf, *bi_valid);

--- a/trees_emit.h
+++ b/trees_emit.h
@@ -17,9 +17,9 @@ extern Z_INTERNAL const ct_data static_dtree[D_CODES];
 extern const unsigned char Z_INTERNAL zng_dist_code[DIST_CODE_LEN];
 extern const unsigned char Z_INTERNAL zng_length_code[STD_MAX_MATCH-STD_MIN_MATCH+1];
 
-/* Combined base + extra_bits tables for single-lookup optimization */
-extern Z_INTERNAL const uint16_t lbase_extra[LENGTH_CODES];
-extern Z_INTERNAL const uint32_t dbase_extra[D_CODES];
+/* Combined mask + extra_bits tables for single-lookup optimization */
+extern Z_INTERNAL const uint16_t lmask_extra[LENGTH_CODES];
+extern Z_INTERNAL const uint32_t dmask_extra[D_CODES];
 
 /* Bit buffer and deflate code stderr tracing */
 #ifdef ZLIB_DEBUG
@@ -115,10 +115,10 @@ static inline void zng_emit_lit(deflate_state *s, const ct_data *ltree, unsigned
  */
 static inline uint32_t zng_emit_dist(deflate_state *s, const ct_data *ltree, const ct_data *dtree,
                                      uint32_t lc, uint32_t dist, uint64_t *bi_buf, uint32_t *bi_valid) {
-    uint32_t c, extra, lext;
-    uint8_t code;
     uint64_t match_bits;
     uint32_t match_bits_len;
+    uint32_t c, extra, lext, mask;
+    uint8_t code;
 
     /* 1. Process Length Code */
     code = zng_length_code[lc];
@@ -130,14 +130,13 @@ static inline uint32_t zng_emit_dist(deflate_state *s, const ct_data *ltree, con
     match_bits = ltree[c].Code;
     match_bits_len = ltree[c].Len;
 
-    /* 2. Get extra bits count and subtract base length */
-    lext = lbase_extra[code];
+    /* 2. Get extra bits count and mask */
+    lext = lmask_extra[code];
     extra = lext >> 8;
-    lc -= lext & 0xff;
+    mask = lext & 0xff;
 
     /*    Send length extra bits */
-    uint32_t l_mask = (1U << extra) - 1;
-    match_bits |= (uint64_t)(lc & l_mask) << match_bits_len;
+    match_bits |= (uint64_t)(lc & mask) << match_bits_len;
     match_bits_len += extra;
 
     /* 3. Process Distance Code */
@@ -150,14 +149,13 @@ static inline uint32_t zng_emit_dist(deflate_state *s, const ct_data *ltree, con
     match_bits |= ((uint64_t)dtree[code].Code << match_bits_len);
     match_bits_len += dtree[code].Len;
 
-    /* 4. Get extra bits count and subtract base distance */
-    lext = dbase_extra[code];
+    /* 4. Get extra bits count and mask */
+    lext = dmask_extra[code];
     extra = lext >> 16;
-    dist -= lext & 0xffff;
+    mask = lext & 0xffff;
 
     /*    Send dist extra bits */
-    uint32_t d_mask = (1U << extra) - 1;
-    match_bits |= ((uint64_t)(dist & d_mask) << match_bits_len);
+    match_bits |= ((uint64_t)(dist & mask) << match_bits_len);
     match_bits_len += extra;
 
     send_bits(s, match_bits, match_bits_len, *bi_buf, *bi_valid);

--- a/trees_tbl.h
+++ b/trees_tbl.h
@@ -73,7 +73,7 @@ Z_INTERNAL const ct_data static_dtree[D_CODES] = {
 {{19},{5}}, {{11},{5}}, {{27},{5}}, {{ 7},{5}}, {{23},{5}}
 };
 
-const unsigned char Z_INTERNAL zng_dist_code[DIST_CODE_LEN] = {
+Z_INTERNAL const unsigned char zng_dist_code[DIST_CODE_LEN] = {
  0,  1,  2,  3,  4,  4,  5,  5,  6,  6,  6,  6,  7,  7,  7,  7,  8,  8,  8,  8,
  8,  8,  8,  8,  9,  9,  9,  9,  9,  9,  9,  9, 10, 10, 10, 10, 10, 10, 10, 10,
 10, 10, 10, 10, 10, 10, 10, 10, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
@@ -102,7 +102,7 @@ const unsigned char Z_INTERNAL zng_dist_code[DIST_CODE_LEN] = {
 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29, 29
 };
 
-const unsigned char Z_INTERNAL zng_length_code[STD_MAX_MATCH-STD_MIN_MATCH+1] = {
+Z_INTERNAL const unsigned char zng_length_code[STD_MAX_MATCH-STD_MIN_MATCH+1] = {
  0,  1,  2,  3,  4,  5,  6,  7,  8,  8,  9,  9, 10, 10, 11, 11, 12, 12, 12, 12,
 13, 13, 13, 13, 14, 14, 14, 14, 15, 15, 15, 15, 16, 16, 16, 16, 16, 16, 16, 16,
 17, 17, 17, 17, 17, 17, 17, 17, 18, 18, 18, 18, 18, 18, 18, 18, 19, 19, 19, 19,

--- a/trees_tbl.h
+++ b/trees_tbl.h
@@ -118,33 +118,33 @@ const unsigned char Z_INTERNAL zng_length_code[STD_MAX_MATCH-STD_MIN_MATCH+1] = 
 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 28
 };
 
-/* Combined base + extra_bits tables for single-lookup optimization.
- * Length table: bits 0-7 = base_length, bits 8-11 = extra_lbits
- * Distance table: bits 0-15 = base_dist, bits 16-19 = extra_dbits
+/* Combined mask + extra_bits tables for single-lookup optimization.
+ * Length table: bits 0-7 = mask, bits 8-11 = extra_lbits
+ * Distance table: bits 0-15 = mask, bits 16-19 = extra_dbits
  */
-#define LBASE_EXTRA(base, extra) ((extra) << 8 | (base))
-#define DBASE_EXTRA(base, extra) ((extra) << 16 | (base))
+#define LMASK_EXTRA(mask, extra) ((extra) << 8 | (mask))
+#define DMASK_EXTRA(mask, extra) ((extra) << 16 | (mask))
 
-Z_INTERNAL const uint16_t lbase_extra[LENGTH_CODES] = {
-LBASE_EXTRA(  0, 0), LBASE_EXTRA(  1, 0), LBASE_EXTRA(  2, 0), LBASE_EXTRA(  3, 0),
-LBASE_EXTRA(  4, 0), LBASE_EXTRA(  5, 0), LBASE_EXTRA(  6, 0), LBASE_EXTRA(  7, 0),
-LBASE_EXTRA(  8, 1), LBASE_EXTRA( 10, 1), LBASE_EXTRA( 12, 1), LBASE_EXTRA( 14, 1),
-LBASE_EXTRA( 16, 2), LBASE_EXTRA( 20, 2), LBASE_EXTRA( 24, 2), LBASE_EXTRA( 28, 2),
-LBASE_EXTRA( 32, 3), LBASE_EXTRA( 40, 3), LBASE_EXTRA( 48, 3), LBASE_EXTRA( 56, 3),
-LBASE_EXTRA( 64, 4), LBASE_EXTRA( 80, 4), LBASE_EXTRA( 96, 4), LBASE_EXTRA(112, 4),
-LBASE_EXTRA(128, 5), LBASE_EXTRA(160, 5), LBASE_EXTRA(192, 5), LBASE_EXTRA(224, 5),
-LBASE_EXTRA(  0, 0)
+Z_INTERNAL const uint16_t lmask_extra[LENGTH_CODES] = {
+LMASK_EXTRA(  0, 0), LMASK_EXTRA(  0, 0), LMASK_EXTRA(  0, 0), LMASK_EXTRA(  0, 0),
+LMASK_EXTRA(  0, 0), LMASK_EXTRA(  0, 0), LMASK_EXTRA(  0, 0), LMASK_EXTRA(  0, 0),
+LMASK_EXTRA(  1, 1), LMASK_EXTRA(  1, 1), LMASK_EXTRA(  1, 1), LMASK_EXTRA(  1, 1),
+LMASK_EXTRA(  3, 2), LMASK_EXTRA(  3, 2), LMASK_EXTRA(  3, 2), LMASK_EXTRA(  3, 2),
+LMASK_EXTRA(  7, 3), LMASK_EXTRA(  7, 3), LMASK_EXTRA(  7, 3), LMASK_EXTRA(  7, 3),
+LMASK_EXTRA( 15, 4), LMASK_EXTRA( 15, 4), LMASK_EXTRA( 15, 4), LMASK_EXTRA( 15, 4),
+LMASK_EXTRA( 31, 5), LMASK_EXTRA( 31, 5), LMASK_EXTRA( 31, 5), LMASK_EXTRA( 31, 5),
+LMASK_EXTRA(  0, 0)
 };
 
-Z_INTERNAL const uint32_t dbase_extra[D_CODES] = {
-DBASE_EXTRA(    0,  0), DBASE_EXTRA(    1,  0), DBASE_EXTRA(    2,  0), DBASE_EXTRA(    3,  0),
-DBASE_EXTRA(    4,  1), DBASE_EXTRA(    6,  1), DBASE_EXTRA(    8,  2), DBASE_EXTRA(   12,  2),
-DBASE_EXTRA(   16,  3), DBASE_EXTRA(   24,  3), DBASE_EXTRA(   32,  4), DBASE_EXTRA(   48,  4),
-DBASE_EXTRA(   64,  5), DBASE_EXTRA(   96,  5), DBASE_EXTRA(  128,  6), DBASE_EXTRA(  192,  6),
-DBASE_EXTRA(  256,  7), DBASE_EXTRA(  384,  7), DBASE_EXTRA(  512,  8), DBASE_EXTRA(  768,  8),
-DBASE_EXTRA( 1024,  9), DBASE_EXTRA( 1536,  9), DBASE_EXTRA( 2048, 10), DBASE_EXTRA( 3072, 10),
-DBASE_EXTRA( 4096, 11), DBASE_EXTRA( 6144, 11), DBASE_EXTRA( 8192, 12), DBASE_EXTRA(12288, 12),
-DBASE_EXTRA(16384, 13), DBASE_EXTRA(24576, 13)
+Z_INTERNAL const uint32_t dmask_extra[D_CODES] = {
+DMASK_EXTRA(    0,  0), DMASK_EXTRA(    0,  0), DMASK_EXTRA(    0,  0), DMASK_EXTRA(    0,  0),
+DMASK_EXTRA(    1,  1), DMASK_EXTRA(    1,  1), DMASK_EXTRA(    3,  2), DMASK_EXTRA(    3,  2),
+DMASK_EXTRA(    7,  3), DMASK_EXTRA(    7,  3), DMASK_EXTRA(   15,  4), DMASK_EXTRA(   15,  4),
+DMASK_EXTRA(   31,  5), DMASK_EXTRA(   31,  5), DMASK_EXTRA(   63,  6), DMASK_EXTRA(   63,  6),
+DMASK_EXTRA(  127,  7), DMASK_EXTRA(  127,  7), DMASK_EXTRA(  255,  8), DMASK_EXTRA(  255,  8),
+DMASK_EXTRA(  511,  9), DMASK_EXTRA(  511,  9), DMASK_EXTRA( 1023, 10), DMASK_EXTRA( 1023, 10),
+DMASK_EXTRA( 2047, 11), DMASK_EXTRA( 2047, 11), DMASK_EXTRA( 4095, 12), DMASK_EXTRA( 4095, 12),
+DMASK_EXTRA( 8191, 13), DMASK_EXTRA( 8191, 13)
 };
 
 #endif /* TREES_TBL_H_ */

--- a/utils/maketrees.c
+++ b/utils/maketrees.c
@@ -126,21 +126,23 @@ static void gen_trees_header(void) {
         printf("%2u%s", length_code[i], SEPARATOR(i, STD_MAX_MATCH-STD_MIN_MATCH, 20));
     }
 
-    printf("/* Combined base + extra_bits tables for single-lookup optimization.\n");
-    printf(" * Length table: bits 0-7 = base_length, bits 8-11 = extra_lbits\n");
-    printf(" * Distance table: bits 0-15 = base_dist, bits 16-19 = extra_dbits\n");
+    printf("/* Combined mask + extra_bits tables for single-lookup optimization.\n");
+    printf(" * Length table: bits 0-7 = mask, bits 8-11 = extra_lbits\n");
+    printf(" * Distance table: bits 0-15 = mask, bits 16-19 = extra_dbits\n");
     printf(" */\n");
-    printf("#define LBASE_EXTRA(base, extra) ((extra) << 8 | (base))\n");
-    printf("#define DBASE_EXTRA(base, extra) ((extra) << 16 | (base))\n\n");
+    printf("#define LMASK_EXTRA(mask, extra) ((extra) << 8 | (mask))\n");
+    printf("#define DMASK_EXTRA(mask, extra) ((extra) << 16 | (mask))\n\n");
 
-    printf("Z_INTERNAL const uint16_t lbase_extra[LENGTH_CODES] = {\n");
+    printf("Z_INTERNAL const uint16_t lmask_extra[LENGTH_CODES] = {\n");
     for (i = 0; i < LENGTH_CODES; i++) {
-        printf("LBASE_EXTRA(%3d, %d)%s", base_length[i], extra_lbits[i], SEPARATOR(i, LENGTH_CODES-1, 4));
+        uint8_t mask = (1U << extra_lbits[i]) - 1;
+        printf("LMASK_EXTRA(%3u, %u)%s", mask, extra_lbits[i], SEPARATOR(i, LENGTH_CODES-1, 4));
     }
 
-    printf("Z_INTERNAL const uint32_t dbase_extra[D_CODES] = {\n");
+    printf("Z_INTERNAL const uint32_t dmask_extra[D_CODES] = {\n");
     for (i = 0; i < D_CODES; i++) {
-        printf("DBASE_EXTRA(%5d, %2d)%s", base_dist[i], extra_dbits[i], SEPARATOR(i, D_CODES-1, 4));
+        uint16_t mask = (1U << extra_dbits[i]) - 1;
+        printf("DMASK_EXTRA(%5u, %2u)%s", mask, extra_dbits[i], SEPARATOR(i, D_CODES-1, 4));
     }
 
     printf("#endif /* TREES_TBL_H_ */\n");

--- a/utils/maketrees.c
+++ b/utils/maketrees.c
@@ -116,12 +116,12 @@ static void gen_trees_header(void) {
         printf("{{%2u},{%u}}%s", static_dtree[i].Code, static_dtree[i].Len, SEPARATOR(i, D_CODES-1, 5));
     }
 
-    printf("const unsigned char Z_INTERNAL zng_dist_code[DIST_CODE_LEN] = {\n");
+    printf("Z_INTERNAL const unsigned char zng_dist_code[DIST_CODE_LEN] = {\n");
     for (i = 0; i < DIST_CODE_LEN; i++) {
         printf("%2u%s", dist_code[i], SEPARATOR(i, DIST_CODE_LEN-1, 20));
     }
 
-    printf("const unsigned char Z_INTERNAL zng_length_code[STD_MAX_MATCH-STD_MIN_MATCH+1] = {\n");
+    printf("Z_INTERNAL const unsigned char zng_length_code[STD_MAX_MATCH-STD_MIN_MATCH+1] = {\n");
     for (i = 0; i < STD_MAX_MATCH-STD_MIN_MATCH+1; i++) {
         printf("%2u%s", length_code[i], SEPARATOR(i, STD_MAX_MATCH-STD_MIN_MATCH, 20));
     }


### PR DESCRIPTION
Optimize zng_emit_dist by removing base and instead adding mask to extra tables.

This alternative is minimal changes from current develop.