### PR TITLE
validate distance in inflateBack MATCH state

### DIFF
--- a/infback.c
+++ b/infback.c
@@ -491,7 +491,12 @@ int32_t Z_EXPORT PREFIX(inflateBack)(PREFIX3(stream) *strm, in_func in, void *in
         case MATCH:
             /* Copy back-reference that inflate_fast() could not complete due to
                insufficient output space. state->length and state->offset were set
-               by the safe_mode MATCH bailout in inflate_fast(). */
+               by the safe_mode MATCH bailout in inflate_fast(), which bails out
+               before validating the distance, so check it here. */
+            if (state->offset > state->wsize - (state->whave < state->wsize ? left : 0)) {
+                SET_BAD("invalid distance too far back");
+                break;
+            }
             do {
                 ROOM();
                 copy = state->wsize - state->offset;

--- a/test/test_inflate_back.cc
+++ b/test/test_inflate_back.cc
@@ -127,3 +127,71 @@ TEST_F(inflate_back, match_state) {
     EXPECT_EQ(out_state.pos, (size_t)data_size);
     EXPECT_EQ(memcmp(decompressed, original, data_size), 0);
 }
+
+/* Test that inflateBack() rejects a distance that reaches past its window when
+ * inflate_fast() bails out to the MATCH state, instead of copying from before
+ * the caller-supplied window. */
+TEST_F(inflate_back, match_state_invalid_distance) {
+    int err;
+    /* Prefix length is chosen so the repeat below starts late in a window pass,
+     * leaving fewer than 258 bytes of window space and forcing inflate_fast()
+     * into its MATCH bailout. */
+    const uint32_t small_wbits = 8;
+    const uint32_t small_wsize = 1U << small_wbits;
+    const uint32_t prefix = small_wsize + 144;
+    const uint32_t src_size = prefix + 258 + 42;
+
+    /* Unpredictable prefix so the first long-distance match is the one below,
+     * then a 258-byte repeat of the start, giving dist > wsize. */
+    uint32_t seed = 0x12345678;
+    for (uint32_t i = 0; i < src_size; i++) {
+        seed = seed * 1103515245 + 12345;
+        original[i] = (uint8_t)(seed >> 16);
+    }
+    memcpy(original + prefix, original, 258);
+
+    /* Compress with a full-size window so the encoder may use the long distance */
+    PREFIX3(stream) c_strm;
+    memset(&c_strm, 0, sizeof(c_strm));
+    err = PREFIX(deflateInit2)(&c_strm, Z_BEST_COMPRESSION, Z_DEFLATED,
+                               -MAX_WBITS, MAX_MEM_LEVEL, Z_DEFAULT_STRATEGY);
+    ASSERT_EQ(err, Z_OK);
+
+    z_uintmax_t comp_bound = PREFIX(deflateBound)(&c_strm, src_size);
+    compressed = (uint8_t *)malloc(comp_bound);
+    ASSERT_NE(compressed, nullptr);
+
+    c_strm.next_in = original;
+    c_strm.avail_in = src_size;
+    c_strm.next_out = compressed;
+    c_strm.avail_out = (uint32_t)comp_bound;
+
+    err = PREFIX(deflate)(&c_strm, Z_FINISH);
+    EXPECT_EQ(err, Z_STREAM_END);
+    uint32_t compressed_size = (uint32_t)c_strm.total_out;
+    PREFIX(deflateEnd)(&c_strm);
+
+    /* Decompress with a window too small for that distance */
+    PREFIX3(stream) d_strm;
+    memset(&d_strm, 0, sizeof(d_strm));
+
+    uint8_t *small_window = (uint8_t *)malloc(small_wsize);
+    ASSERT_NE(small_window, nullptr);
+
+    err = PREFIX(inflateBackInit)(&d_strm, small_wbits, small_window);
+    ASSERT_EQ(err, Z_OK);
+
+    d_strm.next_in = compressed;
+    d_strm.avail_in = compressed_size;
+
+    struct output_state out_state;
+    out_state.buf = decompressed;
+    out_state.size = data_size;
+    out_state.pos = 0;
+
+    err = PREFIX(inflateBack)(&d_strm, pull_all, &d_strm, push_all, &out_state);
+    EXPECT_EQ(err, Z_DATA_ERROR);
+
+    PREFIX(inflateBackEnd)(&d_strm);
+    free(small_window);
+}


### PR DESCRIPTION
The safe_mode bailout in inflate_fast() sets state->mode = MATCH and stores the decoded distance before it reaches the dist > op / op > whave checks a few lines below, so the offset arrives at the MATCH state unvalidated. inflate() copes with that because its own MATCH case re-checks the distance against whave, but inflateBack()'s MATCH case copies straight away, and its DIST case is the only place that validation happens. Feeding inflateBack() a raw deflate stream whose match distance exceeds the caller's window then makes wsize - offset wrap and chunkmemset_safe read from before the caller-supplied window buffer, with those bytes going out through the out() callback. I hit it under asan with a 256-byte window and a length-258 match at distance 400, which lands late enough in a window pass that the bailout fires.

Adding the check that inflateBack()'s DIST case already does, so the stream is rejected as invalid rather than copied. The regression test covers the same shape and fails on the unpatched tree.