### PR TITLE
Note that gzseek() requests are deferred until the next operation.

### DIFF
--- a/zlib-ng.h.in
+++ b/zlib-ng.h.in
@@ -1556,7 +1556,8 @@ z_off64_t zng_gzseek(gzFile file, z_off64_t offset, int whence);
      If the file is opened for reading, this function is emulated but can be
    extremely slow.  If the file is opened for writing, only forward seeks are
    supported; gzseek then compresses a sequence of zeroes up to the new
-   starting position.
+   starting position. For reading or writing, any actual seeking is deferred
+   until the next read or write operation, or close operation when writing.
 
      gzseek returns the resulting offset location as measured in bytes from
    the beginning of the uncompressed stream, or -1 in case of error, in

--- a/zlib.h.in
+++ b/zlib.h.in
@@ -1536,7 +1536,8 @@ Z_EXTERN z_off_t Z_EXPORT gzseek (gzFile file, z_off_t offset, int whence);
      If the file is opened for reading, this function is emulated but can be
    extremely slow.  If the file is opened for writing, only forward seeks are
    supported; gzseek then compresses a sequence of zeroes up to the new
-   starting position.
+   starting position. For reading or writing, any actual seeking is deferred
+   until the next read or write operation, or close operation when writing.
 
      gzseek returns the resulting offset location as measured in bytes from
    the beginning of the uncompressed stream, or -1 in case of error, in


### PR DESCRIPTION
Split out of #2242.

Upstream: https://github.com/madler/zlib/commit/aaf94f38