### PR TITLE
Load a whole chunk for match distances equal to the chunk width

### DIFF
--- a/chunkset_tpl.h
+++ b/chunkset_tpl.h
@@ -142,7 +142,10 @@ static inline uint8_t* CHUNKMEMSET(uint8_t *out, uint8_t *from, size_t len) {
         return out + len;
     } else
 #endif
-    if (dist >= len || dist >= sizeof(chunk_t)) {
+    /* A distance equal to sizeof(chunk_t) falls through to the broadcast path below instead
+     * of going to CHUNKCOPY. CHUNKCOPY would read its source one chunk behind the store it
+     * just issued, so every iteration waits on store to load forwarding. */
+    if (dist >= len || dist > sizeof(chunk_t)) {
         return CHUNKCOPY(out, from, len);
     }
 
@@ -201,7 +204,10 @@ static inline uint8_t* CHUNKMEMSET(uint8_t *out, uint8_t *from, size_t len) {
         chunkmemset_16(from, &chunk_load);
     } else
 #endif
-    {
+    /* A period of exactly one chunk needs no replication, so a plain load fills the magazine */
+    if (dist == sizeof(chunk_t)) {
+        loadchunk(from, &chunk_load);
+    } else {
         /* The permute tables only cover distances below the chunk width */
         Assert(dist < sizeof(chunk_t), "chunk magazine distance out of range");
         chunk_load = GET_CHUNK_MAG(from, &chunk_mod, dist);

--- a/chunkset_tpl.h
+++ b/chunkset_tpl.h
@@ -159,6 +159,8 @@ static inline uint8_t* CHUNKMEMSET(uint8_t *out, uint8_t *from, size_t len) {
             return HALFCHUNKCOPY(out, from, len);
 
         if ((dist % 2) != 0 || dist == 6) {
+            /* The permute tables only cover distances below the half chunk width */
+            Assert(dist < sizeof(halfchunk_t), "half chunk magazine distance out of range");
             halfchunk_t halfchunk_load = GET_HALFCHUNK_MAG(from, &chunk_mod, dist);
 
             if (len == sizeof(halfchunk_t)) {
@@ -199,7 +201,11 @@ static inline uint8_t* CHUNKMEMSET(uint8_t *out, uint8_t *from, size_t len) {
         chunkmemset_16(from, &chunk_load);
     } else
 #endif
-    chunk_load = GET_CHUNK_MAG(from, &chunk_mod, dist);
+    {
+        /* The permute tables only cover distances below the chunk width */
+        Assert(dist < sizeof(chunk_t), "chunk magazine distance out of range");
+        chunk_load = GET_CHUNK_MAG(from, &chunk_mod, dist);
+    }
 
     if (len <= sizeof(chunk_t)) {
 #ifdef HAVE_MASKED_READWRITE

--- a/inffast_tpl.h
+++ b/inffast_tpl.h
@@ -287,7 +287,7 @@ void Z_INTERNAL INFLATE_FAST(PREFIX3(stream) *strm, uint32_t start, int safe_mod
                        so unroll and roundoff operations can write beyond `out+len` so long
                        as they stay within 258 bytes of `out`.
                     */
-                    if (LIKELY(dist >= len || dist >= CHUNKSIZE()))
+                    if (LIKELY(dist >= len || dist > CHUNKSIZE()))
                         out = CHUNKCOPY(out, out - dist, len);
                     else
                         out = CHUNKMEMSET(out, out - dist, len);


### PR DESCRIPTION
`CHUNKMEMSET` routed a match distance of exactly `sizeof(chunk_t)` to `CHUNKCOPY`. That loop reads its source one chunk behind the store it just issued, so each iteration's load waits on store to load forwarding. The period fills the vector register exactly, so an ordinary `loadchunk` builds the magazine and the existing store loop replays it at a constant stride.

The condition is written against `sizeof(chunk_t)` rather than a literal, so every chunkset picks it up. The generic chunkset gains distance 8, the NEON, SSE2, SSSE3, LSX and Power8 chunksets gain distance 16, and the AVX2, AVX-512, LASX and RVV chunksets gain distance 32. No new per-architecture helper is needed. At this distance there is nothing to replicate, so a `chunkmemset_N` would compile to the same load that `loadchunk` already does.

`inflate_fast` carries its own copy of the dispatch condition, so the third commit moves it in step. Without that the change reaches only the safe window paths.

The first commit records what the magazine builders require. `GET_CHUNK_MAG` and `GET_HALFCHUNK_MAG` index `perm_idx_lut[dist - 3]`, sized for distances 3 to 15 on 128 bit chunks and 3 to 31 on 256 bit chunks. Widening the dispatch without respecting that bound reads past the table, which an ASAN run over the template at 256 bit width confirms.

### Results

Apple M5, macOS 26.6.2, Apple clang 21.0.0, Release build.

`chunkmemset_safe` on NEON, 5 repetitions, median:

| benchmark | base | PR | change |
| --- | --- | --- | --- |
| `dist:16/len:258` | 10.9 ns | 7.21 ns | -33.6% |

Inflate of an 8 MiB stream built from a fixed period, best of 60, three interleaved rounds. Distances 8 and 32 take an unchanged path and act as controls.

| distance | base | PR | change |
| --- | --- | --- | --- |
| 8 | 0.622-0.638 ms | 0.626-0.628 ms | flat |
| 16 | 0.698-0.704 ms | 0.662-0.668 ms | -5.2% |
| 32 | 0.664-0.674 ms | 0.657-0.666 ms | flat |

A sweep over distances 4 to 64 moves only distance 16, everything else sits inside the ±2% noise of that harness.

The case is uncommon in text-like data. On a 10 MiB tar of this source tree, distance 16 is 0.03% to 0.08% of copied bytes at levels 1, 6 and 9. It is common in data with a 16 or 32 byte stride.

Tests pass 70/70 in Release and in Debug, the latter with the asserts active. Builds are clean on arm64 and x86-64 with `WITH_MAINTAINER_WARNINGS=ON`.
