### PR TITLE
Correct Neoverse part numbers used for fast PMULL

### DIFF
--- a/arch/arm/arm_features.c
+++ b/arch/arm/arm_features.c
@@ -287,8 +287,7 @@ static inline int arm_has_simd(void) {
 #define ARM_PART_CORTEX_X4   0xd82
 #define ARM_PART_CORTEX_X925 0xd85
 
-/* Neoverse V/N2 series - Multiple PMULL lanes */
-#define ARM_PART_NEOVERSE_N2   0xd49
+/* Neoverse V series - Multiple PMULL lanes */
 #define ARM_PART_NEOVERSE_V1   0xd40
 #define ARM_PART_NEOVERSE_V2   0xd4f
 #define ARM_PART_NEOVERSE_V3AE 0xd83
@@ -345,7 +344,6 @@ static inline int arm_cpu_has_fast_pmull(void) {
             case ARM_PART_CORTEX_X3:
             case ARM_PART_CORTEX_X4:
             case ARM_PART_CORTEX_X925:
-            case ARM_PART_NEOVERSE_N2:
             case ARM_PART_NEOVERSE_V1:
             case ARM_PART_NEOVERSE_V2:
             case ARM_PART_NEOVERSE_V3AE:

--- a/arch/arm/arm_features.c
+++ b/arch/arm/arm_features.c
@@ -288,10 +288,11 @@ static inline int arm_has_simd(void) {
 #define ARM_PART_CORTEX_X925 0xd85
 
 /* Neoverse V/N2 series - Multiple PMULL lanes */
-#define ARM_PART_NEOVERSE_N2 0xd49
-#define ARM_PART_NEOVERSE_V1 0xd40
-#define ARM_PART_NEOVERSE_V2 0xd4f
-#define ARM_PART_NEOVERSE_V3 0xd8e
+#define ARM_PART_NEOVERSE_N2   0xd49
+#define ARM_PART_NEOVERSE_V1   0xd40
+#define ARM_PART_NEOVERSE_V2   0xd4f
+#define ARM_PART_NEOVERSE_V3AE 0xd83
+#define ARM_PART_NEOVERSE_V3   0xd84
 
 /* Snapdragon X Elite/Plus - Custom core */
 #define QUALCOMM_PART_ORYON 0x001
@@ -347,6 +348,7 @@ static inline int arm_cpu_has_fast_pmull(void) {
             case ARM_PART_NEOVERSE_N2:
             case ARM_PART_NEOVERSE_V1:
             case ARM_PART_NEOVERSE_V2:
+            case ARM_PART_NEOVERSE_V3AE:
             case ARM_PART_NEOVERSE_V3:
                 has_fast_pmull = 1;
         }


### PR DESCRIPTION
`ARM_PART_NEOVERSE_V3` was defined as `0xd8e`, which is Neoverse **N3**. The real V3 part number is `0xd84` — looks like N3 and V3 got confused, they're adjacent in every part table.

So `arm_cpu_has_fast_pmull()` was enabling `crc32_armv8_pmull_eor3` on N3 and never on V3, which is backwards. Per Arm's Software Optimization Guides, N3 issues PMULL (64x64) at 1/cycle on a single V0 pipe against a 1/cycle CRC32 unit, so it has nothing to gain; V3 issues 4/cycle across all four FP/ASIMD pipes.

Also adds V3AE (`0xd83`), which is 2/cycle — the same tier as the Cortex-X1/X2/X3 entries already in the list.

Second commit drops N2 for the same reason N3 doesn't qualify: 1/cycle PMULL on a single V0 pipe against a 1/cycle CRC32 unit. No throughput advantage, and the fold's XOR traffic competes for that same narrow pipe, while CRC32 late-forwarding lets a serial `crc32x` chain sustain its full rate. This is a documentation-driven change — if anyone has N2 hardware and measurements that say otherwise, happy to drop that commit.

Sources: [Neoverse V3 SWOG](https://documentation-service.arm.com/static/69c3f3c7351d0c3476bddc36) p37, [Neoverse V3AE SWOG](https://documentation-service.arm.com/static/69c3f177351d0c3476bddc2e) p37, [Neoverse N3 SWOG](https://documentation-service.arm.com/static/67be2073fdbd9d54ee93ff15) p41, [Neoverse N2 SWOG](https://documentation-service.arm.com/static/69c3feda952f302b67bf1c8c) p54/p56, and Linux `arch/arm64/include/asm/cputype.h`.