### PR TITLE
Fix minimum Windows API version for benchmarks under MinGW.

### DIFF
--- a/test/benchmarks/CMakeLists.txt
+++ b/test/benchmarks/CMakeLists.txt
@@ -74,6 +74,11 @@ add_executable(benchmark_zlib ${BENCH_PUBLIC_SRCS})
 target_compile_definitions(benchmark_zlib PRIVATE
     -DBENCHMARK_STATIC_DEFINE
     -DTEST_DATA_DIR="${PROJECT_SOURCE_DIR}/test/data")
+
+if(MINGW)
+    target_compile_definitions(benchmark_zlib PRIVATE -D_WIN32_WINNT=_WIN32_WINNT_WIN10)
+endif()
+
 target_include_directories(benchmark_zlib PRIVATE
     ${PROJECT_SOURCE_DIR}
     ${PROJECT_BINARY_DIR}

--- a/test/benchmarks/benchmark_main.cc
+++ b/test/benchmarks/benchmark_main.cc
@@ -10,7 +10,9 @@
 #include <limits.h>
 
 #ifdef _WIN32
-#  define NOMINMAX
+#  ifndef NOMINMAX
+#    define NOMINMAX
+#  endif
 #  include <windows.h>
 #else
 #  include <unistd.h>
@@ -163,7 +165,7 @@ int main(int argc, char** argv) {
     }
 
     if (no_power_throttling) {
-#  ifdef PROCESS_POWER_THROTTLING_CURRENT_VERSION
+#  if _WIN32_WINNT >= _WIN32_WINNT_WIN10
         /* Clear the execution-speed bit to opt out of EcoQoS so the process runs at full
            clock on performance cores. */
         PROCESS_POWER_THROTTLING_STATE state;
@@ -174,7 +176,7 @@ int main(int argc, char** argv) {
         if (!SetProcessInformation(GetCurrentProcess(), ProcessPowerThrottling, &state, sizeof(state)))
             fprintf(stderr, "warning: failed to disable power throttling (error %lu)\n", GetLastError());
 #  else
-        fprintf(stderr, "warning: --benchmark_no_power_throttling requires a Windows 10 SDK\n");
+        fprintf(stderr, "warning: --benchmark_no_power_throttling requires targeting Windows 10 or later\n");
 #  endif
     }
 


### PR DESCRIPTION
* Fixes missing `SetProcessInformation`
* Don't redefine `NOMINMAX` under MinGW, it's already defined in `bits/os_defines.h`