### PR TITLE
Have gz_skip() update how far it got for later continuation.

### DIFF
--- a/gzguts.h
+++ b/gzguts.h
@@ -124,7 +124,6 @@ typedef struct {
     int reset;              /* true if a reset is pending after a Z_FINISH */
         /* seek request */
     z_off64_t skip;         /* amount to skip (already rewound if backwards) */
-    int seek;               /* true if seek request pending */
         /* error information */
     int err;                /* error code */
     char *msg;              /* error message */

--- a/gzlib.c
+++ b/gzlib.c
@@ -44,6 +44,10 @@ static gzFile gz_state_init(void) {
     state->level = Z_DEFAULT_COMPRESSION;
     state->strategy = Z_DEFAULT_STRATEGY;
     state->msg = NULL;
+
+    state->past = 0;
+    state->skip = 0;
+
     return (gzFile)state;
 }
 
@@ -61,7 +65,7 @@ static void gz_reset(gz_state *state) {
     }
     else                            /* for writing ... */
         state->reset = 0;           /* no deflateReset pending */
-    state->seek = 0;                /* no seek request pending */
+    state->skip = 0;                /* no seek request pending */
     PREFIX(gz_error)(state, Z_OK, NULL);    /* clear error */
     state->x.pos = 0;               /* no uncompressed data yet */
     state->strm.avail_in = 0;       /* no input data yet */
@@ -390,9 +394,10 @@ z_off64_t Z_EXPORT PREFIX4(gzseek)(gzFile file, z_off64_t offset, int whence) {
     /* normalize offset to a SEEK_CUR specification */
     if (whence == SEEK_SET)
         offset -= state->x.pos;
-    else if (state->seek)
-        offset += state->skip;
-    state->seek = 0;
+    else {
+        offset += state->past ? 0 : state->skip;
+        state->skip = 0;
+    }
 
     /* if within raw area while reading, just go there */
     if (state->mode == GZ_READ && state->how == COPY && state->x.pos + offset >= 0) {
@@ -402,7 +407,7 @@ z_off64_t Z_EXPORT PREFIX4(gzseek)(gzFile file, z_off64_t offset, int whence) {
         state->x.have = 0;
         state->eof = 0;
         state->past = 0;
-        state->seek = 0;
+        state->skip = 0;
         PREFIX(gz_error)(state, Z_OK, NULL);
         state->strm.avail_in = 0;
         state->x.pos += offset;
@@ -430,10 +435,7 @@ z_off64_t Z_EXPORT PREFIX4(gzseek)(gzFile file, z_off64_t offset, int whence) {
     }
 
     /* request skip (if not zero) */
-    if (offset) {
-        state->seek = 1;
-        state->skip = offset;
-    }
+    state->skip = offset;
     return state->x.pos + offset;
 }
 
@@ -459,7 +461,7 @@ z_off64_t Z_EXPORT PREFIX4(gztell)(gzFile file) {
         return -1;
 
     /* return position */
-    return state->x.pos + (state->seek ? state->skip : 0);
+    return state->x.pos + (state->past ? 0 : state->skip);
 }
 
 /* -- see zlib.h -- */

--- a/gzread.c
+++ b/gzread.c
@@ -15,7 +15,7 @@ static int gz_avail(gz_state *);
 static int gz_look(gz_state *);
 static int gz_decomp(gz_state *);
 static int gz_fetch(gz_state *);
-static int gz_skip(gz_state *, z_off64_t);
+static int gz_skip(gz_state *);
 static size_t gz_read(gz_state *, void *, size_t);
 
 static int gz_read_init(gz_state *state) {
@@ -242,19 +242,22 @@ static int gz_fetch(gz_state *state) {
 }
 
 /* Skip len uncompressed bytes of output.  Return -1 on error, 0 on success. */
-static int gz_skip(gz_state *state, z_off64_t len) {
+/* Skip state->skip (> 0) uncompressed bytes of output.  Return -1 on error, 0
+   on success. */
+static int gz_skip(gz_state *state) {
     unsigned n;
 
-    /* skip over len bytes or reach end-of-file, whichever comes first */
-    while (len)
+    /* skip over state->skip bytes or reach end-of-file, whichever comes first */
+    do {
         /* skip over whatever is in output buffer */
         if (state->x.have) {
-            n = GT_OFF(state->x.have) || (z_off64_t)state->x.have > len ?
-                (unsigned)len : state->x.have;
+            n = GT_OFF(state->x.have) ||
+                (z_off64_t)state->x.have > state->skip ?
+                (unsigned)state->skip : state->x.have;
             state->x.have -= n;
             state->x.next += n;
             state->x.pos += n;
-            len -= n;
+            state->skip -= n;
         } else if (state->eof && state->strm.avail_in == 0) {
             /* output buffer empty -- return if we're at the end of the input */
             break;
@@ -264,6 +267,7 @@ static int gz_skip(gz_state *state, z_off64_t len) {
             if (gz_fetch(state) == -1)
                 return -1;
         }
+    } while (state->skip);
     return 0;
 }
 
@@ -280,11 +284,8 @@ static size_t gz_read(gz_state *state, void *buf, size_t len) {
         return 0;
 
     /* process a skip request */
-    if (state->seek) {
-        state->seek = 0;
-        if (gz_skip(state, state->skip) == -1)
-            return 0;
-    }
+    if (state->skip && gz_skip(state) == -1)
+        return 0;
 
     /* get len bytes to buf, or less than len if at the end */
     got = 0;
@@ -458,11 +459,8 @@ z_int32_t Z_EXPORT PREFIX(gzungetc)(z_int32_t c, gzFile file) {
         return -1;
 
     /* process a skip request */
-    if (state->seek) {
-        state->seek = 0;
-        if (gz_skip(state, state->skip) == -1)
-            return -1;
-    }
+    if (state->skip && gz_skip(state) == -1)
+        return -1;
 
     /* can't push EOF */
     if (c < 0)
@@ -517,11 +515,8 @@ char * Z_EXPORT PREFIX(gzgets)(gzFile file, char *buf, z_int32_t len) {
         return NULL;
 
     /* process a skip request */
-    if (state->seek) {
-        state->seek = 0;
-        if (gz_skip(state, state->skip) == -1)
-            return NULL;
-    }
+    if (state->skip && gz_skip(state) == -1)
+        return NULL;
 
     /* copy output bytes up to new line or len - 1, whichever comes first --
        append a terminating zero to the string (we don't check for a zero in

--- a/gzwrite.c
+++ b/gzwrite.c
@@ -11,7 +11,7 @@
 /* Local functions */
 static int gz_write_init(gz_state *);
 static int gz_comp(gz_state *, int);
-static int gz_zero(gz_state *, z_off64_t);
+static int gz_zero(gz_state *);
 static size_t gz_write(gz_state *, void const *, size_t);
 
 /* Initialize state for writing a gzip file.  Mark initialization by setting
@@ -121,9 +121,9 @@ static int gz_comp(gz_state *state, int flush) {
     return 0;
 }
 
-/* Compress len zeros to output.  Return -1 on a write error or memory
-   allocation failure by gz_comp(), or 0 on success. */
-static int gz_zero(gz_state *state, z_off64_t len) {
+/* Compress state->skip (> 0) zeros to output.  Return -1 on a write error or
+   memory allocation failure by gz_comp(), or 0 on success. */
+static int gz_zero(gz_state *state) {
     int first;
     unsigned n;
     PREFIX3(stream) *strm = &(state->strm);
@@ -132,10 +132,11 @@ static int gz_zero(gz_state *state, z_off64_t len) {
     if (strm->avail_in && gz_comp(state, Z_NO_FLUSH) == -1)
         return -1;
 
-    /* compress len zeros (len guaranteed > 0) */
+    /* compress state->skip zeros */
     first = 1;
-    while (len) {
-        n = GT_OFF(state->size) || (z_off64_t)state->size > len ? (unsigned)len : state->size;
+    do {
+        n = GT_OFF(state->size) || (z_off64_t)state->size > state->skip ?
+            (unsigned)state->skip : state->size;
         if (first) {
             memset(state->in, 0, n);
             first = 0;
@@ -145,8 +146,8 @@ static int gz_zero(gz_state *state, z_off64_t len) {
         state->x.pos += n;
         if (gz_comp(state, Z_NO_FLUSH) == -1)
             return -1;
-        len -= n;
-    }
+        state->skip -= n;
+    } while (state->skip);
     return 0;
 }
 
@@ -164,11 +165,8 @@ static size_t gz_write(gz_state *state, void const *buf, size_t len) {
         return 0;
 
     /* check for seek request */
-    if (state->seek) {
-        state->seek = 0;
-        if (gz_zero(state, state->skip) == -1)
-            return 0;
-    }
+    if (state->skip && gz_zero(state) == -1)
+        return 0;
 
     /* for small len, copy to input buffer, otherwise compress directly */
     if (len < state->size) {
@@ -285,11 +283,8 @@ z_int32_t Z_EXPORT PREFIX(gzputc)(gzFile file, z_int32_t c) {
         return -1;
 
     /* check for seek request */
-    if (state->seek) {
-        state->seek = 0;
-        if (gz_zero(state, state->skip) == -1)
-            return -1;
-    }
+    if (state->skip && gz_zero(state) == -1)
+        return -1;
 
     /* try writing to input buffer for speed (state->size == 0 if buffer not
        initialized) */
@@ -359,11 +354,8 @@ z_int32_t Z_EXPORTVA PREFIX(gzvprintf)(gzFile file, const char *format, va_list 
         return state->err;
 
     /* check for seek request */
-    if (state->seek) {
-        state->seek = 0;
-        if (gz_zero(state, state->skip) == -1)
-            return state->err;
-    }
+    if (state->skip && gz_zero(state) == -1)
+        return state->err;
 
     /* do the printf() into the input buffer, put length in len -- the input
        buffer is double-sized just for this function, so there is guaranteed to
@@ -421,11 +413,8 @@ z_int32_t Z_EXPORT PREFIX(gzflush)(gzFile file, z_int32_t flush) {
         return Z_STREAM_ERROR;
 
     /* check for seek request */
-    if (state->seek) {
-        state->seek = 0;
-        if (gz_zero(state, state->skip) == -1)
-            return state->err;
-    }
+    if (state->skip && gz_zero(state) == -1)
+        return state->err;
 
     /* compress remaining data with requested flush */
     (void)gz_comp(state, flush);
@@ -452,11 +441,8 @@ z_int32_t Z_EXPORT PREFIX(gzsetparams)(gzFile file, z_int32_t level, z_int32_t s
         return Z_OK;
 
     /* check for seek request */
-    if (state->seek) {
-        state->seek = 0;
-        if (gz_zero(state, state->skip) == -1)
-            return state->err;
-    }
+    if (state->skip && gz_zero(state) == -1)
+        return state->err;
 
     /* change compression parameters for subsequent input */
     if (state->size) {
@@ -485,11 +471,8 @@ z_int32_t Z_EXPORT PREFIX(gzclose_w)(gzFile file) {
         return Z_STREAM_ERROR;
 
     /* check for seek request */
-    if (state->seek) {
-        state->seek = 0;
-        if (gz_zero(state, state->skip) == -1)
-            ret = state->err;
-    }
+    if (state->skip && gz_zero(state) == -1)
+        ret = state->err;
 
     /* flush, free memory, and close file */
     if (gz_comp(state, Z_FINISH) == -1)


### PR DESCRIPTION
This also simplifies seek processing in general by eliminating the separate state->seek flag. Now state->skip > 0 alone indicates a pending seek, and gz_skip()/gz_zero() decrement it as they progress. Split out of #2242.

Upstream: https://github.com/madler/zlib/commit/a4e4521e