### PR TITLE
Optimize deflate_medium Part 2

### DIFF
--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -25,29 +25,25 @@ struct match {
  * - match_len >= WANT_MIN_MATCH
  */
 static void insert_match(deflate_state *s, unsigned char *Z_RESTRICT window, struct match match, const uint32_t max_len) {
+    uint32_t start;
     uint32_t match_len = match.match_length;
-    uint32_t strstart = match.strstart;
+    uint32_t strstart = match.strstart + 1; // string at strstart already in table
+    uint32_t end = strstart + match_len - 1;
 
     /* Insert new strings in the hash table only if the match length
      * is not too large. This saves time but degrades compression.
      */
-    if (match_len <= max_len) {
-        match_len--; /* string at strstart already in table */
-        strstart++;
-
-        if (LIKELY(strstart >= match.orgstart)) {
-            if (LIKELY(strstart + match_len - 1 >= match.orgstart)) {
-                insert_knuth_batch(s, window, strstart, match_len);
-            } else {
-                insert_knuth_batch(s, window, strstart, match.orgstart - strstart + 1);
-            }
-        } else if (match.orgstart < strstart + match_len) {
-            insert_knuth_batch(s, window, match.orgstart, strstart + match_len - match.orgstart);
-        }
+    if (UNLIKELY(match_len > max_len)) {
+        // For too long matches, insert only the tail position.
+        start = end - 1;
     } else {
-        strstart += match_len;
-        insert_knuth(s, window, strstart + 2 - STD_MIN_MATCH);
+        start = strstart;
     }
+
+    if (UNLIKELY(start < (uint32_t)match.orgstart))
+        start = match.orgstart;
+
+    insert_knuth_batch(s, window, start, end - start);
 }
 
 Z_FORCEINLINE static struct match find_best_match(deflate_state *s, uint32_t hash_head) {

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -98,7 +98,6 @@ Z_FORCEINLINE static struct match find_best_match(deflate_state *s, uint32_t has
 static void fizzle_matches(deflate_state *s, unsigned char *Z_RESTRICT window, struct match *Z_RESTRICT current, struct match *Z_RESTRICT next) {
     unsigned char *match, *orig;
     struct match c, n;
-    int changed = 0;
     Pos limit;
 
     match = window + next->match_start + 1 - current->match_length;
@@ -112,7 +111,7 @@ static void fizzle_matches(deflate_state *s, unsigned char *Z_RESTRICT window, s
     n = *next;
 
     /* step one: try to move the "next" match to the left as much as possible */
-    limit = next->strstart > MAX_DIST(s) ? next->strstart - (Pos)MAX_DIST(s) : 0;
+    limit = n.strstart > MAX_DIST(s) ? n.strstart - (Pos)MAX_DIST(s) : 0;
 
     match = window + n.match_start - 1;
     orig = window + n.strstart - 1;
@@ -133,15 +132,12 @@ static void fizzle_matches(deflate_state *s, unsigned char *Z_RESTRICT window, s
         c.match_length--;
         match--;
         orig--;
-        changed++;
     }
 
-    if (changed && c.match_length <= 1) {
+    if (c.match_length <= 1) {
         n.orgstart++;
         *current = c;
         *next = n;
-    } else {
-        return;
     }
 }
 

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -129,29 +129,41 @@ static void fizzle_matches(deflate_state *s, unsigned char *Z_RESTRICT window, s
     int32_t steps = MIN(steps1, steps2);
 
     // If we can't possibly fizzle the current match out, return early
-    if (steps < need)
+    if (LIKELY(steps < (int32_t)need))
         return;
 
-    match = window + n.match_start - 1;
-    orig = window + n.strstart - 1;
+    // The quick exit above already checked the first byte of that range.
+    // Compare the whole range here.
+    if (LIKELY(memcmp(match, orig, (size_t)need) != 0))
+        return;
 
-    for (int32_t i = 0; i < steps; i++) {
-        if (UNLIKELY(*match != *orig))
-            break;
+    // Check whether the final extra backward byte is also possible.
+    // This decides whether the current match becomes length 1 or 0.
+    int extra_byte_ok = (steps == (int32_t)c.match_length);
 
-        n.strstart--;
-        n.match_start--;
-        n.match_length++;
-        c.match_length--;
-        match--;
-        orig--;
+    // Update variables, reduces c.match_length to 1.
+    n.match_start  = n.match_start - need;
+    n.strstart     = n.strstart - need;
+    n.match_length = n.match_length + need;
+    c.match_length = 1;
+
+    // If every constraint allowed one more backward byte, test it.
+    // If it matches, the current match is fully absorbed and becomes length 0.
+    if (extra_byte_ok) {
+        match = window + n.match_start - 1;
+        orig  = window + n.strstart - 1;
+
+        if (*match == *orig) {
+            n.match_start--;
+            n.strstart--;
+            n.match_length++;
+            c.match_length = 0;
+        }
     }
 
-    if (c.match_length <= 1) {
-        n.orgstart++;
-        *current = c;
-        *next = n;
-    }
+    n.orgstart++;
+    *current = c;
+    *next = n;
 }
 
 Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -80,10 +80,20 @@ Z_FORCEINLINE static struct match find_best_match(deflate_state *s, uint32_t has
     return m;
 }
 
-/* fizzle_matches assumes:
- * - current->match_length > 1
- * - (current->match_length - 1) <= next->match_start
- * - (current->match_length - 1) <= next->strstart
+/* fizzle_matches investigates whether next_match (which starts after current_match) can grow backwards
+ * to absorb current_match entirely, or reduce it to a single literal.
+ * This occurs because next_match points to a different historical dictionary position, allowing it to discover
+ * a better matching alignment that current_match bypassed due to the medium-strategy skipping positions.
+ *
+ * fizzle_matches assumes:
+ * - current_match.match_length > 1
+ * - current_match.match_length - 1 <= next->match_start
+ * - current_match.match_length - 1 <= next->strstart
+ * - next_match.match_length >= WANT_MIN_MATCH
+ *
+ * fuzzle_matches returns:
+ * - If successful, current and next are returned modified.
+ *   - current_match.match_length is then either 0, 1
  */
 static void fizzle_matches(deflate_state *s, unsigned char *Z_RESTRICT window, struct match *Z_RESTRICT current, struct match *Z_RESTRICT next) {
     unsigned char *match, *orig;
@@ -91,8 +101,8 @@ static void fizzle_matches(deflate_state *s, unsigned char *Z_RESTRICT window, s
     int changed = 0;
     Pos limit;
 
-    match = window - current->match_length + 1 + next->match_start;
-    orig  = window - current->match_length + 1 + next->strstart;
+    match = window + next->match_start + 1 - current->match_length;
+    orig  = window + next->strstart + 1 - current->match_length;
 
     /* quick exit check.. if this fails then don't bother with anything else */
     if (LIKELY(*match != *orig))
@@ -126,7 +136,7 @@ static void fizzle_matches(deflate_state *s, unsigned char *Z_RESTRICT window, s
         changed++;
     }
 
-    if (changed && c.match_length <= 1 && n.match_length != 2) {
+    if (changed && c.match_length <= 1) {
         n.orgstart++;
         *current = c;
         *next = n;

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -96,35 +96,29 @@ Z_FORCEINLINE static struct match find_best_match(deflate_state *s, uint32_t has
  *   - current_match.match_length is then either 0, 1
  */
 static void fizzle_matches(deflate_state *s, unsigned char *Z_RESTRICT window, struct match *Z_RESTRICT current, struct match *Z_RESTRICT next) {
-    unsigned char *match, *orig;
-    struct match c, n;
-
-    match = window + next->match_start + 1 - current->match_length;
-    orig  = window + next->strstart + 1 - current->match_length;
+    unsigned char *match = window + next->match_start + 1 - current->match_length;
+    unsigned char *orig  = window + next->strstart + 1 - current->match_length;
 
     /* quick exit check.. if this fails then don't bother with anything else */
     if (LIKELY(*match != *orig))
         return;
 
-    c = *current;
-    n = *next;
-
-    int32_t limit = (int32_t)n.strstart > (int32_t)MAX_DIST(s) ? (int32_t)n.strstart - (int32_t)MAX_DIST(s) : 0;
+    int32_t limit = (int32_t)next->strstart > (int32_t)MAX_DIST(s) ? (int32_t)next->strstart - (int32_t)MAX_DIST(s) : 0;
 
     // Steps needed to successfully fizzle match
-    uint16_t need = c.match_length - 1;
+    uint16_t need = current->match_length - 1;
 
     // Protect next->strstart from moving past maximum distance
-    int32_t max_steps_to_limit = (int32_t)n.strstart - limit;
+    int32_t max_steps_to_limit = (int32_t)next->strstart - limit;
 
     // Protect next->match_length from exceeding 256
-    int32_t max_growth_allowed = 256 - (int32_t)n.match_length;
+    int32_t max_growth_allowed = 256 - (int32_t)next->match_length;
 
     // Protect next->match_start from going too far back
-    int32_t max_steps_to_history = (int32_t)n.match_start - 1;
+    int32_t max_steps_to_history = (int32_t)next->match_start - 1;
 
     // steps is the max number of backward steps allowed for each limitation
-    int32_t steps1 = MIN((int32_t)c.match_length, max_steps_to_limit);
+    int32_t steps1 = MIN((int32_t)current->match_length, max_steps_to_limit);
     int32_t steps2 = MIN(max_growth_allowed, max_steps_to_history);
     int32_t steps = MIN(steps1, steps2);
 
@@ -139,31 +133,28 @@ static void fizzle_matches(deflate_state *s, unsigned char *Z_RESTRICT window, s
 
     // Check whether the final extra backward byte is also possible.
     // This decides whether the current match becomes length 1 or 0.
-    int extra_byte_ok = (steps == (int32_t)c.match_length);
+    int extra_byte_ok = (steps == (int32_t)current->match_length);
 
-    // Update variables, reduces c.match_length to 1.
-    n.match_start  = n.match_start - need;
-    n.strstart     = n.strstart - need;
-    n.match_length = n.match_length + need;
-    c.match_length = 1;
+    // Update variables, reduces current->match_length to 1.
+    next->match_start  = next->match_start - need;
+    next->strstart     = next->strstart - need;
+    next->match_length = next->match_length + need;
+    next->orgstart++;
+    current->match_length = 1;
 
     // If every constraint allowed one more backward byte, test it.
     // If it matches, the current match is fully absorbed and becomes length 0.
     if (extra_byte_ok) {
-        match = window + n.match_start - 1;
-        orig  = window + n.strstart - 1;
+        match = window + next->match_start - 1;
+        orig  = window + next->strstart - 1;
 
         if (*match == *orig) {
-            n.match_start--;
-            n.strstart--;
-            n.match_length++;
-            c.match_length = 0;
+            next->match_start--;
+            next->strstart--;
+            next->match_length++;
+            current->match_length = 0;
         }
     }
-
-    n.orgstart++;
-    *current = c;
-    *next = n;
 }
 
 Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -98,7 +98,6 @@ Z_FORCEINLINE static struct match find_best_match(deflate_state *s, uint32_t has
 static void fizzle_matches(deflate_state *s, unsigned char *Z_RESTRICT window, struct match *Z_RESTRICT current, struct match *Z_RESTRICT next) {
     unsigned char *match, *orig;
     struct match c, n;
-    Pos limit;
 
     match = window + next->match_start + 1 - current->match_length;
     orig  = window + next->strstart + 1 - current->match_length;
@@ -110,20 +109,34 @@ static void fizzle_matches(deflate_state *s, unsigned char *Z_RESTRICT window, s
     c = *current;
     n = *next;
 
-    /* step one: try to move the "next" match to the left as much as possible */
-    limit = n.strstart > MAX_DIST(s) ? n.strstart - (Pos)MAX_DIST(s) : 0;
+    int32_t limit = (int32_t)n.strstart > (int32_t)MAX_DIST(s) ? (int32_t)n.strstart - (int32_t)MAX_DIST(s) : 0;
+
+    // Steps needed to successfully fizzle match
+    uint16_t need = c.match_length - 1;
+
+    // Protect next->strstart from moving past maximum distance
+    int32_t max_steps_to_limit = (int32_t)n.strstart - limit;
+
+    // Protect next->match_length from exceeding 256
+    int32_t max_growth_allowed = 256 - (int32_t)n.match_length;
+
+    // Protect next->match_start from going too far back
+    int32_t max_steps_to_history = (int32_t)n.match_start - 1;
+
+    // steps is the max number of backward steps allowed for each limitation
+    int32_t steps1 = MIN((int32_t)c.match_length, max_steps_to_limit);
+    int32_t steps2 = MIN(max_growth_allowed, max_steps_to_history);
+    int32_t steps = MIN(steps1, steps2);
+
+    // If we can't possibly fizzle the current match out, return early
+    if (steps < need)
+        return;
 
     match = window + n.match_start - 1;
     orig = window + n.strstart - 1;
 
-    while (*match == *orig) {
-        if (UNLIKELY(c.match_length < 1))
-            break;
-        if (UNLIKELY(n.strstart <= limit))
-            break;
-        if (UNLIKELY(n.match_length >= 256))
-            break;
-        if (UNLIKELY(n.match_start <= 1))
+    for (int32_t i = 0; i < steps; i++) {
+        if (UNLIKELY(*match != *orig))
             break;
 
         n.strstart--;

--- a/deflate_medium.c
+++ b/deflate_medium.c
@@ -219,8 +219,7 @@ Z_INTERNAL block_state deflate_medium(deflate_state *s, int flush) {
             uint32_t tmp_cmatch_len_sub = curr_match_len - 1;
             if (tmp_cmatch_len_sub
                      && next_match.match_length >= WANT_MIN_MATCH
-                     && tmp_cmatch_len_sub <= next_match.match_start
-                     && tmp_cmatch_len_sub <= next_match.strstart) {
+                     && tmp_cmatch_len_sub <= next_match.match_start) {
                 fizzle_matches(s, window, &current_match, &next_match);
                 curr_match_len = current_match.match_length;
             }


### PR DESCRIPTION
This PR is more about cleanup than optimization, it cleans up fizzle_matches and insert_match functions and make them much less complex.
Compressed output is unchanged.

- Document fizzle_matches.
- Remove unnecessary `match_length != 2` check in fizzle_matches.
- Remove 'changed' variable in fizzle_matches.
- Pre-calculate bound of fizzle_matches loop.
- Rewrite fizzle_matches loop to use memcmp() instead of byte-by-byte matching.
- Fizzle_matches no longer makes changes before it knows it is safe, remove match copying.
- Remove always-true check `curr_match_len - 1 <= next_match.strstart`.
- Remove dead branch and simplify insert_match() code.
