### PR TITLE
Reject invalid MAX_WBITS values at compile time.

### DIFF
--- a/zutil.h
+++ b/zutil.h
@@ -30,7 +30,9 @@ extern z_const char * const PREFIX(z_errmsg)[10]; /* indexed by 2-zlib_error */
 /* To be used only when the state is known to be valid */
 
         /* common constants */
-
+#if MAX_WBITS < 9 || MAX_WBITS > 15
+#  error MAX_WBITS must be in 9..15
+#endif
 #ifndef DEF_WBITS
 #  define DEF_WBITS MAX_WBITS
 #endif


### PR DESCRIPTION
Deflate algorithm doesn't support window bits more than 15 as it would break `slide_hash` that require 1 extra bit for saturated subtraction to work. We don't currently support unofficial Deflate64/Deflate9 algorithm which however does use 16 window bits, but also wider variables. Split out of #2242.

Upstream: https://github.com/madler/zlib/commit/ef24c4c7