### PR TITLE
Avoid out-of-bounds pointer arithmetic in inflateCopy().

### DIFF
--- a/inflate.c
+++ b/inflate.c
@@ -827,7 +827,7 @@ int32_t Z_EXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int32_t flush) {
             while (state->have < 19)
                 state->lens[order[state->have++]] = 0;
             state->next = state->codes;
-            state->lencode = (const code *)(state->next);
+            state->lencode = state->distcode = (const code *)(state->next);
             state->lenbits = 7;
             ret = zng_inflate_table(CODES, state->lens, 19, &(state->next), &(state->lenbits), state->work);
             if (ret) {


### PR DESCRIPTION
Set distcode along with lencode when building code length tables to avoid UBSan complaints about out-of-bounds pointer computation. Split out of #2242.

Upstream: https://github.com/madler/zlib/commit/f7d01aae