### PR TITLE
Clarify the use of errnum in gzerror().

### DIFF
--- a/zlib-ng.h.in
+++ b/zlib-ng.h.in
@@ -1663,9 +1663,10 @@ Z_EXTERN Z_EXPORT
 const char * zng_gzerror(gzFile file, int32_t *errnum);
 /*
      Return the error message for the last error which occurred on file.
-   errnum is set to zlib error number.  If an error occurred in the file system
-   and not in the compression library, errnum is set to Z_ERRNO and the
-   application may consult errno to get the exact error code.
+   If errnum is not NULL, *errnum is set to zlib error number.  If an error
+   occurred in the file system and not in the compression library, *errnum is
+   set to Z_ERRNO and the application may consult errno to get the exact error
+   code.
 
      The application must not modify the returned string.  Future calls to
    this function may invalidate the previously returned string.  If file is

--- a/zlib.h.in
+++ b/zlib.h.in
@@ -1636,9 +1636,10 @@ Z_EXTERN int Z_EXPORT gzclose_w(gzFile file);
 Z_EXTERN const char * Z_EXPORT gzerror(gzFile file, int *errnum);
 /*
      Return the error message for the last error which occurred on file.
-   errnum is set to zlib error number.  If an error occurred in the file system
-   and not in the compression library, errnum is set to Z_ERRNO and the
-   application may consult errno to get the exact error code.
+   If errnum is not NULL, *errnum is set to zlib error number.  If an error
+   occurred in the file system and not in the compression library, *errnum is
+   set to Z_ERRNO and the application may consult errno to get the exact error
+   code.
 
      The application must not modify the returned string.  Future calls to
    this function may invalidate the previously returned string.  If file is


### PR DESCRIPTION
Split out of #2242.

Upstream: https://github.com/madler/zlib/commit/aeab3f6c