### PR TITLE
Deprecate the zng_adler32() and zng_crc32() functions

### DIFF
--- a/test/example.c
+++ b/test/example.c
@@ -790,7 +790,7 @@ static void test_deflate_prime(unsigned char *compr, size_t comprLen, unsigned c
         CHECK_ERR(err, "deflate");
 
     /* Gzip uncompressed data crc32 */
-    crc = PREFIX(crc32)(0, (const uint8_t *)hello, (uint32_t)len);
+    crc = PREFIX(crc32_z)(0, (const uint8_t *)hello, (size_t)len);
     err = deflate_prime_32(&c_stream, crc);
     CHECK_ERR(err, "deflatePrime");
     /* Gzip uncompressed data length */

--- a/test/fuzz/fuzzer_checksum.c
+++ b/test/fuzz/fuzzer_checksum.c
@@ -7,10 +7,10 @@
 #endif
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t dataLen) {
-    uint32_t crc0 = PREFIX(crc32)(0L, NULL, 0);
+    uint32_t crc0 = PREFIX(crc32_z)(0L, NULL, 0);
     uint32_t crc1 = crc0;
     uint32_t crc2 = crc0;
-    uint32_t adler0 = PREFIX(adler32)(0L, NULL, 0);
+    uint32_t adler0 = PREFIX(adler32_z)(0L, NULL, 0);
     uint32_t adler1 = adler0;
     uint32_t adler2 = adler0;
     uint32_t combine1, combine2;

--- a/test/test_deflate_prime.cc
+++ b/test/test_deflate_prime.cc
@@ -60,7 +60,7 @@ TEST(deflate, prime) {
     EXPECT_EQ(err, Z_STREAM_END);
 
     /* Gzip uncompressed data crc32 */
-    crc = PREFIX(crc32)(0, (const uint8_t *)hello, (uint32_t)hello_len);
+    crc = PREFIX(crc32_z)(0, (const uint8_t *)hello, (uint32_t)hello_len);
     err = deflate_prime_32(&c_stream, crc);
     EXPECT_EQ(err, Z_OK);
     /* Gzip uncompressed data length */

--- a/zconf-ng.h.in
+++ b/zconf-ng.h.in
@@ -91,6 +91,15 @@
 #  define Z_EXPORTVA
 #endif
 
+/* API deprecated warning support */
+#if defined(__clang__) || (defined(__GNUC__) && (__GNUC__ >= 4))
+    #define Z_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#elif defined(_MSC_VER) && (_MSC_VER >= 1400)
+    #define Z_DEPRECATED(msg) __declspec(deprecated(msg))
+#else
+    #define Z_DEPRECATED(msg)
+#endif
+
 /* Conditional exports */
 #define ZNG_CONDEXPORT Z_EXPORT
 

--- a/zlib-ng.h.in
+++ b/zlib-ng.h.in
@@ -1733,7 +1733,7 @@ void zng_gzclearerr(gzFile file);
 */
 
 Z_EXTERN Z_EXPORT
-uint32_t zng_adler32(uint32_t adler, const uint8_t *buf, uint32_t len);
+uint32_t zng_adler32_z(uint32_t adler, const uint8_t *buf, size_t len);
 /*
      Update a running Adler-32 checksum with the bytes buf[0..len-1] and
    return the updated checksum. An Adler-32 value is in the range of a 32-bit
@@ -1745,18 +1745,19 @@ uint32_t zng_adler32(uint32_t adler, const uint8_t *buf, uint32_t len);
 
    Usage example:
 
-     uint32_t adler = adler32(0L, NULL, 0);
+     uint32_t adler = zng_adler32_z(0L, NULL, 0);
 
      while (read_buffer(buffer, length) != EOF) {
-       adler = adler32(adler, buffer, length);
+       adler = zng_adler32_z(adler, buffer, length);
      }
      if (adler != original_adler) error();
 */
 
-Z_EXTERN Z_EXPORT
-uint32_t zng_adler32_z(uint32_t adler, const uint8_t *buf, size_t len);
+Z_EXTERN Z_EXPORT Z_DEPRECATED("zng_adler32() is deprecated, use zng_adler32_z() instead.")
+uint32_t zng_adler32(uint32_t adler, const uint8_t *buf, uint32_t len);
 /*
-     Same as adler32(), but with a size_t length.
+     DEPRECATED: will be removed in a later version.
+     Same as zng_adler32_z(), but with a uint32_t length.
 */
 
 Z_EXTERN Z_EXPORT
@@ -1771,7 +1772,7 @@ uint32_t zng_adler32_combine(uint32_t adler1, uint32_t adler2, z_off64_t len2);
 */
 
 Z_EXTERN Z_EXPORT
-uint32_t zng_crc32(uint32_t crc, const uint8_t *buf, uint32_t len);
+uint32_t zng_crc32_z(uint32_t crc, const uint8_t *buf, size_t len);
 /*
      Update a running CRC-32 with the bytes buf[0..len-1] and return the
    updated CRC-32. A CRC-32 value is in the range of a 32-bit unsigned integer.
@@ -1781,18 +1782,19 @@ uint32_t zng_crc32(uint32_t crc, const uint8_t *buf, uint32_t len);
 
    Usage example:
 
-     uint32_t crc = crc32(0L, NULL, 0);
+     uint32_t crc = zng_crc32_z(0L, NULL, 0);
 
      while (read_buffer(buffer, length) != EOF) {
-       crc = crc32(crc, buffer, length);
+       crc = zng_crc32_z(crc, buffer, length);
      }
      if (crc != original_crc) error();
 */
 
-Z_EXTERN Z_EXPORT
-uint32_t zng_crc32_z(uint32_t crc, const uint8_t *buf, size_t len);
+Z_EXTERN Z_EXPORT Z_DEPRECATED("zng_crc32() is deprecated, use zng_crc32_z() instead.")
+uint32_t zng_crc32(uint32_t crc, const uint8_t *buf, uint32_t len);
 /*
-     Same as crc32(), but with a size_t length.
+     DEPRECATED: will be removed in a later version.
+     Same as zng_crc32_z(), but with a uint32_t length.
 */
 
 Z_EXTERN Z_EXPORT


### PR DESCRIPTION
Deprecate the zng_adler32() and zng_crc32() functions.
Steer people towards the _z suffuxed functions that support size_t lengths.