### PR TITLE
Exclude CHECK_* and EXPECT_* macros from branch coverage.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1080,6 +1080,8 @@ jobs:
         python3 -u -m pip install gcovr
         python3 -m gcovr -j 5 --gcov-ignore-parse-errors --verbose \
           --exclude '(.*/|^)(_deps|benchmarks)/.*' \
+          --exclude-branches-by-pattern '.*CHECK_.*' \
+          --exclude-branches-by-pattern '.*EXPECT_.*' \
           --exclude-unreachable-branches \
           --merge-mode-functions separate \
           --merge-lines \
@@ -1094,6 +1096,8 @@ jobs:
         python3.9 -u -m pip install gcovr
         python3.9 -m gcovr -j 5 --gcov-ignore-parse-errors --verbose \
           --exclude '(.*/|^)(_deps|benchmarks)/.*' \
+          --exclude-branches-by-pattern '.*CHECK_.*' \
+          --exclude-branches-by-pattern '.*EXPECT_.*' \
           --exclude-unreachable-branches \
           --merge-mode-functions separate \
           --merge-lines \


### PR DESCRIPTION
* Google Test macros `CHECK_*` and `EXPECT_*` create branches that are expected to be never reached, so lower branch coverage by about 50%