### PR TITLE
Allow gzflush() to write empty gzip members.

### DIFF
--- a/gzwrite.c
+++ b/gzwrite.c
@@ -78,8 +78,9 @@ static int gz_comp(gz_state *state, int flush) {
 
     /* check for a pending reset */
     if (state->reset) {
-        /* don't start a new gzip member unless there is data to write */
-        if (strm->avail_in == 0)
+        /* don't start a new gzip member unless there is data to write and
+           we're not flushing */
+        if (strm->avail_in == 0 && flush == Z_NO_FLUSH)
             return 0;
         PREFIX(deflateReset)(strm);
         state->reset = 0;


### PR DESCRIPTION
Before this, a gzflush() with Z_FINISH and no data to write would do nothing. Now it will write an empty gzip member. Split out of #2242.

Upstream: https://github.com/madler/zlib/commit/a2b61271