### PR TITLE
Add libdeflate comparison benchmarks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1552,7 +1552,7 @@ add_feature_info(WITH_SANITIZER WITH_SANITIZER "Enable sanitizer testing support
 add_feature_info(WITH_GTEST WITH_GTEST "Build tests using Gtest framework")
 add_feature_info(WITH_FUZZERS WITH_FUZZERS "Build test/fuzz")
 add_feature_info(WITH_BENCHMARKS WITH_BENCHMARKS "Build benchmarks using Google Benchmark framework")
-add_feature_info(WITH_BENCHMARK_APPS WITH_BENCHMARK_APPS "Build application benchmarks (currently libpng)")
+add_feature_info(WITH_BENCHMARK_APPS WITH_BENCHMARK_APPS "Build application benchmarks (libpng, libdeflate)")
 add_feature_info(WITH_ALL_FALLBACKS WITH_ALL_FALLBACKS "Build all generic fallback functions")
 add_feature_info(WITH_OPTIM WITH_OPTIM "Build with optimisation")
 add_feature_info(WITH_NEW_STRATEGIES WITH_NEW_STRATEGIES "Use new strategies")

--- a/test/benchmarks/CMakeLists.txt
+++ b/test/benchmarks/CMakeLists.txt
@@ -102,6 +102,64 @@ add_test(NAME benchmark_zlib
 if(WITH_BENCHMARK_APPS)
     option(BUILD_ALT_BENCH "Link against alternative zlib implementation" OFF)
 
+    # Search for libdeflate package
+    find_package(libdeflate 1.19 QUIET)
+    if(NOT libdeflate_FOUND)
+        # Allow specifying alternative libdeflate repository
+        if(NOT DEFINED LIBDEFLATE_REPOSITORY)
+            set(LIBDEFLATE_REPOSITORY https://github.com/ebiggers/libdeflate.git)
+        endif()
+        if(NOT DEFINED LIBDEFLATE_TAG)
+            set(LIBDEFLATE_TAG v1.26)
+        endif()
+
+        set(LIBDEFLATE_BUILD_SHARED_LIB OFF)
+        set(LIBDEFLATE_BUILD_GZIP OFF)
+        set(LIBDEFLATE_BUILD_TESTS OFF)
+
+        FetchContent_Declare(libdeflate
+            GIT_REPOSITORY ${LIBDEFLATE_REPOSITORY}
+            GIT_TAG ${LIBDEFLATE_TAG}
+            ${ZNG_FetchContent_Declare_EXCLUDE_FROM_ALL})
+
+        ZNG_FetchContent_MakeAvailable(libdeflate)
+
+        # Third-party sources are not held to the maintainer warning set
+        if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang|LCC")
+            target_compile_options(libdeflate_static PRIVATE -w)
+        endif()
+    endif()
+
+    # Same sources built once per codec backend so both executables register
+    # identical benchmark names, ready for comparison with compare_runs.py
+    set(BENCH_CODEC_SRCS
+        benchmark_codec.cc
+        benchmark_data_types.cc
+        benchmark_main.cc
+        )
+
+    add_executable(benchmark_zlib_codec ${BENCH_CODEC_SRCS})
+    add_executable(benchmark_libdeflate_codec ${BENCH_CODEC_SRCS})
+    target_compile_definitions(benchmark_libdeflate_codec PRIVATE BENCH_LIBDEFLATE=1)
+    target_link_libraries(benchmark_libdeflate_codec libdeflate::libdeflate_static)
+
+    foreach(codec_target benchmark_zlib_codec benchmark_libdeflate_codec)
+        target_compile_definitions(${codec_target} PRIVATE
+            -DBENCHMARK_STATIC_DEFINE
+            -DTEST_DATA_DIR="${PROJECT_SOURCE_DIR}/test/data")
+        if(MINGW)
+            target_compile_definitions(${codec_target} PRIVATE -D_WIN32_WINNT=_WIN32_WINNT_WIN10)
+        endif()
+        target_include_directories(${codec_target} PRIVATE
+            ${PROJECT_SOURCE_DIR}
+            ${PROJECT_BINARY_DIR}
+            ${benchmark_SOURCE_DIR}/benchmark/include)
+        target_link_libraries(${codec_target} zlib-ng-static benchmark::benchmark)
+        if(WIN32)
+            target_link_libraries(${codec_target} shlwapi)
+        endif()
+    endforeach()
+
     # Search for libpng package
     find_package(PNG QUIET)
 

--- a/test/benchmarks/benchmark_codec.cc
+++ b/test/benchmarks/benchmark_codec.cc
@@ -1,0 +1,472 @@
+/* benchmark_codec.cc -- whole-buffer deflate benchmarks across implementations
+ * Copyright (C) 2026 Nathan Moinvaziri
+ * For conditions of distribution and use, see copyright notice in zlib.h
+ *
+ * Compresses and decompresses corpus files through a minimal whole-buffer
+ * codec interface so identical benchmark names can be produced for different
+ * deflate implementations and compared with compare_runs.py.
+ *
+ * The backend is selected at compile time, zlib-ng by default, libdeflate
+ * when BENCH_LIBDEFLATE is defined. Decompression input is always produced
+ * by zlib-ng at level 9, both backends therefore inflate identical streams.
+ * All benchmark output is verified against the original file contents.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <vector>
+#include <string>
+#include <algorithm>
+#include <benchmark/benchmark.h>
+
+extern "C" {
+#  include "zbuild.h"
+#  if defined(ZLIB_COMPAT)
+#    include "zlib.h"
+#  else
+#    include "zlib-ng.h"
+#  endif
+#  include "test/test_data_p.h"
+}
+
+#ifdef BENCH_LIBDEFLATE
+#  include <libdeflate.h>
+#endif
+
+#include "benchmark_corpora.h"
+#include "benchmark_data_types.h"
+
+static std::vector<corpus_file> corpora_files;
+
+#ifdef BENCH_LIBDEFLATE
+
+/* libdeflate backend, reusable codec objects around the whole-buffer API */
+struct codec_compressor {
+    struct libdeflate_compressor *comp;
+
+    bool init(int level) {
+        comp = libdeflate_alloc_compressor(level);
+        return comp != NULL;
+    }
+
+    size_t bound(size_t in_size) {
+        return libdeflate_deflate_compress_bound(comp, in_size);
+    }
+
+    /* Returns compressed size, 0 on failure */
+    size_t compress(const uint8_t *in, size_t in_size, uint8_t *out, size_t out_size) {
+        return libdeflate_deflate_compress(comp, in, in_size, out, out_size);
+    }
+
+    void end() {
+        libdeflate_free_compressor(comp);
+    }
+};
+
+struct codec_decompressor {
+    struct libdeflate_decompressor *decomp;
+
+    bool init() {
+        decomp = libdeflate_alloc_decompressor();
+        return decomp != NULL;
+    }
+
+    /* Returns decompressed size, 0 on failure */
+    size_t decompress(const uint8_t *in, size_t in_size, uint8_t *out, size_t out_size) {
+        size_t actual = 0;
+        if (libdeflate_deflate_decompress(decomp, in, in_size, out, out_size, &actual) != LIBDEFLATE_SUCCESS)
+            return 0;
+        return actual;
+    }
+
+    void end() {
+        libdeflate_free_decompressor(decomp);
+    }
+};
+
+static const int codec_levels[] = {1, 3, 6, 9, 12};
+
+#else
+
+/* zlib-ng backend, one-shot raw deflate calls on a persistent stream */
+struct codec_compressor {
+    PREFIX3(stream) strm;
+
+    bool init(int level) {
+        memset(&strm, 0, sizeof(strm));
+        return PREFIX(deflateInit2)(&strm, level, Z_DEFLATED, -MAX_WBITS, MAX_MEM_LEVEL,
+                                    Z_DEFAULT_STRATEGY) == Z_OK;
+    }
+
+    size_t bound(size_t in_size) {
+        return (size_t)PREFIX(deflateBound)(&strm, (z_uintmax_t)in_size);
+    }
+
+    /* Returns compressed size, 0 on failure */
+    size_t compress(const uint8_t *in, size_t in_size, uint8_t *out, size_t out_size) {
+        if (PREFIX(deflateReset)(&strm) != Z_OK)
+            return 0;
+
+        strm.next_in = (z_const uint8_t *)in;
+        strm.avail_in = (uint32_t)in_size;
+        strm.next_out = out;
+        strm.avail_out = (uint32_t)out_size;
+
+        if (PREFIX(deflate)(&strm, Z_FINISH) != Z_STREAM_END)
+            return 0;
+        return (size_t)strm.total_out;
+    }
+
+    void end() {
+        PREFIX(deflateEnd)(&strm);
+    }
+};
+
+struct codec_decompressor {
+    PREFIX3(stream) strm;
+
+    bool init() {
+        memset(&strm, 0, sizeof(strm));
+        return PREFIX(inflateInit2)(&strm, -MAX_WBITS) == Z_OK;
+    }
+
+    /* Returns decompressed size, 0 on failure */
+    size_t decompress(const uint8_t *in, size_t in_size, uint8_t *out, size_t out_size) {
+        if (PREFIX(inflateReset)(&strm) != Z_OK)
+            return 0;
+
+        strm.next_in = (z_const uint8_t *)in;
+        strm.avail_in = (uint32_t)in_size;
+        strm.next_out = out;
+        strm.avail_out = (uint32_t)out_size;
+
+        if (PREFIX(inflate)(&strm, Z_FINISH) != Z_STREAM_END)
+            return 0;
+        return (size_t)strm.total_out;
+    }
+
+    void end() {
+        PREFIX(inflateEnd)(&strm);
+    }
+};
+
+static const int codec_levels[] = {1, 3, 6, 9};
+
+#endif
+
+/* Compress a corpus file with zlib-ng raw deflate at level 9, so every codec
+   backend decompresses an identical input stream. Returns a malloc'd buffer. */
+static uint8_t *reference_compress(const corpus_file *cf, size_t *comp_size) {
+    PREFIX3(stream) strm;
+    memset(&strm, 0, sizeof(strm));
+
+    if (PREFIX(deflateInit2)(&strm, Z_BEST_COMPRESSION, Z_DEFLATED, -MAX_WBITS, MAX_MEM_LEVEL,
+                             Z_DEFAULT_STRATEGY) != Z_OK)
+        return NULL;
+
+    size_t bound = (size_t)PREFIX(deflateBound)(&strm, (z_uintmax_t)cf->size);
+    uint8_t *buf = (uint8_t *)malloc(bound);
+    if (buf == NULL) {
+        PREFIX(deflateEnd)(&strm);
+        return NULL;
+    }
+
+    strm.next_in = (z_const uint8_t *)cf->data;
+    strm.avail_in = (uint32_t)cf->size;
+    strm.next_out = buf;
+    strm.avail_out = (uint32_t)bound;
+
+    int err = PREFIX(deflate)(&strm, Z_FINISH);
+    *comp_size = (size_t)strm.total_out;
+    PREFIX(deflateEnd)(&strm);
+
+    if (err != Z_STREAM_END) {
+        free(buf);
+        return NULL;
+    }
+    return buf;
+}
+
+/* Decompress with zlib-ng raw inflate and compare against the original file.
+   Verifying through zlib-ng also proves cross-library interoperability. */
+static bool verify_compressed(const uint8_t *comp, size_t comp_size, const corpus_file *cf) {
+    uint8_t *out = (uint8_t *)malloc(cf->size);
+    if (out == NULL)
+        return false;
+
+    PREFIX3(stream) strm;
+    memset(&strm, 0, sizeof(strm));
+
+    bool ok = PREFIX(inflateInit2)(&strm, -MAX_WBITS) == Z_OK;
+    if (ok) {
+        strm.next_in = (z_const uint8_t *)comp;
+        strm.avail_in = (uint32_t)comp_size;
+        strm.next_out = out;
+        strm.avail_out = (uint32_t)cf->size;
+
+        ok = PREFIX(inflate)(&strm, Z_FINISH) == Z_STREAM_END &&
+             (size_t)strm.total_out == cf->size &&
+             memcmp(out, cf->data, cf->size) == 0;
+        PREFIX(inflateEnd)(&strm);
+    }
+
+    free(out);
+    return ok;
+}
+
+class codec_deflate : public benchmark::Fixture {
+private:
+    corpus_file *cf;
+    int level;
+    uint8_t *outbuff;
+    size_t outbuff_size;
+    size_t compressed_size;
+    codec_compressor comp;
+    bool comp_init;
+
+public:
+    codec_deflate(const std::string &name, corpus_file *cf, int level)
+        : cf(cf), level(level), outbuff(NULL), outbuff_size(0), compressed_size(0),
+          comp(), comp_init(false) {
+        this->SetName(name);
+    }
+
+    void SetUp(const benchmark::State &) override {
+        if (!load_corpus_file(cf))
+            return;
+
+        comp_init = comp.init(level);
+        if (!comp_init)
+            return;
+
+        outbuff_size = comp.bound(cf->size);
+        outbuff = (uint8_t *)malloc(outbuff_size);
+    }
+
+    void BenchmarkCase(benchmark::State &state) override {
+        if (cf->data == NULL || !comp_init || outbuff == NULL) {
+            state.SkipWithError("setup failed");
+            return;
+        }
+
+        for (auto _ : state) {
+            compressed_size = comp.compress(cf->data, cf->size, outbuff, outbuff_size);
+            if (compressed_size == 0) {
+                state.SkipWithError("compress failed");
+                break;
+            }
+        }
+
+        if (state.skipped())
+            return;
+
+        if (!verify_compressed(outbuff, compressed_size, cf)) {
+            state.SkipWithError("roundtrip verification failed");
+            return;
+        }
+
+        state.SetBytesProcessed((int64_t)state.iterations() * (int64_t)cf->size);
+        state.counters["compressed"] = benchmark::Counter(double(compressed_size));
+        state.counters["ratio"] = benchmark::Counter(double(cf->size) / double(compressed_size));
+    }
+
+    void TearDown(const benchmark::State &) override {
+        if (comp_init) {
+            comp.end();
+            comp_init = false;
+        }
+        free(outbuff);
+        outbuff = NULL;
+    }
+};
+
+class codec_inflate : public benchmark::Fixture {
+private:
+    corpus_file *cf;
+    uint8_t *compressed;
+    size_t compressed_size;
+    uint8_t *outbuff;
+    codec_decompressor decomp;
+    bool decomp_init;
+
+public:
+    codec_inflate(const std::string &name, corpus_file *cf)
+        : cf(cf), compressed(NULL), compressed_size(0), outbuff(NULL),
+          decomp(), decomp_init(false) {
+        this->SetName(name);
+    }
+
+    void SetUp(const benchmark::State &) override {
+        if (!load_corpus_file(cf))
+            return;
+
+        compressed = reference_compress(cf, &compressed_size);
+        outbuff = (uint8_t *)malloc(cf->size);
+        decomp_init = decomp.init();
+    }
+
+    void BenchmarkCase(benchmark::State &state) override {
+        if (compressed == NULL || outbuff == NULL || !decomp_init) {
+            state.SkipWithError("setup failed");
+            return;
+        }
+
+        for (auto _ : state) {
+            size_t out_size = decomp.decompress(compressed, compressed_size, outbuff, cf->size);
+            if (out_size != cf->size) {
+                state.SkipWithError("decompress failed");
+                break;
+            }
+        }
+
+        if (state.skipped())
+            return;
+
+        if (memcmp(outbuff, cf->data, cf->size) != 0) {
+            state.SkipWithError("output does not match original");
+            return;
+        }
+
+        state.SetBytesProcessed((int64_t)state.iterations() * (int64_t)cf->size);
+        state.counters["compressed"] = benchmark::Counter(double(compressed_size));
+        state.counters["ratio"] = benchmark::Counter(double(cf->size) / double(compressed_size));
+    }
+
+    void TearDown(const benchmark::State &) override {
+        if (decomp_init) {
+            decomp.end();
+            decomp_init = false;
+        }
+        free(compressed);
+        compressed = NULL;
+        free(outbuff);
+        outbuff = NULL;
+    }
+};
+
+/* Synthetic data-type inflate benchmark, isolates decoder paths by stream composition */
+class codec_inflate_type : public benchmark::Fixture {
+private:
+    enum test_data_type type;
+    corpus_file cf;
+    uint8_t *compressed;
+    size_t compressed_size;
+    uint8_t *outbuff;
+    codec_decompressor decomp;
+    bool decomp_init;
+
+public:
+    codec_inflate_type(const std::string &name, enum test_data_type type)
+        : type(type), cf{"", NULL, 1024 * 1024}, compressed(NULL), compressed_size(0),
+          outbuff(NULL), decomp(), decomp_init(false) {
+        this->SetName(name);
+    }
+
+    void SetUp(const benchmark::State &) override {
+        cf.data = gen_test_data(type, cf.size);
+        if (cf.data == NULL)
+            return;
+
+        compressed = reference_compress(&cf, &compressed_size);
+        outbuff = (uint8_t *)malloc(cf.size);
+        decomp_init = decomp.init();
+    }
+
+    void BenchmarkCase(benchmark::State &state) override {
+        if (compressed == NULL || outbuff == NULL || !decomp_init) {
+            state.SkipWithError("setup failed");
+            return;
+        }
+
+        for (auto _ : state) {
+            size_t out_size = decomp.decompress(compressed, compressed_size, outbuff, cf.size);
+            if (out_size != cf.size) {
+                state.SkipWithError("decompress failed");
+                break;
+            }
+        }
+
+        if (state.skipped())
+            return;
+
+        if (memcmp(outbuff, cf.data, cf.size) != 0) {
+            state.SkipWithError("output does not match original");
+            return;
+        }
+
+        state.SetBytesProcessed((int64_t)state.iterations() * (int64_t)cf.size);
+        state.counters["compressed"] = benchmark::Counter(double(compressed_size));
+        state.counters["ratio"] = benchmark::Counter(double(cf.size) / double(compressed_size));
+    }
+
+    void TearDown(const benchmark::State &) override {
+        if (decomp_init) {
+            decomp.end();
+            decomp_init = false;
+        }
+        free(compressed);
+        compressed = NULL;
+        free(outbuff);
+        outbuff = NULL;
+        free(cf.data);
+        cf.data = NULL;
+    }
+};
+
+/* Registered at runtime for the data types selected by --benchmark_data_types */
+static void codec_register_data_types(uint32_t mask) {
+    static const struct {
+        const char *name;
+        enum test_data_type type;
+    } types[] = {
+        {"text",          TEST_DATA_TEXT},
+        {"short_match",   TEST_DATA_SHORT_MATCH},
+        {"dna",           TEST_DATA_DNA},
+        {"random",        TEST_DATA_RANDOM},
+        {"literals",      TEST_DATA_LITERALS},
+        {"mixed",         TEST_DATA_MIXED},
+        {"realistic_rgb", TEST_DATA_REALISTIC_RGB},
+        {"striped_rgb",   TEST_DATA_STRIPED_RGB},
+    };
+
+    for (size_t i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        if (!(mask & (1u << types[i].type)))
+            continue;
+        std::string name = std::string("codec_inflate/data/") + types[i].name;
+        benchmark::internal::RegisterBenchmarkInternal(
+            ::benchmark::internal::make_unique<codec_inflate_type>(name, types[i].type));
+    }
+}
+
+static int codec_data_types = benchmark_data_types_hook(codec_register_data_types);
+
+/* Dynamic benchmark registration at static init time */
+static int register_codec_benchmarks(void) {
+    corpora_files = discover_corpora();
+    if (corpora_files.empty())
+        return 0;
+
+    size_t prefix_len = strlen(CORPORA_DIR) + 1;
+
+    for (size_t i = 0; i < corpora_files.size(); i++) {
+        corpus_file *cf = &corpora_files[i];
+        std::string label = cf->path.substr(prefix_len);
+        std::replace(label.begin(), label.end(), '\\', '/');
+
+        for (size_t l = 0; l < sizeof(codec_levels) / sizeof(codec_levels[0]); l++) {
+            int level = codec_levels[l];
+            std::string name = "codec_deflate/" + label + "/level:" + std::to_string(level);
+            benchmark::internal::RegisterBenchmarkInternal(
+                ::benchmark::internal::make_unique<codec_deflate>(name, cf, level));
+        }
+
+        std::string name = "codec_inflate/" + label;
+        benchmark::internal::RegisterBenchmarkInternal(
+            ::benchmark::internal::make_unique<codec_inflate>(name, cf));
+    }
+
+    return 0;
+}
+
+static int codec_init = register_codec_benchmarks();

--- a/test/benchmarks/benchmark_corpora.cc
+++ b/test/benchmarks/benchmark_corpora.cc
@@ -17,13 +17,6 @@
 #include <algorithm>
 #include <benchmark/benchmark.h>
 
-#ifdef _WIN32
-#  include <windows.h>
-#else
-#  include <dirent.h>
-#  include <sys/stat.h>
-#endif
-
 extern "C" {
 #  include "zbuild.h"
 #  include "zutil_p.h"
@@ -34,142 +27,9 @@ extern "C" {
 #  endif
 }
 
-/* Absolute path defined by CMake, fallback for standalone builds */
-#ifndef TEST_DATA_DIR
-#  define TEST_DATA_DIR "test/data"
-#endif
-
-#define CORPORA_DIR TEST_DATA_DIR "/corpora"
-
-struct corpus_file {
-    std::string path;
-    uint8_t *data;
-    size_t size;
-};
+#include "benchmark_corpora.h"
 
 static std::vector<corpus_file> corpora_files;
-
-/* List regular files in a directory (non-recursive, skips dotfiles and empty files) */
-static std::vector<corpus_file> list_files(const std::string &dir) {
-    std::vector<corpus_file> files;
-
-#ifdef _WIN32
-    WIN32_FIND_DATAA ffd;
-    std::string pattern = dir + "\\*";
-    HANDLE hFind = FindFirstFileA(pattern.c_str(), &ffd);
-    if (hFind == INVALID_HANDLE_VALUE)
-        return files;
-    do {
-        if (ffd.cFileName[0] == '.')
-            continue;
-        if (ffd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
-            continue;
-        LARGE_INTEGER fsize;
-        fsize.LowPart = ffd.nFileSizeLow;
-        fsize.HighPart = ffd.nFileSizeHigh;
-        if (fsize.QuadPart <= 0)
-            continue;
-        files.push_back({dir + "\\" + ffd.cFileName, NULL, (size_t)fsize.QuadPart});
-    } while (FindNextFileA(hFind, &ffd));
-    FindClose(hFind);
-#else
-    DIR *d = opendir(dir.c_str());
-    if (d == NULL)
-        return files;
-    struct dirent *ent;
-    while ((ent = readdir(d)) != NULL) {
-        if (ent->d_name[0] == '.')
-            continue;
-        std::string fullpath = dir + "/" + ent->d_name;
-        struct stat st;
-        if (stat(fullpath.c_str(), &st) == 0 && S_ISREG(st.st_mode) && st.st_size > 0)
-            files.push_back({fullpath, NULL, (size_t)st.st_size});
-    }
-    closedir(d);
-#endif
-
-    std::sort(files.begin(), files.end(),
-              [](const corpus_file &a, const corpus_file &b) { return a.path < b.path; });
-    return files;
-}
-
-/* List subdirectories in a directory (skips dotfiles) */
-static std::vector<std::string> list_subdirs(const std::string &dir) {
-    std::vector<std::string> subdirs;
-
-#ifdef _WIN32
-    WIN32_FIND_DATAA ffd;
-    std::string pattern = dir + "\\*";
-    HANDLE hFind = FindFirstFileA(pattern.c_str(), &ffd);
-    if (hFind == INVALID_HANDLE_VALUE)
-        return subdirs;
-    do {
-        if (ffd.cFileName[0] == '.')
-            continue;
-        if (ffd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
-            subdirs.push_back(dir + "\\" + ffd.cFileName);
-    } while (FindNextFileA(hFind, &ffd));
-    FindClose(hFind);
-#else
-    DIR *d = opendir(dir.c_str());
-    if (d == NULL)
-        return subdirs;
-    struct dirent *ent;
-    while ((ent = readdir(d)) != NULL) {
-        if (ent->d_name[0] == '.')
-            continue;
-        std::string fullpath = dir + "/" + ent->d_name;
-        struct stat st;
-        if (stat(fullpath.c_str(), &st) == 0 && S_ISDIR(st.st_mode))
-            subdirs.push_back(fullpath);
-    }
-    closedir(d);
-#endif
-
-    std::sort(subdirs.begin(), subdirs.end());
-    return subdirs;
-}
-
-/* Load a single corpus file's data on demand */
-static bool load_corpus_file(corpus_file *cf) {
-    if (cf->data != NULL)
-        return true;
-
-    FILE *fp = fopen(cf->path.c_str(), "rb");
-    if (fp == NULL)
-        return false;
-
-    uint8_t *buf = (uint8_t *)malloc(cf->size);
-    if (buf == NULL) {
-        fclose(fp);
-        return false;
-    }
-
-    size_t bytes_read = fread(buf, 1, cf->size, fp);
-    fclose(fp);
-
-    if (bytes_read != cf->size) {
-        free(buf);
-        return false;
-    }
-
-    cf->data = buf;
-    return true;
-}
-
-/* Discover corpus files without loading their contents */
-static bool discover_corpora(void) {
-    std::vector<std::string> subdirs = list_subdirs(CORPORA_DIR);
-    if (subdirs.empty())
-        return false;
-
-    for (size_t s = 0; s < subdirs.size(); s++) {
-        std::vector<corpus_file> files = list_files(subdirs[s]);
-        corpora_files.insert(corpora_files.end(), files.begin(), files.end());
-    }
-
-    return !corpora_files.empty();
-}
 
 class deflate_corpora : public benchmark::Fixture {
 private:
@@ -333,7 +193,8 @@ public:
 
 /* Dynamic benchmark registration at static init time */
 static int register_corpora_benchmarks(void) {
-    if (!discover_corpora())
+    corpora_files = discover_corpora();
+    if (corpora_files.empty())
         return 0;
 
     int levels[] = {1, 3, 6, 8, 9};

--- a/test/benchmarks/benchmark_corpora.h
+++ b/test/benchmarks/benchmark_corpora.h
@@ -1,0 +1,162 @@
+/* benchmark_corpora.h -- corpus file discovery for benchmarks
+ * Copyright (C) 2026 Nathan Moinvaziri
+ * For conditions of distribution and use, see copyright notice in zlib.h
+ *
+ * Discovers files from the zlib-ng/corpora repository which contains multiple
+ * test corpora (silesia, calgary, canterbury, large, snappy, etc.).
+ *
+ * Clone the corpora repo:
+ *   git clone https://github.com/zlib-ng/corpora test/data/corpora
+ */
+#ifndef BENCHMARK_CORPORA_H
+#define BENCHMARK_CORPORA_H
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <vector>
+#include <string>
+#include <algorithm>
+
+#ifdef _WIN32
+#  include <windows.h>
+#else
+#  include <dirent.h>
+#  include <sys/stat.h>
+#endif
+
+/* Absolute path defined by CMake, fallback for standalone builds */
+#ifndef TEST_DATA_DIR
+#  define TEST_DATA_DIR "test/data"
+#endif
+
+#define CORPORA_DIR TEST_DATA_DIR "/corpora"
+
+struct corpus_file {
+    std::string path;
+    uint8_t *data;
+    size_t size;
+};
+
+/* List regular files in a directory (non-recursive, skips dotfiles and empty files) */
+static std::vector<corpus_file> list_files(const std::string &dir) {
+    std::vector<corpus_file> files;
+
+#ifdef _WIN32
+    WIN32_FIND_DATAA ffd;
+    std::string pattern = dir + "\\*";
+    HANDLE hFind = FindFirstFileA(pattern.c_str(), &ffd);
+    if (hFind == INVALID_HANDLE_VALUE)
+        return files;
+    do {
+        if (ffd.cFileName[0] == '.')
+            continue;
+        if (ffd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+            continue;
+        LARGE_INTEGER fsize;
+        fsize.LowPart = ffd.nFileSizeLow;
+        fsize.HighPart = ffd.nFileSizeHigh;
+        if (fsize.QuadPart <= 0)
+            continue;
+        files.push_back({dir + "\\" + ffd.cFileName, NULL, (size_t)fsize.QuadPart});
+    } while (FindNextFileA(hFind, &ffd));
+    FindClose(hFind);
+#else
+    DIR *d = opendir(dir.c_str());
+    if (d == NULL)
+        return files;
+    struct dirent *ent;
+    while ((ent = readdir(d)) != NULL) {
+        if (ent->d_name[0] == '.')
+            continue;
+        std::string fullpath = dir + "/" + ent->d_name;
+        struct stat st;
+        if (stat(fullpath.c_str(), &st) == 0 && S_ISREG(st.st_mode) && st.st_size > 0)
+            files.push_back({fullpath, NULL, (size_t)st.st_size});
+    }
+    closedir(d);
+#endif
+
+    std::sort(files.begin(), files.end(),
+              [](const corpus_file &a, const corpus_file &b) { return a.path < b.path; });
+    return files;
+}
+
+/* List subdirectories in a directory (skips dotfiles) */
+static std::vector<std::string> list_subdirs(const std::string &dir) {
+    std::vector<std::string> subdirs;
+
+#ifdef _WIN32
+    WIN32_FIND_DATAA ffd;
+    std::string pattern = dir + "\\*";
+    HANDLE hFind = FindFirstFileA(pattern.c_str(), &ffd);
+    if (hFind == INVALID_HANDLE_VALUE)
+        return subdirs;
+    do {
+        if (ffd.cFileName[0] == '.')
+            continue;
+        if (ffd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+            subdirs.push_back(dir + "\\" + ffd.cFileName);
+    } while (FindNextFileA(hFind, &ffd));
+    FindClose(hFind);
+#else
+    DIR *d = opendir(dir.c_str());
+    if (d == NULL)
+        return subdirs;
+    struct dirent *ent;
+    while ((ent = readdir(d)) != NULL) {
+        if (ent->d_name[0] == '.')
+            continue;
+        std::string fullpath = dir + "/" + ent->d_name;
+        struct stat st;
+        if (stat(fullpath.c_str(), &st) == 0 && S_ISDIR(st.st_mode))
+            subdirs.push_back(fullpath);
+    }
+    closedir(d);
+#endif
+
+    std::sort(subdirs.begin(), subdirs.end());
+    return subdirs;
+}
+
+/* Load a single corpus file's data on demand */
+static bool load_corpus_file(corpus_file *cf) {
+    if (cf->data != NULL)
+        return true;
+
+    FILE *fp = fopen(cf->path.c_str(), "rb");
+    if (fp == NULL)
+        return false;
+
+    uint8_t *buf = (uint8_t *)malloc(cf->size);
+    if (buf == NULL) {
+        fclose(fp);
+        return false;
+    }
+
+    size_t bytes_read = fread(buf, 1, cf->size, fp);
+    fclose(fp);
+
+    if (bytes_read != cf->size) {
+        free(buf);
+        return false;
+    }
+
+    cf->data = buf;
+    return true;
+}
+
+/* Discover corpus files without loading their contents */
+static std::vector<corpus_file> discover_corpora(void) {
+    std::vector<corpus_file> corpora_files;
+
+    std::vector<std::string> subdirs = list_subdirs(CORPORA_DIR);
+    for (size_t s = 0; s < subdirs.size(); s++) {
+        std::vector<corpus_file> files = list_files(subdirs[s]);
+        corpora_files.insert(corpora_files.end(), files.begin(), files.end());
+    }
+
+    return corpora_files;
+}
+
+#endif


### PR DESCRIPTION
Right now, this is just a very rough draft..

Adds `benchmark_codec.cc`, a whole-buffer raw deflate benchmark compiled once per deflate implementation under `WITH_BENCHMARK_APPS`. `benchmark_zlib_codec` and `benchmark_libdeflate_codec` register identical benchmark names over the corpora files and the synthetic data types, so their JSON outputs can be diffed directly with comparison tooling. libdeflate is found via `find_package` or fetched and built from source.

Decompression input is always produced by zlib-ng at level 9, both backends therefore inflate identical streams, and every benchmark output is verified byte-for-byte against the original data. Corpus discovery moves into `benchmark_corpora.h` so the existing corpora benchmarks share it.