### PR TITLE
Optimize build_tree using counting sort and a two-queue merge

### DIFF
--- a/deflate.h
+++ b/deflate.h
@@ -259,7 +259,6 @@ struct ALIGNED_(64) internal_state {
     int32_t bi_valid;           /* Number of valid bits in bi_buf.
                                  * All bits above the last valid bit are always zero. */
 
-    int heap_len;               /* number of elements in the heap */
     int heap_max;               /* element of largest frequency */
 
                 /* used by trees.c: */
@@ -307,13 +306,9 @@ struct ALIGNED_(64) internal_state {
     uint16_t bl_count[MAX_BITS+1];
     /* number of codes at each bit length for an optimal tree */
 
-    int heap[2*L_CODES+1];      /* heap used to build the Huffman trees */
-    /* The sons of heap[n] are heap[2*n] and heap[2*n+1]. heap[0] is not used.
-     * The same heap array is used to build all trees.
-     */
-
-    unsigned char depth[2*L_CODES+1];
-    /* Depth of each subtree used as tie breaker for trees of equal frequency
+    int heap[2*L_CODES+1];      /* tree nodes sorted by increasing frequency */
+    /* Filled by build_tree() and consumed by gen_bitlen(). The same array is
+     * used for all trees.
      */
 
     /* Didn't use ct_data typedef below to suppress compiler warning */

--- a/deflate.h
+++ b/deflate.h
@@ -259,8 +259,6 @@ struct ALIGNED_(64) internal_state {
     int32_t bi_valid;           /* Number of valid bits in bi_buf.
                                  * All bits above the last valid bit are always zero. */
 
-    int heap_max;               /* element of largest frequency */
-
                 /* used by trees.c: */
     unsigned int  lit_bufsize;
     /* Size of match buffer for literals/lengths.  There are 4 reasons for
@@ -305,11 +303,6 @@ struct ALIGNED_(64) internal_state {
 
     uint16_t bl_count[MAX_BITS+1];
     /* number of codes at each bit length for an optimal tree */
-
-    int heap[2*L_CODES+1];      /* tree nodes sorted by increasing frequency */
-    /* Filled by build_tree() and consumed by gen_bitlen(). The same array is
-     * used for all trees.
-     */
 
     /* Didn't use ct_data typedef below to suppress compiler warning */
     struct ct_data_s dyn_ltree[HEAP_SIZE];   /* literal and length tree */

--- a/test/benchmarks/benchmark_deflate.cc
+++ b/test/benchmarks/benchmark_deflate.cc
@@ -34,7 +34,9 @@ public:
     void SetUp(::benchmark::State&) {}
 
     void DoSetUp(::benchmark::State& state, enum test_data_type data_type) {
-        outbuff_size = PREFIX(deflateBound)(NULL, MAX_SIZE);
+        /* deflateBound does not cover the empty stored blocks that sync flushing emits,
+         * so reserve room for one marker per smallest chunk. */
+        outbuff_size = PREFIX(deflateBound)(NULL, MAX_SIZE) + (MAX_SIZE / 1024 + 1) * 16;
         outbuff = (uint8_t *)malloc(outbuff_size);
         if (outbuff == NULL) {
             state.SkipWithError("malloc failed");
@@ -50,10 +52,20 @@ public:
         }
     }
 
-    void Bench(benchmark::State& state, int window_bits, int strategy) {
+    void Bench(benchmark::State& state, int window_bits, int strategy, int sync) {
         int err;
-        size_t size = (size_t)state.range(0);
+        size_t size, chunk;
         int level = (int)state.range(1);
+
+        /* Sync variants compress MAX_SIZE in Args(chunk)-sized pieces with Z_SYNC_FLUSH
+         * between them. Whole-buffer variants are the degenerate case of one chunk. */
+        if (sync) {
+            size = MAX_SIZE;
+            chunk = (size_t)state.range(0);
+        } else {
+            size = (size_t)state.range(0);
+            chunk = size;
+        }
 
         PREFIX3(stream) strm;
         strm.zalloc = NULL;
@@ -78,12 +90,23 @@ public:
                 return;
             }
 
-            strm.avail_in = (uint32_t)size;
-            strm.next_in = (z_const uint8_t *)inbuff;
             strm.next_out = outbuff;
             strm.avail_out = (uint32_t)outbuff_size;
 
-            err = PREFIX(deflate)(&strm, Z_FINISH);
+            size_t offset = 0;
+            while (offset < size) {
+                size_t len = size - offset < chunk ? size - offset : chunk;
+                strm.next_in = (z_const uint8_t *)inbuff + offset;
+                strm.avail_in = (uint32_t)len;
+                offset += len;
+
+                err = PREFIX(deflate)(&strm, offset < size ? Z_SYNC_FLUSH : Z_FINISH);
+                if (err != Z_OK && err != Z_STREAM_END) {
+                    state.SkipWithError("deflate did not return Z_OK");
+                    PREFIX(deflateEnd)(&strm);
+                    return;
+                }
+            }
             if (err != Z_STREAM_END) {
                 state.SkipWithError("deflate did not return Z_STREAM_END");
                 PREFIX(deflateEnd)(&strm);
@@ -101,11 +124,11 @@ public:
         state.counters["ratio"] = benchmark::Counter(double(size) / double(strm.total_out));
     }
 
-    void Dispatch(benchmark::State& state, enum test_data_type data_type, int window_bits, int strategy) {
+    void Dispatch(benchmark::State& state, enum test_data_type data_type, int window_bits, int strategy, int sync) {
         DoSetUp(state, data_type);
         if (state.skipped())
             return;
-        Bench(state, window_bits, strategy);
+        Bench(state, window_bits, strategy, sync);
     }
 
     void TearDown(const ::benchmark::State&) {
@@ -131,33 +154,40 @@ public:
     ->Args({131072, 3})->Args({131072, 6})->Args({131072, 9}) \
     ->Args({1048576, 3})->Args({1048576, 6})->Args({1048576, 9})
 
-#define DEFLATE_VARIANT(variant, data, wbits, strategy, dt) \
+/* Sync-flush variants use Args(chunk, level), two cadences at the default level */
+#define DEFLATE_SYNC_ARGS \
+    ->Args({1024, 6})->Args({4096, 6})
+
+#define DEFLATE_VARIANT(variant, data, wbits, strategy, sync, dt) \
     BENCHMARK_DEFINE_F(deflate_bench, variant##_##data)(benchmark::State& state) { \
-        Dispatch(state, dt, wbits, strategy); \
+        Dispatch(state, dt, wbits, strategy, sync); \
     }
 
-#define DEFLATE_ALL_DATA(variant, wbits, strategy) \
-    DEFLATE_VARIANT(variant, text,          wbits, strategy, TEST_DATA_TEXT); \
-    DEFLATE_VARIANT(variant, short_match,   wbits, strategy, TEST_DATA_SHORT_MATCH); \
-    DEFLATE_VARIANT(variant, dna,           wbits, strategy, TEST_DATA_DNA); \
-    DEFLATE_VARIANT(variant, random,        wbits, strategy, TEST_DATA_RANDOM); \
-    DEFLATE_VARIANT(variant, literals,      wbits, strategy, TEST_DATA_LITERALS); \
-    DEFLATE_VARIANT(variant, mixed,         wbits, strategy, TEST_DATA_MIXED); \
-    DEFLATE_VARIANT(variant, realistic_rgb, wbits, strategy, TEST_DATA_REALISTIC_RGB); \
-    DEFLATE_VARIANT(variant, striped_rgb,   wbits, strategy, TEST_DATA_STRIPED_RGB)
+#define DEFLATE_ALL_DATA(variant, wbits, strategy, sync) \
+    DEFLATE_VARIANT(variant, text,          wbits, strategy, sync, TEST_DATA_TEXT); \
+    DEFLATE_VARIANT(variant, short_match,   wbits, strategy, sync, TEST_DATA_SHORT_MATCH); \
+    DEFLATE_VARIANT(variant, dna,           wbits, strategy, sync, TEST_DATA_DNA); \
+    DEFLATE_VARIANT(variant, random,        wbits, strategy, sync, TEST_DATA_RANDOM); \
+    DEFLATE_VARIANT(variant, literals,      wbits, strategy, sync, TEST_DATA_LITERALS); \
+    DEFLATE_VARIANT(variant, mixed,         wbits, strategy, sync, TEST_DATA_MIXED); \
+    DEFLATE_VARIANT(variant, realistic_rgb, wbits, strategy, sync, TEST_DATA_REALISTIC_RGB); \
+    DEFLATE_VARIANT(variant, striped_rgb,   wbits, strategy, sync, TEST_DATA_STRIPED_RGB)
 
 /* Parameterized deflate with zlib wrapping (includes adler32 checksum) */
-DEFLATE_ALL_DATA(level,    MAX_WBITS,  Z_DEFAULT_STRATEGY);
+DEFLATE_ALL_DATA(level,      MAX_WBITS,  Z_DEFAULT_STRATEGY, 0);
 /* Parameterized raw deflate without checksum */
-DEFLATE_ALL_DATA(nocrc,    -MAX_WBITS, Z_DEFAULT_STRATEGY);
+DEFLATE_ALL_DATA(nocrc,      -MAX_WBITS, Z_DEFAULT_STRATEGY, 0);
 /* Parameterized deflate with filtered strategy */
-DEFLATE_ALL_DATA(filtered, MAX_WBITS,  Z_FILTERED);
+DEFLATE_ALL_DATA(filtered,   MAX_WBITS,  Z_FILTERED, 0);
 /* Parameterized deflate with Huffman-only strategy */
-DEFLATE_ALL_DATA(huffman,  MAX_WBITS,  Z_HUFFMAN_ONLY);
+DEFLATE_ALL_DATA(huffman,    MAX_WBITS,  Z_HUFFMAN_ONLY, 0);
 /* Parameterized deflate with RLE strategy */
-DEFLATE_ALL_DATA(rle,      MAX_WBITS,  Z_RLE);
+DEFLATE_ALL_DATA(rle,        MAX_WBITS,  Z_RLE, 0);
 /* Parameterized deflate with fixed Huffman codes */
-DEFLATE_ALL_DATA(fixed,    MAX_WBITS,  Z_FIXED);
+DEFLATE_ALL_DATA(fixed,      MAX_WBITS,  Z_FIXED, 0);
+/* Parameterized deflate with periodic Z_SYNC_FLUSH, cutting many small blocks so
+   tree construction is a much larger share of the work than whole-buffer runs show */
+DEFLATE_ALL_DATA(sync_flush, MAX_WBITS,  Z_DEFAULT_STRATEGY, 1);
 
 /* Registered at runtime for the data types selected by --benchmark_data_types */
 #define DEFLATE_REGISTER(variant, data, dt, args_macro) \
@@ -166,23 +196,24 @@ DEFLATE_ALL_DATA(fixed,    MAX_WBITS,  Z_FIXED);
             ::benchmark::internal::make_unique<deflate_bench_##variant##_##data##_Benchmark>()) \
             ->Name("deflate_bench/" #variant "/" #data) args_macro
 
-#define DEFLATE_REGISTER_ALL_DATA(variant, text_args_macro) \
+#define DEFLATE_REGISTER_ALL_DATA(variant, text_args_macro, data_args_macro) \
     DEFLATE_REGISTER(variant, text,          TEST_DATA_TEXT,          text_args_macro); \
-    DEFLATE_REGISTER(variant, short_match,   TEST_DATA_SHORT_MATCH,   DEFLATE_DATA_ARGS); \
-    DEFLATE_REGISTER(variant, dna,           TEST_DATA_DNA,           DEFLATE_DATA_ARGS); \
-    DEFLATE_REGISTER(variant, random,        TEST_DATA_RANDOM,        DEFLATE_DATA_ARGS); \
-    DEFLATE_REGISTER(variant, literals,      TEST_DATA_LITERALS,      DEFLATE_DATA_ARGS); \
-    DEFLATE_REGISTER(variant, mixed,         TEST_DATA_MIXED,         DEFLATE_DATA_ARGS); \
-    DEFLATE_REGISTER(variant, realistic_rgb, TEST_DATA_REALISTIC_RGB, DEFLATE_DATA_ARGS); \
-    DEFLATE_REGISTER(variant, striped_rgb,   TEST_DATA_STRIPED_RGB,   DEFLATE_DATA_ARGS)
+    DEFLATE_REGISTER(variant, short_match,   TEST_DATA_SHORT_MATCH,   data_args_macro); \
+    DEFLATE_REGISTER(variant, dna,           TEST_DATA_DNA,           data_args_macro); \
+    DEFLATE_REGISTER(variant, random,        TEST_DATA_RANDOM,        data_args_macro); \
+    DEFLATE_REGISTER(variant, literals,      TEST_DATA_LITERALS,      data_args_macro); \
+    DEFLATE_REGISTER(variant, mixed,         TEST_DATA_MIXED,         data_args_macro); \
+    DEFLATE_REGISTER(variant, realistic_rgb, TEST_DATA_REALISTIC_RGB, data_args_macro); \
+    DEFLATE_REGISTER(variant, striped_rgb,   TEST_DATA_STRIPED_RGB,   data_args_macro)
 
 static void deflate_register_data_types(uint32_t mask) {
-    DEFLATE_REGISTER_ALL_DATA(level,    DEFLATE_ARGS);
-    DEFLATE_REGISTER_ALL_DATA(nocrc,    DEFLATE_ARGS);
-    DEFLATE_REGISTER_ALL_DATA(filtered, DEFLATE_STRATEGY_ARGS);
-    DEFLATE_REGISTER_ALL_DATA(huffman,  DEFLATE_STRATEGY_ARGS);
-    DEFLATE_REGISTER_ALL_DATA(rle,      DEFLATE_STRATEGY_ARGS);
-    DEFLATE_REGISTER_ALL_DATA(fixed,    DEFLATE_STRATEGY_ARGS);
+    DEFLATE_REGISTER_ALL_DATA(level,      DEFLATE_ARGS,          DEFLATE_DATA_ARGS);
+    DEFLATE_REGISTER_ALL_DATA(nocrc,      DEFLATE_ARGS,          DEFLATE_DATA_ARGS);
+    DEFLATE_REGISTER_ALL_DATA(filtered,   DEFLATE_STRATEGY_ARGS, DEFLATE_DATA_ARGS);
+    DEFLATE_REGISTER_ALL_DATA(huffman,    DEFLATE_STRATEGY_ARGS, DEFLATE_DATA_ARGS);
+    DEFLATE_REGISTER_ALL_DATA(rle,        DEFLATE_STRATEGY_ARGS, DEFLATE_DATA_ARGS);
+    DEFLATE_REGISTER_ALL_DATA(fixed,      DEFLATE_STRATEGY_ARGS, DEFLATE_DATA_ARGS);
+    DEFLATE_REGISTER_ALL_DATA(sync_flush, DEFLATE_SYNC_ARGS,     DEFLATE_SYNC_ARGS);
 }
 
 static int deflate_data_types = benchmark_data_types_hook(deflate_register_data_types);

--- a/trees.c
+++ b/trees.c
@@ -67,7 +67,7 @@ static const static_tree_desc  static_bl_desc =
  */
 
 static void init_block       (deflate_state *s);
-static inline void pqdownheap       (uint32_t *pq, const int heap_len, int k);
+static void pq_radix_pass    (const uint32_t *src, uint32_t *dst, int n, int shift);
 static void build_tree       (deflate_state *s, tree_desc *desc);
 static void gen_bitlen       (deflate_state *s, tree_desc *desc);
 static void scan_tree        (deflate_state *s, ct_data *tree, int max_code);
@@ -121,46 +121,40 @@ static void init_block(deflate_state *s) {
     s->sym_next = 0;
 }
 
-#define SMALLEST 1
-/* Index within the heap array of least frequent node in the Huffman tree */
-
-/* Heap entries pack freq above the node index, so a single 32-bit compare orders nodes by
+/* Queue entries pack freq above the node index, so a single 32-bit compare orders nodes by
  * frequency, breaking ties by node index: leaves first, then internal nodes in creation order,
- * which keeps the worst-case code length small. Freq of a node never changes while it is in
- * the heap, so packed entries stay valid. */
+ * which keeps the worst-case code length small. */
 #define PQ_NODE_BITS 10
 #define pq_pack(freq, node) (((uint32_t)(freq) << PQ_NODE_BITS) | (unsigned)(node))
 #define pq_node(e)  ((int)((e) & ((1u << PQ_NODE_BITS) - 1)))
 #define pq_freq(e)  ((e) >> PQ_NODE_BITS)
 
 /* ===========================================================================
- * Restore the heap property by moving down the tree starting at node k,
- * exchanging a node with the smallest of its two sons if necessary, stopping
- * when the heap property is re-established (each father smaller than its
- * two sons). Used by build_tree().
+ * One stable counting-sort pass over an 8-bit digit of the packed entries.
+ * Used by build_tree().
  */
-static inline void pqdownheap(uint32_t *pq, const int heap_len, int k) {
-    /* k: node to move down */
-    int j = k << 1;  /* left son of k */
-    const uint32_t v = pq[k];
+static void pq_radix_pass(const uint32_t *src, uint32_t *dst, int n, int shift) {
+    uint16_t count[257];
+    int i;
 
-    while (j <= heap_len) {
-        /* Set j to the smallest of the two sons: */
-        if (j < heap_len && pq[j+1] < pq[j]) {
-            j++;
-        }
-        /* Exit if v is smaller than both sons */
-        if (v < pq[j])
-            break;
+    memset(count, 0, sizeof(count));
+    for (i = 0; i < n; i++)
+        count[((src[i] >> shift) & 0xFF) + 1]++;
+    for (i = 1; i <= 256; i++)
+        count[i] = (uint16_t)(count[i] + count[i-1]);
+    for (i = 0; i < n; i++)
+        dst[count[(src[i] >> shift) & 0xFF]++] = src[i];
+}
 
-        /* Exchange v with the smallest son */
-        pq[k] = pq[j];
-        k = j;
-
-        /* And continue down the tree, setting j to the left son of k */
-        j <<= 1;
-    }
-    pq[k] = v;
+/* ===========================================================================
+ * Take the smaller of the two queue heads: the next unused leaf, or the next
+ * created internal node. Used by build_tree().
+ */
+static inline uint32_t pq_take(const uint32_t *leaves, int *li, int nleaves,
+                               const uint32_t *internals, int *ihead, int itail) {
+    if (*li < nleaves && (*ihead == itail || leaves[*li] < internals[*ihead]))
+        return leaves[(*li)++];
+    return internals[(*ihead)++];
 }
 
 /* ===========================================================================
@@ -179,17 +173,17 @@ static void build_tree(deflate_state *s, tree_desc *desc) {
     int n, m;          /* iterate over heap elements */
     int max_code = -1; /* largest code with non zero frequency */
     int node;          /* new node being created */
-    int heap_len = 0;
+    int nleaves = 0;
     int heap_max = HEAP_SIZE;
-    uint32_t pq[L_CODES + 1]; /* packed priority queue, entries 1..heap_len */
+    int li = 0, ihead = 0, itail = 0;  /* queue positions for leaves and internal nodes */
+    int merges;
+    uint32_t leaves[L_CODES + 1];  /* packed leaf entries, sorted by frequency */
+    uint32_t scratch[L_CODES + 1]; /* radix buffer, then FIFO of created internal nodes */
+    uint32_t *internals = scratch;
 
-    /* Construct the initial heap, with least frequent element in
-     * pq[SMALLEST]. The sons of pq[n] are pq[2*n] and pq[2*n+1].
-     * pq[0] is not used.
-     */
     for (n = 0; n < elems; n++) {
         if (tree[n].Freq != 0) {
-            pq[++heap_len] = pq_pack(tree[n].Freq, n);
+            leaves[nleaves++] = pq_pack(tree[n].Freq, n);
             max_code = n;
         } else {
             tree[n].Len = 0;
@@ -201,9 +195,9 @@ static void build_tree(deflate_state *s, tree_desc *desc) {
      * possible code. So to avoid special checks later on we force at least
      * two codes of non zero frequency.
      */
-    while (heap_len < 2) {
+    while (nleaves < 2) {
         node = (max_code < 2 ? ++max_code : 0);
-        pq[++heap_len] = pq_pack(1, node);
+        leaves[nleaves++] = pq_pack(1, node);
         tree[node].Freq = 1;
         s->opt_len--;
         if (stree)
@@ -212,22 +206,29 @@ static void build_tree(deflate_state *s, tree_desc *desc) {
     }
     desc->max_code = max_code;
 
-    /* The elements pq[heap_len/2+1 .. heap_len] are leaves of the tree,
-     * establish sub-heaps of increasing lengths:
-     */
-    for (n = heap_len/2; n >= 1; n--)
-        pqdownheap(pq, heap_len, n);
+    /* Sort the leaves by packed entry. The scan above appended them in node order, which is
+     * ascending in the node bits, so two stable passes over the freq bytes finish the sort.
+     * A forced node can arrive out of node order, but then there are exactly two leaves. */
+    if (nleaves == 2) {
+        if (leaves[0] > leaves[1]) {
+            const uint32_t t = leaves[0];
+            leaves[0] = leaves[1];
+            leaves[1] = t;
+        }
+    } else {
+        pq_radix_pass(leaves, scratch, nleaves, PQ_NODE_BITS);
+        pq_radix_pass(scratch, leaves, nleaves, PQ_NODE_BITS + 8);
+    }
 
-    /* Construct the Huffman tree by repeatedly combining the least two
-     * frequent nodes.
+    /* Construct the Huffman tree by repeatedly combining the least two frequent nodes.
+     * Sorted leaves and the FIFO of created nodes are each ascending, because merge sums
+     * never decrease, so the two smallest nodes are always at the queue heads.
      */
     node = elems;              /* next internal node of the tree */
-    do {
-        /* n = node of least frequency, m = node of next least frequency */
-        const uint32_t en = pq[SMALLEST];
-        pq[SMALLEST] = pq[heap_len--];
-        pqdownheap(pq, heap_len, SMALLEST);
-        const uint32_t em = pq[SMALLEST];
+    for (merges = nleaves - 1; merges > 0; merges--) {
+        /* en = entry of least frequency, em = entry of next least frequency */
+        const uint32_t en = pq_take(leaves, &li, nleaves, internals, &ihead, itail);
+        const uint32_t em = pq_take(leaves, &li, nleaves, internals, &ihead, itail);
         n = pq_node(en);
         m = pq_node(em);
 
@@ -245,13 +246,12 @@ static void build_tree(deflate_state *s, tree_desc *desc) {
                     node, tree[node].Freq, n, tree[n].Freq, m, tree[m].Freq);
         }
 #endif
-        /* and insert the new node in the heap */
-        pq[SMALLEST] = pq_pack(f, node);
+        /* and append the new node to the internal queue */
+        internals[itail++] = pq_pack(f, node);
         node++;
-        pqdownheap(pq, heap_len, SMALLEST);
-    } while (heap_len >= 2);
+    }
 
-    s->heap[--heap_max] = pq_node(pq[SMALLEST]);
+    s->heap[--heap_max] = node - 1; /* the last created node is the root */
     s->heap_max = heap_max;
 
     /* At this point, the fields freq and dad are set. We can now

--- a/trees.c
+++ b/trees.c
@@ -67,7 +67,7 @@ static const static_tree_desc  static_bl_desc =
  */
 
 static void init_block       (deflate_state *s);
-static inline void pqdownheap       (uint64_t *pq, const int heap_len, int k);
+static inline void pqdownheap       (uint32_t *pq, const int heap_len, int k);
 static void build_tree       (deflate_state *s, tree_desc *desc);
 static void gen_bitlen       (deflate_state *s, tree_desc *desc);
 static void scan_tree        (deflate_state *s, ct_data *tree, int max_code);
@@ -124,16 +124,14 @@ static void init_block(deflate_state *s) {
 #define SMALLEST 1
 /* Index within the heap array of least frequent node in the Huffman tree */
 
-/* Heap entries pack (freq << 8 | depth) above the node index, so a single 64-bit compare orders
- * nodes by frequency, breaking ties by subtree depth to minimize the worst-case code length.
- * Freq and depth of a node never change while it is in the heap, so packed entries stay valid. */
+/* Heap entries pack freq above the node index, so a single 32-bit compare orders nodes by
+ * frequency, breaking ties by node index: leaves first, then internal nodes in creation order,
+ * which keeps the worst-case code length small. Freq of a node never changes while it is in
+ * the heap, so packed entries stay valid. */
 #define PQ_NODE_BITS 10
-#define pq_pack(freq, depth, node) \
-    (((uint64_t)(freq) << (PQ_NODE_BITS + 8)) | ((uint64_t)(depth) << PQ_NODE_BITS) | (unsigned)(node))
-#define pq_key(e)   ((e) >> PQ_NODE_BITS)
-#define pq_node(e)  ((int)((e) & (((uint64_t)1 << PQ_NODE_BITS) - 1)))
-#define pq_freq(e)  ((uint32_t)((e) >> (PQ_NODE_BITS + 8)))
-#define pq_depth(e) ((uint32_t)(((e) >> PQ_NODE_BITS) & 0xFF))
+#define pq_pack(freq, node) (((uint32_t)(freq) << PQ_NODE_BITS) | (unsigned)(node))
+#define pq_node(e)  ((int)((e) & ((1u << PQ_NODE_BITS) - 1)))
+#define pq_freq(e)  ((e) >> PQ_NODE_BITS)
 
 /* ===========================================================================
  * Restore the heap property by moving down the tree starting at node k,
@@ -141,19 +139,18 @@ static void init_block(deflate_state *s) {
  * when the heap property is re-established (each father smaller than its
  * two sons). Used by build_tree().
  */
-static inline void pqdownheap(uint64_t *pq, const int heap_len, int k) {
+static inline void pqdownheap(uint32_t *pq, const int heap_len, int k) {
     /* k: node to move down */
     int j = k << 1;  /* left son of k */
-    const uint64_t v = pq[k];
-    const uint64_t vk = pq_key(v);
+    const uint32_t v = pq[k];
 
     while (j <= heap_len) {
         /* Set j to the smallest of the two sons: */
-        if (j < heap_len && pq_key(pq[j+1]) <= pq_key(pq[j])) {
+        if (j < heap_len && pq[j+1] < pq[j]) {
             j++;
         }
         /* Exit if v is smaller than both sons */
-        if (vk <= pq_key(pq[j]))
+        if (v < pq[j])
             break;
 
         /* Exchange v with the smallest son */
@@ -184,7 +181,7 @@ static void build_tree(deflate_state *s, tree_desc *desc) {
     int node;          /* new node being created */
     int heap_len = 0;
     int heap_max = HEAP_SIZE;
-    uint64_t pq[L_CODES + 1]; /* packed priority queue, entries 1..heap_len */
+    uint32_t pq[L_CODES + 1]; /* packed priority queue, entries 1..heap_len */
 
     /* Construct the initial heap, with least frequent element in
      * pq[SMALLEST]. The sons of pq[n] are pq[2*n] and pq[2*n+1].
@@ -192,7 +189,7 @@ static void build_tree(deflate_state *s, tree_desc *desc) {
      */
     for (n = 0; n < elems; n++) {
         if (tree[n].Freq != 0) {
-            pq[++heap_len] = pq_pack(tree[n].Freq, 0, n);
+            pq[++heap_len] = pq_pack(tree[n].Freq, n);
             max_code = n;
         } else {
             tree[n].Len = 0;
@@ -206,7 +203,7 @@ static void build_tree(deflate_state *s, tree_desc *desc) {
      */
     while (heap_len < 2) {
         node = (max_code < 2 ? ++max_code : 0);
-        pq[++heap_len] = pq_pack(1, 0, node);
+        pq[++heap_len] = pq_pack(1, node);
         tree[node].Freq = 1;
         s->opt_len--;
         if (stree)
@@ -227,21 +224,19 @@ static void build_tree(deflate_state *s, tree_desc *desc) {
     node = elems;              /* next internal node of the tree */
     do {
         /* n = node of least frequency, m = node of next least frequency */
-        const uint64_t en = pq[SMALLEST];
+        const uint32_t en = pq[SMALLEST];
         pq[SMALLEST] = pq[heap_len--];
         pqdownheap(pq, heap_len, SMALLEST);
-        const uint64_t em = pq[SMALLEST];
+        const uint32_t em = pq[SMALLEST];
         n = pq_node(en);
         m = pq_node(em);
 
         s->heap[--heap_max] = n; /* keep the nodes sorted by frequency */
         s->heap[--heap_max] = m;
 
-        /* Create a new node father of n and m. Freq and depth wrap the same way the uint16_t
-         * and unsigned char state fields did. */
+        /* Create a new node father of n and m. Freq wraps the same way the uint16_t
+         * state field did. */
         const uint16_t f = (uint16_t)(pq_freq(en) + pq_freq(em));
-        const unsigned char d = (unsigned char)((pq_depth(en) >= pq_depth(em) ?
-                                          pq_depth(en) : pq_depth(em)) + 1);
         tree[node].Freq = f;
         tree[n].Dad = tree[m].Dad = (uint16_t)node;
 #ifdef DUMP_BL_TREE
@@ -251,7 +246,7 @@ static void build_tree(deflate_state *s, tree_desc *desc) {
         }
 #endif
         /* and insert the new node in the heap */
-        pq[SMALLEST] = pq_pack(f, d, node);
+        pq[SMALLEST] = pq_pack(f, node);
         node++;
         pqdownheap(pq, heap_len, SMALLEST);
     } while (heap_len >= 2);

--- a/trees.c
+++ b/trees.c
@@ -176,6 +176,7 @@ static void build_tree(deflate_state *s, tree_desc *desc) {
     int merges;
     uint32_t leaves[L_CODES + 1];  /* packed leaf entries, sorted by frequency */
     uint32_t scratch[L_CODES + 1]; /* radix buffer, then FIFO of created internal nodes */
+    uint32_t *sorted = leaves;
     uint32_t *internals = scratch;
     int order[HEAP_SIZE];          /* tree nodes in merge order, filled from the top down */
     uint16_t count_lo[257];        /* histogram of the low frequency byte, at offset +1 */
@@ -221,6 +222,13 @@ static void build_tree(deflate_state *s, tree_desc *desc) {
             leaves[0] = leaves[1];
             leaves[1] = t;
         }
+    } else if ((int)count_hi[1] == nleaves) {
+        /* Every frequency fits in one byte, so the first pass already produces the final
+         * order. The sorted entries then live in scratch, so the internal-node FIFO takes
+         * over the leaves buffer instead. */
+        pq_radix_pass(leaves, scratch, nleaves, PQ_NODE_BITS, count_lo);
+        sorted = scratch;
+        internals = leaves;
     } else {
         pq_radix_pass(leaves, scratch, nleaves, PQ_NODE_BITS, count_lo);
         pq_radix_pass(scratch, leaves, nleaves, PQ_NODE_BITS + 8, count_hi);
@@ -233,8 +241,8 @@ static void build_tree(deflate_state *s, tree_desc *desc) {
     node = elems;              /* next internal node of the tree */
     for (merges = nleaves - 1; merges > 0; merges--) {
         /* en = entry of least frequency, em = entry of next least frequency */
-        const uint32_t en = pq_take(leaves, &li, nleaves, internals, &ihead, itail);
-        const uint32_t em = pq_take(leaves, &li, nleaves, internals, &ihead, itail);
+        const uint32_t en = pq_take(sorted, &li, nleaves, internals, &ihead, itail);
+        const uint32_t em = pq_take(sorted, &li, nleaves, internals, &ihead, itail);
         n = pq_node(en);
         m = pq_node(em);
 

--- a/trees.c
+++ b/trees.c
@@ -69,7 +69,7 @@ static const static_tree_desc  static_bl_desc =
 static void init_block       (deflate_state *s);
 static void pq_radix_pass    (const uint32_t *src, uint32_t *dst, int n, int shift);
 static void build_tree       (deflate_state *s, tree_desc *desc);
-static void gen_bitlen       (deflate_state *s, tree_desc *desc);
+static void gen_bitlen       (deflate_state *s, tree_desc *desc, const int *order, int order_max);
 static void scan_tree        (deflate_state *s, ct_data *tree, int max_code);
 static void send_tree        (deflate_state *s, ct_data *tree, int max_code);
 static int  build_bl_tree    (deflate_state *s);
@@ -174,12 +174,13 @@ static void build_tree(deflate_state *s, tree_desc *desc) {
     int max_code = -1; /* largest code with non zero frequency */
     int node;          /* new node being created */
     int nleaves = 0;
-    int heap_max = HEAP_SIZE;
+    int order_max = HEAP_SIZE;
     int li = 0, ihead = 0, itail = 0;  /* queue positions for leaves and internal nodes */
     int merges;
     uint32_t leaves[L_CODES + 1];  /* packed leaf entries, sorted by frequency */
     uint32_t scratch[L_CODES + 1]; /* radix buffer, then FIFO of created internal nodes */
     uint32_t *internals = scratch;
+    int order[HEAP_SIZE];          /* tree nodes in merge order, filled from the top down */
 
     for (n = 0; n < elems; n++) {
         if (tree[n].Freq != 0) {
@@ -232,8 +233,8 @@ static void build_tree(deflate_state *s, tree_desc *desc) {
         n = pq_node(en);
         m = pq_node(em);
 
-        s->heap[--heap_max] = n; /* keep the nodes sorted by frequency */
-        s->heap[--heap_max] = m;
+        order[--order_max] = n; /* keep the nodes sorted by frequency */
+        order[--order_max] = m;
 
         /* Create a new node father of n and m. Freq wraps the same way the uint16_t
          * state field did. */
@@ -251,13 +252,12 @@ static void build_tree(deflate_state *s, tree_desc *desc) {
         node++;
     }
 
-    s->heap[--heap_max] = node - 1; /* the last created node is the root */
-    s->heap_max = heap_max;
+    order[--order_max] = node - 1; /* the last created node is the root */
 
     /* At this point, the fields freq and dad are set. We can now
      * generate the bit lengths.
      */
-    gen_bitlen(s, (tree_desc *)desc);
+    gen_bitlen(s, (tree_desc *)desc, order, order_max);
 
     /* The field len is now set, we can generate the bit codes */
     gen_codes((ct_data *)tree, max_code, s->bl_count);
@@ -266,14 +266,14 @@ static void build_tree(deflate_state *s, tree_desc *desc) {
 /* ===========================================================================
  * Compute the optimal bit lengths for a tree and update the total bit length
  * for the current block.
- * IN assertion: the fields freq and dad are set, heap[heap_max] and
+ * IN assertion: the fields freq and dad are set, order[order_max] and
  *    above are the tree nodes sorted by increasing frequency.
  * OUT assertions: the field len is set to the optimal bit length, the
  *     array bl_count contains the frequencies for each bit length.
  *     The length opt_len is updated; static_len is also updated if stree is
  *     not null. Used by build_tree().
  */
-static void gen_bitlen(deflate_state *s, tree_desc *desc) {
+static void gen_bitlen(deflate_state *s, tree_desc *desc, const int *order, int order_max) {
     /* desc: the tree descriptor */
     ct_data *tree           = desc->dyn_tree;
     int max_code            = desc->max_code;
@@ -294,10 +294,10 @@ static void gen_bitlen(deflate_state *s, tree_desc *desc) {
     /* In a first pass, compute the optimal bit lengths (which may
      * overflow in the case of the bit length tree).
      */
-    tree[s->heap[s->heap_max]].Len = 0; /* root of the heap */
+    tree[order[order_max]].Len = 0; /* root of the tree */
 
-    for (h = s->heap_max + 1; h < HEAP_SIZE; h++) {
-        n = s->heap[h];
+    for (h = order_max + 1; h < HEAP_SIZE; h++) {
+        n = order[h];
         bits = tree[tree[n].Dad].Len + 1u;
         if (bits > max_length){
             bits = max_length;
@@ -346,7 +346,7 @@ static void gen_bitlen(deflate_state *s, tree_desc *desc) {
     for (bits = max_length; bits != 0; bits--) {
         n = s->bl_count[bits];
         while (n != 0) {
-            m = s->heap[--h];
+            m = order[--h];
             if (m > max_code)
                 continue;
             if (tree[m].Len != bits) {

--- a/trees.c
+++ b/trees.c
@@ -67,7 +67,7 @@ static const static_tree_desc  static_bl_desc =
  */
 
 static void init_block       (deflate_state *s);
-static inline void pqdownheap       (unsigned char *depth, int *heap, const int heap_len, ct_data *tree, int k);
+static inline void pqdownheap       (uint64_t *pq, const int heap_len, int k);
 static void build_tree       (deflate_state *s, tree_desc *desc);
 static void gen_bitlen       (deflate_state *s, tree_desc *desc);
 static void scan_tree        (deflate_state *s, ct_data *tree, int max_code);
@@ -124,24 +124,16 @@ static void init_block(deflate_state *s) {
 #define SMALLEST 1
 /* Index within the heap array of least frequent node in the Huffman tree */
 
-
-/* ===========================================================================
- * Compares to subtrees, using the tree depth as tie breaker when
- * the subtrees have equal frequency. This minimizes the worst case length.
- */
-#define smaller(tree, n, m, depth) \
-    (tree[n].Freq < tree[m].Freq || \
-    (tree[n].Freq == tree[m].Freq && depth[n] <= depth[m]))
-
-/* ===========================================================================
- * Remove the smallest element from the heap and recreate the heap with
- * one less element. Updates heap and heap_len. Used by build_tree().
- */
-#define pqremove(s, depth, heap, tree, top) { \
-    top = heap[SMALLEST]; \
-    heap[SMALLEST] = heap[s->heap_len--]; \
-    pqdownheap(depth, heap, s->heap_len, tree, SMALLEST); \
-}
+/* Heap entries pack (freq << 8 | depth) above the node index, so a single 64-bit compare orders
+ * nodes by frequency, breaking ties by subtree depth to minimize the worst-case code length.
+ * Freq and depth of a node never change while it is in the heap, so packed entries stay valid. */
+#define PQ_NODE_BITS 10
+#define pq_pack(freq, depth, node) \
+    (((uint64_t)(freq) << (PQ_NODE_BITS + 8)) | ((uint64_t)(depth) << PQ_NODE_BITS) | (unsigned)(node))
+#define pq_key(e)   ((e) >> PQ_NODE_BITS)
+#define pq_node(e)  ((int)((e) & (((uint64_t)1 << PQ_NODE_BITS) - 1)))
+#define pq_freq(e)  ((uint32_t)((e) >> (PQ_NODE_BITS + 8)))
+#define pq_depth(e) ((uint32_t)(((e) >> PQ_NODE_BITS) & 0xFF))
 
 /* ===========================================================================
  * Restore the heap property by moving down the tree starting at node k,
@@ -149,29 +141,29 @@ static void init_block(deflate_state *s) {
  * when the heap property is re-established (each father smaller than its
  * two sons). Used by build_tree().
  */
-static inline void pqdownheap(unsigned char *depth, int *heap, const int heap_len, ct_data *tree, int k) {
-    /* tree: the tree to restore */
+static inline void pqdownheap(uint64_t *pq, const int heap_len, int k) {
     /* k: node to move down */
     int j = k << 1;  /* left son of k */
-    const int v = heap[k];
+    const uint64_t v = pq[k];
+    const uint64_t vk = pq_key(v);
 
     while (j <= heap_len) {
         /* Set j to the smallest of the two sons: */
-        if (j < heap_len && smaller(tree, heap[j+1], heap[j], depth)) {
+        if (j < heap_len && pq_key(pq[j+1]) <= pq_key(pq[j])) {
             j++;
         }
         /* Exit if v is smaller than both sons */
-        if (smaller(tree, v, heap[j], depth))
+        if (vk <= pq_key(pq[j]))
             break;
 
         /* Exchange v with the smallest son */
-        heap[k] = heap[j];
+        pq[k] = pq[j];
         k = j;
 
         /* And continue down the tree, setting j to the left son of k */
         j <<= 1;
     }
-    heap[k] = v;
+    pq[k] = v;
 }
 
 /* ===========================================================================
@@ -184,26 +176,24 @@ static inline void pqdownheap(unsigned char *depth, int *heap, const int heap_le
  */
 static void build_tree(deflate_state *s, tree_desc *desc) {
     /* desc: the tree descriptor */
-    unsigned char *depth  = s->depth;
-    int *heap             = s->heap;
     ct_data *tree         = desc->dyn_tree;
     const ct_data *stree  = desc->stat_desc->static_tree;
     int elems             = desc->stat_desc->elems;
     int n, m;          /* iterate over heap elements */
     int max_code = -1; /* largest code with non zero frequency */
     int node;          /* new node being created */
+    int heap_len = 0;
+    int heap_max = HEAP_SIZE;
+    uint64_t pq[L_CODES + 1]; /* packed priority queue, entries 1..heap_len */
 
     /* Construct the initial heap, with least frequent element in
-     * heap[SMALLEST]. The sons of heap[n] are heap[2*n] and heap[2*n+1].
-     * heap[0] is not used.
+     * pq[SMALLEST]. The sons of pq[n] are pq[2*n] and pq[2*n+1].
+     * pq[0] is not used.
      */
-    s->heap_len = 0;
-    s->heap_max = HEAP_SIZE;
-
     for (n = 0; n < elems; n++) {
         if (tree[n].Freq != 0) {
-            heap[++(s->heap_len)] = max_code = n;
-            depth[n] = 0;
+            pq[++heap_len] = pq_pack(tree[n].Freq, 0, n);
+            max_code = n;
         } else {
             tree[n].Len = 0;
         }
@@ -214,10 +204,10 @@ static void build_tree(deflate_state *s, tree_desc *desc) {
      * possible code. So to avoid special checks later on we force at least
      * two codes of non zero frequency.
      */
-    while (s->heap_len < 2) {
-        node = heap[++(s->heap_len)] = (max_code < 2 ? ++max_code : 0);
+    while (heap_len < 2) {
+        node = (max_code < 2 ? ++max_code : 0);
+        pq[++heap_len] = pq_pack(1, 0, node);
         tree[node].Freq = 1;
-        depth[node] = 0;
         s->opt_len--;
         if (stree)
             s->static_len -= stree[node].Len;
@@ -225,27 +215,34 @@ static void build_tree(deflate_state *s, tree_desc *desc) {
     }
     desc->max_code = max_code;
 
-    /* The elements heap[heap_len/2+1 .. heap_len] are leaves of the tree,
+    /* The elements pq[heap_len/2+1 .. heap_len] are leaves of the tree,
      * establish sub-heaps of increasing lengths:
      */
-    for (n = s->heap_len/2; n >= 1; n--)
-        pqdownheap(depth, heap, s->heap_len, tree, n);
+    for (n = heap_len/2; n >= 1; n--)
+        pqdownheap(pq, heap_len, n);
 
     /* Construct the Huffman tree by repeatedly combining the least two
      * frequent nodes.
      */
     node = elems;              /* next internal node of the tree */
     do {
-        pqremove(s, depth, heap, tree, n);  /* n = node of least frequency */
-        m = heap[SMALLEST]; /* m = node of next least frequency */
+        /* n = node of least frequency, m = node of next least frequency */
+        const uint64_t en = pq[SMALLEST];
+        pq[SMALLEST] = pq[heap_len--];
+        pqdownheap(pq, heap_len, SMALLEST);
+        const uint64_t em = pq[SMALLEST];
+        n = pq_node(en);
+        m = pq_node(em);
 
-        heap[--(s->heap_max)] = n; /* keep the nodes sorted by frequency */
-        heap[--(s->heap_max)] = m;
+        s->heap[--heap_max] = n; /* keep the nodes sorted by frequency */
+        s->heap[--heap_max] = m;
 
-        /* Create a new node father of n and m */
-        tree[node].Freq = tree[n].Freq + tree[m].Freq;
-        depth[node] = (unsigned char)((depth[n] >= depth[m] ?
-                                          depth[n] : depth[m]) + 1);
+        /* Create a new node father of n and m. Freq and depth wrap the same way the uint16_t
+         * and unsigned char state fields did. */
+        const uint16_t f = (uint16_t)(pq_freq(en) + pq_freq(em));
+        const unsigned char d = (unsigned char)((pq_depth(en) >= pq_depth(em) ?
+                                          pq_depth(en) : pq_depth(em)) + 1);
+        tree[node].Freq = f;
         tree[n].Dad = tree[m].Dad = (uint16_t)node;
 #ifdef DUMP_BL_TREE
         if (tree == s->bl_tree) {
@@ -254,11 +251,13 @@ static void build_tree(deflate_state *s, tree_desc *desc) {
         }
 #endif
         /* and insert the new node in the heap */
-        heap[SMALLEST] = node++;
-        pqdownheap(depth, heap, s->heap_len, tree, SMALLEST);
-    } while (s->heap_len >= 2);
+        pq[SMALLEST] = pq_pack(f, d, node);
+        node++;
+        pqdownheap(pq, heap_len, SMALLEST);
+    } while (heap_len >= 2);
 
-    heap[--(s->heap_max)] = heap[SMALLEST];
+    s->heap[--heap_max] = pq_node(pq[SMALLEST]);
+    s->heap_max = heap_max;
 
     /* At this point, the fields freq and dad are set. We can now
      * generate the bit lengths.

--- a/trees.c
+++ b/trees.c
@@ -67,7 +67,7 @@ static const static_tree_desc  static_bl_desc =
  */
 
 static void init_block       (deflate_state *s);
-static void pq_radix_pass    (const uint32_t *src, uint32_t *dst, int n, int shift);
+static void pq_radix_pass    (const uint32_t *src, uint32_t *dst, int n, int shift, uint16_t *count);
 static void build_tree       (deflate_state *s, tree_desc *desc);
 static void gen_bitlen       (deflate_state *s, tree_desc *desc, const int *order, int order_max);
 static void scan_tree        (deflate_state *s, ct_data *tree, int max_code);
@@ -131,15 +131,12 @@ static void init_block(deflate_state *s) {
 
 /* ===========================================================================
  * One stable counting-sort pass over an 8-bit digit of the packed entries.
- * Used by build_tree().
+ * count holds the digit histogram at offset +1, accumulated during the leaf
+ * scan, and is turned into running start positions here. Used by build_tree().
  */
-static void pq_radix_pass(const uint32_t *src, uint32_t *dst, int n, int shift) {
-    uint16_t count[257];
+static void pq_radix_pass(const uint32_t *src, uint32_t *dst, int n, int shift, uint16_t *count) {
     int i;
 
-    memset(count, 0, sizeof(count));
-    for (i = 0; i < n; i++)
-        count[((src[i] >> shift) & 0xFF) + 1]++;
     for (i = 1; i <= 256; i++)
         count[i] = (uint16_t)(count[i] + count[i-1]);
     for (i = 0; i < n; i++)
@@ -181,10 +178,17 @@ static void build_tree(deflate_state *s, tree_desc *desc) {
     uint32_t scratch[L_CODES + 1]; /* radix buffer, then FIFO of created internal nodes */
     uint32_t *internals = scratch;
     int order[HEAP_SIZE];          /* tree nodes in merge order, filled from the top down */
+    uint16_t count_lo[257];        /* histogram of the low frequency byte, at offset +1 */
+    uint16_t count_hi[257];        /* histogram of the high frequency byte, at offset +1 */
 
+    memset(count_lo, 0, sizeof(count_lo));
+    memset(count_hi, 0, sizeof(count_hi));
     for (n = 0; n < elems; n++) {
-        if (tree[n].Freq != 0) {
-            leaves[nleaves++] = pq_pack(tree[n].Freq, n);
+        const uint16_t freq = tree[n].Freq;
+        if (freq != 0) {
+            leaves[nleaves++] = pq_pack(freq, n);
+            count_lo[(freq & 0xFF) + 1]++;
+            count_hi[(freq >> 8) + 1]++;
             max_code = n;
         } else {
             tree[n].Len = 0;
@@ -209,7 +213,8 @@ static void build_tree(deflate_state *s, tree_desc *desc) {
 
     /* Sort the leaves by packed entry. The scan above appended them in node order, which is
      * ascending in the node bits, so two stable passes over the freq bytes finish the sort.
-     * A forced node can arrive out of node order, but then there are exactly two leaves. */
+     * A forced node can arrive out of node order, but then there are exactly two leaves,
+     * so the radix path only ever sorts entries the histograms counted. */
     if (nleaves == 2) {
         if (leaves[0] > leaves[1]) {
             const uint32_t t = leaves[0];
@@ -217,8 +222,8 @@ static void build_tree(deflate_state *s, tree_desc *desc) {
             leaves[1] = t;
         }
     } else {
-        pq_radix_pass(leaves, scratch, nleaves, PQ_NODE_BITS);
-        pq_radix_pass(scratch, leaves, nleaves, PQ_NODE_BITS + 8);
+        pq_radix_pass(leaves, scratch, nleaves, PQ_NODE_BITS, count_lo);
+        pq_radix_pass(scratch, leaves, nleaves, PQ_NODE_BITS + 8, count_hi);
     }
 
     /* Construct the Huffman tree by repeatedly combining the least two frequent nodes.


### PR DESCRIPTION
Replaces the binary heap in `build_tree` with sorted construction, eliminating the heap's data-dependent sift-down branches.

Seven commits, each building and passing tests independently:

1. Pack freq, depth and node into 64-bit heap entries, making each heap comparison a single compare with no loads from `tree[]` or `depth[]`. Bit-identical output.
2. Break equal-frequency ties by node index instead of subtree depth. The only commit that changes output bytes: net -87 bytes across calgary, canterbury and silesia at levels 6 and 9 (139.7 MB total), single files within ±58 bytes.
3. Replace the heap with counting sort and a two-queue merge. The sorted leaves form one queue and newly created internal nodes form a second, which stays sorted on its own because merge sums never decrease, so every merge takes the two smallest nodes from the queue heads. Byte-identical to its parent, since a total order makes the merge sequence unique.
4. Move the merge-order array out of `deflate_state`. With commit 1 the struct shrinks by ~2.9 KiB.
5. Build the radix histograms during the leaf scan, which already visits every nonzero frequency, reducing each counting-sort pass to prefix sums plus placement.
6. Sort with a single radix pass when every frequency fits in one byte, the common case for the distance and bit length trees and for small flush blocks.
7. Add a `sync_flush` variant to the deflate benchmark, since the suite had no workload that exercises flush-cadence tree construction. Whole-buffer compression becomes the degenerate single-chunk case of the same bench loop.

Measured on Apple M5 (arm64, clang), silesia.tar, whole series versus the PR base with an interleaved single-binary A/B: both `build_tree` variants plus a zero-effect control copy of the base compiled into one library, executed round-robin. The control stayed within ±0.1% of the base in every run, and per-run checksums verified each variant's output.

| workload | vs develop |
|---|---|
| level 6 bulk | -3.1% |
| level 6, 64 KiB `Z_SYNC_FLUSH` chunks | -4.2% |
| level 6, 16 KiB chunks | -8.6% |
| level 6, 4 KiB chunks | -20.9% |
| level 6, 1 KiB chunks | -30.7% |
| level 3 bulk | -4.7% |
| level 9 bulk | -1.4% |

The win scales with flush frequency because tree construction dominates when blocks are small, ~24% of all deflate cycles at a 4 KiB cadence. Level 1 is unaffected, `deflate_quick` never builds dynamic trees.

Supersedes #2409.


