### PR TITLE
Avoid implicit conversion warning in trees.c.

### DIFF
--- a/trees.c
+++ b/trees.c
@@ -433,7 +433,7 @@ static void scan_tree(deflate_state *s, ct_data *tree, int max_code) {
         if (++count < max_count && curlen == nextlen) {
             continue;
         } else if (count < min_count) {
-            s->bl_tree[curlen].Freq += count;
+            s->bl_tree[curlen].Freq += (uint16_t)count;
         } else if (curlen != 0) {
             if (curlen != prevlen)
                 s->bl_tree[curlen].Freq++;


### PR DESCRIPTION
Split out of #2242.

Upstream: https://github.com/madler/zlib/commit/8a76f02e