### PR TITLE
Pack up to four consecutive literals per send_bits

### DIFF
--- a/trees.c
+++ b/trees.c
@@ -708,6 +708,19 @@ void Z_INTERNAL zng_tr_flush_block(deflate_state *s, unsigned char *buf, uint32_
 /* ===========================================================================
  * Send the block data compressed using the given Huffman trees
  */
+#if !defined(LIT_MEM) && OPTIMAL_CMP >= 64
+/* One 64-bit little-endian load at sx spans the next three symbols' dist fields
+ * (bits 0..15, 24..39, 48..63) and two of their literals (bits 16..23, 40..47). */
+#define LIT3_DIST_MASK 0xFFFF00FFFF00FFFFULL
+
+/* Prepend one literal below whatever tail already holds, so entering the switch at case k
+ * emits exactly the first k symbols in order. */
+Z_FORCEINLINE static void lit_prepend(const ct_data *ltree, unsigned lc, uint64_t *tail, uint32_t *tbits) {
+    *tail = (uint64_t)ltree[lc].Code | (*tail << ltree[lc].Len);
+    *tbits += ltree[lc].Len;
+}
+#endif
+
 static void compress_block(deflate_state *s, const ct_data *ltree, const ct_data *dtree) {
     /* ltree: literal tree */
     /* dtree: distance tree */
@@ -735,9 +748,9 @@ static void compress_block(deflate_state *s, const ct_data *ltree, const ct_data
             lc = l_buf[sx++];
 #else
 #  if OPTIMAL_CMP >= 32
-            uint32_t val = Z_U32_FROM_LE(zng_memread_4(&sym_buf[sx]));
-            dist = val & 0xffff;
-            lc = (val >> 16) & 0xff;
+            uint32_t dist_lc = Z_U32_FROM_LE(zng_memread_4(&sym_buf[sx]));
+            dist = dist_lc & 0xffff;
+            lc = (dist_lc >> 16) & 0xff;
 #  else
             dist = sym_buf[sx] + ((unsigned)sym_buf[sx + 1] << 8);
             lc = sym_buf[sx + 2];
@@ -745,7 +758,42 @@ static void compress_block(deflate_state *s, const ct_data *ltree, const ct_data
             sx += 3;
 #endif
             if (dist == 0) {
+#if !defined(LIT_MEM) && OPTIMAL_CMP >= 64
+                /* Pack up to 4 consecutive literals into a single send_bits. Their codes are
+                 * at most 15 bits each, so 4 fit inside the 64-bit bit buffer. */
+                uint64_t bits = ltree[lc].Code;
+                uint32_t nbits = ltree[lc].Len;
+
+                if (sx + 9 <= sym_next) {
+                    uint64_t v = Z_U64_FROM_LE(zng_memread_8(&sym_buf[sx]));
+                    /* The lowest set bit says which dist field broke the run, so ctz/24 counts
+                     * the literals that follow. No bits set at all means all three are literals. */
+                    uint64_t t = v & LIT3_DIST_MASK;
+                    unsigned n = t ? (unsigned)(zng_ctz64(t) / 24) : 3;
+                    uint64_t tail = 0;
+                    uint32_t tbits = 0;
+
+                    switch (n) {
+                    case 3:
+                        lit_prepend(ltree, sym_buf[sx + 8], &tail, &tbits);
+                        Z_FALLTHROUGH;
+                    case 2:
+                        lit_prepend(ltree, (v >> 40) & 0xff, &tail, &tbits);
+                        Z_FALLTHROUGH;
+                    case 1:
+                        lit_prepend(ltree, (v >> 16) & 0xff, &tail, &tbits);
+                        Z_FALLTHROUGH;
+                    case 0:
+                        break;
+                    }
+                    bits |= tail << nbits;
+                    nbits += tbits;
+                    sx += 3 * n;
+                }
+                send_bits(s, bits, nbits, bi_buf, bi_valid);
+#else
                 zng_emit_lit(s, ltree, lc, &bi_buf, &bi_valid);
+#endif
             } else {
                 zng_emit_dist(s, ltree, dtree, lc, dist, &bi_buf, &bi_valid);
             } /* literal or match pair ? */

--- a/trees.c
+++ b/trees.c
@@ -713,6 +713,10 @@ void Z_INTERNAL zng_tr_flush_block(deflate_state *s, unsigned char *buf, uint32_
  * (bits 0..15, 24..39, 48..63) and two of their literals (bits 16..23, 40..47). */
 #define LIT3_DIST_MASK 0xFFFF00FFFF00FFFFULL
 
+/* The second symbol's dist field alone, which separates a one-literal run from a two-literal
+ * one once the all-three case has been ruled out. */
+#define LIT3_DIST1_MASK 0x000000FFFF000000ULL
+
 /* Prepend one literal below whatever tail already holds, so entering the switch at case k
  * emits exactly the first k symbols in order. */
 Z_FORCEINLINE static void lit_prepend(const ct_data *ltree, unsigned lc, uint64_t *tail, uint32_t *tbits) {
@@ -766,29 +770,30 @@ static void compress_block(deflate_state *s, const ct_data *ltree, const ct_data
 
                 if (sx + 9 <= sym_next) {
                     uint64_t v = Z_U64_FROM_LE(zng_memread_8(&sym_buf[sx]));
-                    /* The lowest set bit says which dist field broke the run, so ctz/24 counts
-                     * the literals that follow. No bits set at all means all three are literals. */
-                    uint64_t t = v & LIT3_DIST_MASK;
-                    unsigned n = t ? (unsigned)(zng_ctz64(t) / 24) : 3;
-                    uint64_t tail = 0;
-                    uint32_t tbits = 0;
+                    uint64_t dist_bits = v & LIT3_DIST_MASK;
 
-                    switch (n) {
-                    case 3:
-                        lit_prepend(ltree, sym_buf[sx + 8], &tail, &tbits);
-                        Z_FALLTHROUGH;
-                    case 2:
-                        lit_prepend(ltree, (v >> 40) & 0xff, &tail, &tbits);
-                        Z_FALLTHROUGH;
-                    case 1:
-                        lit_prepend(ltree, (v >> 16) & 0xff, &tail, &tbits);
-                        Z_FALLTHROUGH;
-                    case 0:
-                        break;
+                    /* A dist field is zero exactly when that symbol is a literal, so the first
+                     * nonzero one ends the run. There are only three fields, so three tests
+                     * locate it and no bit scan is needed. */
+                    if (dist_bits == 0 || (uint16_t)v == 0) {
+                        unsigned nextra = dist_bits == 0 ? 3 : (v & LIT3_DIST1_MASK) ? 1 : 2;
+                        uint64_t tail = 0;
+                        uint32_t tbits = 0;
+
+                        switch (nextra) {
+                        case 3:
+                            lit_prepend(ltree, sym_buf[sx + 8], &tail, &tbits);
+                            Z_FALLTHROUGH;
+                        case 2:
+                            lit_prepend(ltree, (v >> 40) & 0xff, &tail, &tbits);
+                            Z_FALLTHROUGH;
+                        default:
+                            lit_prepend(ltree, (v >> 16) & 0xff, &tail, &tbits);
+                        }
+                        bits |= tail << nbits;
+                        nbits += tbits;
+                        sx += 3 * nextra;
                     }
-                    bits |= tail << nbits;
-                    nbits += tbits;
-                    sx += 3 * n;
                 }
                 send_bits(s, bits, nbits, bi_buf, bi_valid);
 #else


### PR DESCRIPTION
`compress_block` emits one symbol at a time, so each literal's Huffman code waits on the previous symbol's length before it can be placed. Literal codes are at most 15 bits, so four of them fit inside the 64-bit bit buffer and a single `send_bits` can carry a whole run.

The 3-byte symbol packing puts the next three distance fields at bits 0..15, 24..39 and 48..63 of one little-endian load, so a single masked test covers all three, and the lowest set bit of the masked word gives the run length directly as `ctz/24`. The common case costs one load and a ctz rather than a load and a test per symbol.

Gated on `OPTIMAL_CMP >= 64` and the `sym_buf` layout. `LIT_MEM` and narrower targets keep the existing path, so they are unaffected.

### Results

Apple M5, Apple clang 21, 1 MB inputs, minimum of 12 rounds, run order rotated between base and PR so neither is systematically first. Noise floor, measured by comparing a binary against itself, is ±0.8%.

`compress_block` is roughly a tenth of deflate and literals are roughly a quarter of the symbols under the default strategy, so the effect is diluted about tenfold there. Under `Z_HUFFMAN_ONLY` there is no match finding and every symbol is a literal, which isolates the path this touches:

| data type | develop ms | PR ms | delta |
|---|---|---|---|
| text | 2.919 | 2.246 | -23.06% |
| realistic_rgb | 3.164 | 2.574 | -18.65% |
| literals | 5.239 | 4.413 | -15.77% |
| dna | 3.126 | 2.635 | -15.71% |
| short_match | 5.212 | 4.456 | -14.50% |
| mixed | 6.157 | 5.612 | -8.85% |
| **mean** | | | **-16.09%** |

Full deflate at the default strategy is the number that matters for most callers, and it is much smaller: **-0.71% mean**, from -4.72% (literals, level 6) to +1.42% (realistic_rgb, level 9). The gains concentrate on literal-heavy data at levels 3 and 6; level 9 is flat, which is expected since `longest_match` dominates there.

I have not run deflatebench over silesia, so the corpus-level number is still open.

Output is byte-identical to develop across three corpora × five strategies × ten levels. `gtest_zlib` passes, 1523 tests. Build is warning-free under `-D WITH_MAINTAINER_WARNINGS=ON`.

### Notes

Batching three literals with a plain loop gets about -13% of the `Z_HUFFMAN_ONLY` figure on its own; going to four and consolidating the three per-symbol tests into one masked load and a ctz accounts for the rest.

An `if` cascade over the masks, and a variant with a paired accumulate, both measure the same within noise. This shape was chosen because it is the leanest code on x86-64, where there are 16 general registers rather than 32: 196 instructions and 8 stack references, against 215/10 and 227/15 for those alternatives, the last of which spills `bits` mid-loop. That is a static `objdump` comparison — I have no x86 hardware to time it on, so it would be worth a check there.

This composes with #2365 and is independent of it; both were measured together and stack.