### PR TITLE
arm: probe hw.optional.arm.FEAT_CRC32 with legacy fallback on Darwin

### DIFF
--- a/arch/arm/arm_features.c
+++ b/arch/arm/arm_features.c
@@ -61,8 +61,14 @@ static int arm_has_crc32(void) {
 #elif defined(__APPLE__)
     int has_feat = 0;
     size_t size = sizeof(has_feat);
-    has_crc32 = sysctlbyname("hw.optional.armv8_crc32", &has_feat, &size, NULL, 0) == 0
+    has_crc32 = sysctlbyname("hw.optional.arm.FEAT_CRC32", &has_feat, &size, NULL, 0) == 0
         && has_feat == 1;
+    /* Fallback to legacy name for older macOS versions */
+    if (!has_crc32) {
+        size = sizeof(has_feat);
+        has_crc32 = sysctlbyname("hw.optional.armv8_crc32", &has_feat, &size, NULL, 0) == 0
+            && has_feat == 1;
+    }
 #elif defined(_WIN32)
     has_crc32 = IsProcessorFeaturePresent(PF_ARM_V8_CRC32_INSTRUCTIONS_AVAILABLE);
 #endif


### PR DESCRIPTION
### Summary
Probe `hw.optional.arm.FEAT_CRC32` with a fallback to `hw.optional.armv8_crc32` on Darwin (macOS/iOS).

### Background
While integrating zlib-ng into [TTZip](https://github.com/wittkung/TTZip) as our streaming Deflate engine and validating hardware-accelerated feature detection on macOS (Apple Silicon), we noticed a small inconsistency in Darwin CPU feature probing.

First of all, huge thanks to the zlib-ng maintainers for building such a solid, high-performance library! We would love to contribute this minor cleanup back upstream.

### Historical Context & Prior Decisions
In recent ARM64 Darwin probing improvements—notably PR #2023 (commit `b5638a82`) and PR #2041 (commit `1c20d159`)—feature detection routines in `arch/arm/arm_features.c` transitioned to querying modern Apple Silicon sysctl keys (`hw.optional.arm.FEAT_*`) with legacy fallback mechanisms where applicable:
- `arm_has_pmull()` queries `hw.optional.arm.FEAT_PMULL` (introduced in PR #2023);
- `arm_has_dotprod()` queries `hw.optional.arm.FEAT_DotProd`;
- `arm_has_eor3()` queries `hw.optional.arm.FEAT_SHA3`, falling back to `hw.optional.armv8_2_sha3` (PR #2041).

However, `arm_has_crc32()` was previously still querying only the older `hw.optional.armv8_crc32` key. This PR brings `arm_has_crc32()` into complete consistency with the pattern established in PR #2023 and PR #2041 by:
1. First probing `hw.optional.arm.FEAT_CRC32` (standard on modern Darwin / macOS 14+);
2. Gracefully falling back to `hw.optional.armv8_crc32` if the first sysctl query fails.

### Technical Details & Boundary Safety
- **Zero Overhead on Modern Systems**: On Apple Silicon running macOS 14+, `hw.optional.arm.FEAT_CRC32` succeeds on the first call, skipping the fallback branch.
- **Defensive Size Reset**: `size` is explicitly reset to `sizeof(has_feat)` prior to the fallback call, ensuring the correct buffer size is passed to `sysctlbyname()`.
- **Clean Invariant**: If both queries fail (e.g. non-CRC32 environment or legacy emulation), `has_crc32` remains `0` safely.

### Verification
- **Target Platform**: Apple Silicon (arm64), macOS Sonoma / Sequoia (Darwin 23.x / 24.x)
- **Compiler**: Apple Clang 16.0.0 (`-O3 -Wall -Wextra`)
- **Direct Probe Verification**:
  - `sysctlbyname("hw.optional.arm.FEAT_CRC32", ...)` -> `ret = 0, val = 1`
  - `sysctlbyname("hw.optional.armv8_crc32", ...)` -> `ret = 0, val = 1`
- **Regression Suite**:
  - `ctest --test-dir build --output-on-failure` passed **70/70 tests (100%)**.

---
*Happy to make any further adjustments if preferred by the maintainers!*
