### PR TITLE
Check for negative lengths in crc32_combine functions.

### DIFF
--- a/crc32_braid_comb.c
+++ b/crc32_braid_comb.c
@@ -13,10 +13,14 @@
 
 /* ========================================================================= */
 static uint32_t crc32_combine_(uint32_t crc1, uint32_t crc2, z_off64_t len2) {
+    if (len2 < 0)
+        return 0;
     return multmodp(x2nmodp(len2, 3), crc1) ^ crc2;
 }
 static uint32_t crc32_combine_gen_(z_off64_t len2) {
-     return x2nmodp(len2, 3);
+    if (len2 < 0)
+        return 0;
+    return x2nmodp(len2, 3);
 }
 static uint32_t crc32_combine_op_(uint32_t crc1, uint32_t crc2, const uint32_t op) {
     return multmodp(op, crc1) ^ crc2;


### PR DESCRIPTION
Though zlib.h says that len2 must be non-negative, this avoids the possibility of an accidental infinite loop. Split out of #2242.

Upstream: https://github.com/madler/zlib/commit/ba829a45