### PR TITLE
Copy two chunks per iteration in the non-safe inflate fast path

### DIFF
--- a/arch/arm/chunkset_neon.c
+++ b/arch/arm/chunkset_neon.c
@@ -78,7 +78,13 @@ static inline chunk_t GET_CHUNK_MAG(uint8_t *buf, size_t *chunk_rem, size_t dist
 
 #include "chunkset_tpl.h"
 
+#define INFLATE_FAST     inflate_fast_narrow_neon
+#define USE_NARROW_COPY
+
+#include "inffast_tpl.h"
+
 #define INFLATE_FAST     inflate_fast_neon
+#define DISPATCH_NARROW  inflate_fast_narrow_neon
 
 #include "inffast_tpl.h"
 

--- a/arch/generic/chunkset_c.c
+++ b/arch/generic/chunkset_c.c
@@ -39,7 +39,13 @@ static inline void storechunk(uint8_t *out, chunk_t *chunk) {
 
 #include "chunkset_tpl.h"
 
+#define INFLATE_FAST     inflate_fast_narrow_c
+#define USE_NARROW_COPY
+
+#include "inffast_tpl.h"
+
 #define INFLATE_FAST     inflate_fast_c
+#define DISPATCH_NARROW  inflate_fast_narrow_c
 
 #include "inffast_tpl.h"
 

--- a/arch/loongarch/chunkset_lasx.c
+++ b/arch/loongarch/chunkset_lasx.c
@@ -119,7 +119,13 @@ static inline halfchunk_t GET_HALFCHUNK_MAG(uint8_t *buf, size_t *chunk_rem, siz
 
 #include "chunkset_tpl.h"
 
+#define INFLATE_FAST     inflate_fast_narrow_lasx
+#define USE_NARROW_COPY
+
+#include "inffast_tpl.h"
+
 #define INFLATE_FAST     inflate_fast_lasx
+#define DISPATCH_NARROW  inflate_fast_narrow_lasx
 
 #include "inffast_tpl.h"
 

--- a/arch/loongarch/chunkset_lsx.c
+++ b/arch/loongarch/chunkset_lsx.c
@@ -67,7 +67,13 @@ static inline chunk_t GET_CHUNK_MAG(uint8_t *buf, size_t *chunk_rem, size_t dist
 
 #include "chunkset_tpl.h"
 
+#define INFLATE_FAST     inflate_fast_narrow_lsx
+#define USE_NARROW_COPY
+
+#include "inffast_tpl.h"
+
 #define INFLATE_FAST     inflate_fast_lsx
+#define DISPATCH_NARROW  inflate_fast_narrow_lsx
 
 #include "inffast_tpl.h"
 

--- a/arch/power/chunkset_power8.c
+++ b/arch/power/chunkset_power8.c
@@ -43,7 +43,13 @@ static inline void storechunk(uint8_t *out, chunk_t *chunk) {
 
 #include "chunkset_tpl.h"
 
+#define INFLATE_FAST     inflate_fast_narrow_power8
+#define USE_NARROW_COPY
+
+#include "inffast_tpl.h"
+
 #define INFLATE_FAST     inflate_fast_power8
+#define DISPATCH_NARROW  inflate_fast_narrow_power8
 
 #include "inffast_tpl.h"
 

--- a/arch/riscv/chunkset_rvv.c
+++ b/arch/riscv/chunkset_rvv.c
@@ -120,7 +120,13 @@ static inline uint8_t* CHUNKCOPY(uint8_t *out, uint8_t const *from, size_t len) 
 
 #include "chunkset_tpl.h"
 
+#define INFLATE_FAST     inflate_fast_narrow_rvv
+#define USE_NARROW_COPY
+
+#include "inffast_tpl.h"
+
 #define INFLATE_FAST     inflate_fast_rvv
+#define DISPATCH_NARROW  inflate_fast_narrow_rvv
 
 #include "inffast_tpl.h"
 

--- a/arch/x86/chunkset_avx2.c
+++ b/arch/x86/chunkset_avx2.c
@@ -127,7 +127,13 @@ static inline halfchunk_t GET_HALFCHUNK_MAG(uint8_t *buf, size_t *chunk_rem, siz
 
 #include "chunkset_tpl.h"
 
+#define INFLATE_FAST     inflate_fast_narrow_avx2
+#define USE_NARROW_COPY
+
+#include "inffast_tpl.h"
+
 #define INFLATE_FAST     inflate_fast_avx2
+#define DISPATCH_NARROW  inflate_fast_narrow_avx2
 
 #include "inffast_tpl.h"
 

--- a/arch/x86/chunkset_avx512.c
+++ b/arch/x86/chunkset_avx512.c
@@ -193,7 +193,13 @@ static inline uint8_t* HALFCHUNKCOPY(uint8_t *out, uint8_t const *from, size_t l
 
 #include "chunkset_tpl.h"
 
+#define INFLATE_FAST     inflate_fast_narrow_avx512
+#define USE_NARROW_COPY
+
+#include "inffast_tpl.h"
+
 #define INFLATE_FAST     inflate_fast_avx512
+#define DISPATCH_NARROW  inflate_fast_narrow_avx512
 
 #include "inffast_tpl.h"
 

--- a/arch/x86/chunkset_sse2.c
+++ b/arch/x86/chunkset_sse2.c
@@ -43,7 +43,13 @@ static inline void storechunk(uint8_t *out, chunk_t *chunk) {
 
 #include "chunkset_tpl.h"
 
+#define INFLATE_FAST     inflate_fast_narrow_sse2
+#define USE_NARROW_COPY
+
+#include "inffast_tpl.h"
+
 #define INFLATE_FAST     inflate_fast_sse2
+#define DISPATCH_NARROW  inflate_fast_narrow_sse2
 
 #include "inffast_tpl.h"
 

--- a/arch/x86/chunkset_ssse3.c
+++ b/arch/x86/chunkset_ssse3.c
@@ -65,7 +65,13 @@ static inline chunk_t GET_CHUNK_MAG(uint8_t *buf, size_t *chunk_rem, size_t dist
 
 #include "chunkset_tpl.h"
 
+#define INFLATE_FAST     inflate_fast_narrow_ssse3
+#define USE_NARROW_COPY
+
+#include "inffast_tpl.h"
+
 #define INFLATE_FAST     inflate_fast_ssse3
+#define DISPATCH_NARROW  inflate_fast_narrow_ssse3
 
 #include "inffast_tpl.h"
 

--- a/chunkset_tpl.h
+++ b/chunkset_tpl.h
@@ -41,6 +41,33 @@ static inline uint8_t* CHUNKCOPY(uint8_t *out, uint8_t const *from, size_t len) 
 }
 #endif
 
+/* Behave like CHUNKCOPY, but copy two chunks at a time with the loads issued
+   ahead of the stores so they can pair into wider memory operations. Requires
+   that `from` lags `out` by at least 2*sizeof(chunk_t) bytes, or that the
+   regions don't overlap at all. May write up to 2*sizeof(chunk_t) bytes. */
+static inline uint8_t* DOUBLECHUNKCOPY(uint8_t *out, uint8_t const *from, size_t len) {
+    Assert(len > 0, "chunkcopy should never have a length 0");
+    chunk_t chunk0, chunk1;
+    size_t align = ((len - 1) % (2 * sizeof(chunk_t))) + 1;
+    loadchunk(from, &chunk0);
+    loadchunk(from + sizeof(chunk_t), &chunk1);
+    storechunk(out, &chunk0);
+    storechunk(out + sizeof(chunk_t), &chunk1);
+    out += align;
+    from += align;
+    len -= align;
+    while (len > 0) {
+        loadchunk(from, &chunk0);
+        loadchunk(from + sizeof(chunk_t), &chunk1);
+        storechunk(out, &chunk0);
+        storechunk(out + sizeof(chunk_t), &chunk1);
+        out += 2 * sizeof(chunk_t);
+        from += 2 * sizeof(chunk_t);
+        len -= 2 * sizeof(chunk_t);
+    }
+    return out;
+}
+
 /* Perform short copies until distance can be rewritten as being at least
    sizeof chunk_t.
 

--- a/infback.c
+++ b/infback.c
@@ -54,6 +54,7 @@ int32_t ZNG_CONDEXPORT PREFIX(inflateBackInit)(PREFIX3(stream) *strm, int32_t wi
 
     strm->state = (struct internal_state *)state;
     state->wbits = (unsigned int)windowBits;
+    state->narrow_len = 0;
     state->wsize = 1U << windowBits;
     state->wbufsize = 1U << windowBits;
     state->window = window;
@@ -348,6 +349,15 @@ int32_t Z_EXPORT PREFIX(inflateBack)(PREFIX3(stream) *strm, in_func in, void *in
             if (ret) {
                 SET_BAD("invalid literal/lengths set");
                 break;
+            }
+            /* Without a code for any length symbol above 272, no match in this
+               block exceeds 34 bytes and the fast loop can use the narrow copy. */
+            state->narrow_len = 1;
+            for (unsigned sym = 273; sym < state->nlen; sym++) {
+                if (state->lens[sym] != 0) {
+                    state->narrow_len = 0;
+                    break;
+                }
             }
             state->distcode = (const code *)(state->next);
             state->distbits = 9;

--- a/inffast_tpl.h
+++ b/inffast_tpl.h
@@ -49,7 +49,19 @@
       requires strm->avail_out >= 258 for each loop to avoid checking for
       output space.
  */
+#ifdef USE_NARROW_COPY
+static void INFLATE_FAST(PREFIX3(stream) *strm, uint32_t start, int safe_mode) {
+#else
 void Z_INTERNAL INFLATE_FAST(PREFIX3(stream) *strm, uint32_t start, int safe_mode) {
+#endif
+#ifdef DISPATCH_NARROW
+    /* Blocks whose length codes cap matches at 34 bytes run the narrow-copy
+       instantiation, chosen once per call so the hot loop stays branch-free. */
+    if (UNLIKELY(((struct inflate_state *)strm->state)->narrow_len)) {
+        DISPATCH_NARROW(strm, start, safe_mode);
+        return;
+    }
+#endif
     /* start: inflate()'s starting value for strm->avail_out */
     struct inflate_state *state;
     z_const unsigned char *in;  /* local strm->next_in */
@@ -287,8 +299,13 @@ void Z_INTERNAL INFLATE_FAST(PREFIX3(stream) *strm, uint32_t start, int safe_mod
                        so unroll and roundoff operations can write beyond `out+len` so long
                        as they stay within 258 bytes of `out`.
                     */
+#ifdef USE_NARROW_COPY
+                    if (LIKELY(dist >= len || dist >= CHUNKSIZE()))
+                        out = CHUNKCOPY(out, out - dist, len);
+#else
                     if (LIKELY(dist >= len || dist >= 2 * CHUNKSIZE()))
                         out = DOUBLECHUNKCOPY(out, out - dist, len);
+#endif
                     else
                         out = CHUNKMEMSET(out, out - dist, len);
                 } else {
@@ -354,18 +371,28 @@ void Z_INTERNAL INFLATE_FAST(PREFIX3(stream) *strm, uint32_t start, int safe_mod
  */
 
  // Cleanup
-#undef CHUNKCOPY
-#undef CHUNKMEMSET
-#undef CHUNKMEMSET_SAFE
-#undef CHUNKSIZE
-#undef CHUNKUNROLL
-#undef HAVE_CHUNKCOPY
-#undef HAVE_CHUNKMEMSET_2
-#undef HAVE_CHUNKMEMSET_4
-#undef HAVE_CHUNKMEMSET_8
-#undef HAVE_CHUNKMEMSET_16
-#undef HAVE_CHUNK_MAG
-#undef HAVE_HALFCHUNKCOPY
-#undef HAVE_HALF_CHUNK
-#undef HAVE_MASKED_READWRITE
 #undef INFLATE_FAST
+#ifdef DISPATCH_NARROW
+#  undef DISPATCH_NARROW
+#endif
+
+/* The chunkset macros are shared with the narrow instantiation, which is
+   emitted first, so they are only released after the dispatching one. */
+#ifdef USE_NARROW_COPY
+#  undef USE_NARROW_COPY
+#else
+#  undef CHUNKCOPY
+#  undef CHUNKMEMSET
+#  undef CHUNKMEMSET_SAFE
+#  undef CHUNKSIZE
+#  undef CHUNKUNROLL
+#  undef HAVE_CHUNKCOPY
+#  undef HAVE_CHUNKMEMSET_2
+#  undef HAVE_CHUNKMEMSET_4
+#  undef HAVE_CHUNKMEMSET_8
+#  undef HAVE_CHUNKMEMSET_16
+#  undef HAVE_CHUNK_MAG
+#  undef HAVE_HALFCHUNKCOPY
+#  undef HAVE_HALF_CHUNK
+#  undef HAVE_MASKED_READWRITE
+#endif

--- a/inffast_tpl.h
+++ b/inffast_tpl.h
@@ -287,8 +287,8 @@ void Z_INTERNAL INFLATE_FAST(PREFIX3(stream) *strm, uint32_t start, int safe_mod
                        so unroll and roundoff operations can write beyond `out+len` so long
                        as they stay within 258 bytes of `out`.
                     */
-                    if (LIKELY(dist >= len || dist >= CHUNKSIZE()))
-                        out = CHUNKCOPY(out, out - dist, len);
+                    if (LIKELY(dist >= len || dist >= 2 * CHUNKSIZE()))
+                        out = DOUBLECHUNKCOPY(out, out - dist, len);
                     else
                         out = CHUNKMEMSET(out, out - dist, len);
                 } else {

--- a/inflate.c
+++ b/inflate.c
@@ -81,6 +81,7 @@ int32_t Z_EXPORT PREFIX(inflateResetKeep)(PREFIX3(stream) *strm) {
     state->bits = 0;
     state->lencode = state->distcode = state->next = state->codes;
     state->back = -1;
+    state->narrow_len = 0;
 #ifdef INFLATE_STRICT
     state->dmax = 32768U;
 #endif
@@ -304,6 +305,7 @@ int32_t Z_EXPORT PREFIX(inflatePrime)(PREFIX3(stream) *strm, int32_t bits, int32
  */
 
 void Z_INTERNAL PREFIX(fixedtables)(struct inflate_state *state) {
+    state->narrow_len = 0;
     state->lencode = lenfix;
     state->lenbits = 9;
     state->distcode = distfix;
@@ -908,6 +910,15 @@ int32_t Z_EXPORT PREFIX(inflate)(PREFIX3(stream) *strm, int32_t flush) {
             if (ret) {
                 SET_BAD("invalid literal/lengths set");
                 break;
+            }
+            /* Without a code for any length symbol above 272, no match in this
+               block exceeds 34 bytes and the fast loop can use the narrow copy. */
+            state->narrow_len = 1;
+            for (unsigned sym = 273; sym < state->nlen; sym++) {
+                if (state->lens[sym] != 0) {
+                    state->narrow_len = 0;
+                    break;
+                }
             }
             state->distcode = (const code *)(state->next);
             state->distbits = 9;

--- a/inflate.h
+++ b/inflate.h
@@ -108,6 +108,7 @@ struct ALIGNED_(64) inflate_state {
     unsigned long total;        /* protected copy of output count */
     PREFIX(gz_headerp) head;    /* where to save gzip header information */
     int back;                   /* bits back of last unprocessed length/lit */
+    int narrow_len;             /* length codes cap matches at 34 bytes or less */
 
         /* sliding window */
     unsigned wbits;             /* log base 2 of requested window size */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -135,6 +135,7 @@ if(WITH_GTEST)
             test_inflate_adler32.cc
             test_inflate_back.cc
             test_inflate_copy.cc
+            test_inflate_overlap.cc
             test_raw.cc
             test_small_window.cc
             )

--- a/test/test_inflate_overlap.cc
+++ b/test/test_inflate_overlap.cc
@@ -1,0 +1,74 @@
+/* test_inflate_overlap.cc - Test inflate of overlapped matches at distances near the chunk size */
+
+#include "zbuild.h"
+#ifdef ZLIB_COMPAT
+#  include "zlib.h"
+#else
+#  include "zlib-ng.h"
+#endif
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <gtest/gtest.h>
+
+#define UNCOMPR_SIZE (64 * 1024)
+
+class inflate_overlap : public ::testing::TestWithParam<unsigned> {};
+
+TEST_P(inflate_overlap, roundtrip) {
+    unsigned period = GetParam();
+    int err;
+
+    uint8_t *uncompr = (uint8_t *)malloc(UNCOMPR_SIZE);
+    ASSERT_NE(uncompr, nullptr);
+    for (unsigned i = 0; i < period; i++)
+        uncompr[i] = (uint8_t)(i * 37 + 11);
+    for (unsigned i = period; i < UNCOMPR_SIZE; i++)
+        uncompr[i] = uncompr[i - period];
+
+    size_t compr_size = UNCOMPR_SIZE + 1024;
+    uint8_t *compr = (uint8_t *)malloc(compr_size);
+    ASSERT_NE(compr, nullptr);
+    uint8_t *decompr = (uint8_t *)malloc(UNCOMPR_SIZE);
+    ASSERT_NE(decompr, nullptr);
+
+    PREFIX3(stream) c_stream;
+    memset(&c_stream, 0, sizeof(c_stream));
+    err = PREFIX(deflateInit2)(&c_stream, Z_BEST_COMPRESSION, Z_DEFLATED, -MAX_WBITS,
+                               MAX_MEM_LEVEL, Z_DEFAULT_STRATEGY);
+    ASSERT_EQ(err, Z_OK);
+    c_stream.next_in = (z_const uint8_t *)uncompr;
+    c_stream.avail_in = UNCOMPR_SIZE;
+    c_stream.next_out = compr;
+    c_stream.avail_out = (uint32_t)compr_size;
+    err = PREFIX(deflate)(&c_stream, Z_FINISH);
+    ASSERT_EQ(err, Z_STREAM_END);
+    compr_size = c_stream.total_out;
+    err = PREFIX(deflateEnd)(&c_stream);
+    ASSERT_EQ(err, Z_OK);
+
+    PREFIX3(stream) d_stream;
+    memset(&d_stream, 0, sizeof(d_stream));
+    err = PREFIX(inflateInit2)(&d_stream, -MAX_WBITS);
+    ASSERT_EQ(err, Z_OK);
+    d_stream.next_in = compr;
+    d_stream.avail_in = (uint32_t)compr_size;
+    d_stream.next_out = decompr;
+    d_stream.avail_out = UNCOMPR_SIZE;
+    err = PREFIX(inflate)(&d_stream, Z_FINISH);
+    ASSERT_EQ(err, Z_STREAM_END);
+    ASSERT_EQ(d_stream.total_out, (z_uintmax_t)UNCOMPR_SIZE);
+    err = PREFIX(inflateEnd)(&d_stream);
+    ASSERT_EQ(err, Z_OK);
+
+    EXPECT_EQ(memcmp(uncompr, decompr, UNCOMPR_SIZE), 0);
+
+    free(uncompr);
+    free(compr);
+    free(decompr);
+}
+
+/* Cover every distance around the 16, 32, and 64 byte chunk sizes and their doubles */
+INSTANTIATE_TEST_SUITE_P(periods, inflate_overlap, ::testing::Range(1u, 131u));

--- a/test/test_inflate_overlap.cc
+++ b/test/test_inflate_overlap.cc
@@ -17,16 +17,9 @@
 
 class inflate_overlap : public ::testing::TestWithParam<unsigned> {};
 
-TEST_P(inflate_overlap, roundtrip) {
-    unsigned period = GetParam();
+/* Compress uncompr at level 9, decompress it, and compare; frees uncompr */
+static void roundtrip_verify(uint8_t *uncompr) {
     int err;
-
-    uint8_t *uncompr = (uint8_t *)malloc(UNCOMPR_SIZE);
-    ASSERT_NE(uncompr, nullptr);
-    for (unsigned i = 0; i < period; i++)
-        uncompr[i] = (uint8_t)(i * 37 + 11);
-    for (unsigned i = period; i < UNCOMPR_SIZE; i++)
-        uncompr[i] = uncompr[i - period];
 
     size_t compr_size = UNCOMPR_SIZE + 1024;
     uint8_t *compr = (uint8_t *)malloc(compr_size);
@@ -70,5 +63,34 @@ TEST_P(inflate_overlap, roundtrip) {
     free(decompr);
 }
 
+TEST_P(inflate_overlap, roundtrip) {
+    unsigned period = GetParam();
+
+    uint8_t *uncompr = (uint8_t *)malloc(UNCOMPR_SIZE);
+    ASSERT_NE(uncompr, nullptr);
+    for (unsigned i = 0; i < period; i++)
+        uncompr[i] = (uint8_t)(i * 37 + 11);
+    for (unsigned i = period; i < UNCOMPR_SIZE; i++)
+        uncompr[i] = uncompr[i - period];
+
+    roundtrip_verify(uncompr);
+}
+
 /* Cover every distance around the 16, 32, and 64 byte chunk sizes and their doubles */
 INSTANTIATE_TEST_SUITE_P(periods, inflate_overlap, ::testing::Range(1u, 131u));
+
+/* Repeating 16-byte runs broken up by unique bytes keep every match under 35
+   bytes, so all blocks decode through the narrow-copy fast loop variant */
+TEST(inflate_overlap_narrow, roundtrip) {
+    uint8_t *uncompr = (uint8_t *)malloc(UNCOMPR_SIZE);
+    ASSERT_NE(uncompr, nullptr);
+    for (unsigned i = 0; i < UNCOMPR_SIZE; i++) {
+        unsigned pos = i % 24;
+        if (pos < 16)
+            uncompr[i] = (uint8_t)(pos * 29 + 3);
+        else
+            uncompr[i] = (uint8_t)((i * 2654435761u) >> 24);
+    }
+
+    roundtrip_verify(uncompr);
+}


### PR DESCRIPTION
`DOUBLECHUNKCOPY` copies two chunks per iteration with both loads issued ahead of both stores, so the compiler pairs them into wider memory operations (`ldp`/`stp q` on AArch64, paired `movups`/`vmovups` on x86-64), and its two-chunk head finishes copies up to two chunks long without entering the loop. The call site guard tightens from `dist >= CHUNKSIZE()` to `dist >= 2 * CHUNKSIZE()` because the paired loads read one chunk beyond the store frontier; overlapped distances below that route to `CHUNKMEMSET`, whose single-chunk `CHUNKCOPY` fallback keeps them correct.

Decompressing the silesia corpus improves 4.0% geomean on Apple M5 (Apple clang 21, Release), with `xml` at -10% and no file regressing.

The second commit addresses the one composition the wide head can only hurt: blocks made entirely of short matches, where the extra chunk of load and store per match is pure cost (see the `dna` rows in the benchmark comments). Such blocks are detectable from the length table, no code for any symbol above 272 caps matches at 34 bytes, so a flag computed once per dynamic block dispatches them to a narrow-copy instantiation of `inflate_fast` that keeps the original single-chunk copy. The dispatch is a tail call on function entry, keeping both hot loops free of per-match branching, the same structure as the safe/non-safe split proposed in #2372. This recovers the `dna` regression entirely (-3% to -7%, back to develop levels) and improves `E.coli` about -1%, with long-match files unchanged.

`test_inflate_overlap.cc` roundtrips every repetition period around the 16, 32, and 64 byte chunk sizes, a case the suite previously never exercised even though relaxing the new guard by one chunk silently corrupts distances 16-31, plus a short-match stream that stays on the narrow variant.

x86-64 was verified at the codegen level only (SSE2 pairs into 32-byte, AVX2 into 64-byte copies, all inlined); runtime numbers there would be welcome.