### PR TITLE
Fix import library name on non-MSVC Windows targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1367,6 +1367,9 @@ if(WIN32)
     # Shared library
     if(NOT DEFINED BUILD_SHARED_LIBS OR BUILD_SHARED_LIBS)
         set_target_properties(zlib-ng PROPERTIES OUTPUT_NAME zlib${SUFFIX})
+        if(NOT MSVC)
+            set_target_properties(zlib-ng PROPERTIES ARCHIVE_OUTPUT_NAME z${SUFFIX})
+        endif()
     endif()
     # Static library
     if(NOT DEFINED BUILD_SHARED_LIBS)


### PR DESCRIPTION
* pkgconfig expects import library to be named libz.dll.a or libz-ng.dll.a

Downstream packages already have renamed the import library.

Fixes #1864.