### PR TITLE
Disable the machine outliner for Apple clang builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,6 +296,14 @@ elseif(CMAKE_C_COMPILER_ID MATCHES "GNU" OR CMAKE_C_COMPILER_ID MATCHES "Clang" 
     if(FNO_LTO_AVAILABLE)
         set(ZNOLTOFLAG "-fno-lto")
     endif()
+    if(CMAKE_C_COMPILER_ID STREQUAL "AppleClang")
+        # Apple clang runs the machine outliner by default, adding call overhead in hot loops.
+        # Disabling it is faster for every deflate strategy.
+        check_c_compiler_flag(-mno-outline HAVE_NO_OUTLINE)
+        if(HAVE_NO_OUTLINE)
+            add_compile_options($<$<COMPILE_LANGUAGE:C>:-mno-outline>)
+        endif()
+    endif()
     if(NOT WITH_NATIVE_INSTRUCTIONS)
         if(BASEARCH_ARM_FOUND)
             if(ARCH_32BIT AND NOT CMAKE_C_FLAGS MATCHES "-mfloat-abi")

--- a/configure
+++ b/configure
@@ -1045,6 +1045,21 @@ EOF
   fi
 fi
 
+# Apple clang runs the machine outliner by default, adding call overhead in hot loops.
+# Disabling it is faster for every deflate strategy.
+if test $gcc -eq 1 && $cc --version 2>&1 | grep -i apple > /dev/null; then
+  cat > $test.c <<EOF
+int main() { return 0; }
+EOF
+  if $cc $CFLAGS -Werror -mno-outline -c $test.c >> configure.log 2>&1; then
+    echo "Checking for -mno-outline... Yes." | tee -a configure.log
+    CFLAGS="${CFLAGS} -mno-outline"
+    SFLAGS="${SFLAGS} -mno-outline"
+  else
+    echo "Checking for -mno-outline... No." | tee -a configure.log
+  fi
+fi
+
 # see if we can hide zlib internal symbols that are linked between separate source files using hidden
 if test "$gcc" -eq 1 && test "$visibility" -eq 1; then
   echo >> configure.log


### PR DESCRIPTION
Apple clang enables the AArch64 machine outliner at `-O2` and `-O3` (upstream LLVM clang and GCC do not). In zlib-ng it fires only in the five deflate strategy files, where it extracts repeated instruction sequences from the hot match loops into `OUTLINED_FUNCTION_*` helpers, adding `bl`/`ret` pairs per loop iteration. Every other object in the library compiles byte-identical with or without the flag.

Chromium disables outlining the same way on all arm64 clang builds ([crbug.com/931297](https://crbug.com/931297), [crbug.com/1410297](https://crbug.com/1410297)).

Measured on Apple M5 (macOS 26.6.2, Apple clang 21, CMake Release, static libs) with `deflate_bench/nocrc`, median of 5 repetitions, negative = `-mno-outline` faster:

| data type | L1 128K | L1 1MB | L3 128K | L3 1MB | L6 128K | L6 1MB | L9 128K | L9 1MB |
|---|---|---|---|---|---|---|---|---|
| text | +1.5% | +0.6% | -6.5% | -2.9% | -3.9% | -0.5% | -3.9% | -0.2% |
| short_match | — | — | -9.0% | -3.9% | -1.8% | -0.2% | +0.4% | +0.1% |
| dna | — | — | -2.4% | -0.9% | -0.2% | -0.1% | -0.6% | -0.5% |
| random | — | — | -4.7% | -1.4% | -3.7% | -1.5% | -13.5% | -2.5% |
| literals | — | — | -5.0% | -1.6% | -3.8% | +0.9% | -5.9% | +0.5% |
| mixed | — | — | -7.7% | -9.1% | -2.1% | -0.2% | -0.8% | +1.4% |
| realistic_rgb | — | — | -3.8% | -2.3% | -5.0% | -0.2% | -2.8% | +0.3% |
| striped_rgb | — | — | -1.4% | -0.4% | +0.2% | -0.3% | +1.1% | +1.1% |

Overall geomean is -2.2% (levels 3/6/9: -4.0%/-1.4%/-1.7%). A control re-run of the unchanged binary drifted -0.9% geomean with single rows up to ±3%, so isolated cells inside that range are noise; the strong cells (`short_match` -9.0% L3, `mixed` -9.1% L3, `random` -13.5% L9) are well beyond it. Only `text` registers level 1 in the benchmark ladder.

Library text size grows 86,844 → 87,072 bytes (+228, +0.26%).
