### PR TITLE
Note the use of gzungetc() to run a deferred seek while reading.

### DIFF
--- a/zlib-ng.h.in
+++ b/zlib-ng.h.in
@@ -1527,6 +1527,11 @@ int32_t zng_gzungetc(int32_t c, gzFile file);
    output buffer size of pushed characters is allowed.  (See gzbuffer above.)
    The pushed character will be discarded if the stream is repositioned with
    gzseek() or gzrewind().
+
+     gzungetc(-1, file) will force any pending seek to execute. Then gztell()
+   will report the position, even if the requested seek reached end of file.
+   This can be used to determine the number of uncompressed bytes in a gzip
+   file without having to read it into a buffer.
 */
 
 Z_EXTERN Z_EXPORT

--- a/zlib.h.in
+++ b/zlib.h.in
@@ -1508,6 +1508,11 @@ Z_EXTERN int Z_EXPORT gzungetc(int c, gzFile file);
    output buffer size of pushed characters is allowed.  (See gzbuffer above.)
    The pushed character will be discarded if the stream is repositioned with
    gzseek() or gzrewind().
+
+     gzungetc(-1, file) will force any pending seek to execute. Then gztell()
+   will report the position, even if the requested seek reached end of file.
+   This can be used to determine the number of uncompressed bytes in a gzip
+   file without having to read it into a buffer.
 */
 
 Z_EXTERN int Z_EXPORT gzflush(gzFile file, int flush);


### PR DESCRIPTION
Split out of #2242.

Upstream: https://github.com/madler/zlib/commit/a9bb8c48