### PR TITLE
Optimize zng_emit_dist alternative B

### DIFF
--- a/trees.h
+++ b/trees.h
@@ -33,6 +33,15 @@ static const unsigned char bl_order[BL_CODES]
   * probability, to avoid transmitting the lengths for unused bit length codes.
   */
 
+typedef struct {
+    uint8_t     mask;
+    uint8_t     extra;
+} lmask_extra_s;
+
+typedef struct {
+    uint16_t     mask;
+    uint16_t     extra;
+} dmask_extra_s;
 
 /* Function definitions */
 void gen_codes        (ct_data *tree, int max_code, uint16_t *bl_count);

--- a/trees_emit.h
+++ b/trees_emit.h
@@ -17,9 +17,9 @@ extern Z_INTERNAL const ct_data static_dtree[D_CODES];
 extern const unsigned char Z_INTERNAL zng_dist_code[DIST_CODE_LEN];
 extern const unsigned char Z_INTERNAL zng_length_code[STD_MAX_MATCH-STD_MIN_MATCH+1];
 
-/* Combined base + extra_bits tables for single-lookup optimization */
-extern Z_INTERNAL const uint16_t lbase_extra[LENGTH_CODES];
-extern Z_INTERNAL const uint32_t dbase_extra[D_CODES];
+/* Combined mask + extra_bits tables for single-lookup optimization */
+extern Z_INTERNAL const lmask_extra_s lmask_extra[LENGTH_CODES];
+extern Z_INTERNAL const dmask_extra_s dmask_extra[D_CODES];
 
 /* Bit buffer and deflate code stderr tracing */
 #ifdef ZLIB_DEBUG
