### PR TITLE
Move NOLTOFLAG selection next to the -fno-lto check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,6 +295,10 @@ elseif(CMAKE_C_COMPILER_ID MATCHES "GNU" OR CMAKE_C_COMPILER_ID MATCHES "Clang" 
     set(CMAKE_REQUIRED_FLAGS)
     if(FNO_LTO_AVAILABLE)
         set(ZNOLTOFLAG "-fno-lto")
+        # Arch-specific sources opt out of LTO unless the whole build is native
+        if(NOT WITH_NATIVE_INSTRUCTIONS)
+            set(NOLTOFLAG ${ZNOLTOFLAG})
+        endif()
     endif()
     if(NOT WITH_NATIVE_INSTRUCTIONS)
         if(BASEARCH_ARM_FOUND)
@@ -331,10 +335,6 @@ elseif(CMAKE_C_COMPILER_ID MATCHES "GNU" OR CMAKE_C_COMPILER_ID MATCHES "Clang" 
         elseif(BASEARCH_X86_FOUND AND CMAKE_C_COMPILER_ID MATCHES "NVHPC")
             # nVidia compiler defaults to native build, so set target to any x86-64 processor
             add_compile_options(-tp px)
-        endif()
-        # Disable LTO unless Native Instructions are enabled
-        if(FNO_LTO_AVAILABLE)
-            set(NOLTOFLAG ${ZNOLTOFLAG})
         endif()
     endif()
     if(MINGW)


### PR DESCRIPTION
I found this weird oddity and had Claude create a PR for it.. 
 ... the comment didn't match the logic: it mentioned native instructions, but didn't check them..

> `NOLTOFLAG` was assigned at the tail of the `if(NOT WITH_NATIVE_INSTRUCTIONS)` block, after the unrelated ARM float-ABI probing, so an LTO policy decision read like part of that section. It also sat behind an `if(FNO_LTO_AVAILABLE)` guard that is *redundant*, since `ZNOLTOFLAG` is only ever non-empty when that check passed.