### PR TITLE
Cache pending index in local for put_short/put_uint32/put_uint64

### DIFF
--- a/deflate.h
+++ b/deflate.h
@@ -356,9 +356,10 @@ typedef enum {
  * IN assertion: there is enough room in pending_buf.
  */
 static inline void put_short(deflate_state *s, uint16_t w) {
+    uint32_t pending = s->pending;
     w = Z_U16_TO_LE(w);
-    zng_memwrite_2(&s->pending_buf[s->pending], w);
-    s->pending += 2;
+    zng_memwrite_2(&s->pending_buf[pending], w);
+    s->pending = pending + 2;
 }
 
 /* ===========================================================================
@@ -366,9 +367,10 @@ static inline void put_short(deflate_state *s, uint16_t w) {
  * IN assertion: there is enough room in pending_buf.
  */
 static inline void put_short_msb(deflate_state *s, uint16_t w) {
+    uint32_t pending = s->pending;
     w = Z_U16_TO_BE(w);
-    zng_memwrite_2(&s->pending_buf[s->pending], w);
-    s->pending += 2;
+    zng_memwrite_2(&s->pending_buf[pending], w);
+    s->pending = pending + 2;
 }
 
 /* ===========================================================================
@@ -376,9 +378,10 @@ static inline void put_short_msb(deflate_state *s, uint16_t w) {
  * IN assertion: there is enough room in pending_buf.
  */
 static inline void put_uint32(deflate_state *s, uint32_t dw) {
+    uint32_t pending = s->pending;
     dw = Z_U32_TO_LE(dw);
-    zng_memwrite_4(&s->pending_buf[s->pending], dw);
-    s->pending += 4;
+    zng_memwrite_4(&s->pending_buf[pending], dw);
+    s->pending = pending + 4;
 }
 
 /* ===========================================================================
@@ -386,9 +389,10 @@ static inline void put_uint32(deflate_state *s, uint32_t dw) {
  * IN assertion: there is enough room in pending_buf.
  */
 static inline void put_uint32_msb(deflate_state *s, uint32_t dw) {
+    uint32_t pending = s->pending;
     dw = Z_U32_TO_BE(dw);
-    zng_memwrite_4(&s->pending_buf[s->pending], dw);
-    s->pending += 4;
+    zng_memwrite_4(&s->pending_buf[pending], dw);
+    s->pending = pending + 4;
 }
 
 /* ===========================================================================
@@ -396,9 +400,10 @@ static inline void put_uint32_msb(deflate_state *s, uint32_t dw) {
  * IN assertion: there is enough room in pending_buf.
  */
 static inline void put_uint64(deflate_state *s, uint64_t lld) {
+    uint32_t pending = s->pending;
     lld = Z_U64_TO_LE(lld);
-    zng_memwrite_8(&s->pending_buf[s->pending], lld);
-    s->pending += 8;
+    zng_memwrite_8(&s->pending_buf[pending], lld);
+    s->pending = pending + 8;
 }
 
 #define MIN_LOOKAHEAD (STD_MAX_MATCH + STD_MIN_MATCH + 1)


### PR DESCRIPTION
The `put_*` helpers read and write `s->pending` around a store to `s->pending_buf[]`. Since `pending_buf` is an `unsigned char *`, the compiler cannot prove the store does not alias `s->pending`, so every helper reloads the field after the buffer write. Caching `s->pending` in a local removes the reload.

On AArch64 (clang, Release) this removes one load per call in the `put_uint64` flush path used by `compress_block`, and trees.c.o drops from 1858 to 1819 instructions with loads of `s->pending` down from 77 to 40. In `zng_tr_stored_block` the LEN/NLEN pair now shares a single `pending += 4` update.

On x86-64 the memory-destination `addl` splits into `lea` + `mov`, so instruction count rises slightly, but each helper still performs one fewer load and no new stack spills appear.

`put_byte` is unchanged because its post-increment reads `s->pending` before the store, so it never had the reload.