### PR TITLE
Improve portability to RISC OS.

### DIFF
--- a/zutil.h
+++ b/zutil.h
@@ -110,7 +110,7 @@ extern z_const char * const PREFIX(z_errmsg)[10]; /* indexed by 2-zlib_error */
 #  define OS_CODE  7
 #endif
 
-#ifdef __acorn
+#if defined(__acorn) || defined(__riscos)
 #  define OS_CODE 13
 #endif
 


### PR DESCRIPTION
Split out of #2242. [RISC OS](https://en.wikipedia.org/wiki/RISC_OS) was originally developed by [Acorn Computers](https://en.wikipedia.org/wiki/Acorn_Computers) before Acorn was acquired and dismantled, and subsequently RISC OS was forked by [RISC OS Open](https://en.wikipedia.org/wiki/RISC_OS_Open) community.

Upstream: https://github.com/madler/zlib/commit/4de0b054