### PR TITLE
riscv: remove ineffective Zbc HWCAP fallback

### DIFF
--- a/arch/riscv/riscv_features.c
+++ b/arch/riscv/riscv_features.c
@@ -18,7 +18,6 @@
 #endif
 
 #define ISA_V_HWCAP (1 << ('v' - 'a'))
-#define ISA_ZBC_HWCAP (1 << 29)
 
 static int riscv_check_features_runtime_hwprobe(struct riscv_cpu_features *features) {
 #if defined(__NR_riscv_hwprobe) && defined(RISCV_HWPROBE_KEY_IMA_EXT_0)
@@ -58,8 +57,10 @@ static int riscv_check_features_runtime_hwcap(struct riscv_cpu_features *feature
 #if defined(__linux__) && defined(HAVE_SYS_AUXV_H)
     unsigned long hw_cap = getauxval(AT_HWCAP);
 
+    /* AT_HWCAP only encodes single-letter ISA extensions, so Zbc cannot be
+     * detected here and has_zbc keeps its default of 0. Multi-letter
+     * extensions are only detectable via hwprobe (Linux 6.8+ for Zbc). */
     features->has_rvv = hw_cap & ISA_V_HWCAP;
-    features->has_zbc = hw_cap & ISA_ZBC_HWCAP;
 
     return 1;
 #else


### PR DESCRIPTION
The `AT_HWCAP` fallback path in `riscv_features.c` tests `ISA_ZBC_HWCAP`, defined as `1 << 29`. No such hwcap bit exists: Linux only encodes single-letter ISA extensions in `AT_HWCAP` (the highest defined bit is `COMPAT_HWCAP_ISA_V`, `'V' - 'A'` = 21), and the kernel has ruled out adding hwcap bits for multi-letter extensions — hwprobe is the designated mechanism ([uapi/asm/hwcap.h](https://github.com/torvalds/linux/blob/master/arch/riscv/include/uapi/asm/hwcap.h), [cpufeature.c comment](https://github.com/torvalds/linux/blob/0d7bee10beeb59b1133bf5a4749b17a4ef3bbb01/arch/riscv/kernel/cpufeature.c#L611)).

So this check can never succeed on any mainline kernel, and Zbc goes undetected on the hwcap fallback path either way. Worse, since bit 29 is unassigned, a downstream kernel could give it a different meaning, in which case `has_zbc` would false-positive and crc32 would execute `clmul` on hardware without Zbc (SIGILL).

This removes the define and the assignment, and documents why `has_zbc` intentionally stays 0 on the hwcap path.

Behavior is unchanged on all kernels:
- The `cpu_features` struct is zeroed in `cpu_features_setup()` before `riscv_check_features()` runs, so `has_zbc` simply remains 0 when hwprobe is unavailable — exactly what the bit-29 test already yields today.
- The working detection via hwprobe (`RISCV_HWPROBE_EXT_ZBC`, Linux 6.8+), added in #2130, is untouched.

References #1997, which documented this with the same kernel citations.

**Tested:** SpaceMiT K3 (X100: Zbc + Zvbc silicon), Linux 6.18, native build with `-DWITH_GTEST=ON -DWITH_BENCHMARKS=ON`: full ctest suite passes (71/71); Zbc is still detected via hwprobe and the `crc32/riscv` benchmark variant runs unchanged (~6.5 GB/s at 256 KiB). `grep -rn ISA_ZBC_HWCAP` confirms no other references in the tree.