### PR TITLE
Replace `__cpucfg` with `getauxval`, which is recommended for use in user space

### DIFF
--- a/arch/loongarch/loongarch_features.c
+++ b/arch/loongarch/loongarch_features.c
@@ -10,22 +10,32 @@
 #include "zbuild.h"
 #include "loongarch_features.h"
 
-#include <larchintrin.h>
+#ifdef HAVE_SYS_AUXV_H
+#  include <sys/auxv.h>
+#endif
+
+#ifndef HWCAP_LOONGARCH_LSX
+#  define HWCAP_LOONGARCH_LSX   (1 << 4)
+#endif
+#ifndef HWCAP_LOONGARCH_LASX
+#  define HWCAP_LOONGARCH_LASX  (1 << 5)
+#endif
+#ifndef HWCAP_LOONGARCH_CRC32
+#  define HWCAP_LOONGARCH_CRC32 (1 << 6)
+#endif
 
 /*
- * https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html
+ * Application must obtain CPU features through the getauxval system call provided by the kernel.
  *
- * Word number Bit number  Annotation  Implication
- * 0x1         25          CRC         1 indicates support for CRC instruction
- * 0x1         6           LSX         1 indicates support for 128-bit vector extension
- * 0x1         7           LASX        1 indicates support for 256-bit vector expansion
+ * https://github.com/loongson/la-softdev-convention/blob/master/la-softdev-convention.adoc#91-kernel-development
  */
 
 void Z_INTERNAL loongarch_check_features(struct loongarch_cpu_features *features) {
-    unsigned int w1 = __cpucfg(0x1);
-    features->has_crc = w1 & 0x2000000;
-    features->has_lsx = w1 & 0x40;
-    features->has_lasx = w1 & 0x80;
+    unsigned long hwcap = getauxval(AT_HWCAP);
+
+    features->has_crc = (hwcap & HWCAP_LOONGARCH_CRC32) != 0;
+    features->has_lsx = (hwcap & HWCAP_LOONGARCH_LSX) != 0;
+    features->has_lasx = (hwcap & HWCAP_LOONGARCH_LASX) != 0;
 }
 
 #endif


### PR DESCRIPTION
The `cpucfg` instruction only tests the hardware support, causing a `SIGILL` if the hardware supports LSX or `LASX` but the kernel does not.

Use `getauxval(AT_HWCAP)` as the ["Software Development and Build Convention for LoongArch Architectures"](https://github.com/loongson/la-softdev-convention/blob/master/la-softdev-convention.adoc#kernel-constraints) manual suggests.