### PR TITLE
Optimize deflate_medium Part 1

### DIFF
--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -21,7 +21,7 @@ struct match {
 };
 
 /* insert_match assumes: s->lookahead > match.match_length + WANT_MIN_MATCH */
-static void insert_match(deflate_state *s, unsigned char *window, struct match match, const uint32_t max_len) {
+static void insert_match(deflate_state *s, unsigned char *Z_RESTRICT window, struct match match, const uint32_t max_len) {
     uint32_t match_len = match.match_length;
     uint32_t strstart = match.strstart;
 
@@ -98,7 +98,7 @@ Z_FORCEINLINE static struct match find_best_match(deflate_state *s, uint32_t has
  * - (current->match_length - 1) <= next->match_start
  * - (current->match_length - 1) <= next->strstart
  */
-static void fizzle_matches(deflate_state *s, unsigned char *window, struct match *current, struct match *next) {
+static void fizzle_matches(deflate_state *s, unsigned char *Z_RESTRICT window, struct match *Z_RESTRICT current, struct match *Z_RESTRICT next) {
     unsigned char *match, *orig;
     struct match c, n;
     int changed = 0;

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -67,7 +67,7 @@ static void insert_match(deflate_state *s, unsigned char *window, struct match m
     /* Insert new strings in the hash table only if the match length
      * is not too large. This saves time but degrades compression.
      */
-    if (match_len <= max_len && s->lookahead >= WANT_MIN_MATCH) {
+    if (match_len <= max_len) {
         match_len--; /* string at strstart already in table */
         strstart++;
 
@@ -83,10 +83,6 @@ static void insert_match(deflate_state *s, unsigned char *window, struct match m
     } else {
         strstart += match_len;
         insert_knuth(s, window, strstart + 2 - STD_MIN_MATCH);
-
-        /* If lookahead < WANT_MIN_MATCH, ins_h is garbage, but it does not
-         * matter since it will be recomputed at next deflate call.
-         */
     }
 }
 

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -184,6 +184,7 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
 
     for (;;) {
         int bflush = 0;       /* set if current block must be flushed */
+        uint32_t curr_match_len;
 
         /* Make sure that we always have enough lookahead, except
          * at the end of the input file. We need STD_MAX_MATCH bytes
@@ -216,26 +217,32 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
 
             current_match = find_best_match(s, hash_head);
         }
+        curr_match_len = current_match.match_length;
 
-        if (LIKELY(s->lookahead > (unsigned int)(current_match.match_length + WANT_MIN_MATCH)))
+        if (LIKELY(s->lookahead > (unsigned int)(curr_match_len + WANT_MIN_MATCH)))
             insert_match(s, window, current_match, max_len);
 
         /* now, look ahead one */
-        if (LIKELY(!early_exit && s->lookahead > MIN_LOOKAHEAD && (uint32_t)(current_match.strstart + current_match.match_length) < window_end)) {
-            s->strstart = current_match.strstart + current_match.match_length;
+        if (LIKELY(!early_exit && s->lookahead > MIN_LOOKAHEAD && (uint32_t)(current_match.strstart + curr_match_len) < window_end)) {
+            s->strstart = current_match.strstart + curr_match_len;
             uint32_t hash_head = insert_knuth(s, window, s->strstart);
 
             next_match = find_best_match(s, hash_head);
 
-            uint32_t tmp_cmatch_len_sub = current_match.match_length - 1;
+            uint32_t tmp_cmatch_len_sub = curr_match_len - 1;
             if (tmp_cmatch_len_sub
                      && next_match.match_length >= WANT_MIN_MATCH
                      && tmp_cmatch_len_sub <= next_match.match_start
                      && tmp_cmatch_len_sub <= next_match.strstart) {
                 fizzle_matches(s, window, &current_match, &next_match);
+                curr_match_len = current_match.match_length;
             }
 
             s->strstart = current_match.strstart;
+            if (curr_match_len == 0) {
+                /* If current match fizzled out, jump to next loop iteration */
+                continue;
+            }
         } else {
             next_match.match_length = 0;
         }
@@ -244,7 +251,7 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
         bflush = emit_match(s, window, current_match);
 
         /* move the "cursor" forward */
-        s->strstart += current_match.match_length;
+        s->strstart += curr_match_len;
 
         if (UNLIKELY(bflush))
             FLUSH_BLOCK(s, window, 0);

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -187,7 +187,6 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
     int early_exit = s->level < 5;
 
     for (;;) {
-        uint32_t hash_head = 0;    /* head of the hash chain */
         int bflush = 0;       /* set if current block must be flushed */
 
         /* Make sure that we always have enough lookahead, except
@@ -214,7 +213,7 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
             current_match = next_match;
             next_match.match_length = 0;
         } else {
-            hash_head = 0;
+            uint32_t hash_head = 0;   /* head of the hash chain */
             if (LIKELY(s->lookahead >= WANT_MIN_MATCH)) {
                 hash_head = insert_knuth(s, window, s->strstart);
             }
@@ -228,7 +227,7 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
         /* now, look ahead one */
         if (LIKELY(!early_exit && s->lookahead > MIN_LOOKAHEAD && (uint32_t)(current_match.strstart + current_match.match_length) < window_end)) {
             s->strstart = current_match.strstart + current_match.match_length;
-            hash_head = insert_knuth(s, window, s->strstart);
+            uint32_t hash_head = insert_knuth(s, window, s->strstart);
 
             next_match = find_best_match(s, hash_head);
 

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -20,26 +20,13 @@ struct match {
     uint16_t orgstart;
 };
 
-/* insert_match assumes: s->lookahead > match.match_length + WANT_MIN_MATCH */
+/* insert_match assumes:
+ * - s->lookahead > match.match_length + WANT_MIN_MATCH
+ * - match_len >= WANT_MIN_MATCH
+ */
 static void insert_match(deflate_state *s, unsigned char *Z_RESTRICT window, struct match match, const uint32_t max_len) {
     uint32_t match_len = match.match_length;
     uint32_t strstart = match.strstart;
-
-    /* matches that are not long enough we need to emit as literals */
-    if (LIKELY(match_len < WANT_MIN_MATCH)) {
-        strstart++;
-        match_len--;
-        if (UNLIKELY(match_len > 0)) {
-            if (strstart >= match.orgstart) {
-                if (strstart + match_len - 1 >= match.orgstart) {
-                    insert_knuth_batch(s, window, strstart, match_len);
-                } else {
-                    insert_knuth_batch(s, window, strstart, match.orgstart - strstart + 1);
-                }
-            }
-        }
-        return;
-    }
 
     /* Insert new strings in the hash table only if the match length
      * is not too large. This saves time but degrades compression.
@@ -196,8 +183,9 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
         }
         curr_match_len = current_match.match_length;
 
-        if (LIKELY(s->lookahead > (unsigned int)(curr_match_len + WANT_MIN_MATCH)))
+        if (curr_match_len >= WANT_MIN_MATCH && s->lookahead > (unsigned int)(curr_match_len + WANT_MIN_MATCH )) {
             insert_match(s, window, current_match, max_len);
+        }
 
         /* now, look ahead one */
         if (LIKELY(!early_exit && s->lookahead > MIN_LOOKAHEAD && (uint32_t)(current_match.strstart + curr_match_len) < window_end)) {

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -44,7 +44,7 @@ static int emit_match(deflate_state *s, unsigned char *window, struct match matc
 }
 
 /* insert_match assumes: s->lookahead > match.match_length + WANT_MIN_MATCH */
-static void insert_match(deflate_state *s, unsigned char *window, struct match match) {
+static void insert_match(deflate_state *s, unsigned char *window, struct match match, const uint32_t max_len) {
     uint32_t match_len = match.match_length;
     uint32_t strstart = match.strstart;
 
@@ -67,7 +67,7 @@ static void insert_match(deflate_state *s, unsigned char *window, struct match m
     /* Insert new strings in the hash table only if the match length
      * is not too large. This saves time but degrades compression.
      */
-    if (match_len <= 16 * s->max_insert_length && s->lookahead >= WANT_MIN_MATCH) {
+    if (match_len <= max_len && s->lookahead >= WANT_MIN_MATCH) {
         match_len--; /* string at strstart already in table */
         strstart++;
 
@@ -180,6 +180,8 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
     ALIGNED_(16) struct match current_match = {0};
                  struct match next_match = {0};
     unsigned char *window = s->window;
+    uint32_t window_end = s->window_size - MIN_LOOKAHEAD;
+    uint32_t max_len = 16 * s->max_insert_length;
 
     /* For levels below 5, don't check the next position for a better match */
     int early_exit = s->level < 5;
@@ -221,10 +223,10 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
         }
 
         if (LIKELY(s->lookahead > (unsigned int)(current_match.match_length + WANT_MIN_MATCH)))
-            insert_match(s, window, current_match);
+            insert_match(s, window, current_match, max_len);
 
         /* now, look ahead one */
-        if (LIKELY(!early_exit && s->lookahead > MIN_LOOKAHEAD && (uint32_t)(current_match.strstart + current_match.match_length) < (s->window_size - MIN_LOOKAHEAD))) {
+        if (LIKELY(!early_exit && s->lookahead > MIN_LOOKAHEAD && (uint32_t)(current_match.strstart + current_match.match_length) < window_end)) {
             s->strstart = current_match.strstart + current_match.match_length;
             hash_head = insert_knuth(s, window, s->strstart);
 

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -20,29 +20,6 @@ struct match {
     uint16_t orgstart;
 };
 
-static int emit_match(deflate_state *s, unsigned char *window, struct match match) {
-    int bflush = 0;
-    uint32_t match_len = match.match_length;
-
-    /* None of the below functions care about s->lookahead, so decrement it early */
-    s->lookahead -= match_len;
-
-    /* matches that are not long enough we need to emit as literals */
-    if (match_len < WANT_MIN_MATCH) {
-        while (match_len) {
-            bflush += zng_tr_tally_lit(s, window[match.strstart]);
-            match_len--;
-            match.strstart++;
-        }
-        return bflush;
-    }
-
-    check_match(s, match.strstart, match.match_start, match_len);
-
-    bflush += zng_tr_tally_dist(s, match.strstart - match.match_start, match_len - STD_MIN_MATCH);
-    return bflush;
-}
-
 /* insert_match assumes: s->lookahead > match.match_length + WANT_MIN_MATCH */
 static void insert_match(deflate_state *s, unsigned char *window, struct match match, const uint32_t max_len) {
     uint32_t match_len = match.match_length;
@@ -248,7 +225,14 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
         }
 
         /* now emit the current match */
-        bflush = emit_match(s, window, current_match);
+        s->lookahead -= curr_match_len;
+        if (LIKELY(curr_match_len == 1)) {
+            /* matches shorter than WANT_MIN_MATCH are set to 1, we need to emit these as literals */
+            bflush = zng_tr_tally_lit(s, window[current_match.strstart]);
+        } else {
+            check_match(s, current_match.strstart, current_match.match_start, curr_match_len);
+            bflush = zng_tr_tally_dist(s, current_match.strstart - current_match.match_start, curr_match_len - STD_MIN_MATCH);
+        }
 
         /* move the "cursor" forward */
         s->strstart += curr_match_len;

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -92,13 +92,13 @@ static void insert_match(deflate_state *s, unsigned char *window, struct match m
 
 Z_FORCEINLINE static struct match find_best_match(deflate_state *s, uint32_t hash_head) {
     struct match m;
-    int64_t dist;
+    int32_t dist;
 
     m.strstart = (uint16_t)s->strstart;
     m.orgstart = m.strstart;
 
-    dist = (int64_t)s->strstart - hash_head;
-    if (dist <= MAX_DIST(s) && dist > 0 && hash_head != 0) {
+    dist = (int32_t)s->strstart - (int32_t)hash_head;
+    if (dist <= (int32_t)MAX_DIST(s) && dist > 0 && hash_head != 0) {
         /* To simplify the code, we prevent matches with the string
          * of window index 0 (in particular we have to avoid a match
          * of the string with itself at the start of the input file).


### PR DESCRIPTION
- Precompute max_len and window_end to avoid doing it every loop iteration.
- Use local lookahead variable to avoid repeated indirection penalty.
- Add restrict for pointers that will not alias.
- Force inlining of insert_match, normally already being inlined.
- Don't init hash_head twice.
- Reduce dist from int64_t to int32_t.
- Remove emit_match().
- Remove dead code in insert_match()

Turns out the only reason we had a loop in emit_match() is because match_len can be 0 or 1, so it would fail without a check for 0.

None of this should cause changes in compression output.

PS: Easiest to review one commit at a time.