### PR TITLE
Use z_const for setting msg to literal strings.

### DIFF
--- a/inflate_p.h
+++ b/inflate_p.h
@@ -146,7 +146,7 @@ typedef unsigned bits_t;
 #define SET_BAD(errmsg) \
     do { \
         state->mode = BAD; \
-        strm->msg = (char *)errmsg; \
+        strm->msg = (z_const char *)errmsg; \
     } while (0)
 
 /* Huffman code table entry format for length/distance codes (op & 16 set):


### PR DESCRIPTION
Update SET_BAD macro to cast error message strings as z_const char * instead of char *. Split out of #2242.

Upstream: https://github.com/madler/zlib/commit/2ba25b2d