@@ -115,10 +115,10 @@ static inline void zng_emit_lit(deflate_state *s, const ct_data *ltree, unsigned
  */
 static inline uint32_t zng_emit_dist(deflate_state *s, const ct_data *ltree, const ct_data *dtree,
                                      uint32_t lc, uint32_t dist, uint64_t *bi_buf, uint32_t *bi_valid) {
-    uint32_t c, extra, lext;
-    uint8_t code;
     uint64_t match_bits;
     uint32_t match_bits_len;
+    uint32_t c;
+    uint8_t code;
 
     /* 1. Process Length Code */
     code = zng_length_code[lc];
@@ -130,15 +130,12 @@ static inline uint32_t zng_emit_dist(deflate_state *s, const ct_data *ltree, con
     match_bits = ltree[c].Code;
     match_bits_len = ltree[c].Len;
 
-    /* 2. Get extra bits count and subtract base length */
-    lext = lbase_extra[code];
-    extra = lext >> 8;
-    lc -= lext & 0xff;
+    /* 2. Get extra bits count and mask */
+    const lmask_extra_s lmex = lmask_extra[code];
 
     /*    Send length extra bits */
-    uint32_t l_mask = (1U << extra) - 1;
-    match_bits |= (uint64_t)(lc & l_mask) << match_bits_len;
-    match_bits_len += extra;
+    match_bits |= (uint64_t)(lc & lmex.mask) << match_bits_len;
+    match_bits_len += lmex.extra;
 
     /* 3. Process Distance Code */
     dist--; /* dist is now the match distance - 1 */
@@ -150,18 +147,14 @@ static inline uint32_t zng_emit_dist(deflate_state *s, const ct_data *ltree, con
     match_bits |= ((uint64_t)dtree[code].Code << match_bits_len);
     match_bits_len += dtree[code].Len;
 
-    /* 4. Get extra bits count and subtract base distance */
-    lext = dbase_extra[code];
-    extra = lext >> 16;
-    dist -= lext & 0xffff;
+    /* 4. Get extra bits count and mask */
+    const dmask_extra_s dmex = dmask_extra[code];
 
     /*    Send dist extra bits */
-    uint32_t d_mask = (1U << extra) - 1;
-    match_bits |= ((uint64_t)(dist & d_mask) << match_bits_len);
-    match_bits_len += extra;
+    match_bits |= ((uint64_t)(dist & dmex.mask) << match_bits_len);
+    match_bits_len += dmex.extra;
 
     send_bits(s, match_bits, match_bits_len, *bi_buf, *bi_valid);
-
     return match_bits_len;
 }
 

--- a/trees_tbl.h
+++ b/trees_tbl.h
@@ -118,33 +118,21 @@ const unsigned char Z_INTERNAL zng_length_code[STD_MAX_MATCH-STD_MIN_MATCH+1] = 
 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 28
 };
 
-/* Combined base + extra_bits tables for single-lookup optimization.
- * Length table: bits 0-7 = base_length, bits 8-11 = extra_lbits
- * Distance table: bits 0-15 = base_dist, bits 16-19 = extra_dbits
- */
-#define LBASE_EXTRA(base, extra) ((extra) << 8 | (base))
-#define DBASE_EXTRA(base, extra) ((extra) << 16 | (base))
-
-Z_INTERNAL const uint16_t lbase_extra[LENGTH_CODES] = {
-LBASE_EXTRA(  0, 0), LBASE_EXTRA(  1, 0), LBASE_EXTRA(  2, 0), LBASE_EXTRA(  3, 0),
-LBASE_EXTRA(  4, 0), LBASE_EXTRA(  5, 0), LBASE_EXTRA(  6, 0), LBASE_EXTRA(  7, 0),
-LBASE_EXTRA(  8, 1), LBASE_EXTRA( 10, 1), LBASE_EXTRA( 12, 1), LBASE_EXTRA( 14, 1),
-LBASE_EXTRA( 16, 2), LBASE_EXTRA( 20, 2), LBASE_EXTRA( 24, 2), LBASE_EXTRA( 28, 2),
-LBASE_EXTRA( 32, 3), LBASE_EXTRA( 40, 3), LBASE_EXTRA( 48, 3), LBASE_EXTRA( 56, 3),
-LBASE_EXTRA( 64, 4), LBASE_EXTRA( 80, 4), LBASE_EXTRA( 96, 4), LBASE_EXTRA(112, 4),
-LBASE_EXTRA(128, 5), LBASE_EXTRA(160, 5), LBASE_EXTRA(192, 5), LBASE_EXTRA(224, 5),
-LBASE_EXTRA(  0, 0)
+/* Combined mask + extra_bits tables for single-lookup optimization. */
+Z_INTERNAL const lmask_extra_s lmask_extra[LENGTH_CODES] = {
+{ 0, 0}, { 0, 0}, { 0, 0}, { 0, 0}, { 0, 0}, { 0, 0},
+{ 0, 0}, { 0, 0}, { 1, 1}, { 1, 1}, { 1, 1}, { 1, 1},
+{ 3, 2}, { 3, 2}, { 3, 2}, { 3, 2}, { 7, 3}, { 7, 3},
+{ 7, 3}, { 7, 3}, {15, 4}, {15, 4}, {15, 4}, {15, 4},
+{31, 5}, {31, 5}, {31, 5}, {31, 5}, { 0, 0}
 };
 
-Z_INTERNAL const uint32_t dbase_extra[D_CODES] = {
-DBASE_EXTRA(    0,  0), DBASE_EXTRA(    1,  0), DBASE_EXTRA(    2,  0), DBASE_EXTRA(    3,  0),
-DBASE_EXTRA(    4,  1), DBASE_EXTRA(    6,  1), DBASE_EXTRA(    8,  2), DBASE_EXTRA(   12,  2),
-DBASE_EXTRA(   16,  3), DBASE_EXTRA(   24,  3), DBASE_EXTRA(   32,  4), DBASE_EXTRA(   48,  4),
-DBASE_EXTRA(   64,  5), DBASE_EXTRA(   96,  5), DBASE_EXTRA(  128,  6), DBASE_EXTRA(  192,  6),
-DBASE_EXTRA(  256,  7), DBASE_EXTRA(  384,  7), DBASE_EXTRA(  512,  8), DBASE_EXTRA(  768,  8),
-DBASE_EXTRA( 1024,  9), DBASE_EXTRA( 1536,  9), DBASE_EXTRA( 2048, 10), DBASE_EXTRA( 3072, 10),
-DBASE_EXTRA( 4096, 11), DBASE_EXTRA( 6144, 11), DBASE_EXTRA( 8192, 12), DBASE_EXTRA(12288, 12),
-DBASE_EXTRA(16384, 13), DBASE_EXTRA(24576, 13)
+Z_INTERNAL const dmask_extra_s dmask_extra[D_CODES] = {
+{   0,  0}, {   0,  0}, {   0,  0}, {   0,  0}, {   1,  1}, {   1,  1},
+{   3,  2}, {   3,  2}, {   7,  3}, {   7,  3}, {  15,  4}, {  15,  4},
+{  31,  5}, {  31,  5}, {  63,  6}, {  63,  6}, { 127,  7}, { 127,  7},
+{ 255,  8}, { 255,  8}, { 511,  9}, { 511,  9}, {1023, 10}, {1023, 10},
+{2047, 11}, {2047, 11}, {4095, 12}, {4095, 12}, {8191, 13}, {8191, 13}
 };
 
 #endif /* TREES_TBL_H_ */

--- a/utils/maketrees.c
+++ b/utils/maketrees.c
@@ -126,21 +126,18 @@ static void gen_trees_header(void) {
         printf("%2u%s", length_code[i], SEPARATOR(i, STD_MAX_MATCH-STD_MIN_MATCH, 20));
     }
 
-    printf("/* Combined base + extra_bits tables for single-lookup optimization.\n");
-    printf(" * Length table: bits 0-7 = base_length, bits 8-11 = extra_lbits\n");
-    printf(" * Distance table: bits 0-15 = base_dist, bits 16-19 = extra_dbits\n");
-    printf(" */\n");
-    printf("#define LBASE_EXTRA(base, extra) ((extra) << 8 | (base))\n");
-    printf("#define DBASE_EXTRA(base, extra) ((extra) << 16 | (base))\n\n");
+    printf("/* Combined mask + extra_bits tables for single-lookup optimization. */\n");
 
-    printf("Z_INTERNAL const uint16_t lbase_extra[LENGTH_CODES] = {\n");
+    printf("Z_INTERNAL const lmask_extra_s lmask_extra[LENGTH_CODES] = {\n");
     for (i = 0; i < LENGTH_CODES; i++) {
-        printf("LBASE_EXTRA(%3d, %d)%s", base_length[i], extra_lbits[i], SEPARATOR(i, LENGTH_CODES-1, 4));
+        uint8_t mask = (1U << extra_lbits[i]) - 1;
+        printf("{%2u, %u}%s", mask, extra_lbits[i], SEPARATOR(i, LENGTH_CODES-1, 6));
     }
 
-    printf("Z_INTERNAL const uint32_t dbase_extra[D_CODES] = {\n");
+    printf("Z_INTERNAL const dmask_extra_s dmask_extra[D_CODES] = {\n");
     for (i = 0; i < D_CODES; i++) {
-        printf("DBASE_EXTRA(%5d, %2d)%s", base_dist[i], extra_dbits[i], SEPARATOR(i, D_CODES-1, 4));
+        uint16_t mask = (1U << extra_dbits[i]) - 1;
+        printf("{%4u, %2u}%s", mask, extra_dbits[i], SEPARATOR(i, D_CODES-1, 6));
     }
 
     printf("#endif /* TREES_TBL_H_ */\n");


### PR DESCRIPTION
Optimize zng_emit_dist by having removing base and instead adding mask to extra tables.

This alternative uses structs instead of shifts, resulting in cleaner code.