### PR TITLE
Add comments about correct z_const usage

### DIFF
--- a/zconf-ng.h.in
+++ b/zconf-ng.h.in
@@ -19,7 +19,8 @@
 #  define __has_declspec_attribute(x) 0
 #endif
 
-/* Always define z_const as const */
+/* Always define z_const as const.
+ * Only for use on API-visible variables. */
 #define z_const const
 
 /* Maximum value for memLevel in deflateInit2 */

--- a/zconf.h.in
+++ b/zconf.h.in
@@ -19,6 +19,7 @@
 #  define __has_declspec_attribute(x) 0
 #endif
 
+/* Only for use on API-visible variables. */
 #ifndef z_const
 #  ifdef ZLIB_CONST
 #    define z_const const


### PR DESCRIPTION
zlib-ng uses const internally and only needs z_const for externally visible variables.
Add comments to that effect at definition of z_const.