### PR TITLE
Use a branchless byte-granular bit writer in compress_block

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -170,6 +170,15 @@ static const config configuration_table[10] = {
 #  define LOGSZPL(name,size,loc,pad)
 #endif
 
+/* Extra bytes reserved between the pending buffer and the symbol buffers, and at
+ * the end of the pending allocation. send_bits_flush stores 8 bytes unconditionally but
+ * only advances past the complete ones, so its stores reach up to 7 bytes beyond the
+ * logical output position, which may otherwise clobber unread symbols as the output
+ * chases the symbol buffer, or run past the allocation. */
+#define PENDING_BUF_PAD 8
+
+#define PENDING_BUF_SIZE(lit_bufsize) (((lit_bufsize) * LIT_BUFS) + 1 + PENDING_BUF_PAD)
+
 /* ===========================================================================
  * Allocate a big buffer and divide it up into the various buffers deflate needs.
  * Handles alignment of allocated buffer and alignment of individual buffers.
@@ -181,7 +190,7 @@ Z_INTERNAL deflate_allocs* alloc_deflate(PREFIX3(stream) *strm, int windowBits, 
     int window_size = DEFLATE_ADJUST_WINDOW_SIZE((1 << windowBits) * 2);
     int prev_size = (1 << windowBits) * (int)sizeof(Pos);
     int head_size = HASH_SIZE * sizeof(Pos);
-    int pending_size = (lit_bufsize * LIT_BUFS) + 1;
+    int pending_size = PENDING_BUF_SIZE(lit_bufsize);
     int state_size = sizeof(deflate_state);
     int alloc_size = sizeof(deflate_allocs);
 
@@ -364,11 +373,11 @@ int32_t ZNG_CONDEXPORT PREFIX(deflateInit2)(PREFIX3(stream) *strm, int32_t level
     s->pending_buf_size = s->lit_bufsize * 4;
 
 #ifdef LIT_MEM
-    s->d_buf = (uint16_t *)(s->pending_buf + (s->lit_bufsize << 1));
-    s->l_buf = s->pending_buf + (s->lit_bufsize << 2);
+    s->d_buf = (uint16_t *)(s->pending_buf + (s->lit_bufsize << 1) + PENDING_BUF_PAD);
+    s->l_buf = s->pending_buf + (s->lit_bufsize << 2) + PENDING_BUF_PAD;
     s->sym_end = s->lit_bufsize - 1;
 #else
-    s->sym_buf = s->pending_buf + s->lit_bufsize;
+    s->sym_buf = s->pending_buf + s->lit_bufsize + PENDING_BUF_PAD;
     s->sym_end = (s->lit_bufsize - 1) * 3;
 #endif
     /* We avoid equality with lit_bufsize*3 because of wraparound at 64K
@@ -1158,14 +1167,14 @@ int32_t Z_EXPORT PREFIX(deflateCopy)(PREFIX3(stream) *dest, PREFIX3(stream) *sou
     memcpy(ds->window, ss->window, DEFLATE_ADJUST_WINDOW_SIZE(ds->w_size * 2 * sizeof(unsigned char)));
     memcpy(ds->prev, ss->prev, ds->w_size * sizeof(Pos));
     memcpy(ds->head, ss->head, HASH_SIZE * sizeof(Pos));
-    memcpy(ds->pending_buf, ss->pending_buf, ds->lit_bufsize * LIT_BUFS);
+    memcpy(ds->pending_buf, ss->pending_buf, PENDING_BUF_SIZE(ds->lit_bufsize));
 
     ds->pending_out = ds->pending_buf + (ss->pending_out - ss->pending_buf);
 #ifdef LIT_MEM
-    ds->d_buf = (uint16_t *)(ds->pending_buf + (ds->lit_bufsize << 1));
-    ds->l_buf = ds->pending_buf + (ds->lit_bufsize << 2);
+    ds->d_buf = (uint16_t *)(ds->pending_buf + (ds->lit_bufsize << 1) + PENDING_BUF_PAD);
+    ds->l_buf = ds->pending_buf + (ds->lit_bufsize << 2) + PENDING_BUF_PAD;
 #else
-    ds->sym_buf = ds->pending_buf + ds->lit_bufsize;
+    ds->sym_buf = ds->pending_buf + ds->lit_bufsize + PENDING_BUF_PAD;
 #endif
 
     ds->l_desc.dyn_tree = ds->dyn_ltree;

--- a/trees.c
+++ b/trees.c
@@ -710,20 +710,10 @@ void Z_INTERNAL zng_tr_flush_block(deflate_state *s, unsigned char *buf, uint32_
  * Send the block data compressed using the given Huffman trees
  */
 #if !defined(LIT_MEM) && OPTIMAL_CMP >= 64
-/* One 64-bit little-endian load at sx spans the next three symbols' dist fields
- * (bits 0..15, 24..39, 48..63) and two of their literals (bits 16..23, 40..47). */
-#define LIT3_DIST_MASK 0xFFFF00FFFF00FFFFULL
-
-/* The second symbol's dist field alone, which separates a one-literal run from a two-literal
- * one once the all-three case has been ruled out. */
+/* One 64-bit little-endian load at sx spans the next two symbols' dist fields
+ * (bits 0..15, 24..39) and literals (bits 16..23, 40..47). The second symbol's dist
+ * field alone separates a one-literal run from a two-literal one. */
 #define LIT3_DIST1_MASK 0x000000FFFF000000ULL
-
-/* Prepend one literal below whatever tail already holds, so entering the switch at case k
- * emits exactly the first k symbols in order. */
-Z_FORCEINLINE static void lit_prepend(const ct_data *ltree, unsigned lc, uint64_t *tail, uint32_t *tbits) {
-    *tail = (uint64_t)ltree[lc].Code | (*tail << ltree[lc].Len);
-    *tbits += ltree[lc].Len;
-}
 #endif
 
 static void compress_block(deflate_state *s, const ct_data *ltree, const ct_data *dtree) {
@@ -742,12 +732,14 @@ static void compress_block(deflate_state *s, const ct_data *ltree, const ct_data
     unsigned char *sym_buf = s->sym_buf;
 #endif
 
-    /* Keep bi_buf and bi_valid in registers across the entire loop */
+    /* Keep the bit writer state in registers across the entire loop */
     uint64_t bi_buf = s->bi_buf;
     uint32_t bi_valid = s->bi_valid;
+    uint32_t pending = s->pending;
 
     if (sym_next != 0) {
         do {
+            send_bits_flush(s, bi_buf, bi_valid, pending);
 #ifdef LIT_MEM
             dist = d_buf[sx];
             lc = l_buf[sx++];
@@ -763,56 +755,50 @@ static void compress_block(deflate_state *s, const ct_data *ltree, const ct_data
             sx += 3;
 #endif
             if (dist == 0) {
+                uint64_t bits = 0;
+                uint32_t nbits = 0;
+
+                send_code_merge(s, lc, ltree, bits, nbits);
 #if !defined(LIT_MEM) && OPTIMAL_CMP >= 64
-                /* Pack up to 4 consecutive literals into a single send_bits. Their codes are
-                 * at most 15 bits each, so 4 fit inside the 64-bit bit buffer. */
-                uint64_t bits = ltree[lc].Code;
-                uint32_t nbits = ltree[lc].Len;
+                /* Accumulate up to 2 more consecutive literals into the same merge. Their
+                 * codes are at most 15 bits each, so all three fit alongside the at most
+                 * 7 bits the flush above leaves behind. */
+                if (sx + 8 <= sym_next) {
+                    uint64_t next_syms = Z_U64_FROM_LE(zng_memread_8(&sym_buf[sx]));
 
-                if (sx + 9 <= sym_next) {
-                    uint64_t v = Z_U64_FROM_LE(zng_memread_8(&sym_buf[sx]));
-                    uint64_t dist_bits = v & LIT3_DIST_MASK;
+                    /* A dist field is zero exactly when that symbol is a literal */
+                    if ((uint16_t)next_syms == 0) {
+                        send_code_merge(s, (unsigned)((next_syms >> 16) & 0xff), ltree, bits, nbits);
+                        sx += 3;
 
-                    /* A dist field is zero exactly when that symbol is a literal, so the first
-                     * nonzero one ends the run. There are only three fields, so three tests
-                     * locate it and no bit scan is needed. */
-                    if (dist_bits == 0 || (uint16_t)v == 0) {
-                        unsigned nextra = dist_bits == 0 ? 3 : (v & LIT3_DIST1_MASK) ? 1 : 2;
-                        uint64_t tail = 0;
-                        uint32_t tbits = 0;
-
-                        switch (nextra) {
-                        case 3:
-                            lit_prepend(ltree, sym_buf[sx + 8], &tail, &tbits);
-                            Z_FALLTHROUGH;
-                        case 2:
-                            lit_prepend(ltree, (v >> 40) & 0xff, &tail, &tbits);
-                            Z_FALLTHROUGH;
-                        default:
-                            lit_prepend(ltree, (v >> 16) & 0xff, &tail, &tbits);
+                        if ((next_syms & LIT3_DIST1_MASK) == 0) {
+                            send_code_merge(s, (unsigned)((next_syms >> 40) & 0xff), ltree, bits, nbits);
+                            sx += 3;
                         }
-                        bits |= tail << nbits;
-                        nbits += tbits;
-                        sx += 3 * nextra;
                     }
                 }
-                send_bits(s, bits, nbits, bi_buf, bi_valid);
-#else
-                zng_emit_lit(s, ltree, lc, &bi_buf, &bi_valid);
 #endif
+                /* The codes were traced and counted as they accumulated */
+                Assert(bi_valid + nbits <= 64, "bit buffer overflow");
+                bi_buf |= bits << bi_valid;
+                bi_valid += nbits;
             } else {
-                zng_emit_dist(s, ltree, dtree, lc, dist, &bi_buf, &bi_valid);
+                uint32_t match_bits_len;
+                uint64_t match_bits = zng_assemble_dist(s, ltree, dtree, lc, dist, &match_bits_len);
+
+                send_bits_merge(s, match_bits, match_bits_len, bi_buf, bi_valid);
             } /* literal or match pair ? */
 
             /* Check for no overlay of pending_buf on needed symbols */
 #ifdef LIT_MEM
-            Assert(s->pending < 2 * (s->lit_bufsize + sx), "pending_buf overflow");
+            Assert(pending < 2 * (s->lit_bufsize + sx), "pending_buf overflow");
 #else
-            Assert(s->pending < s->lit_bufsize + sx, "pending_buf overflow");
+            Assert(pending < s->lit_bufsize + sx, "pending_buf overflow");
 #endif
         } while (sx < sym_next);
     }
 
+    s->pending = pending;
     zng_emit_end_block(s, ltree, 0, &bi_buf, &bi_valid);
 
     /* Write back to state */

--- a/trees_emit.h
+++ b/trees_emit.h
@@ -63,6 +63,27 @@ extern Z_INTERNAL const uint32_t dmask_extra[D_CODES];
     bi_valid = total_bits;\
 } while (0)
 
+/* Merge bits into the bit buffer without flushing. The caller must guarantee room,
+ * i.e. bi_valid + len <= 64. Pair with send_bits_flush, which leaves at most 7 bits. */
+#define send_bits_merge(s, t_val, t_len, bi_buf, bi_valid) do {\
+    Assert((bi_valid) + (uint32_t)(t_len) <= 64, "bit buffer overflow");\
+    trace_bits(s, (uint64_t)(t_val), (uint32_t)(t_len));\
+    sent_bits_add(s, t_len);\
+    bi_buf |= (uint64_t)(t_val) << (bi_valid);\
+    bi_valid += (uint32_t)(t_len);\
+} while (0)
+
+/* Store the bit buffer unconditionally and consume its complete bytes, leaving at most
+ * 7 valid bits. The unconditional 8-byte store reaches up to 7 bytes past the logical
+ * output position, which the pending buffer layout must reserve room for
+ * (see PENDING_BUF_PAD in deflate.c). */
+#define send_bits_flush(s, bi_buf, bi_valid, pending) do {\
+    zng_memwrite_8((s)->pending_buf + (pending), Z_U64_TO_LE(bi_buf));\
+    pending += (bi_valid) >> 3;\
+    bi_buf >>= ((bi_valid) & ~7U);\
+    bi_valid &= 7;\
+} while (0)
+
 /* Send a code of the given tree. c and tree must not have side effects */
 #ifdef ZLIB_DEBUG
 #  define send_code(s, c, tree, bi_buf, bi_valid) { \
@@ -72,6 +93,17 @@ extern Z_INTERNAL const uint32_t dmask_extra[D_CODES];
 #else
 #  define send_code(s, c, tree, bi_buf, bi_valid) \
     send_bits(s, tree[c].Code, tree[c].Len, bi_buf, bi_valid)
+#endif
+
+/* Merge a code of the given tree without flushing. c and tree must not have side effects */
+#ifdef ZLIB_DEBUG
+#  define send_code_merge(s, c, tree, bi_buf, bi_valid) { \
+    trace_code(s, c); \
+    send_bits_merge(s, tree[c].Code, tree[c].Len, bi_buf, bi_valid); \
+}
+#else
+#  define send_code_merge(s, c, tree, bi_buf, bi_valid) \
+    send_bits_merge(s, tree[c].Code, tree[c].Len, bi_buf, bi_valid)
 #endif
 
 /* ===========================================================================

--- a/trees_emit.h
+++ b/trees_emit.h
@@ -110,10 +110,11 @@ Z_FORCEINLINE static void zng_emit_lit(deflate_state *s, const ct_data *ltree, u
 }
 
 /* ===========================================================================
- * Emit match distance/length code
+ * Assemble a match's length code + extra bits + distance code + extra bits into
+ * a single bit string, at most 48 bits. Returns the bits, length via *bits_len.
  */
-static inline uint32_t zng_emit_dist(deflate_state *s, const ct_data *ltree, const ct_data *dtree,
-                                     uint32_t lc, uint32_t dist, uint64_t *bi_buf, uint32_t *bi_valid) {
+Z_FORCEINLINE static uint64_t zng_assemble_dist(deflate_state *s, const ct_data *ltree, const ct_data *dtree,
+                                                uint32_t lc, uint32_t dist, uint32_t *bits_len) {
     uint64_t match_bits;
     uint32_t match_bits_len;
     uint32_t mask_ext;  // Contains both mask and extra, can safely be used directly as mask
@@ -156,6 +157,19 @@ static inline uint32_t zng_emit_dist(deflate_state *s, const ct_data *ltree, con
     /*    Send dist extra bits */
     match_bits |= ((uint64_t)(dist & mask_ext) << match_bits_len);
     match_bits_len += extra;
+
+    Z_UNUSED(s);
+    *bits_len = match_bits_len;
+    return match_bits;
+}
+
+/* ===========================================================================
+ * Emit match distance/length code
+ */
+static inline uint32_t zng_emit_dist(deflate_state *s, const ct_data *ltree, const ct_data *dtree,
+                                     uint32_t lc, uint32_t dist, uint64_t *bi_buf, uint32_t *bi_valid) {
+    uint32_t match_bits_len;
+    uint64_t match_bits = zng_assemble_dist(s, ltree, dtree, lc, dist, &match_bits_len);
 
     send_bits(s, match_bits, match_bits_len, *bi_buf, *bi_valid);
 


### PR DESCRIPTION
`send_bits` flushes when the accumulated bits cross the 64-bit boundary, a data-dependent branch that mispredicts constantly with variable-length codes. The new `send_bits_flush` stores the bit buffer unconditionally once per symbol and consumes only the complete bytes, so the flush needs no branch. This is the byte-granular writer pattern used by libdeflate and by igzip's assembly emitters. The literal batch drops from four codes to three since a merge must fit alongside the flush residue in 64 bits, and `zng_emit_dist` is split into a `zng_assemble_dist` helper so the match bit assembly can be shared by the merge path.

The unconditional store reaches up to 7 bytes beyond the output position, so the symbol buffers move up by `PENDING_BUF_PAD` bytes and the pending allocation grows by the same amount.

Output is bit-identical across levels, strategies and flush patterns. On Apple M5, deflate runs 2-5% faster at levels 3 through 9 (geomean -2.7%), `Z_HUFFMAN_ONLY` 13-25% and `Z_RLE` 13-20%. Level 1 is unaffected since `deflate_quick` does not use `compress_block`. x86-64 has not been measured yet.

Full deflate, `deflate_corpora` benchmarks, Apple M5 (macOS 26.6, Apple clang), 5 repetitions, CPU time medians:

| benchmark | level 3 | level 6 | level 9 |
|---|---|---|---|
| silesia/dickens | -3.1% | -2.9% | -2.2% |
| silesia/osdb | -3.6% | -2.9% | -3.7% |
| silesia/xml | -4.3% | -2.0% | -0.5% |
| tars/silesia.tar | | -2.2% | |
| tars/silesia.tar level 1 (control) | | -0.3% | |

Geomean across the set is -2.7%, compressed size delta is exactly 0 bytes on every row.

Strategies where `compress_block` dominates, one-shot deflate at level 6, interleaved A/B, medians of 15:

| strategy | dickens | osdb | x-ray |
|---|---|---|---|
| `Z_HUFFMAN_ONLY` | -25.1% | -15.7% | -13.2% |
| `Z_RLE` | -20.4% | -13.3% | -14.8% |

Static instruction check of `compress_block`, same compiler both sides (LLVM clang 22.1.5, `-O2`):

| | instructions | cond. branches | loads | stores | stack refs |
|---|---|---|---|---|---|
| arm64 develop | 149 | 10 | 34 | 9 | 6 |
| arm64 PR | 116 (-22%) | 7 | 28 | 8 | 4 |
| x86-64 develop | 184 | 10 | 43 | 8 | 6 |
| x86-64 PR | 155 (-16%) | 7 | 38 | 9 | 7 |

Both architectures lose the same three conditional branches (the `send_bits` boundary branch at each emit site) with no spill growth; stores are per-symbol dynamically but fewer static sites.
