### PR TITLE
X86 alignment tweaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -434,6 +434,34 @@ else()
     add_compile_options(${WARNFLAGS} ${WARNFLAGS_DISABLE})
 endif()
 
+#
+# Intel JCC Erratum mitigation alignment for x86 architectures
+# see: https://www.intel.com/content/www/us/en/developer/articles/technical/software-security-guidance/best-practices/mitigation-strategies-jcc-microcode.html
+#
+if(BASEARCH_X86_FOUND)
+    if(CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_C_COMPILER_ID MATCHES "IntelLLVM")
+        check_c_compiler_flag(-mbranches-within-32B-boundaries HAVE_BRANCHES_WITHIN32)
+        if(HAVE_BRANCHES_WITHIN32)
+            add_compile_options("-mbranches-within-32B-boundaries")
+        endif()
+    elseif(CMAKE_C_COMPILER_ID MATCHES "GNU")
+        check_c_compiler_flag(-Wa,-mbranches-within-32B-boundaries HAVE_BRANCHES_WITHIN32)
+        if(HAVE_BRANCHES_WITHIN32)
+            add_compile_options("-Wa,-mbranches-within-32B-boundaries")
+        endif()
+    elseif(CMAKE_C_COMPILER_ID MATCHES "NVC" OR CMAKE_C_COMPILER_ID MATCHES "NVHPC")
+        check_c_compiler_flag(-Wa,-mbranches-within-32B-boundaries HAVE_BRANCHES_WITHIN32)
+        if(HAVE_BRANCHES_WITHIN32)
+            add_compile_options("-Wa,-mbranches-within-32B-boundaries")
+        endif()
+    elseif (MSVC)
+        check_c_compiler_flag(/QIntel-jcc-erratum HAVE_BRANCHES_WITHIN32)
+        if(HAVE_BRANCHES_WITHIN32)
+            add_compile_options("/QIntel-jcc-erratum")
+        endif()
+    endif()
+endif()
+
 # Set code coverage compiler flags
 if(WITH_CODE_COVERAGE)
     add_code_coverage()

--- a/arch/x86/chunkset_avx512.c
+++ b/arch/x86/chunkset_avx512.c
@@ -89,6 +89,7 @@ static inline uint8_t* CHUNKCOPY(uint8_t *out, uint8_t const *from, size_t len) 
     size_t rem = len % sizeof(chunk_t);
 
     if (len < sizeof(chunk_t)) {
+        P2ALIGN(5);
         mask_t rem_mask = gen_mask(rem);
         chunk = _mm256_maskz_loadu_epi8(rem_mask, from);
         _mm256_mask_storeu_epi8(out, rem_mask, chunk);

--- a/configure
+++ b/configure
@@ -158,6 +158,10 @@ OBJC='$(OBJZ)'
 PIC_OBJC='$(PIC_OBJZ)'
 INSTALLTARGETS="install-shared install-static"
 UNINSTALLTARGETS="uninstall-shared uninstall-static"
+branch_within32_clang="-mbranches-within-32B-boundaries"
+branch_within32_gcc="-Wa,-mbranches-within-32B-boundaries"
+# Need this set to something that will initially fail the compiler check test
+branch_within32_flag="UNSUPPORTED"
 
 TEST="teststatic"
 
@@ -1346,6 +1350,31 @@ EOF
     fi
 }
 
+check_branch_within32_compiler_flag() {
+    # Check whether the JCC mitigation workaround is supported
+    if test $clang -eq 1; then
+        branch_within32_flag="$branch_within32_clang"
+    elif test $gcc -eq 1; then
+        branch_within32_flag="$branch_within32_gcc"
+    elif test $nvc -eq 1; then
+        branch_within32_flag="$branch_within32_gcc"
+    else
+        BRANCH_WITHIN32_SUPPORTED=0
+    fi
+
+    cat > $test.c << EOF
+int main(void) { return 0; }
+EOF
+    if try $CC -c $CFLAGS $branch_within32_flag $test.c; then
+        BRANCH_WITHIN32_SUPPORTED=1
+        echo "Check whether $branch_within32_flag is available ... Yes." | tee -a configure.log
+    else
+        BRANCH_WITHIN32_SUPPORTED=0
+        branch_within32_flag=
+        echo "Check whether $branch_within32_flag is available ... No." | tee -a configure.log
+    fi
+}
+
 check_neon_compiler_flag() {
     if test "$ARCH" = "aarch64"; then
         neonflag="-march=armv8-a+simd"
@@ -1966,6 +1995,13 @@ case "${ARCH}" in
 
             if test ${MTUNE_RAPTORLAKE_AVAILABLE} -eq 1; then
                 avx2vnniflag="${avx2vnniflag} -mtune=raptorlake"
+            fi
+
+            check_branch_within32_compiler_flag
+
+            if test ${BRANCH_WITHIN32_SUPPORTED} -eq 1; then
+                CFLAGS="${CFLAGS} ${branch_within32_flag}"
+                SFLAGS="${SFLAGS} ${branch_within32_flag}"
             fi
 
             check_avx512_intrinsics

--- a/zbuild.h
+++ b/zbuild.h
@@ -356,4 +356,15 @@
 #  define OPTIMAL_CMP 16
 #endif
 
+/* Allow the developer to specify a power of two sized alignment for a given
+ * code segment. This mitigates some bad DSB2MITE penalties on several Intel
+ * CPUs */
+#if defined(__GNUC__) || defined(__clang__)
+#   define ALIGN_TO_STR_(x) #x
+#   define ALIGN_TO_STR(x) ALIGN_TO_STR_(x)
+#   define P2ALIGN(power) __asm__ volatile (".p2align " ALIGN_TO_STR(power))
+#else
+#   define P2ALIGN(power)
+#endif
+
 #endif


### PR DESCRIPTION
This mitigates some rather nasty x86 performance penalties we've been hitting.  I'm going to run a battery of benchmarks against -march=x86-64-v4 compiled binaries (but otherwise vanilla build flags).

We still are losing a very advantageous code alignment lottery that we were hitting for calgary/geo at one point or another.  Oddly it seems to show up heavily in top down analysis as "tma_bad_speculation".  Somehow we started mispredicting much worse for that dataset than the others.  